### PR TITLE
Add missing SENTRY_DSN var

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,3 +16,4 @@ applications:
       RUNNER_BASE: ((RUNNER_BASE))
       API_KEY: ((API_KEY))
       PAAS_ENVIRONMENT: ((PAAS_ENVIRONMENT))
+      SENTRY_DSN: ((SENTRY_DSN))


### PR DESCRIPTION
#### What problem does the pull request solve?
I noticed that sentry didn't seem to be reporting any states for forms-admin. The reason seems to be that we are not setting `SENTRY_DSN` environment val.
#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


