### PR TITLE
Edit pages tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@
 
 /node_modules
 
-.env
+.env*
+!.env.test
 
 # Ignore Cypress output
 /cypress/screenshots

--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -43,20 +43,6 @@ module Forms
       @form.pages.find { |p| p.next = id }
     end
 
-    def update_next_page(form, page)
-      next_page = page.next
-
-      if form.start_page == page.id
-        page_to_update = form
-        page_to_update.start_page = next_page
-      else
-        page_to_update = previous_page(page.id)
-        page_to_update.next = next_page
-      end
-
-      page_to_update
-    end
-
     def load_page_variables
       @form = Form.find(params[:form_id])
       @confirm_deletion_options = delete_confirmation_options
@@ -89,9 +75,8 @@ module Forms
 
     def delete_page(form, page)
       success_url = form_path(form)
-      page_to_update = update_next_page(form, page)
 
-      if page_to_update.save && page.destroy
+      if page.destroy
         flash[:message] = "Successfully deleted #{page.question_text}"
         redirect_to success_url, status: :see_other
       else

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,7 +8,8 @@ class PagesController < ApplicationController
   def create
     @page = Page.new(page_params(@form.id))
 
-    if @form.save_page(@page)
+    # if @form.save_page(@page)
+    if @page.save
       handle_submit_action
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,43 +1,31 @@
 class PagesController < ApplicationController
+  before_action :fetch_form
+
   def new
-    @form = Form.find(params[:form_id])
     @page = Page.new(form_id: @form.id)
-    @page_number = @form.pages.length + 1
   end
 
   def create
-    @form = Form.find(params[:form_id])
     @page = Page.new(page_params(@form.id))
-    @page_number = @form.pages.length + 1
 
-    if @page.save
-      if @page_number > 1
-        page_to_update = previous_last_page
-        page_to_update.next = @page.id
-        page_to_update.save!
-      end
-
-      redirect_to form_path(@form)
+    if @form.save_page(@page)
+      handle_submit_action
     else
       render :new, status: :unprocessable_entity
     end
   end
 
   def edit
-    @form = Form.find(params[:form_id])
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    @page_number = @form.pages.index(@page) + 1
   end
 
   def update
-    @form = Form.find(params[:form_id])
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    @page_number = @form.pages.index(@page) + 1
 
     @page.load(page_params(@form.id))
 
     if @page.save
-      redirect_to form_path(@form)
+      handle_submit_action
     else
       render :edit, status: :unprocessable_entity
     end
@@ -45,11 +33,25 @@ class PagesController < ApplicationController
 
 private
 
-  def previous_last_page
-    @form.pages.find { |p| !p.has_next? }
-  end
-
   def page_params(form_id)
     params.require(:page).permit(:question_text, :question_short_name, :hint_text, :answer_type).merge(form_id:)
+  end
+
+  def fetch_form
+    @form = Form.find(params[:form_id])
+  end
+
+  def handle_submit_action
+    # if user chose to save and reload current page
+    return redirect_to edit_page_path(@form, @page) if params[:save_preview]
+
+    return redirect_to delete_page_path(@form, @page) if params[:delete]
+
+    # Default: either edit the next page or create a new one
+    if @page.has_next?
+      redirect_to edit_page_path(@form, @page.next)
+    else
+      redirect_to new_page_path(@form)
+    end
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -3,4 +3,23 @@ class Form < ActiveResource::Base
   self.include_format_in_path = false
 
   has_many :pages
+
+  def last_page
+    pages.find { |p| !p.has_next? }
+  end
+
+  def save_page(page)
+    page.save && append_page(page)
+  end
+
+  def append_page(page)
+    return true if pages.empty?
+
+    # if there is already a last page, set it's next value to our new page. This
+    # should probably be done in the API, here we cannot add a page and set
+    # the next value atomically
+    current_last_page = last_page
+    current_last_page.next = page.id
+    current_last_page.save!
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -10,4 +10,11 @@ class Page < ActiveResource::Base
   def has_next?
     attributes.include?("next") && !attributes["next"].nil?
   end
+
+  def number(form)
+    # If this page is in form, return the position, else it must be new so
+    # return the number if it was inserted at the end
+    index = form.pages.index(self)
+    (index.nil? ? form.pages.length : index) + 1
+  end
 end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -1,51 +1,23 @@
+<%= f.govuk_error_summary %>
+<!-- Long question text input -->
+<%= f.govuk_text_field :question_text, label: { size: 'm' } %>
 
