### PR TITLE
Add make live

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :development, :test do
   gem "i18n-tasks", "~> 1.0.11"
   gem "rails-controller-testing"
   gem "rubocop-govuk", require: false
+  gem "timecop"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,6 +360,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
+    timecop (0.9.5)
     timeout (0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -428,6 +429,7 @@ DEPENDENCIES
   sentry-ruby
   simplecov (~> 0.21.2)
   sprockets-rails
+  timecop
   tzinfo-data
   validate_url
   web-console

--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -1,7 +1,7 @@
 module Forms
   class MakeLiveController < BaseController
     def new
-      redirect_to live_confirmation_url if current_form.live_at.present?
+      redirect_to live_confirmation_url if current_form.live?
       @make_live_form = MakeLiveForm.new(form: current_form)
     end
 
@@ -20,7 +20,8 @@ module Forms
     end
 
     def confirmation
-      redirect_to make_live_path if current_form.live_at.blank?
+      redirect_to make_live_path if current_form.draft?
+      @form = current_form
     end
 
   private

--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -1,0 +1,32 @@
+module Forms
+  class MakeLiveController < BaseController
+    def new
+      redirect_to live_confirmation_url if current_form.live_at.present?
+      @make_live_form = MakeLiveForm.new(form: current_form)
+    end
+
+    def create
+      @make_live_form = MakeLiveForm.new(**make_live_form_params)
+
+      if @make_live_form.submit
+        if @make_live_form.made_live?
+          redirect_to live_confirmation_path(@make_live_form.form)
+        else
+          redirect_to form_path(@make_live_form.form)
+        end
+      else
+        render :new
+      end
+    end
+
+    def confirmation
+      redirect_to make_live_path if current_form.live_at.blank?
+    end
+
+  private
+
+    def make_live_form_params
+      params.require(:forms_make_live_form).permit(:confirm_make_live).merge(form: current_form)
+    end
+  end
+end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -30,5 +30,12 @@ private
                     rows: [
                       { task_name: t("forms.task_lists.section_3.privacy_policy"), path: privacy_policy_path(@form.id) },
                     ] }]
+
+    unless @form.live?
+      @task_list.append({ title: t("forms.task_lists.section_4.title"),
+                          rows: [
+                            { task_name: t("forms.task_lists.section_4.make_live"), path: make_live_path(@form.id) },
+                          ] })
+    end
   end
 end

--- a/app/forms/forms/make_live_form.rb
+++ b/app/forms/forms/make_live_form.rb
@@ -1,0 +1,27 @@
+class Forms::MakeLiveForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :form, :confirm_make_live
+
+  CONFIRM_LIVE_VALUES = { made_live: "made_live", not_made_live: "not_made_live" }.freeze
+
+  validates :confirm_make_live, presence: true, inclusion: { in: CONFIRM_LIVE_VALUES.values }
+
+  def submit
+    return false if invalid?
+    # we are valid and didn't need to save
+    return true unless made_live?
+
+    form.live_at = Time.zone.now
+    form.save!
+  end
+
+  def made_live?
+    confirm_make_live == CONFIRM_LIVE_VALUES[:made_live]
+  end
+
+  def values
+    CONFIRM_LIVE_VALUES.keys
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,4 +25,8 @@ module ApplicationHelper
       classes:,
     )
   end
+
+  def link_to_runner(runner_url, form_id)
+    "#{runner_url}/form/#{form_id}"
+  end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -3,10 +3,26 @@ class Form < ActiveResource::Base
   self.include_format_in_path = false
   headers["X-API-Token"] = ENV["API_KEY"]
 
+  STATUSES = { draft: "draft", live: "live" }.freeze
+
   has_many :pages
 
   def last_page
     pages.find { |p| !p.has_next_page? }
+  end
+
+  def live?
+    live_at.present?
+  end
+
+  def draft?
+    !live?
+  end
+
+  def status
+    return STATUSES[:live] if live?
+
+    STATUSES[:draft]
   end
 
   def save_page(page)

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-xl">its live!</h1>

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -1,7 +1,9 @@
+<% set_page_title(t('page_titles.your_form_is_live')) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= @form.name %></span>
-    <h1 class="govuk-heading-l">Your form is live</h1>
+    <h1 class="govuk-heading-l"><%= t('page_titles.your_form_is_live') %></h1>
 
     <p class="govuk-body">
       The URL for your form is:
