### PR TITLE
Stop page titles being double html escaped

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
   end
 
   def set_page_title(title)
-    content_for(:title) { title }
+    content_for(:title) { title.html_safe }
   end
 
   def title_with_error_prefix(title, error)

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe "pages/edit.html.erb" do
+  let(:question_text) { nil }
+
+  before do
+    # Initialize models
+    page = Page.new(id: 1, question_text:, form_id: 1)
+    form = Form.new(id: 1, name: "Form 1", form_id: 1, pages: [page])
+
+    # If models aren't persisted, they won't work with form builders correctly
+    allow(page).to receive(:persisted?).and_return(true)
+    allow(form).to receive(:persisted?).and_return(true)
+
+    # Assign instance variables so they can be accessed from views
+    assign(:form, form)
+    assign(:page, page)
+    assign(:answer_types, [])
+
+    # This is normally done in the ApplicationController, but we aren't using
+    # that in this test
+    ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
+
+    # Render the template with layout to include page title, we could check
+    # expect(view.content_for(:title)).to have_content("Question'<> 1 – GOV.UK Forms")
+    # instead, but this checks behaviour better
+    render(template: "pages/edit", layout: "layouts/application")
+  end
+
+  context "when given a title with characters which need escaping" do
+    let(:question_text) { "Question'<> 1" }
+
+    it "has the correct title" do
+      expect(rendered).to have_title("Question'<> 1 – GOV.UK Forms")
+    end
+  end
+end


### PR DESCRIPTION
See https://trello.com/c/vBKqVumH/127-bug-title-text-isnt-properly-encoded

When editing pages, the title of the page uses question_text. When the question_text contains some characters, such as ', rails escapes them twice, which produces titles with hex codes in.

This commit stops that happening and adds a view test to the edit page view. There are other tests which could be added - testing the title helper etc. but the view test seemed like the most reliable way to test the escaping behaviour. This means rendering using the application layout, which breaks out of the unit testing model a bit.

#### What problem does the pull request solve?

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