-<%= form_with model: [form, page], url: url, method: method do |f| %>
-      <%= f.govuk_error_summary %>
-      <!-- Long question text input -->
-      <%= f.govuk_text_field :question_text, label: { size: 'm' } %>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
-      <!-- Short question text input -->
-      <%= f.govuk_text_field :question_short_name, label: { size: 'm' } %>
-      <hr
-        class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
-      />
+<!-- Hint text -->
+<%= f.govuk_text_field :hint_text, label: { class: 'govuk-label--m', text: t("pages.add_hint_text")  } %>
 
-      <!-- Hint text -->
-      <details
-        class="govuk-details govuk-!-margin-bottom-0"
-        data-module="govuk-details"
-      >
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            <%= t("pages.add_hint_text") %>
-          </span>
-        </summary>
-        <div class="govuk-details__text govuk-!-padding-bottom-0">
-          <%= f.govuk_text_field :hint_text, label: { hidden: true } %>
-        </div>
-      </details>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
-      <hr
-        class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
-      />
+<!-- Answer type -->
+<% answer_types= [
+  OpenStruct.new(value: 'single_line'),
+  OpenStruct.new(value: 'address'),
+  OpenStruct.new(value: 'date'),
+  OpenStruct.new(value: 'email'),
+  OpenStruct.new(value: 'national_insurance_number'),
+  OpenStruct.new(value: 'phone_number')
+]  %>
 
-      <!-- Answer type -->
-      <% answer_types= [
-        OpenStruct.new(value: 'single_line'),
-        OpenStruct.new(value: 'address'),
-        OpenStruct.new(value: 'date'),
-        OpenStruct.new(value: 'email'),
-        OpenStruct.new(value: 'national_insurance_number'),
-        OpenStruct.new(value: 'phone_number')
-      ]  %>
+<%= f.govuk_collection_radio_buttons :answer_type, answer_types, :value, small: true %>
 
-      <%= f.govuk_collection_radio_buttons :answer_type, answer_types, :value, small: true %>
-
-      <div class="govuk-button-group">
-        <%= f.govuk_submit t("pages.submit") %>
-
-        <p class="govuk-body">
-          <%=t('pages.or')%> <%= link_to t('pages.go_to_form_overview'), form_path(form), class: "govuk-link govuk-link--no-visited-state" %>
-        </p>
-      </div>
-    <% end %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -7,9 +7,19 @@
       <p class="govuk-body"><%= flash[:message] %></p>
     <% end %>
 
-    <span class="govuk-caption-l"><%= t("pages.question") %> <%= @page_number %></span>
+    <span class="govuk-caption-l"><%= t("pages.question") %> <%= @page.number(@form) %></span>
     <h1 class="govuk-heading-l"><%= t("pages.heading") %></h1>
-    <%= render :partial => 'form', locals: {form: @form, page: @page, url: update_page_path(@form), method: 'PATCH'} %>
-    <%= govuk_button_link_to t("pages.delete_question"), delete_page_path(@form, @page), warning: true %>
+
+    <%= form_with model: [@form, @page], url: update_page_path(@form, @page) do |f| %>
+      <%= render :partial => 'form', locals: { f: f } %>
+      <%= f.govuk_submit @page.has_next? ? t("pages.submit_edit") : t("pages.submit_add") do %>
+        <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>
+      <% end %>
+      <%= f.govuk_submit t('pages.delete_question'), name: :delete, warning: true %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= link_to t('pages.go_to_form_overview'), form_path(@form), class: "govuk-link govuk-link--no-visited-state" %>
+    </p>
   </div>
 </div>

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -2,8 +2,19 @@
 <% content_for :back_link, govuk_back_link_to(form_path(@form)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"><%= t("pages.question") %> <%= @page_number %></span>
+
+    <span class="govuk-caption-l"><%= t("pages.question") %> <%= @page.number(@form) %></span>
     <h1 class="govuk-heading-l"><%= t("pages.heading") %></h1>
-    <%= render :partial => 'form', locals: {form: @form, page: @page, url: create_page_path(@form), method: 'POST'} %>
+
+    <%= form_with model: [@form, @page], url: create_page_path(@form) do |f| %>
+      <%= render :partial => 'form', locals: { f: f } %>
+      <%= f.govuk_submit @page.has_next? ? t("pages.submit_edit") : t("pages.submit_add") do %>
+        <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>
+      <% end %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= link_to t('pages.go_to_form_overview'), form_path(@form), class: "govuk-link govuk-link--no-visited-state" %>
+    </p>
   </div>
 </div>

--- a/config/locales/pages.yml
+++ b/config/locales/pages.yml
@@ -3,9 +3,10 @@ en:
     heading: Edit question
     question: Question
     add_hint_text: Add hint text to help people answer the question
-    submit: Save and continue
-    or: or
-    go_to_form_overview: go to form overview
+    submit_add: Save and add next question
+    submit_edit: Save and edit next question
+    submit_save: Save question
+    go_to_form_overview: Go to form overview
     delete_question: Delete question
   pages_list:
     heading: Your questions

--- a/cypress/e2e/create-page.cy.js
+++ b/cypress/e2e/create-page.cy.js
@@ -11,7 +11,7 @@ describe('Create a page page', function () {
   })
 
   it('allows the user to navigate back to the form overview page', function () {
-    cy.contains('go to form overview').click()
+    cy.contains('Go to form overview').click()
     cy.url().should('eq', `${Cypress.config().baseUrl}/forms/${this.formId}`)
   })
 })

