### PR TITLE
Remove validation for "What happens next" to make it optional

### DIFF
--- a/app/forms/forms/what_happens_next_form.rb
+++ b/app/forms/forms/what_happens_next_form.rb
@@ -4,7 +4,7 @@ class Forms::WhatHappensNextForm
 
   attr_accessor :form, :what_happens_next_text
 
-  validates :what_happens_next_text, presence: true, length: { maximum: 2000 }
+  validates :what_happens_next_text, length: { maximum: 2000 }
 
   def submit
     return false if invalid?

--- a/config/locales/forms/what_happens_next.yml
+++ b/config/locales/forms/what_happens_next.yml
@@ -9,5 +9,4 @@ en:
         forms/what_happens_next_form:
           attributes:
             what_happens_next_text:
-              blank: Enter some information about what happens next
               too_long: The information about what happens next cannot be longer than 2,000 characters

--- a/spec/forms/what_happens_next_form_spec.rb
+++ b/spec/forms/what_happens_next_form_spec.rb
@@ -29,29 +29,23 @@ RSpec.describe Forms::WhatHappensNextForm, type: :model do
       end
     end
 
-    it "is invalid if blank" do
+    it "is valid if blank" do
       what_happens_next_form = described_class.new(what_happens_next_text: "")
-      error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.blank")
 
-      expect(what_happens_next_form).not_to be_valid
-
-      what_happens_next_form.validate(:what_happens_next_text)
-
-      expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
-        "What happens next text #{error_message}",
-      )
+      expect(what_happens_next_form).to be_valid
     end
     # More tests are required here -  e.g. that a valid submission updates the Form object
   end
 
   describe "#submit" do
     it "returns false if the data is invalid" do
-      form = described_class.new(what_happens_next_text: nil, form: { what_happens_next_text: "" })
+      form = described_class.new(what_happens_next_text: ("abc" * 2001), form: { what_happens_next_text: "" })
       expect(form.submit).to eq false
     end
 
     it "sets the form's attribute value" do
-      what_happens_next_form = described_class.new(form: OpenStruct.new(what_happens_next_text: nil))
+      form = OpenStruct.new(what_happens_next_text: "abc")
+      what_happens_next_form = described_class.new(form:)
       what_happens_next_form.what_happens_next_text = "Thank you for submitting"
       what_happens_next_form.submit
       expect(what_happens_next_form.form.what_happens_next_text).to eq "Thank you for submitting"


### PR DESCRIPTION
#### What problem does the pull request solve?
We have decided that "What happens next" should be optional for the time being. We will need to get users to manually add in this information to any existing forms. By removing this validation we also enable them to "delete/clear" a previous saved content relating to what happens next if they decide not to have any copy at all.

Related to https://trello.com/c/4mCMqpda/356-add-what-happens-next-to-the-confirmation-page-should-have
#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


