### PR TITLE
Allow runner URL helper to create live links and add copy to clipboard button

### DIFF
--- a/app/components/form_url_component/view.html.erb
+++ b/app/components/form_url_component/view.html.erb
@@ -1,7 +1,9 @@
-<p class="govuk-body">
-  <%= t("form_url_component.url_is") %>
+<div data-module="copy-to-clipboard" data-copy-button-text="Copy URL to clipboard">
+  <p class="govuk-body">
+    <%= t("form_url_component.url_is") %>
+  </p>
 
-  <span class="govuk-!-display-block govuk-!-margin-top-6 govuk-!-padding-bottom-6">
-    <%= govuk_link_to @runner_link, @runner_link, { target:"_blank", rel:"noopener noreferrer"} %>
-  </span>
-</p>
+  <p class="govuk-body" data-copy-target>
+    <strong><%= @runner_link %><strong>
+  </p>
+</div>

--- a/app/components/form_url_component/view.html.erb
+++ b/app/components/form_url_component/view.html.erb
@@ -1,4 +1,4 @@
-<div data-module="copy-to-clipboard" data-copy-button-text="Copy URL to clipboard">
+<%= tag.div "data-module": "copy-to-clipboard", "data-copy-button-text": t("form_url_component.copy_to_clipboard") do %>
   <p class="govuk-body">
     <%= t("form_url_component.url_is") %>
   </p>
@@ -7,3 +7,4 @@
     <strong><%= @runner_link %><strong>
   </p>
 </div>
+<% end %>

--- a/app/components/form_url_component/view.html.erb
+++ b/app/components/form_url_component/view.html.erb
@@ -6,5 +6,4 @@
   <p class="govuk-body" data-copy-target>
     <strong><%= @runner_link %><strong>
   </p>
-</div>
 <% end %>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,7 @@ module ApplicationHelper
     )
   end
 
-  def link_to_runner(runner_url, form_id, live = false)
+  def link_to_runner(runner_url, form_id, live: false)
     mode_segment = live ? "form" : "preview-form"
     "#{runner_url}/#{mode_segment}/#{form_id}"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,8 @@ module ApplicationHelper
     )
   end
 
-  def link_to_runner(runner_url, form_id)
-    "#{runner_url}/preview-form/#{form_id}"
+  def link_to_runner(runner_url, form_id, live = false)
+    mode_segment = live ? "form" : "preview-form"
+    "#{runner_url}/#{mode_segment}/#{form_id}"
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,15 @@
 // Entry point for the build script in your package.json
 import { initAll } from 'govuk-frontend'
+import copyToClipboard from './modules/copy-to-clipboard'
+
+document
+  .querySelectorAll('[data-module="copy-to-clipboard"]')
+  .forEach(element => {
+    copyToClipboard(
+      element,
+      element.querySelector('[data-copy-target]'),
+      element.dataset.copyButtonText
+    )
+  })
 
 initAll()

--- a/app/javascript/modules/copy-to-clipboard/index.js
+++ b/app/javascript/modules/copy-to-clipboard/index.js
@@ -1,0 +1,33 @@
+/**
+ * Creates a GOV.UK secondary button with arbitrary text
+ * @param {string} text - The text that will be displayed on the button.
+ */
+const createButton = text => {
+  const button = document.createElement('button')
+  button.innerHTML = text
+  button.className = 'govuk-button govuk-button--secondary'
+  button.dataset.module = 'govuk-button'
+  return button
+}
+
+/**
+ * Adds a copy button to an element.
+ * @param {HTMLElement} element - The root element in which the copy button will be appended.
+ * @param {HTMLElement} copyTarget - The element whose text will be copied to the clipboard.
+ * @param {string} buttonText - The text that will be displayed on the copy button.
+ */
+const copyToClipboard = (element, copyTarget, buttonText) => {
+  if (navigator?.clipboard?.writeText) {
+    const button = createButton(buttonText)
+    try {
+      button.addEventListener('click', () => {
+        navigator.clipboard.writeText(copyTarget.textContent.trim())
+      })
+      element.appendChild(button)
+    } catch {
+      button.remove()
+    }
+  }
+}
+
+export default copyToClipboard

