### PR TITLE
Move setup steps into Rails setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,19 @@ We recommend using a version manager to install and manage these, such as:
 git clone git@github.com:alphagov/forms-admin.git
 cd forms-admin
 
-# 2. Install the ruby dependencies
-bundle install
-
-# 3. Set up the database
-rake db:prepare
-
-# 4. Install the node dependencies
-yarn
-
-# 5. Run the frontend build tasks
-yarn build & yarn build:css
+# 2. Run the setup script
+bin/setup
 ```
+
+`bin/setup` is idempotent, so you can also run it whenever you pull new changes.
 
 ### Environment variables
 
-| Name | Purpose |
-| ------------- | ------------- |
+| Name           | Purpose                                                            |
+| -------------- | ------------------------------------------------------------------ |
 | `DATABASE_URL` | The URL to the postgres instance (without the database at the end) |
-| `SENTRY_DSN` | The DSN provided by Sentry |
-| `API_BASE` | The base url for the API - E.g. `http://localhost:9090/api` |
+| `SENTRY_DSN`   | The DSN provided by Sentry                                         |
+| `API_BASE`     | The base url for the API - E.g. `http://localhost:9090/api`        |
 
 ### Running the app
 
@@ -83,14 +76,15 @@ yarn cypress
 
 ## Explain how to use Sentry
 
-We currently have a very basic setup for Sentry in this repo for testing, which we will continue to build upon. 
+We currently have a very basic setup for Sentry in this repo for testing, which we will continue to build upon.
 
 In order to use this:
-  - first sign up to [Sentry](https://sentry.io) and create a new project
-  - create a file called `.env` in the root of this repo
-  - add the Sentry DNS to`.env` as a variable named `SENTRY_DNS`
-  - uncomment out the exception triggers in [this file](config/initializers/sentry.rb)
-  - Build the project and watch the errors come through on Sentry
+
+- first sign up to [Sentry](https://sentry.io) and create a new project
+- create a file called `.env` in the root of this repo
+- add the Sentry DNS to`.env` as a variable named `SENTRY_DNS`
+- uncomment out the exception triggers in [this file](config/initializers/sentry.rb)
+- Build the project and watch the errors come through on Sentry
 
 ## Support
 

--- a/bin/setup
+++ b/bin/setup
@@ -28,6 +28,12 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
+  puts "\n== Installing frontend dependencies =="
+  system! "yarn"
+
+  puts "\n== Building frontend assets =="
+  system! "yarn build & yarn build:css"
+
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
By default Rails provides a setup file which can be used for initial setup and update tasks. Previouslty we weren't really using this, so this PR moves some of our setup tasks into this file. 
Tem members and contributors can now run `bin/setup` when first cloning the repo or when pulling changes to make sure that their dependencies, FE assets and database are up to date.

#### Checklist

- [x] I've used the pull request template
- [x] I've updated the documentation in (If any documentation requires updating)
    - [x] README.md

