### PR TITLE
Align form creation with the prototype

### DIFF
--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -1,34 +1,37 @@
-<h1 class="govuk-heading-l">Edit form</h1>
-
-<% if flash[:message] %>
-  <p class="govuk-body">
-    <%= flash[:message] %>
-  </p>
+<% content_for :back_link do %>
+  <%= link_to "Back", form_path(@form.id), class: "govuk-back-link" %>
 <% end %>
 
-<%= form_with model: @form, method: "PATCH" do |form| %>
-  <div class="govuk-form-group">
-    <h1 class="govuk-label-wrapper">
-      <%= form.label :name, "What is the name of your form?", class: "govuk-label" %>
-    </h1>
-    <div id="form-title-hint" class="govuk-hint">
-      The form name will be shown at the top of each page of the form. Use a name that describes what the form will help people to do. For example 'Apply for a juggling licence'.
-    </div>
-    <%= form.text_field :name, class: "govuk-input", 'aria-describedby': "form-title-hint" %>
-  </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Edit form</h1>
 
-  <div class="govuk-form-group">
-    <label class="govuk-label" for="email">
-      Email address
-      <%= form.label :submission_email, "What email should responses be sent to?", class: "govuk-label" %>
-    </label>
-    <div id="email-hint" class="govuk-hint">
-      This should be a departmental shared inbox.
-    </div>
-    <%= form.email_field :submission_email, class: "govuk-input", 'aria-describedby': "email-hint", spellcheck: "false", autocomplete: "email" %>
-  </div>
+    <% if flash[:message] %>
+      <p class="govuk-body">
+        <%= flash[:message] %>
+      </p>
+    <% end %>
 
-  <div>
-    <%= form.submit "Save and continue", class: "govuk-button" %>
+    <%= form_with model: @form, method: "PATCH" do |form| %>
+      <div class="govuk-form-group">
+        <%= form.label :name, "What is the name of your form?", class: "govuk-label" %>
+        <div id="form-title-hint" class="govuk-hint">
+          The form name will be shown at the top of each page of the form. Use a name that describes what the form will help people to do. For example 'Apply for a juggling licence'.
+        </div>
+        <%= form.text_field :name, class: "govuk-input", 'aria-describedby': "form-title-hint" %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.label :submission_email, "What email should responses be sent to?", class: "govuk-label" %>
+        <div id="email-hint" class="govuk-hint">
+          This should be a departmental shared inbox.
+        </div>
+        <%= form.email_field :submission_email, class: "govuk-input", 'aria-describedby': "email-hint", spellcheck: "false", autocomplete: "email" %>
+      </div>
+
+      <div>
+        <%= form.submit "Save and continue", class: "govuk-button" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -1,34 +1,37 @@
-<h1 class="govuk-heading-l">Create a form</h1>
-
-<% if flash[:message] %>
-  <p class="govuk-body">
-    <%= flash[:message] %>
-  </p>
+<% content_for :back_link do %>
+  <%= link_to "Back", root_path, class: "govuk-back-link" %>
 <% end %>
 
-<%= form_with url: forms_path do |form| %>
-  <div class="govuk-form-group">
-    <h1 class="govuk-label-wrapper">
-      <%= form.label :name, "What is the name of your form?", class: "govuk-label" %>
-    </h1>
-    <div id="form-title-hint" class="govuk-hint">
-      The form name will be shown at the top of each page of the form. Use a name that describes what the form will help people to do. For example 'Apply for a juggling licence'.
-    </div>
-    <%= form.text_field :name, class: "govuk-input", 'aria-describedby': "form-title-hint" %>
-  </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+  <h1 class="govuk-heading-l">Create a form</h1>
 
-  <div class="govuk-form-group">
-    <label class="govuk-label" for="email">
-      Email address
-      <%= form.label :submission_email, "What email should responses be sent to?", class: "govuk-label" %>
-    </label>
-    <div id="email-hint" class="govuk-hint">
-      This should be a departmental shared inbox.
-    </div>
-    <%= form.email_field :submission_email, class: "govuk-input", 'aria-describedby': "email-hint", spellcheck: "false", autocomplete: "email" %>
-  </div>
+    <% if flash[:message] %>
+      <p class="govuk-body">
+        <%= flash[:message] %>
+      </p>
+    <% end %>
 