--- a/app/javascript/modules/copy-to-clipboard/index.test.js
+++ b/app/javascript/modules/copy-to-clipboard/index.test.js
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+Object.defineProperty(navigator, 'clipboard', {
+  value: {
+    writeText: () => {}
+  }
+})
+
+describe('Copy to clipboard', () => {
+  document.body.innerHTML = `
+    <div data-module="copy-to-clipboard" data-copy-button-text="Copy to clipboard">
+      <p data-copy-target>It worked!</p>
+    </div>
+  `
+  require('../../application.js')
+  const copyButton = document.querySelector('button')
+
+  test('button is created', () => {
+    expect(copyButton.innerHTML).toBe('Copy to clipboard')
+  })
+
+  test('text is written to clipboard', () => {
+    jest.spyOn(navigator.clipboard, 'writeText')
+    copyButton.click()
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('It worked!')
+  })
+})

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -5,7 +5,7 @@
     <span class="govuk-caption-l"><%= @form.name %></span>
     <h1 class="govuk-heading-l"><%= t('page_titles.your_form_is_live') %></h1>
 
-    <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id )) %>
+    <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, true )) %>
 
     <%= t("make_live.confirmation.body_html") %>
 

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -5,7 +5,7 @@
     <span class="govuk-caption-l"><%= @form.name %></span>
     <h1 class="govuk-heading-l"><%= t('page_titles.your_form_is_live') %></h1>
 
-    <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, true )) %>
+    <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, live: true )) %>
 
     <%= t("make_live.confirmation.body_html") %>
 

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <% if @form.live? %>
-      <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, true ))%>
+      <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, live: true ))%>
 
       <div class="govuk-inset-text">
         <p><%= t("live_form_warning.notification_heading") %></p>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <% if @form.live? %>
-      <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id ))%>
+      <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, true ))%>
 
       <div class="govuk-inset-text">
         <p><%= t("live_form_warning.notification_heading") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
     privacy: Privacy
   form_url_component:
     copy_to_clipboard: Copy URL to clipboard
-    url_is: "The URL for your form is:"
+    url_is: 'The URL for your form is:'
   forms:
     delete_form: Delete form
     form_overview:
@@ -128,7 +128,7 @@ en:
   page_titles:
     change_email_form: What email address should form responses be sent to?
     change_name_form: Name your form
-    error_prefix: "Error: "
+    error_prefix: 'Error: '
     home: Home
     internal_server_error: Sorry, there is a problem with the service
     make_live_form: Make form live

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,8 @@ en:
     helpful_links: Helpful links
     privacy: Privacy
   form_url_component:
-    url_is: 'The URL for your form is:'
+    copy_to_clipboard: Copy URL to clipboard
+    url_is: "The URL for your form is:"
   forms:
     delete_form: Delete form
     form_overview:
@@ -127,7 +128,7 @@ en:
   page_titles:
     change_email_form: What email address should form responses be sent to?
     change_name_form: Name your form
-    error_prefix: 'Error: '
+    error_prefix: "Error: "
     home: Home
     internal_server_error: Sorry, there is a problem with the service
     make_live_form: Make form live

--- a/package.json
+++ b/package.json
@@ -58,7 +58,10 @@
       "Cypress",
       "beforeEach",
       "before",
-      "after"
+      "after",
+      "test",
+      "jest",
+      "expect"
     ]
   },
   "stylelint": {

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context "with live set to false" do
       it "returns url to the form-runner's preview form" do
-        expect(helper.link_to_runner("example.com", 2, false)).to eq "example.com/preview-form/2"
+        expect(helper.link_to_runner("example.com", 2, live: false)).to eq "example.com/preview-form/2"
       end
     end
 
     context "with live set to true" do
       it "returns url to the form-runner's live form" do
-        expect(helper.link_to_runner("example.com", 2, true)).to eq "example.com/form/2"
+        expect(helper.link_to_runner("example.com", 2, live: true)).to eq "example.com/form/2"
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,8 +2,22 @@ require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
   describe "#link_to_runner" do
-    it "returns url to the form-runners form" do
-      expect(helper.link_to_runner("example.com", 2)).to eq "example.com/preview-form/2"
+    context "with no live argument" do
+      it "returns url to the form-runner's preview form" do
+        expect(helper.link_to_runner("example.com", 2)).to eq "example.com/preview-form/2"
+      end
+    end
+
+    context "with live set to false" do
+      it "returns url to the form-runner's preview form" do
+        expect(helper.link_to_runner("example.com", 2, false)).to eq "example.com/preview-form/2"
+      end
+    end
+
+    context "with live set to true" do
+      it "returns url to the form-runner's live form" do
+        expect(helper.link_to_runner("example.com", 2, true)).to eq "example.com/form/2"
+      end
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
- Adds the correct live URL to the form overview and the make live confirmation 
- Makes the live form URL plain text, not a hyperlink (we want people to copy it, rather than click on it)
- Adds a button to copy the URL to the clipboard

Trello card: https://trello.com/c/Jdrh6XZ6/154-bug-preview-link-shown-in-live-form-url-component

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [x] Elsewhere (marked up new JS functions with JSDoc syntax)


