### PR TITLE
Runner user friendly urls

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,8 +26,8 @@ module ApplicationHelper
     )
   end
 
-  def link_to_runner(runner_url, form_id, live: false)
+  def link_to_runner(runner_url, form_id, form_slug, live: false)
     mode_segment = live ? "form" : "preview-form"
-    "#{runner_url}/#{mode_segment}/#{form_id}"
+    "#{runner_url}/#{mode_segment}/#{form_id}/#{form_slug}"
   end
 end

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -5,7 +5,7 @@
     <span class="govuk-caption-l"><%= @form.name %></span>
     <h1 class="govuk-heading-l"><%= t('page_titles.your_form_is_live') %></h1>
 
-    <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, live: true )) %>
+    <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug, live: true )) %>
 
     <%= t("make_live.confirmation.body_html") %>
 

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <% if @form.live? %>
-      <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, live: true ))%>
+      <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug, live: true ))%>
 
       <div class="govuk-inset-text">
         <p><%= t("live_form_warning.notification_heading") %></p>
@@ -26,7 +26,7 @@
     %>
 
     <p class="govuk-body govuk-!-margin-bottom-9">
-      <%= govuk_link_to t("home.preview"),link_to_runner(ENV["RUNNER_BASE"], @form.id ), { target:"_blank", rel:"noopener noreferrer"} %>
+      <%= govuk_link_to t("home.preview"),link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug), { target:"_blank", rel:"noopener noreferrer"} %>
     </p>
 
     <%= govuk_button_link_to t("forms.delete_form"), delete_form_path(@form.id), warning: true %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -17,7 +17,7 @@
       summary_list.row do |row|
         row.key { form.name }
         row.action(text: t("home.edit"), href: form_path(form.id), visually_hidden_text: form.name )
-        row.action(text: t("home.preview"), href: link_to_runner(ENV["RUNNER_BASE"], form.id ), visually_hidden_text: ": #{form.name}", html_attributes: { target:"_blank", rel:"noopener noreferrer"})
+        row.action(text: t("home.preview"), href: link_to_runner(ENV["RUNNER_BASE"], form.id, form.form_slug), visually_hidden_text: ": #{form.name}", html_attributes: { target:"_blank", rel:"noopener noreferrer"})
       end
     end
   end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -17,7 +17,7 @@
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), new_page_path(@form), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
-      <%= govuk_link_to t("home.preview"), link_to_runner(ENV["RUNNER_BASE"], @form.id ), { target:"_blank", rel:"noopener noreferrer"} %>
+      <%= govuk_link_to t("home.preview"), link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug), { target:"_blank", rel:"noopener noreferrer"} %>
     </div>
 
     <% if @pages.any? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,14 +24,15 @@ Rails.application.routes.draw do
   post "forms/:id/what-happens-next" => "forms/what_happens_next#create", as: :what_happens_next_create
 
   # Page routes
-  get "forms/:form_id/pages" => "pages#index", as: :form_pages
-  get "forms/:form_id/pages/:page_id/edit" => "pages#edit", as: :edit_page
-  patch "forms/:form_id/pages/:page_id/edit" => "pages#update", as: :update_page
-  get "forms/:form_id/pages/new" => "pages#new", as: :new_page
-  post "forms/:form_id/pages/new" => "pages#create", as: :create_page
-  get "forms/:form_id/pages/:page_id/delete" => "forms/delete_confirmation#delete", as: :delete_page
-  delete "forms/:form_id/pages/:page_id/delete" => "forms/delete_confirmation#destroy", as: :destroy_page
-
+  scope "forms/:form_id/pages" do
+    get "/" => "pages#index", as: :form_pages
+    get "/:page_id/edit" => "pages#edit", as: :edit_page
+    patch "/:page_id/edit" => "pages#update", as: :update_page
+    get "/new" => "pages#new", as: :new_page
+    post "/new" => "pages#create", as: :create_page
+    get "/:page_id/delete" => "forms/delete_confirmation#delete", as: :delete_page
+    delete "/:page_id/delete" => "forms/delete_confirmation#destroy", as: :destroy_page
+  end
   match "/404", to: "errors#not_found", as: :error_404, via: :all
   match "/500", to: "errors#internal_server_error", as: :error_500, via: :all
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4,19 +4,19 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "#link_to_runner" do
     context "with no live argument" do
       it "returns url to the form-runner's preview form" do
-        expect(helper.link_to_runner("example.com", 2)).to eq "example.com/preview-form/2"
+        expect(helper.link_to_runner("example.com", 2, "garden-form-slug")).to eq "example.com/preview-form/2/garden-form-slug"
       end
     end
 
     context "with live set to false" do
       it "returns url to the form-runner's preview form" do
-        expect(helper.link_to_runner("example.com", 2, live: false)).to eq "example.com/preview-form/2"
+        expect(helper.link_to_runner("example.com", 2, "garden-form-slug", live: false)).to eq "example.com/preview-form/2/garden-form-slug"
       end
     end
 
     context "with live set to true" do
       it "returns url to the form-runner's live form" do
