### PR TITLE
Hide heading on home page if no forms exist

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -9,14 +9,16 @@
 
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_form_path) %>
 
-<h2 class="govuk-heading-m"><%= t("home.your_forms") %></h2>
+<% if @forms.any? %>
+  <h2 class="govuk-heading-m"><%= t("home.your_forms") %></h2>
 
-<%= govuk_summary_list do |summary_list|
-  @forms.each do |form|
-    summary_list.row do |row|
-      row.key { form.name }
-      row.action(text: t("home.edit"), href: form_path(form.id), visually_hidden_text: form.name )
-      row.action(text: t("home.preview"), href: "#{ENV['RUNNER_BASE']}/form/#{form.id}", visually_hidden_text: ": #{form.name}")
+  <%= govuk_summary_list do |summary_list|
+    @forms.each do |form|
+      summary_list.row do |row|
+        row.key { form.name }
+        row.action(text: t("home.edit"), href: form_path(form.id), visually_hidden_text: form.name )
+        row.action(text: t("home.preview"), href: "#{ENV['RUNNER_BASE']}/form/#{form.id}", visually_hidden_text: ": #{form.name}")
+      end
     end
-  end
-end %>
+  end %>
+<% end %>


### PR DESCRIPTION
#### What problem does the pull request solve?
During the demo we had today of the prototype and what we built so far, I spotted that we were displaying the "Your forms" heading when no forms were created.
#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