@@ -11,13 +13,10 @@
       </span>
     </p>
 
-    <p class="govuk-body">
-      The form will not be indexed by search engines, so people will not be able to find it easily.
-      Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
-    </p>
+    <%= t("make_live.confirmation.body_html") %>
 
     <p class="govuk-body">
-      <%= govuk_link_to "Continue to form details", form_path(@form.id) %>
+      <%= govuk_link_to t("make_live.confirmation.continue_link"), form_path(@form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -7,7 +7,7 @@
       The URL for your form is:
 
       <span class="govuk-!-display-block govuk-!-margin-top-6 govuk-!-padding-bottom-6">
-        <%= govuk_link_to "#{ENV['RUNNER_BASE']}/form/#{@form.id}","#{ENV['RUNNER_BASE']}/form/#{@form.id}", { target:"_blank", rel:"noopener noreferrer"} %>
+        <%= govuk_link_to link_to_runner(ENV["RUNNER_BASE"], @form.id ), link_to_runner(ENV["RUNNER_BASE"], @form.id ), { target:"_blank", rel:"noopener noreferrer"} %>
       </span>
     </p>
 

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -1,1 +1,23 @@
-<h1 class="govuk-heading-xl">its live!</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @form.name %></span>
+    <h1 class="govuk-heading-l">Your form is live</h1>
+
+    <p class="govuk-body">
+      The URL for your form is:
+
+      <span class="govuk-!-display-block govuk-!-margin-top-6 govuk-!-padding-bottom-6">
+        <%= govuk_link_to "#{ENV['RUNNER_BASE']}/form/#{@form.id}","#{ENV['RUNNER_BASE']}/form/#{@form.id}", { target:"_blank", rel:"noopener noreferrer"} %>
+      </span>
+    </p>
+
+    <p class="govuk-body">
+      The form will not be indexed by search engines, so people will not be able to find it easily.
+      Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to "Continue to form details", form_path(@form.id) %>
+    </p>
+  </div>
+</div>

--- a/app/views/forms/make_live/new.html.erb
+++ b/app/views/forms/make_live/new.html.erb
@@ -4,38 +4,33 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Make your form live</h1>
+    <%= form_with(model: @make_live_form, url: make_live_create_path) do |f| %>
+      <% if @make_live_form&.errors&.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
 
-    <p class="govuk-body">
-      When you make your form live you will get a URL for the form. The form
-      will not be indexed by search engines, so people will not be able to
-      find it easily. Contact your GOV.UK publishing team to publish a link to
-      your form on GOV.UK so people can find it.
-    </p>
-    <p></p>
-    <p class="govuk-body">
-      Make sure you are happy with the form before you make it live. After you
-      have made your form live:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>completed forms will be sent to asd</li>
-      <li>you will not be able to change the name of the form</li>
-    </ul>
-    <div
-      class="govuk-notification-banner"
-      role="region"
-      aria-labelledby="govuk-notification-banner-title"
-      data-module="govuk-notification-banner"
-    >
-      <div class="govuk-notification-banner__header">
-        <h2
-          class="govuk-notification-banner__title"
-          id="govuk-notification-banner-title"
-        >
-          Important
-        </h2>
-      </div>
-      <div class="govuk-notification-banner__content">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @make_live_form.form.name %></span>
+        Make your form live
+      </h1>
+
+      <p class="govuk-body">
+        When you make your form live you will get a URL for the form. The form
+        will not be indexed by search engines, so people will not be able to
+        find it easily. Contact your GOV.UK publishing team to publish a link to
+        your form on GOV.UK so people can find it.
+      </p>
+      <p></p>
+      <p class="govuk-body">
+        Make sure you are happy with the form before you make it live. After you
+        have made your form live:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>completed forms will be sent to <%= @make_live_form.form.submission_email %></li>
+        <li>you will not be able to change the name of the form</li>
+      </ul>
+      <%= govuk_notification_banner(title_text: "Important") do  %>
         <p class="govuk-notification-banner__heading">
           Any changes you make to a live form will be updated in the form
           immediately.
@@ -45,15 +40,12 @@
           the same time. They may lose any answers they have already provided
           and may need to start again.
         </p>
-      </div>
-    </div>
-
-    <%= form_with(model: @make_live_form, url: make_live_create_path) do |f| %>
-      <% if @make_live_form&.errors&.any? %>
-        <%= f.govuk_error_summary %>
       <% end %>
-      <span class="govuk-caption-l"><%= @item_name %></span>
-      <%= f.govuk_collection_radio_buttons :confirm_make_live, @make_live_form.values, ->(option) { option }, ->(option) { I18n.t('helpers.label.forms_make_live_form.options.' + "#{option}") }, legend: { text: I18n.t('helpers.label.forms_make_live_form.confirm_make_live'), size: 'l', tag: 'h1' } %>
+
+      <%= f.govuk_collection_radio_buttons :confirm_make_live,
+                                           @make_live_form.values, ->(option) { option }, ->(option) { I18n.t('helpers.label.forms_make_live_form.options.' + "#{option}") },
+                                           legend: { text: I18n.t('helpers.label.forms_make_live_form.confirm_make_live'),
+                                                     size: 'm'}, inline: true %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/forms/make_live/new.html.erb
+++ b/app/views/forms/make_live/new.html.erb
@@ -1,56 +1,60 @@
 <% set_page_title(title_with_error_prefix(t('page_titles.make_live_form'), @make_live_form.errors.any?)) %>
 <% content_for :back_link, govuk_back_link_to(form_path, "Back to create a form") %>
-<h1 class="govuk-heading-l">Make your form live</h1>
 
-<p class="govuk-body">
-  When you make your form live you will get a URL for the form. The form
-  will not be indexed by search engines, so people will not be able to
-  find it easily. Contact your GOV.UK publishing team to publish a link to
-  your form on GOV.UK so people can find it.
-</p>
-<p></p>
-<p class="govuk-body">
-  Make sure you are happy with the form before you make it live. After you
-  have made your form live:
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>completed forms will be sent to asd</li>
-  <li>you will not be able to change the name of the form</li>
-</ul>
-<div
-  class="govuk-notification-banner"
-  role="region"
-  aria-labelledby="govuk-notification-banner-title"
-  data-module="govuk-notification-banner"
->
-  <div class="govuk-notification-banner__header">
-    <h2
-      class="govuk-notification-banner__title"
-      id="govuk-notification-banner-title"
-    >
-      Important
-    </h2>
-  </div>
-  <div class="govuk-notification-banner__content">
-    <p class="govuk-notification-banner__heading">
-      Any changes you make to a live form will be updated in the form
-      immediately.
-    </p>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Make your form live</h1>
+
     <p class="govuk-body">
-      This could have an impact on people who are filling in the form at
-      the same time. They may lose any answers they have already provided
-      and may need to start again.
+      When you make your form live you will get a URL for the form. The form
+      will not be indexed by search engines, so people will not be able to
+      find it easily. Contact your GOV.UK publishing team to publish a link to
+      your form on GOV.UK so people can find it.
     </p>
+    <p></p>
+    <p class="govuk-body">
+      Make sure you are happy with the form before you make it live. After you
+      have made your form live:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>completed forms will be sent to asd</li>
+      <li>you will not be able to change the name of the form</li>
+    </ul>
+    <div
+      class="govuk-notification-banner"
+      role="region"
+      aria-labelledby="govuk-notification-banner-title"
+      data-module="govuk-notification-banner"
+    >
+      <div class="govuk-notification-banner__header">
+        <h2
+          class="govuk-notification-banner__title"
+          id="govuk-notification-banner-title"
+        >
+          Important
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">
+          Any changes you make to a live form will be updated in the form
+          immediately.
+        </p>
+        <p class="govuk-body">
+          This could have an impact on people who are filling in the form at
+          the same time. They may lose any answers they have already provided
+          and may need to start again.
+        </p>
+      </div>
+    </div>
+
+    <%= form_with(model: @make_live_form, url: make_live_create_path) do |f| %>
+      <% if @make_live_form&.errors&.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+      <span class="govuk-caption-l"><%= @item_name %></span>
+      <%= f.govuk_collection_radio_buttons :confirm_make_live, @make_live_form.values, ->(option) { option }, ->(option) { I18n.t('helpers.label.forms_make_live_form.options.' + "#{option}") }, legend: { text: I18n.t('helpers.label.forms_make_live_form.confirm_make_live'), size: 'l', tag: 'h1' } %>
+      <%= f.govuk_submit %>
+    <% end %>
   </div>
 </div>
-
-<%# <% set_page_title(title_with_error_prefix(@confirm_deletion_legend, @delete_confirmation_form.errors.any?)) %1> %>
-<%# <% content_for :back_link, govuk_back_link_to(@back_url) %1> %>
-<%= form_with(model: @make_live_form, url: make_live_create_path) do |f| %>
-  <% if @make_live_form&.errors&.any? %>
-    <%= f.govuk_error_summary %>
-  <% end %>
-  <span class="govuk-caption-l"><%= @item_name %></span>
-  <%= f.govuk_collection_radio_buttons :confirm_make_live, @make_live_form.values, ->(option) { option }, ->(option) { I18n.t('helpers.label.forms_make_live_form.options.' + "#{option}") }, legend: { text: I18n.t('helpers.label.forms_make_live_form.confirm_make_live'), size: 'l', tag: 'h1' } %>
-  <%= f.govuk_submit %>
-<% end %>

--- a/app/views/forms/make_live/new.html.erb
+++ b/app/views/forms/make_live/new.html.erb
@@ -9,37 +9,15 @@
         <%= f.govuk_error_summary %>
       <% end %>
 
-
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= @make_live_form.form.name %></span>
-        Make your form live
+        <%= t("page_titles.make_live_form") %>
       </h1>
 
-      <p class="govuk-body">
-        When you make your form live you will get a URL for the form. The form
-        will not be indexed by search engines, so people will not be able to
-        find it easily. Contact your GOV.UK publishing team to publish a link to
-        your form on GOV.UK so people can find it.
-      </p>
-      <p></p>
-      <p class="govuk-body">
-        Make sure you are happy with the form before you make it live. After you
-        have made your form live:
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>completed forms will be sent to <%= @make_live_form.form.submission_email %></li>
-        <li>you will not be able to change the name of the form</li>
-      </ul>
+      <%= t("make_live.new.body_html", submission_email: @make_live_form.form.submission_email) %>
+
       <%= govuk_notification_banner(title_text: "Important") do  %>
-        <p class="govuk-notification-banner__heading">
-          Any changes you make to a live form will be updated in the form
-          immediately.
-        </p>
-        <p class="govuk-body">
-          This could have an impact on people who are filling in the form at
-          the same time. They may lose any answers they have already provided
-          and may need to start again.
-        </p>
+        <%= t("make_live.new.notification_content_html") %>
       <% end %>
 
       <%= f.govuk_collection_radio_buttons :confirm_make_live,

--- a/app/views/forms/make_live/new.html.erb
+++ b/app/views/forms/make_live/new.html.erb
@@ -1,105 +1,56 @@
-    <span class="govuk-caption-l">test form</span>
-    <h1 class="govuk-heading-l">Make your form live</h1>
+<% set_page_title(title_with_error_prefix(t('page_titles.make_live_form'), @make_live_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(form_path, "Back to create a form") %>
+<h1 class="govuk-heading-l">Make your form live</h1>
 
-    <p class="govuk-body">
-      When you make your form live you will get a URL for the form. The form
-      will not be indexed by search engines, so people will not be able to
-      find it easily. Contact your GOV.UK publishing team to publish a link to
-      your form on GOV.UK so people can find it.&nbsp;
-    </p>
-    <p></p>
-    <p class="govuk-body">
-      Make sure you are happy with the form before you make it live. After you
-      have made your form live:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>completed forms will be sent to asd</li>
-      <li>you will not be able to change the name of the form</li>
-    </ul>
-    <div
-      class="govuk-notification-banner"
-      role="region"
-      aria-labelledby="govuk-notification-banner-title"
-      data-module="govuk-notification-banner"
+<p class="govuk-body">
+  When you make your form live you will get a URL for the form. The form
+  will not be indexed by search engines, so people will not be able to
+  find it easily. Contact your GOV.UK publishing team to publish a link to
+  your form on GOV.UK so people can find it.
+</p>
+<p></p>
+<p class="govuk-body">
+  Make sure you are happy with the form before you make it live. After you
+  have made your form live:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>completed forms will be sent to asd</li>
+  <li>you will not be able to change the name of the form</li>
+</ul>
+<div
+  class="govuk-notification-banner"
+  role="region"
+  aria-labelledby="govuk-notification-banner-title"
+  data-module="govuk-notification-banner"
+>
+  <div class="govuk-notification-banner__header">
+    <h2
+      class="govuk-notification-banner__title"
+      id="govuk-notification-banner-title"
     >
-      <div class="govuk-notification-banner__header">
-        <h2
-          class="govuk-notification-banner__title"
-          id="govuk-notification-banner-title"
-        >
-          Important
-        </h2>
-      </div>
-      <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">
-          Any changes you make to a live form will be updated in the form
-          immediately.
-        </p>
-        <p class="govuk-body">
-          This could have an impact on people who are filling in the form at
-          the same time. They may lose any answers they have already provided
-          and may need to start again.&nbsp;
-        </p>
-      </div>
-    </div>
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      Any changes you make to a live form will be updated in the form
+      immediately.
+    </p>
+    <p class="govuk-body">
+      This could have an impact on people who are filling in the form at
+      the same time. They may lose any answers they have already provided
+      and may need to start again.
+    </p>
+  </div>
+</div>
 
-    <%# <% set_page_title(title_with_error_prefix(@confirm_deletion_legend, @delete_confirmation_form.errors.any?)) %1> %>
-    <%# <% content_for :back_link, govuk_back_link_to(@back_url) %1> %>
-    <%= form_with(model: @make_live_form, url: make_live_create_path) do |f| %>
-      <% if @make_live_form&.errors&.any? %>
-        <%= f.govuk_error_summary %>
-      <% end %>
-      <span class="govuk-caption-l"><%= @item_name %></span>
-      <%= f.govuk_collection_radio_buttons :confirm_make_live, @make_live_form.values, ->(option) { option }, legend: { text: @confirm_deletion_legend, size: 'l', tag: 'h1' } %>
-      <%= f.govuk_submit %>
-    <% end %>
-    <form method="post">
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-            Are you sure you want to make your form live?
-          </legend>
-
-          <div
-            class="govuk-radios govuk-radios--inline"
-            data-module="govuk-radios"
-          >
-            <div class="govuk-radios__item">
-              <input
-                class="govuk-radios__input"
-                id="makeFormLive"
-                name="makeFormLive"
-                type="radio"
-                value="yes"
-              />
-              <label
-                class="govuk-label govuk-radios__label"
-                for="makeFormLive"
-              >
-                Yes
-              </label>
-            </div>
-
-            <div class="govuk-radios__item">
-              <input
-                class="govuk-radios__input"
-                id="makeFormLive-2"
-                name="makeFormLive"
-                type="radio"
-                value="no"
-              />
-              <label
-                class="govuk-label govuk-radios__label"
-                for="makeFormLive-2"
-              >
-                No
-              </label>
-            </div>
-          </div>
-        </fieldset>
-      </div>
-
-      <button class="govuk-button" data-module="govuk-button">
-        Continue
-      </button>
-    </form>
+<%# <% set_page_title(title_with_error_prefix(@confirm_deletion_legend, @delete_confirmation_form.errors.any?)) %1> %>
+<%# <% content_for :back_link, govuk_back_link_to(@back_url) %1> %>
+<%= form_with(model: @make_live_form, url: make_live_create_path) do |f| %>
+  <% if @make_live_form&.errors&.any? %>
+    <%= f.govuk_error_summary %>
+  <% end %>
+  <span class="govuk-caption-l"><%= @item_name %></span>
+  <%= f.govuk_collection_radio_buttons :confirm_make_live, @make_live_form.values, ->(option) { option }, ->(option) { I18n.t('helpers.label.forms_make_live_form.options.' + "#{option}") }, legend: { text: I18n.t('helpers.label.forms_make_live_form.confirm_make_live'), size: 'l', tag: 'h1' } %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/forms/make_live/new.html.erb
+++ b/app/views/forms/make_live/new.html.erb
@@ -1,0 +1,105 @@
+    <span class="govuk-caption-l">test form</span>
+    <h1 class="govuk-heading-l">Make your form live</h1>
+
+    <p class="govuk-body">
+      When you make your form live you will get a URL for the form. The form
+      will not be indexed by search engines, so people will not be able to
+      find it easily. Contact your GOV.UK publishing team to publish a link to
+      your form on GOV.UK so people can find it.&nbsp;
+    </p>
+    <p></p>
+    <p class="govuk-body">
+      Make sure you are happy with the form before you make it live. After you
+      have made your form live:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>completed forms will be sent to asd</li>
+      <li>you will not be able to change the name of the form</li>
+    </ul>
+    <div
+      class="govuk-notification-banner"
+      role="region"
+      aria-labelledby="govuk-notification-banner-title"
+      data-module="govuk-notification-banner"
+    >
+      <div class="govuk-notification-banner__header">
+        <h2
+          class="govuk-notification-banner__title"
+          id="govuk-notification-banner-title"
+        >
+          Important
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">
+          Any changes you make to a live form will be updated in the form
+          immediately.
+        </p>
+        <p class="govuk-body">
+          This could have an impact on people who are filling in the form at
+          the same time. They may lose any answers they have already provided
+          and may need to start again.&nbsp;
+        </p>
+      </div>
+    </div>
+
+    <%# <% set_page_title(title_with_error_prefix(@confirm_deletion_legend, @delete_confirmation_form.errors.any?)) %1> %>
+    <%# <% content_for :back_link, govuk_back_link_to(@back_url) %1> %>
+    <%= form_with(model: @make_live_form, url: make_live_create_path) do |f| %>
+      <% if @make_live_form&.errors&.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+      <span class="govuk-caption-l"><%= @item_name %></span>
+      <%= f.govuk_collection_radio_buttons :confirm_make_live, @make_live_form.values, ->(option) { option }, legend: { text: @confirm_deletion_legend, size: 'l', tag: 'h1' } %>
+      <%= f.govuk_submit %>
+    <% end %>
+    <form method="post">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            Are you sure you want to make your form live?
+          </legend>
+
+          <div
+            class="govuk-radios govuk-radios--inline"
+            data-module="govuk-radios"
+          >
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="makeFormLive"
+                name="makeFormLive"
+                type="radio"
+                value="yes"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="makeFormLive"
+              >
+                Yes
+              </label>
+            </div>
+
+            <div class="govuk-radios__item">
+              <input
+                class="govuk-radios__input"
+                id="makeFormLive-2"
+                name="makeFormLive"
+                type="radio"
+                value="no"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="makeFormLive-2"
+              >
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <button class="govuk-button" data-module="govuk-button">
+        Continue
+      </button>
+    </form>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -17,7 +17,7 @@
     %>
 
     <p class="govuk-body govuk-!-margin-bottom-9">
-      <%= govuk_link_to t("home.preview"),"#{ENV['RUNNER_BASE']}/form/#{@form.id}", { target:"_blank", rel:"noopener noreferrer"} %>
+      <%= govuk_link_to t("home.preview"),link_to_runner(ENV["RUNNER_BASE"], @form.id ), { target:"_blank", rel:"noopener noreferrer"} %>
     </p>
 
     <%= govuk_button_link_to t("forms.delete_form"), delete_form_path(@form.id), warning: true %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -17,7 +17,7 @@
       summary_list.row do |row|
         row.key { form.name }
         row.action(text: t("home.edit"), href: form_path(form.id), visually_hidden_text: form.name )
-        row.action(text: t("home.preview"), href: "#{ENV['RUNNER_BASE']}/form/#{form.id}", visually_hidden_text: ": #{form.name}", html_attributes: { target:"_blank", rel:"noopener noreferrer"})
+        row.action(text: t("home.preview"), href: link_to_runner(ENV["RUNNER_BASE"], form.id ), visually_hidden_text: ": #{form.name}", html_attributes: { target:"_blank", rel:"noopener noreferrer"})
       end
     end
   end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -12,7 +12,7 @@
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), new_page_path(@form), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
-      <%= govuk_link_to t("home.preview"),"#{ENV['RUNNER_BASE']}/form/#{@form.id}", { target:"_blank", rel:"noopener noreferrer"} %>
+      <%= govuk_link_to t("home.preview"), link_to_runner(ENV["RUNNER_BASE"], @form.id ), { target:"_blank", rel:"noopener noreferrer"} %>
     </div>
 
     <% if @pages.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,41 @@ en:
   internal_server_error:
     body: Please try again later.
     title: Sorry, there is a problem with the service
+  make_live:
+    confirmation:
+      body_html: |
+        <p class="govuk-body">
+          The form will not be indexed by search engines, so people will not be able to find it easily.
+          Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
+        </p>
+      continue_link: Continue to form details
+    new:
+      body_html: |
+        <p class="govuk-body">
+          When you make your form live you will get a URL for the form. The form
+          will not be indexed by search engines, so people will not be able to
+          find it easily. Contact your GOV.UK publishing team to publish a link to
+          your form on GOV.UK so people can find it.
+        </p>
+
+        <p class="govuk-body">
+          Make sure you are happy with the form before you make it live. After you
+          have made your form live:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>completed forms will be sent to %{submission_email}</li>
+          <li>you will not be able to change the name of the form</li>
+        </ul>
+      notification_content_html: |
+        <p class="govuk-notification-banner__heading">
+          Any changes you make to a live form will be updated in the form
+          immediately.
+        </p>
+        <p class="govuk-body">
+          This could have an impact on people who are filling in the form at
+          the same time. They may lose any answers they have already provided
+          and may need to start again.
+        </p>
   not_found:
     body: |
       If you typed the web address, check it is correct.
@@ -96,6 +131,7 @@ en:
     not_found: Page not found
     privacy_policy_form: Provide a link to privacy information for this form
     service_unavailable: Sorry, the service is unavailable
+    your_form_is_live: Your form is live
   pages:
     delete_question: Delete question
     go_to_your_questions: Go to your questions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,8 @@ en:
           Ask a question the way you would in person. For example ‘What is your
           address?’
     label:
+      forms_make_live_form:
+        confirm_make_live: Are you sure you want to make your form live?
       page:
         answer_type_options:
           descriptions:
@@ -86,6 +88,7 @@ en:
     error_prefix: 'Error: '
     home: Home
     internal_server_error: Sorry, there is a problem with the service
+    make_live_form: Make form live
     new_page_form: Edit question
     not_found: Page not found
     privacy_policy_form: Provide a link to privacy information for this form

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,9 @@ en:
       section_3:
         privacy_policy: Provide a link to privacy information for this form
         title: Provide privacy and contact details
+      section_4:
+        make_live: Make your form live
+        title: Make your form live
   forms_delete_confirmation_form:
     confirm_deletion_form: Are you sure you want to delete this form?
     confirm_deletion_page: Are you sure you want to delete this page?

--- a/config/locales/forms/make_live.yml
+++ b/config/locales/forms/make_live.yml
@@ -1,0 +1,14 @@
+en:
+  helpers:
+    label:
+      forms_make_live_form:
+        options:
+          made_live: "Yes"
+          not_made_live: "No"
+  activemodel:
+    errors:
+      models:
+        forms/make_live_form:
+          attributes:
+            confirm_make_live:
+              blank: You must choose an option

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
   delete "forms/:form_id/delete" => "forms/delete_confirmation#destroy", as: :destroy_form
   get "forms/:id/privacy_policy" => "forms/privacy_policy#new", as: :privacy_policy
   post "forms/:id/privacy_policy" => "forms/privacy_policy#create"
+  get "forms/:id/make_live" => "forms/make_live#new", as: :make_live
+  post "forms/:id/make_live" => "forms/make_live#create", as: :make_live_create
+  get "forms/:id/live_confirmation" => "forms/make_live#confirmation", as: :live_confirmation
 
   # Page routes
   get "forms/:form_id/pages" => "pages#index", as: :form_pages

--- a/spec/forms/make_live_form_spec.rb
+++ b/spec/forms/make_live_form_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe Forms::MakeLiveForm, type: :model do
+  let(:error_message) { I18n.t("activemodel.errors.models.forms/make_live_form.attributes.confirm_make_live.blank") }
+
+  describe "Make Live Form" do
+    it "is invalid if blank" do
+      make_live_form = described_class.new(confirm_make_live: "")
+      make_live_form.validate(:confirm_make_live)
+
+      expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include(
+        "Confirm make live #{error_message}",
+      )
+    end
+  end
+
+  describe "#submit" do
+    let(:form) { described_class.new(form: OpenStruct.new(live_at: nil)) }
+
+    context "when form is invalid" do
+      it "returns false" do
+        expect(form.submit).to eq false
+      end
+
+      it "sets error messages" do
+        make_live_form = form
+        make_live_form.submit
+        expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include(
+          "Confirm make live #{error_message}",
+        )
+      end
+    end
+
+    context "when admin user decides not to make form live" do
+      before do
+        form.confirm_make_live = "not_made_live"
+      end
+
+      it "returns true" do
+        expect(form.submit).to eq true
+      end
+
+      it "sets no error messages" do
+        make_live_form = form
+        make_live_form.submit
+        expect(make_live_form.errors).to be_empty
+      end
+    end
+
+    context "when form is being made live" do
+      around do |example|
+        Timecop.freeze(Time.zone.local(2021, 1, 1, 4, 30, 0)) do
+          example.run
+        end
+      end
+
+      before do
+        form.confirm_make_live = "made_live"
+      end
+
+      it "sets live_at to current date/time" do
+        make_form = form
+        form.submit
+        expect(make_form.form.live_at).to eq " 2021-01-01 04:30:00.000000000 +0000"
+      end
+
+      it "sets no error messages" do
+        make_live_form = form
+        make_live_form.submit
+        expect(make_live_form.errors).to be_empty
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#link_to_runner" do
+    it "returns url to the form-runners form" do
+      expect(helper.link_to_runner("example.com", 2)).to eq "example.com/form/2"
+    end
+  end
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe Form do
+  let(:form) { described_class.new(name: "Form 1", org: "Test org", live_at: "") }
+
+  describe "#live?" do
+    context "when form is draft" do
+      it "return false" do
+        form.live_at = ""
+        expect(form.live?).to eq false
+      end
+    end
+
+    context "when form is live" do
+      it "return true" do
+        form.live_at = "2021-01-01T00:00:00.000Z"
+        expect(form.live?).to eq true
+      end
+    end
+  end
+
+  describe "#status" do
+    context "when form is draft (live_at not set)" do
+      it "returns 'draft'" do
+        form.live_at = ""
+        expect(form.status).to eq "draft"
+      end
+    end
+
+    context "when form is live (live_at is set)" do
+      it "returns 'live'" do
+        form.live_at = Time.zone.now.to_s
+        expect(form.status).to eq "live"
+      end
+    end
+  end
+end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Forms", type: :request do
           name: "Form name",
           submission_email: "submission@email.com",
           privacy_policy_url: "https://example.com/privacy_policy",
+          live_at: "",
         })
       end
 
@@ -57,6 +58,7 @@ RSpec.describe "Forms", type: :request do
           id: 2,
           org: "test-org",
           start_page: 1,
+          live_at: "",
         })
       end
 


### PR DESCRIPTION
#### Add a live journey to the admin

In order to make forms live, a new route /make_live has been added. This shows a confirmation screen with some information and allows the form creator to set the live_at property of forms. 

If the form is already live, the confirmation screen is skipped and the user is redirected to the live_screen. This should allow them to get the URL for the service if the form is already live, if they were to hit this route. There are other options here - e.g. 404, but this seems reasonable.


Relates to: https://trello.com/c/rcu9p97d/366-add-new-designs-to-forms-admin-that-fake-making-a-form-live-and-getting-the-link-to-the-already-live-form-should-have 


#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


