### PR TITLE
Set next page parameter

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,6 +11,12 @@ class PagesController < ApplicationController
     @page_number = @form.pages.length + 1
 
     if @page.save
+      if @page_number > 1
+        page_to_update = previous_last_page
+        page_to_update.next = @page.id
+        page_to_update.save!
+      end
+
       redirect_to form_path(@form)
     else
       render :new, status: :unprocessable_entity
@@ -38,6 +44,10 @@ class PagesController < ApplicationController
   end
 
 private
+
+  def previous_last_page
+    @form.pages.find { |p| !p.has_next? }
+  end
 
   def page_params(form_id)
     params.require(:page).permit(:question_text, :question_short_name, :hint_text, :answer_type).merge(form_id: form_id)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,4 +6,8 @@ class Page < ActiveResource::Base
   belongs_to :form
   validates :question_text, presence: true
   validates :answer_type, presence: true, inclusion: { in: %w[single_line address date email national_insurance_number phone_number] }
+
+  def has_next?
+    attributes.include?("next") && !attributes["next"].nil?
+  end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -141,26 +141,15 @@ RSpec.describe "Pages", type: :request do
   end
 
   describe "Creating a new page" do
+    let(:form_response) do
+      {
+        name: "Form name",
+        submission_email: "submission@email.com",
+        id: 2,
+      }.to_json
+    end
+
     describe "Given a valid page" do
-      let(:form_response) do
-        {
-          name: "Form name",
-          submission_email: "submission@email.com",
-          id: 2,
-        }.to_json
-      end
-
-      let(:form_pages_response) do
-        [{
-          id: 1,
-          form_id: 2,
-          question_text: "What is your work address?",
-          question_short_name: "Work address",
-          hint_text: "This should be the location stated in your contract.",
-          answer_type: "address",
-        }].to_json
-      end
-
       let(:new_page_data) do
         {
           question_text: "What is your home address?",
@@ -173,7 +162,7 @@ RSpec.describe "Pages", type: :request do
       before do
         ActiveResource::HttpMock.respond_to do |mock|
           mock.get "/api/v1/forms/2", {}, form_response, 200
-          mock.get "/api/v1/forms/2/pages", {}, form_pages_response, 200
+          mock.get "/api/v1/forms/2/pages", {}, [].to_json, 200
           mock.post "/api/v1/forms/2/pages"
         end
 
@@ -192,6 +181,53 @@ RSpec.describe "Pages", type: :request do
       it "Creates the page on the API" do
         expected_request = ActiveResource::Request.new(:post, "/api/v1/forms/2/pages", new_page_data.to_json)
         expect(ActiveResource::HttpMock.requests).to include(expected_request)
+      end
+    end
+
+    describe "Given multiple pages exist" do
+      let(:form_pages_data) do
+        [
+          Page.new(
+            id: 1,
+            question_text: "What is your work address?",
+            question_short_name: "Work address",
+            hint_text: "This should be the location stated in your contract.",
+            answer_type: "address",
+            next: "2",
+            form_id: 2,
+          ),
+          Page.new(
+            id: 2,
+            question_text: "What is your work address?",
+            question_short_name: "Work address",
+            hint_text: "This should be the location stated in your contract.",
+            answer_type: "address",
+            next: nil,
+            form_id: 2,
+          ),
+        ]
+      end
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms/2", {}, form_response, 200
+          mock.get "/api/v1/forms/2/pages", {}, form_pages_data.to_json, 200
+          mock.post "/api/v1/forms/2/pages", {}, { id: "3" }.to_json
+          mock.put "/api/v1/forms/2/pages/2"
+        end
+
+        post create_page_path(2), params: { page: {
+          question_text: "What is your home address?",
+          question_short_name: "Home address",
+          hint_text: "This should be the location stated in your contract.",
+          answer_type: "address",
+        } }
+      end
+
+      it "Updates the previous last page to point to the new page" do
+        second_page = form_pages_data.last
+        second_page.next = "3"
+        expect(second_page).to have_been_updated
       end
     end
   end

--- a/spec/support/matchers/active_resource/have_been_deleted.rb
+++ b/spec/support/matchers/active_resource/have_been_deleted.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :have_been_deleted do
   match do |resource|
-    expected_request_path = resource.class.element_path(resource.id)
+    expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
     expected_request = ActiveResource::Request.new(:delete, expected_request_path)
 
     matched_request = ActiveResource::HttpMock.requests.find do |request|
@@ -12,7 +12,7 @@ RSpec::Matchers.define :have_been_deleted do
   end
 
   failure_message do |resource|
-    expected_request_path = resource.class.collection_path(resource.prefix_options)
+    expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
     expected_request = ActiveResource::Request.new(:delete, expected_request_path)
 
     HelperMethods.format_failure_message(resource, expected_request, ActiveResource::HttpMock.requests)

--- a/spec/support/matchers/active_resource/have_been_read.rb
+++ b/spec/support/matchers/active_resource/have_been_read.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :have_been_read do
   match do |resource|
-    expected_request_path = resource.class.element_path(resource.id)
+    expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
     expected_request = ActiveResource::Request.new(:get, expected_request_path)
 
     matched_request = ActiveResource::HttpMock.requests.find do |request|
@@ -12,7 +12,7 @@ RSpec::Matchers.define :have_been_read do
   end
 
   failure_message do |resource|
-    expected_request_path = resource.class.collection_path(resource.prefix_options)
+    expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
     expected_request = ActiveResource::Request.new(:get, expected_request_path)
 
     HelperMethods.format_failure_message(resource, expected_request, ActiveResource::HttpMock.requests)

--- a/spec/support/matchers/active_resource/have_been_updated.rb
+++ b/spec/support/matchers/active_resource/have_been_updated.rb
@@ -2,7 +2,7 @@ require_relative "helper_methods"
 
 RSpec::Matchers.define :have_been_updated do
   match do |resource|
-    expected_request_path = resource.class.element_path(resource.id)
+    expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
     expected_request = ActiveResource::Request.new(:put, expected_request_path, resource.to_json)
     matched_request = ActiveResource::HttpMock.requests.find do |request|
       request.method == expected_request.method &&
@@ -14,7 +14,7 @@ RSpec::Matchers.define :have_been_updated do
   end
 
   failure_message do |resource|
-    expected_request_path = resource.class.element_path(resource.id)
+    expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
     expected_request = ActiveResource::Request.new(:put, expected_request_path, resource.to_json)
 
     HelperMethods.format_failure_message(resource, expected_request, ActiveResource::HttpMock.requests)


### PR DESCRIPTION
#### What problem does the pull request solve?

We need to set the next page param when new pages are created, this is for the runner to be able to navigate from page to page and in the future to allow for branching and page re-ordering

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- **N/A** I've updated the documentation in (If any documentation requires updating)

