### PR TITLE
"What happens next" feature

### DIFF
--- a/app/controllers/forms/what_happens_next_controller.rb
+++ b/app/controllers/forms/what_happens_next_controller.rb
@@ -1,0 +1,23 @@
+module Forms
+  class WhatHappensNextController < BaseController
+    def new
+      @what_happens_next_form = WhatHappensNextForm.new(form: current_form).assign_form_values
+    end
+
+    def create
+      @what_happens_next_form = WhatHappensNextForm.new(**what_happens_next_form_params)
+
+      if @what_happens_next_form.submit
+        redirect_to form_path(@what_happens_next_form.form)
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def what_happens_next_form_params
+      params.require(:forms_what_happens_next_form).permit(:what_happens_next_text).merge(form: current_form)
+    end
+  end
+end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -25,6 +25,7 @@ private
                     rows: [
                       { task_name: t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form) },
                       { task_name: t("forms.task_lists.section_1.add_or_edit_questions"), path: @question_path },
+                      { task_name: t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id) },
                     ] },
                   { title: t("forms.task_lists.section_2.title"),
                     rows: [

--- a/app/forms/forms/what_happens_next_form.rb
+++ b/app/forms/forms/what_happens_next_form.rb
@@ -1,0 +1,20 @@
+class Forms::WhatHappensNextForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :form, :what_happens_next_text
+
+  validates :what_happens_next_text, presence: true, length: { maximum: 2000 }
+
+  def submit
+    return false if invalid?
+
+    form.what_happens_next_text = what_happens_next_text
+    form.save!
+  end
+
+  def assign_form_values
+    self.what_happens_next_text = form.what_happens_next_text
+    self
+  end
+end

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -1,0 +1,32 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.make_live_form'), @what_happens_next_form.errors.present?)) %>
+<% content_for :back_link, govuk_back_link_to(form_path(@what_happens_next_form.form), "Back to create a form") %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @what_happens_next_form, url: what_happens_next_create_path(@what_happens_next_form.form)) do |f| %>
+      <% if @what_happens_next_form&.errors&.present? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @what_happens_next_form.form.name %></span>
+        <%= t("page_titles.what_happens_next_form") %>
+      </h1>
+
+      <p class="govuk-body">This page will be shown after someone has completed and submitted the form to let them know that the form has been submitted successfully.</p>
+
+      <p class="govuk-body">Add some content to let people know what will happen next and when, so they know what to expect.</p>
+
+      <h2 class="govuk-heading-s">Example</h2>
+
+      <%= govuk_inset_text do %>
+        We'll send you an email to let you know the outcome. You'll usually get a response within 10 working days.
+      <% end %>
+
+      <%= f.govuk_text_area :what_happens_next_text, max_chars: 2000, label: {size: 'm' } %>
+
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
     task_lists:
       section_1:
         add_or_edit_questions: Add and edit your questions
+        add_what_happens_next: Add information about what happens next
         change_name: Edit the name of your form
         title: Create your form
       section_2:
@@ -134,6 +135,7 @@ en:
     not_found: Page not found
     privacy_policy_form: Provide a link to privacy information for this form
     service_unavailable: Sorry, the service is unavailable
+    what_happens_next_form: Form submitted page
     your_form_is_live: Your form is live
   pages:
     delete_question: Delete question

--- a/config/locales/forms/what_happens_next.yml
+++ b/config/locales/forms/what_happens_next.yml
@@ -1,0 +1,13 @@
+en:
+  helpers:
+    label:
+      forms_what_happens_next_form:
+        what_happens_next_text: Enter some information to tell people what will happen next
+  activemodel:
+    errors:
+      models:
+        forms/what_happens_next_form:
+          attributes:
+            what_happens_next_text:
+              blank: Enter some information about what happens next
+              too_long: The information about what happens next cannot be longer than 2,000 characters

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
   get "forms/:id/make_live" => "forms/make_live#new", as: :make_live
   post "forms/:id/make_live" => "forms/make_live#create", as: :make_live_create
   get "forms/:id/live_confirmation" => "forms/make_live#confirmation", as: :live_confirmation
+  get "forms/:id/what-happens-next" => "forms/what_happens_next#new", as: :what_happens_next
+  post "forms/:id/what-happens-next" => "forms/what_happens_next#create", as: :what_happens_next_create
 
   # Page routes
   get "forms/:form_id/pages" => "pages#index", as: :form_pages

--- a/spec/forms/what_happens_next_form_spec.rb
+++ b/spec/forms/what_happens_next_form_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Forms::WhatHappensNextForm, type: :model do
+  describe "validations" do
+    describe "Character length" do
+      it "is valid if less than 2000 characters" do
+        what_happens_next_form = described_class.new(what_happens_next_text: "a")
+
+        expect(what_happens_next_form).to be_valid
+      end
+
+      it "is valid if 2000 characters" do
+        what_happens_next_form = described_class.new(what_happens_next_text: "a" * 2000)
+
+        expect(what_happens_next_form).to be_valid
+      end
+
+      it "is invalid if more than 2000 characters" do
+        what_happens_next_form = described_class.new(what_happens_next_text: "a" * 2001)
+        error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
+
+        expect(what_happens_next_form).not_to be_valid
+
+        what_happens_next_form.validate(:what_happens_next_text)
+
+        expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
+          "What happens next text #{error_message}",
+          )
+      end
+    end
+
+    it "is invalid if blank" do
+      what_happens_next_form = described_class.new(what_happens_next_text: "")
+      error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.blank")
+
+      expect(what_happens_next_form).not_to be_valid
+
+      what_happens_next_form.validate(:what_happens_next_text)
+
+      expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
+        "What happens next text #{error_message}",
+      )
+    end
+    # More tests are required here -  e.g. that a valid submission updates the Form object
+  end
+
+  describe "#submit" do
+    it "returns false if the data is invalid" do
+      form = described_class.new(what_happens_next_text: nil, form: { what_happens_next_text: "" })
+      expect(form.submit).to eq false
+    end
+
+    it "sets the form's attribute value" do
+      what_happens_next_form = described_class.new(form: OpenStruct.new(what_happens_next_text: nil))
+      what_happens_next_form.what_happens_next_text = "Thank you for submitting"
+      what_happens_next_form.submit
+      expect(what_happens_next_form.form.what_happens_next_text).to eq "Thank you for submitting"
+    end
+  end
+end