-  <div>
-    <%= form.submit "Save and continue", class: "govuk-button" %>
+    <%= form_with url: forms_path do |form| %>
+      <div class="govuk-form-group">
+        <%= form.label :name, "What is the name of your form?", class: "govuk-label" %>
+        <div id="form-title-hint" class="govuk-hint">
+          The form name will be shown at the top of each page of the form. Use a name that describes what the form will help people to do. For example 'Apply for a juggling licence'.
+        </div>
+        <%= form.text_field :name, class: "govuk-input", 'aria-describedby': "form-title-hint" %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.label :submission_email, "What email should responses be sent to?", class: "govuk-label" %>
+        <div id="email-hint" class="govuk-hint">
+          This should be a departmental shared inbox.
+        </div>
+        <%= form.email_field :submission_email, class: "govuk-input", 'aria-describedby': "email-hint", spellcheck: "false", autocomplete: "email" %>
+      </div>
+
+      <div>
+        <%= form.submit "Save and continue", class: "govuk-button" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/cypress/integration/create-form.js
+++ b/cypress/integration/create-form.js
@@ -1,0 +1,17 @@
+describe('Create a form page', () => {
+  beforeEach(() => {
+    cy.visit('/forms/new')
+  })
+
+  it('contains an empty form field for the form title', () => {
+    cy.get('form')
+      .findByLabelText('What is the name of your form?')
+      .should('exist')
+      .should('have.value', '')
+  })
+
+  it('allows the user to navigate back to the home page', () => {
+    cy.contains('Back').click()
+    cy.url().should('eq', `${Cypress.config().baseUrl}/`)
+  })
+})

--- a/cypress/integration/edit-form.js
+++ b/cypress/integration/edit-form.js
@@ -1,0 +1,17 @@
+describe('Edit a form page', () => {
+  beforeEach(() => {
+    cy.visit('/forms/2/edit')
+  })
+
+  it('contains a populated form field for the form title', () => {
+    cy.get('form')
+      .findByLabelText('What is the name of your form?')
+      .should('exist')
+      .should('have.value', 'Apply for a forms licence')
+  })
+
+  it('allows the user to navigate back to the form overview page', () => {
+    cy.contains('Back').click()
+    cy.url().should('eq', `${Cypress.config().baseUrl}/forms/2`)
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,4 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+import '@testing-library/cypress/add-commands'

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "stylelint-config-gds": "^0.2.0"
   },
   "dependencies": {
+    "@testing-library/cypress": "^8.0.2",
     "govuk-frontend": "^4.1.0"
   },
   "standard": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,13 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6":
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
+  integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
@@ -1268,6 +1275,28 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@testing-library/cypress@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.2.tgz#b13f0ff2424dec4368b6670dfbfb7e43af8eefc9"
+  integrity sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    "@testing-library/dom" "^8.1.0"
+
+"@testing-library/dom@^8.1.0":
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
+  integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -1277,6 +1306,11 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -1590,6 +1624,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -2806,6 +2845,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-serializer@^1.0.1:
   version "1.3.2"
@@ -5405,6 +5449,11 @@ lru-cache@^7.4.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.10.1.tgz#db577f42a94c168f676b638d15da8fb073448cab"
   integrity sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
 magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
@@ -6433,7 +6482,7 @@ pretty-bytes@^5.6.0:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
-pretty-format@^27.5.1:
+pretty-format@^27.0.2, pretty-format@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
   integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==


### PR DESCRIPTION
#### What problem does the pull request solve?
Closes #41 

This cleans up the HTML for the Create and Edit pages, and adds tests. This doesn't strictly match the design in the prototype - since we've currently got two form fields on this page, we have to mark it up slightly differently to comply with the design system, and I've prioritised compliance over visual fidelity here. Once we remove the email field from this page, we can change the design to match the prototype more closely.
The tests don't cover the email field, since we know we're going to get rid of this in the near future.

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)


