### PR TITLE
Add footer links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,25 +63,8 @@
       </main>
     </div>
 
-    <footer class="govuk-footer " role="contentinfo">
-      <div class="govuk-width-container ">
-        <div class="govuk-footer__meta">
-          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-
-            <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
-              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-            </svg>
-            <span class="govuk-footer__licence-description">
-              <%= t("footer.licence_main_text_html", url: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", link_text: t("footer.licence_link_text")) %>
-            </span>
-          </div>
-          <div class="govuk-footer__meta-item">
-            <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"><%= t("footer.crown_copyright") %></a>
-          </div>
-        </div>
-      </div>
-    </footer>
-
+    <% meta_links = {t("footer.accessibility_statement") => "https://www.forms.service.gov.uk/accessibility", t("footer.cookies") => "https://www.forms.service.gov.uk/cookies", t("footer.privacy") => "https://www.forms.service.gov.uk/privacy"} %>
+    <%= govuk_footer meta_items_title: t("footer.helpful_links"), meta_items: meta_links %>
 
     <%= javascript_include_tag "application" %>
   </body>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,7 +124,7 @@ en:
   page_titles:
     change_email_form: What email address should form responses be sent to?
     change_name_form: Name your form
-    error_prefix: "Error: "
+    error_prefix: 'Error: '
     home: Home
     internal_server_error: Sorry, there is a problem with the service
     make_live_form: Make form live

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,9 +10,10 @@ en:
             question_text:
               blank: Question text can't be blank
   footer:
-    crown_copyright: "© Crown copyright"
-    licence_link_text: Open Government Licence v3.0
-    licence_main_text_html: All content is available under the <a class="govuk-footer__link" href="%{url}" rel="license">%{link_text}</a>, except where otherwise stated
+    accessibility_statement: Accessibility statement
+    cookies: Cookies
+    helpful_links: Helpful links
+    privacy: Privacy
   forms:
     delete_form: Delete form
     form_overview:
@@ -123,7 +124,7 @@ en:
   page_titles:
     change_email_form: What email address should form responses be sent to?
     change_name_form: Name your form
-    error_prefix: 'Error: '
+    error_prefix: "Error: "
     home: Home
     internal_server_error: Sorry, there is a problem with the service
     make_live_form: Make form live


### PR DESCRIPTION
#### What problem does the pull request solve?
This adds links to the product page's Accessibility, Cookies and Privacy pages in the footer of the admin app.

It should be merged after the [corresponding product page change](https://github.com/alphagov/forms-product-page/pull/13) is deployed, or the cookies link will return a 404.

Trello card: https://trello.com/c/wLbTy34H/55-draft-and-publish-cookie-information-to-cover-the-product-product-pages-and-forms

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


