### PR TITLE
Only allow .gov.uk email addresses

### DIFF
--- a/app/forms/forms/change_email_form.rb
+++ b/app/forms/forms/change_email_form.rb
@@ -5,7 +5,9 @@ class Forms::ChangeEmailForm
   attr_accessor :form, :submission_email
 
   EMAIL_REGEX = /.*@.*/
+  GOVUK_EMAIL_REGEX = /\.gov\.uk\z/
   validates :submission_email, presence: true, format: { with: EMAIL_REGEX, message: :invalid_email }
+  validates :submission_email, format: { with: GOVUK_EMAIL_REGEX, message: :non_govuk_email }
 
   def submit
     return false if invalid?

--- a/config/locales/forms/change_email.yml
+++ b/config/locales/forms/change_email.yml
@@ -15,3 +15,4 @@ en:
             submission_email:
               blank: Enter an email address
               invalid_email: Enter an email address in the correct format, like name@example.com
+              non_govuk_email: Enter an email address ending in .gov.uk

--- a/spec/forms/change_email_form_spec.rb
+++ b/spec/forms/change_email_form_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Forms::ChangeEmailForm, type: :model do
       )
     end
 
+    it "is invalid if email address does not end in .gov.uk" do
+      change_email_form = described_class.new(submission_email: "laura.mipsum@gmail.com")
+      error_message = I18n.t("activemodel.errors.models.forms/change_email_form.attributes.submission_email.non_govuk_email")
+
+      change_email_form.validate(:submission_email)
+
+      expect(change_email_form.errors.full_messages_for(:submission_email)).to include(
+        "Submission email #{error_message}",
+      )
+    end
+
     # More tests are required here -  e.g. that a valid submission updates the Form object
   end
 end

--- a/spec/requests/change_email_spec.rb
+++ b/spec/requests/change_email_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "ChangeEmail controller", type: :request do
     {
       id: 2,
       name: "Form name",
-      submission_email: "submission@email.com",
+      submission_email: "submission@test-org.gov.uk",
       start_page: 1,
       org: "test-org",
     }.to_json
@@ -14,7 +14,7 @@ RSpec.describe "ChangeEmail controller", type: :request do
   let(:form) do
     Form.new(
       name: "Form name",
-      submission_email: "submission@email.com",
+      submission_email: "submission@test-org.gov.uk",
       id: 2,
       org: "test-org",
     )
@@ -24,7 +24,7 @@ RSpec.describe "ChangeEmail controller", type: :request do
     Form.new({
       id: 2,
       name: "Form name",
-      submission_email: "new_submission@email.com",
+      submission_email: "new_submission@test-org.gov.uk",
       org: "test-org",
     })
   end
@@ -76,7 +76,7 @@ RSpec.describe "ChangeEmail controller", type: :request do
         mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
         mock.put "/api/v1/forms/2", post_headers
       end
-      post change_form_email_path(id: 2), params: { forms_change_email_form: { submission_email: "new_submission@email.com" } }
+      post change_form_email_path(id: 2), params: { forms_change_email_form: { submission_email: "new_submission@test-org.gov.uk" } }
     end
 
     it "Reads the form from the API" do


### PR DESCRIPTION
#### What problem does the pull request solve?
Validates submission email addresses to make sure they end in .gov.uk.

Trello card: https://trello.com/c/4NTjtdJL/123-only-allow-govuk-email-addresses-in-forms-admin

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


