### PR TITLE
Add privacy policy link page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem "gds-sso"
 gem "govuk-components", "3.1.5"
 gem "govuk_design_system_formbuilder", "3.1.2"
 
+# Use validate_url so we don't have to write custom URL validation
+gem "validate_url"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,9 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     view_component (2.56.2)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
@@ -426,6 +429,7 @@ DEPENDENCIES
   simplecov (~> 0.21.2)
   sprockets-rails
   tzinfo-data
+  validate_url
   web-console
   webdrivers
   webmock

--- a/app/controllers/forms/privacy_policy_controller.rb
+++ b/app/controllers/forms/privacy_policy_controller.rb
@@ -1,0 +1,23 @@
+module Forms
+  class PrivacyPolicyController < BaseController
+    def new
+      @privacy_policy_form = PrivacyPolicyForm.new(form: current_form).assign_form_values
+    end
+
+    def create
+      @privacy_policy_form = PrivacyPolicyForm.new(privacy_policy_form_params)
+
+      if @privacy_policy_form.submit
+        redirect_to form_path(@privacy_policy_form.form)
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def privacy_policy_form_params
+      params.require(:forms_privacy_policy_form).permit(:privacy_policy_url).merge(form: current_form)
+    end
+  end
+end

--- a/app/forms/forms/privacy_policy_form.rb
+++ b/app/forms/forms/privacy_policy_form.rb
@@ -1,0 +1,22 @@
+require "uri"
+
+class Forms::PrivacyPolicyForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :form, :privacy_policy_url
+
+  validates :privacy_policy_url, presence: true, url: true
+
+  def submit
+    return false if invalid?
+
+    form.privacy_policy_url = privacy_policy_url
+    form.save!
+  end
+
+  def assign_form_values
+    self.privacy_policy_url = form.privacy_policy_url
+    self
+  end
+end

--- a/app/views/forms/privacy_policy/new.html.erb
+++ b/app/views/forms/privacy_policy/new.html.erb
@@ -1,0 +1,21 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.privacy_policy_form'), @privacy_policy_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(form_path, "Back to create a form") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with(model: @privacy_policy_form, url: privacy_policy_path) do |f| %>
+      <% if @privacy_policy_form&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <%= t('privacy_policy_form.heading') %>
+      </h1>
+
+      <%= t('privacy_policy_form.body_html') %>
+      <%= f.govuk_text_field :privacy_policy_url, label: {  size: 'm' }, class: "govuk-!-width-two-thirds", spellcheck: "false"  %>
+      <%= f.govuk_submit t('privacy_policy_form.submit_button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -56,6 +56,24 @@
         </dd>
       </div>
     </dl>
+
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">
+      <%= t("forms.form_overview.privacy_policy") %>
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+          <%= @form.privacy_policy_url %>
+        </dt>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to privacy_policy_path(@form.id), class: "govuk-link govuk-link--no-visited-state" do %>
+              <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= t("forms.form_overview.privacy_policy") %></span>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
     <%= govuk_button_link_to t("forms.delete_form"), delete_form_path(@form), warning: true %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
       add_or_edit_questions: Add and edit your questions
       edit: Edit
       form_name: Form name
+      privacy_policy: Privacy policy link
       submission_email: Submission email
       title: Form overview
       your_questions: Your questions
@@ -80,6 +81,7 @@ en:
     internal_server_error: Sorry, there is a problem with the service
     new_page_form: Edit question
     not_found: Page not found
+    privacy_policy_form: Provide a link to privacy information for this form
     service_unavailable: Sorry, the service is unavailable
   pages:
     delete_question: Delete question
@@ -96,6 +98,39 @@ en:
     after_link: will help us improve it.
     before_link: This is a new service, your
     link: feedback
+  privacy_policy_form:
+    body_html: |
+      <p class="govuk-body">
+        To comply with the UK General Data Protection Regulation (UK GDPR), you must provide privacy information for the people who will enter their data into your form.
+      </p>
+
+      <p class="govuk-body">
+        The privacy information must include details such as:
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            your purposes for processing the personal data
+          </li>
+          <li>
+            how long you’ll keep the personal data
+          </li>
+          <li>
+            who the data will be shared with
+          </li>
+          <li>
+            contact details for your department and your data protection officer
+          </li>
+        </ul>
+      </p>
+
+      <p class="govuk-body">
+        You may already publish this information, for example in a privacy notice or personal information charter. Existing privacy information may need to be updated to cover the data you are collecting in this form, or you may need a new privacy notice.
+      </p>
+
+      <p class="govuk-body">
+        To get help, contact your department’s data protection officer or data protection manager.
+      </p>
+    heading: Provide a link to privacy information for this form
+    submit_button: Save and continue
   service_unavailable:
     body: Contact the GOV.UK Forms team if you need to make changes to your forms or speak to someone about the service.
     title: Sorry, the service is unavailable

--- a/config/locales/forms/privacy_policy.yml
+++ b/config/locales/forms/privacy_policy.yml
@@ -1,0 +1,19 @@
+en:
+  errors:
+    messages:
+      url: Enter a link in the correct format, like https://www.gov.uk/help/privacy-notice
+  helpers:
+    label:
+      forms_privacy_policy_form:
+        privacy_policy_url: Enter a link to privacy information for this form
+    hint:
+      forms_privacy_policy_form:
+        privacy_policy_url: |-
+          For example, https://www.gov.uk/help/privacy-notice
+  activemodel:
+    errors:
+      models:
+        forms/privacy_policy_form:
+          attributes:
+            privacy_policy_url:
+              blank: Enter a link to privacy information

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   post "forms/:id/change-email" => "forms/change_email#create"
   get "forms/:form_id/delete" => "forms/delete_confirmation#delete", as: :delete_form
   delete "forms/:form_id/delete" => "forms/delete_confirmation#destroy", as: :destroy_form
+  get "forms/:id/privacy_policy" => "forms/privacy_policy#new", as: :privacy_policy
+  post "forms/:id/privacy_policy" => "forms/privacy_policy#create"
 
   # Page routes
   get "forms/:form_id/pages" => "pages#index", as: :form_pages

--- a/spec/forms/privacy_policy_form_spec.rb
+++ b/spec/forms/privacy_policy_form_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Forms::PrivacyPolicyForm, type: :model do
+  describe "Privacy policy URL" do
+    it "is invalid if blank" do
+      privacy_policy_form = described_class.new(privacy_policy_url: "")
+      error_message = I18n.t("activemodel.errors.models.forms/privacy_policy_form.attributes.privacy_policy_url.blank")
+
+      privacy_policy_form.validate(:privacy_policy_url)
+
+      expect(privacy_policy_form.errors.full_messages_for(:privacy_policy_url)).to include(
+        "Privacy policy url #{error_message}",
+      )
+    end
+
+    it { is_expected.to validate_url_of(:privacy_policy_url) }
+
+    # More tests are required here -  e.g. that a valid submission updates the Form object
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 require "spec_helper"
 require "view_component/test_helpers"
 require "capybara/rspec"
+require "validate_url/rspec_matcher"
 
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
@@ -23,7 +24,7 @@ require "rspec/rails"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+# Dir[Rails.root.join("spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Forms", type: :request do
           id: 2,
           name: "Form name",
           submission_email: "submission@email.com",
+          privacy_policy_url: "https://example.com/privacy_policy",
         })
       end
 