--- a/spec/forms/what_happens_next_form_spec.rb
+++ b/spec/forms/what_happens_next_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Forms::WhatHappensNextForm, type: :model do
 
         expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
           "What happens next text #{error_message}",
-          )
+        )
       end
     end
 

--- a/spec/requests/forms/what_happens_next/what_happens_next_spec.rb
+++ b/spec/requests/forms/what_happens_next/what_happens_next_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe "WhatHappensNext controller", type: :request do
+  let(:form_response_data) do
+    {
+      id: 2,
+      name: "Form name",
+      submission_email: "submission@email.com",
+      start_page: 1,
+      org: "test-org",
+      what_happens_next_text: "Good things come to those who wait",
+    }.to_json
+  end
+
+  let(:form) do
+    Form.new(
+      name: "Form name",
+      submission_email: "submission@email.com",
+      id: 2,
+      org: "test-org",
+      what_happens_next_text: "",
+    )
+  end
+
+  let(:updated_form) do
+    Form.new({
+      name: "Form name",
+      submission_email: "submission@email.com",
+      id: 2,
+      org: "test-org",
+      what_happens_next_text: "Wait until you get a reply",
+    })
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Content-Type" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+      mock.put "/api/v1/forms/2", req_headers
+    end
+
+    ActiveResourceMock.mock_resource(form,
+                                     {
+                                       read: { response: form, status: 200 },
+                                       update: { response: updated_form, status: 200 },
+                                     })
+  end
+
+  describe "#new" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.put "/api/v1/forms/2", post_headers
+        mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+      end
+      get what_happens_next_path(id: 2)
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+  end
+
+  describe "#create" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+        mock.put "/api/v1/forms/2", post_headers
+      end
+      post what_happens_next_path(id: 2), params: { forms_what_happens_next_form: { what_happens_next_text: "Wait until you get a reply" } }
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+
+    it "Updates the form on the API" do
+      expect(updated_form).to have_been_updated
+    end
+
+    it "Redirects you to the form overview page" do
+      expect(response).to redirect_to(form_path(2))
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
Admin users need to be able to tell their form users what to expect once they have completed the form.


#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


