### PR TITLE
Switch summary list markup to govuk-component

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -10,18 +10,13 @@
 <%= govuk_start_button(text: "Create a form", href: new_form_path) %>
 
 <h2 class="govuk-heading-m">Your forms</h2>
-<dl class="govuk-summary-list">
-  <% @forms.each do |form| %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-        <p class="govuk-body"><%= form.name %></p>
-      </dt>
-      <dd class="govuk-summary-list__actions">
-        <%= link_to form_path(form.id), class: "govuk-link govuk-link--no-visited-state" do %>
-          Edit <span class="govuk-visually-hidden"> <%= form.name %></span>
-        <% end %><br>
-        <a class="govuk-link govuk-link--no-visited-state" href="<%= ENV['RUNNER_BASE'] %>/form/<%= form.id %>">View in runner<span class="govuk-visually-hidden">: <%= form.name %></span></a>
-      </dd>
-    </div>
-  <% end %>
-</dl>
+
+<%= govuk_summary_list do |summary_list|
+  @forms.each do |form|
+    summary_list.row do |row|
+      row.key { form.name }
+      row.action(text: "Edit", href: form_path(form.id), visually_hidden_text: form.name )
+      row.action(text: "View in runner", href: "#{ENV['RUNNER_BASE']}/form/#{form.id}", visually_hidden_text: ": #{form.name}")
+    end
+  end
+end %>


### PR DESCRIPTION
#### What problem does the pull request solve?

`govuk-component` gem provides us with a summary list component.
Theres a couple of benefits here in that the govuk-component version
should always match the implementation of govuk-frontend nunjucks version.
This means that we don't have to worry about manually updating our version
if govuk-frontend updates their components and ends up breaking our one.

Apart for the key values being made bold and the actions being on one line,
I think govuk-component implementation does a better job with the actions
because now the screenreader would alert the user to the fact that there
is a list of actions rather than not realising that there is more actions
without navigation through the page.

#### Before 
![Screenshot 2022-08-10 at 08 52 33](https://user-images.githubusercontent.com/3441519/183846048-6750a821-dec1-40f8-b158-8f88037f8855.png)

#### After
![Screenshot 2022-08-10 at 08 51 58](https://user-images.githubusercontent.com/3441519/183846091-9fe67708-2051-4b38-81c5-904551ad6825.png)

#### Checklist

- [x] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