--- a/spec/requests/privacy_policy_spec.rb
+++ b/spec/requests/privacy_policy_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe "PrivacyPolicy controller", type: :request do
+  let(:form_response_data) do
+    {
+      id: 2,
+      name: "Form name",
+      submission_email: "submission@email.com",
+      start_page: 1,
+      org: "test-org",
+      privacy_policy_url: "https://www.example.com",
+    }.to_json
+  end
+
+  let(:form) do
+    Form.new(
+      name: "Form name",
+      submission_email: "submission@email.com",
+      id: 2,
+      org: "test-org",
+      privacy_policy_url: "https://www.example.com",
+    )
+  end
+
+  let(:updated_form) do
+    Form.new({
+      name: "Form name",
+      submission_email: "submission@email.com",
+      id: 2,
+      org: "test-org",
+      privacy_policy_url: "https://www.example.gov.uk/privacy-policy",
+    })
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Content-Type" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+      mock.put "/api/v1/forms/2", req_headers
+    end
+
+    ActiveResourceMock.mock_resource(form,
+                                     {
+                                       read: { response: form, status: 200 },
+                                       update: { response: updated_form, status: 200 },
+                                     })
+  end
+
+  describe "#new" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.put "/api/v1/forms/2", post_headers
+        mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+      end
+      get privacy_policy_path(id: 2)
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+  end
+
+  describe "#create" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+        mock.put "/api/v1/forms/2", post_headers
+      end
+      post privacy_policy_path(id: 2), params: { forms_privacy_policy_form: { privacy_policy_url: "https://www.example.gov.uk/privacy-policy" } }
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+
+    it "Updates the form on the API" do
+      expect(updated_form).to have_been_updated
+    end
+
+    it "Redirects you to the form overview page" do
+      expect(response).to redirect_to(form_path(2))
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
Allows a user to set their form's privacy policy URL.

Trello card: https://trello.com/c/nmMtizUC/365-add-provide-a-link-to-your-privacy-information-to-forms-admin-needs-dev-review


#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


