### PR TITLE
Fix missing favicons

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link_tree ../../../node_modules/govuk-frontend/govuk/assets

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,16 +10,16 @@
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
-    <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png">
-    <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png">
+    <%= favicon_link_tag "images/favicon.ico", rel:"shortcut icon", sizes:"16x16 32x32 48x48", type:"image/x-icon" %>
+    <%= favicon_link_tag "images/govuk-mask-icon.svg", rel:"mask-icon", color:"#0b0c0c", type: nil %>
+    <%= favicon_link_tag "images/govuk-apple-touch-icon-180x180.png", rel:"apple-touch-icon", sizes:"180x180", type: nil %>
+    <%= favicon_link_tag "images/govuk-apple-touch-icon-167x167.png", rel:"apple-touch-icon", sizes:"167x167", type: nil %>
+    <%= favicon_link_tag "images/govuk-apple-touch-icon-152x152.png", rel:"apple-touch-icon", sizes:"152x152", type: nil %>
+    <%= favicon_link_tag "images/govuk-apple-touch-icon.png", rel:"apple-touch-icon", type: nil %>
 
     <%= stylesheet_link_tag "application" %>
 
-    <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
+    <meta property="og:image" content="<%= image_path 'images/govuk-opengraph-image.png' %>">
   </head>
 
   <body class="govuk-template__body ">


### PR DESCRIPTION
#### What problem does the pull request solve?
- Uses the correct Rails import statements to import the favicon / apple icons / facebook meta image
- Adds the images to the manifest.js so that they're precompiled
- Removes the Rails blank default favicon from the public folder

Trello card: https://trello.com/c/T1w27bgy/105-fix-missing-favicons

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


