### PR TITLE
43 create initial form overview screen

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -41,7 +41,7 @@ class FormsController < ApplicationController
 
   def destroy
     form = Form.find(params[:id])
-    form.destroy!
+    form.destroy
 
     flash[:message] = "Successfully deleted #{form.name}"
     redirect_to root_path, status: :see_other

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -35,7 +35,7 @@ class FormsController < ApplicationController
     flash[:message] = "Successfully updated!"
     redirect_to action: "show", id: form.id
   rescue StandardError
-    flash[:message] = "Unsuccessful"
+    flash[:message] = "Update unsuccessful"
     redirect_to :edit_form, id: params[:id]
   end
 
@@ -46,7 +46,7 @@ class FormsController < ApplicationController
     flash[:message] = "Successfully deleted #{form.name}"
     redirect_to root_path, status: :see_other
   rescue StandardError
-    flash[:message] = "Unsuccessful"
+    flash[:message] = "Deletion unsuccessful"
     redirect_to :form, id: params[:id]
   end
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -41,10 +41,12 @@ class FormsController < ApplicationController
 
   def destroy
     form = Form.find(params[:id])
-    form.destroy
-
-    flash[:message] = "Successfully deleted #{form.name}"
-    redirect_to root_path, status: :see_other
+    if form.destroy
+      flash[:message] = "Successfully deleted #{form.name}"
+      redirect_to root_path, status: :see_other
+    else
+      raise StandardError, "Deletion unsuccessful"
+    end
   rescue StandardError
     flash[:message] = "Deletion unsuccessful"
     redirect_to :form, id: params[:id]

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -47,7 +47,7 @@ class FormsController < ApplicationController
     redirect_to root_path, status: :see_other
   rescue StandardError
     flash[:message] = "Unsuccessful"
-    render :edit
+    redirect_to :form, id: params[:id]
   end
 
 private

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -32,5 +32,3 @@
     <%= form.submit "Save and continue", class: "govuk-button" %>
   </div>
 <% end %>
-
-<%= button_to "Delete #{@form.name}", @form, :method => :delete, class: "govuk-button govuk-button--warning", "data-module": "govuk-button" %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,12 +1,50 @@
-<h1 class="govuk-heading-l"><%= @form.name %></h1>
+<% set_page_title(@form.name) %>
 
-<% if flash[:message] %>
-  <p class="govuk-body">
-    <%= flash[:message] %>
-  </p>
+<% content_for :back_link do %>
+  <%= link_to "Back", root_path, class: "govuk-back-link" %>
 <% end %>
 
-<p class="govuk-body"><%= @form.submission_email %></p>
-<p class="govuk-body"><%= @form.id %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @form.name %></span>
+    <h1 class="govuk-heading-l">Form overview</h1>
 
-<%= link_to "Edit form", edit_form_path(@form.id), class: "govuk-link govuk-link--no-visited-state" %>
+    <% if flash[:message] %>
+      <p class="govuk-body"><%= flash[:message] %></p>
+    <% end %>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">
+      Form name
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+          <%= @form.name %>
+        </dt>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to edit_form_path(@form.id), class: "govuk-link govuk-link--no-visited-state" do %>
+              Edit<span class="govuk-visually-hidden"> form name</span>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">
+      Submission email
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+          <%= @form.submission_email %>
+        </dt>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to edit_form_path(@form.id), class: "govuk-link govuk-link--no-visited-state" do %>
+              Edit<span class="govuk-visually-hidden"> submission email</span>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -46,5 +46,6 @@
         </dd>
       </div>
     </dl>
+    <%= button_to "Delete form", @form, :method => :delete, class: "govuk-button govuk-button--warning", "data-module": "govuk-button" %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,9 @@
     </header>
 
     <div class="govuk-width-container ">
-      <main class="govuk-main-wrapper " id="main-content" role="main">
+      <%= yield :back_link %>
+
+      <main class="govuk-main-wrapper <% if !content_for?(:back_link) %>govuk-main-wrapper--auto-spacing<% end %>" id="main-content" role="main">
         <%= yield %>
       </main>
     </div>

--- a/cypress/integration/form-overview.js
+++ b/cypress/integration/form-overview.js
@@ -1,0 +1,15 @@
+describe('Form overview page', () => {
+  beforeEach(() => {
+    cy.visit('/forms/2')
+  })
+
+  it('allows the user to edit the form', () => {
+    cy.contains('Edit').click()
+    cy.url().should('eq', `${Cypress.config().baseUrl}/forms/2/edit`)
+  })
+
+  it('allows the user to navigate back to the home page', () => {
+    cy.contains('Back').click()
+    cy.url().should('eq', `${Cypress.config().baseUrl}/`)
+  })
+})

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -96,4 +96,32 @@ RSpec.describe "Forms", type: :request do
       end
     end
   end
+
+  describe "Deleting an existing form form" do
+    describe "Given a valid form" do
+      let(:form_response) do
+        stub_request(:get, "#{ENV['API_BASE']}/v1/forms/2")
+          .to_return(status: 200, body: { name: "Form name", submission_email: "submission@email.com", id: 2 }.to_json)
+      end
+
+      let(:form_deletion_request) do
+        stub_request(:delete, "#{ENV['API_BASE']}/v1/forms/2").
+          to_return(status: 200, body: "", headers: {})
+      end
+
+      before do
+        form_response
+        form_deletion_request
+        delete form_path(id: 2), params: { id: 2 }
+      end
+
+      it "Redirects you to the home screen" do
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "Deletes the form on the API" do
+        expect(form_deletion_request).to have_been_made
+      end
+    end
+  end
 end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe "Forms", type: :request do
       end
 
       let(:form_deletion_request) do
-        stub_request(:delete, "#{ENV['API_BASE']}/v1/forms/2").
-          to_return(status: 200, body: "", headers: {})
+        stub_request(:delete, "#{ENV['API_BASE']}/v1/forms/2")
+        .to_return(status: 200, body: "", headers: {})
       end
 
       before do


### PR DESCRIPTION
#### What problem does the pull request solve?
Closes #43  
Includes an initial version of the overview page which is largely the same as the equivalent page in the prototype in style and structure terms. There are some slight tweaks:
- It doesn't contain an 'Add question' button yet, since this feature doesn't exist yet
- It does include delete button (i've moved this from the edit page) - we don't have a concept of deleting forms in the prototype yet
- It lists the submission email (this felt like a useful addition for the time being)

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