-        expect(helper.link_to_runner("example.com", 2, live: true)).to eq "example.com/form/2"
+        expect(helper.link_to_runner("example.com", 2, "garden-form-slug", live: true)).to eq "example.com/form/2/garden-form-slug"
       end
     end
   end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Forms", type: :request do
         Form.new({
           id: 2,
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           privacy_policy_url: "https://example.com/privacy_policy",
           live_at: "",
@@ -85,6 +86,7 @@ RSpec.describe "Forms", type: :request do
       let(:form) do
         Form.new({
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           id: 2,
           org: "test-org",
@@ -126,6 +128,7 @@ RSpec.describe "Forms", type: :request do
       let(:form) do
         Form.new(
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           id: 2,
         )

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe "Home", type: :request do
         [{
           id: 2,
           name: "Form",
+          form_slug: "form",
           submission_email: "submission@email.com",
           org: "test-org",
         },
          {
            id: 3,
            name: "Another form",
+           form_slug: "another-form",
            submission_email: "submission@email.com",
            org: "test-org",
          }]
@@ -22,12 +24,14 @@ RSpec.describe "Home", type: :request do
         [{
           id: 3,
           name: "Another form",
+          form_slug: "another-form",
           submission_email: "submission@email.com",
           org: "test-org",
         },
          {
            id: 2,
            name: "Form",
+           form_slug: "form",
            submission_email: "submission@email.com",
            org: "test-org",
          }]

--- a/spec/requests/make_form_live_spec.rb
+++ b/spec/requests/make_form_live_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "MakeLive controller", type: :request do
     {
       id: 2,
       name: "Form name",
+      form_slug: "form-name",
       submission_email: "submission@email.com",
       start_page: 1,
       org: "test-org",
@@ -16,6 +17,7 @@ RSpec.describe "MakeLive controller", type: :request do
   let(:form) do
     Form.new(
       name: "Form name",
+      form_slug: "form-name",
       submission_email: "submission@email.com",
       id: 2,
       org: "test-org",
@@ -27,6 +29,7 @@ RSpec.describe "MakeLive controller", type: :request do
   let(:updated_form) do
     Form.new({
       name: "Form name",
+      form_slug: "form-name",
       submission_email: "submission@email.com",
       id: 2,
       org: "test-org",
@@ -84,6 +87,7 @@ RSpec.describe "MakeLive controller", type: :request do
       let(:form) do
         Form.new(
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           id: 2,
           org: "test-org",
@@ -115,6 +119,7 @@ RSpec.describe "MakeLive controller", type: :request do
       let(:form) do
         Form.new(
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           id: 2,
           org: "test-org",

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Pages", type: :request do
         Form.new({
           id: 2,
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           live_at: "",
         })
@@ -57,6 +58,7 @@ RSpec.describe "Pages", type: :request do
       let(:form_response) do
         {
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           id: 2,
           org: "test-org",
@@ -120,6 +122,7 @@ RSpec.describe "Pages", type: :request do
       let(:form_response) do
         {
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           id: 2,
           org: "test-org",
@@ -211,6 +214,7 @@ RSpec.describe "Pages", type: :request do
     let(:form_response) do
       {
         name: "Form name",
+        form_slug: "form-name",
         submission_email: "submission@email.com",
         id: 2,
         org: "test-org",
@@ -272,6 +276,7 @@ RSpec.describe "Pages", type: :request do
       let(:form) do
         Form.new({
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           id: 2,
           org: "test-org",
@@ -322,6 +327,7 @@ RSpec.describe "Pages", type: :request do
       let(:form) do
         {
           name: "Form name",
+          form_slug: "form-name",
           submission_email: "submission@email.com",
           id: 2,
           org: "test-org",

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe "forms/show.html.erb" do
   end
 
   before do
-    assign(:form, OpenStruct.new(id: 1, name: "Form 1"))
+    assign(:form, OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1"))
     render template: "forms/show"
   end
 
@@ -18,7 +18,7 @@ describe "forms/show.html.erb" do
   end
 
   it "contains a link to preview the form" do
-    expect(rendered).to have_link("Preview this form", href: "runner-host/preview-form/1", visible: :all)
+    expect(rendered).to have_link("Preview this form", href: "runner-host/preview-form/1/form-1", visible: :all)
   end
 
   it "contains a link to delete the form" do

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -25,7 +25,7 @@ describe "home/index.html.erb" do
     end
 
     before do
-      assign(:forms, [OpenStruct.new(id: 1, name: "Form 1"), OpenStruct.new(id: 2, name: "Form 2")])
+      assign(:forms, [OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1"), OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2")])
       render template: "home/index"
     end
 
@@ -39,8 +39,8 @@ describe "home/index.html.erb" do
     end
 
     it "displays preview links for each form" do
-      expect(rendered).to have_link("Preview this form : Form 1", href: "runner-host/preview-form/1", visible: :all)
-      expect(rendered).to have_link("Preview this form : Form 2", href: "runner-host/preview-form/2", visible: :all)
+      expect(rendered).to have_link("Preview this form : Form 1", href: "runner-host/preview-form/1/form-1", visible: :all)
+      expect(rendered).to have_link("Preview this form : Form 2", href: "runner-host/preview-form/2/form-2", visible: :all)
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
We added the form_slug to the runners url so it would end up like
```
/{preview-form |form}/{form id}/{form slug}
/form/1/form-1
/preview-form/1/form-1
```

These changes makes sure that we are consistent between our apps.

Relates to https://trello.com/c/J5E6JuuY/92-use-human-readable-url-paths-for-forms-instead-of-id-based-paths
#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