--- a/cypress/e2e/edit-page.cy.js
+++ b/cypress/e2e/edit-page.cy.js
@@ -11,7 +11,7 @@ describe('Edit a form page', function () {
   })
 
   it('allows the user to navigate back to the form overview page', function () {
-    cy.contains('go to form overview').click()
+    cy.contains('Go to form overview').click()
     cy.url().should('eq', `${Cypress.config().baseUrl}/forms/${this.formId}`)
   })
 })

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -124,9 +124,6 @@ RSpec.describe "Pages", type: :request do
         form_request = ActiveResource::Request.new(:get, "/api/v1/forms/2")
         expect(ActiveResource::HttpMock.requests).to include form_request
 
-        form_pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/2/pages")
-        expect(ActiveResource::HttpMock.requests).to include form_pages_request
-
         page_request = ActiveResource::Request.new(:put, "/api/v1/forms/2/pages/1")
         expect(ActiveResource::HttpMock.requests).to include page_request
       end
@@ -136,8 +133,8 @@ RSpec.describe "Pages", type: :request do
         expect(ActiveResource::HttpMock.requests).to include(expected_request)
       end
 
-      it "Redirects you to the page list" do
-        expect(response).to redirect_to(form_path(id: 2))
+      it "Redirects you to the current edit page" do
+        expect(response).to redirect_to(new_page_path(form_id: 2))
       end
     end
   end
@@ -178,7 +175,7 @@ RSpec.describe "Pages", type: :request do
       end
 
       it "Redirects you to the page list" do
-        expect(response).to redirect_to(form_path(id: 2))
+        expect(response).to redirect_to(new_page_path(form_id: 2))
       end
 
       it "Creates the page on the API" do

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -183,53 +183,6 @@ RSpec.describe "Pages", type: :request do
         expect(ActiveResource::HttpMock.requests).to include(expected_request)
       end
     end
-
-    describe "Given multiple pages exist" do
-      let(:form_pages_data) do
-        [
-          Page.new(
-            id: 1,
-            question_text: "What is your work address?",
-            question_short_name: "Work address",
-            hint_text: "This should be the location stated in your contract.",
-            answer_type: "address",
-            next: "2",
-            form_id: 2,
-          ),
-          Page.new(
-            id: 2,
-            question_text: "What is your work address?",
-            question_short_name: "Work address",
-            hint_text: "This should be the location stated in your contract.",
-            answer_type: "address",
-            next: nil,
-            form_id: 2,
-          ),
-        ]
-      end
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", {}, form_response, 200
-          mock.get "/api/v1/forms/2/pages", {}, form_pages_data.to_json, 200
-          mock.post "/api/v1/forms/2/pages", {}, { id: "3" }.to_json
-          mock.put "/api/v1/forms/2/pages/2"
-        end
-
-        post create_page_path(2), params: { page: {
-          question_text: "What is your home address?",
-          question_short_name: "Home address",
-          hint_text: "This should be the location stated in your contract.",
-          answer_type: "address",
-        } }
-      end
-
-      it "Updates the previous last page to point to the new page" do
-        second_page = form_pages_data.last
-        second_page.next = "3"
-        expect(second_page).to have_been_updated
-      end
-    end
   end
 
   describe "Deleting an existing page" do


### PR DESCRIPTION
# Change the edit-question screen to better match the prototype
https://trello.com/c/ut4hFA9P/428-update-edit-question-page

- Hide short name
- Change hint text heading
- Update buttons content and style
- 'Go to form overview' is a separate link

This commit requires the API change to be merged: https://github.com/alphagov/forms-api/pull/47

There is a bit of duplication in the edit/new view pages which might be worth removing but I didn't want to over complicate it. If there is a neat approach or it's too painful as it is, I'll change it.

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


