### PR TITLE
Only show preview links on forms with pages

### DIFF
--- a/app/components/preview_link_component/view.html.erb
+++ b/app/components/preview_link_component/view.html.erb
@@ -1,0 +1,3 @@
+<% if @pages.any? %>
+  <%= govuk_link_to t("home.preview"), @link, { target:"_blank", rel:"noopener noreferrer"} %>
+<% end %>

--- a/app/components/preview_link_component/view.html.erb
+++ b/app/components/preview_link_component/view.html.erb
@@ -1,3 +1,1 @@
-<% if @pages.any? %>
-  <%= govuk_link_to t("home.preview"), @link, { target:"_blank", rel:"noopener noreferrer"} %>
-<% end %>
+<%= govuk_link_to t("home.preview"), @link, { target:"_blank", rel:"noopener noreferrer"} %>

--- a/app/components/preview_link_component/view.rb
+++ b/app/components/preview_link_component/view.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PreviewLinkComponent
+  class View < ViewComponent::Base
+    def initialize(pages, link)
+      super
+      @pages = pages
+      @link = link
+    end
+  end
+end

--- a/app/components/preview_link_component/view.rb
+++ b/app/components/preview_link_component/view.rb
@@ -7,5 +7,9 @@ module PreviewLinkComponent
       @pages = pages
       @link = link
     end
+
+    def render?
+      @pages.any?
+    end
   end
 end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -5,6 +5,7 @@ class FormsController < ApplicationController
 
   def show
     @form = Form.find(params[:id])
+    @pages = @form.pages
     create_form_task_list
   end
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -5,7 +5,6 @@ class FormsController < ApplicationController
 
   def show
     @form = Form.find(params[:id])
-    @pages = @form.pages
     create_form_task_list
   end
 

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -32,7 +32,7 @@
     %>
 
     <p class="govuk-body govuk-!-margin-bottom-9">
-      <%= render PreviewLinkComponent::View.new(@pages, link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug)) %>
+      <%= render PreviewLinkComponent::View.new(@form.pages, link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug)) %>
     </p>
 
     <%= govuk_button_link_to t("forms.delete_form"), delete_form_path(@form.id), warning: true %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -32,7 +32,7 @@
     %>
 
     <p class="govuk-body govuk-!-margin-bottom-9">
-      <%= govuk_link_to t("home.preview"),link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug), { target:"_blank", rel:"noopener noreferrer"} %>
+      <%= render PreviewLinkComponent::View.new(@pages, link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug)) %>
     </p>
 
     <%= govuk_button_link_to t("forms.delete_form"), delete_form_path(@form.id), warning: true %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -23,7 +23,7 @@
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), new_page_path(@form), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
-      <%= govuk_link_to t("home.preview"), link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug), { target:"_blank", rel:"noopener noreferrer"} %>
+      <%= render PreviewLinkComponent::View.new(@pages, link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug)) %>
     </div>
 
     <% if @pages.any? %>

--- a/spec/components/preview_link_component/preview_link_component_preview.rb
+++ b/spec/components/preview_link_component/preview_link_component_preview.rb
@@ -1,0 +1,10 @@
+class PreviewLinkComponent::PreviewLinkComponentPreview < ViewComponent::Preview
+  def without_pages
+    render(PreviewLinkComponent::View.new([], "https://submit.forms.service.gov.uk/example-form"))
+  end
+
+  def with_pages
+    pages = [{ id: 183, question_text: "What is your address?", question_short_name: nil, hint_text: "", answer_type: "address", next_page: nil }]
+    render(PreviewLinkComponent::View.new(pages, "https://submit.forms.service.gov.uk/example-form"))
+  end
+end

--- a/spec/components/preview_link_component/view_spec.rb
+++ b/spec/components/preview_link_component/view_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PreviewLinkComponent::View, type: :component do
-  let(:preview_url) { "https://example.com"}
+  let(:preview_url) { "https://example.com" }
 
   context "when the form has pages" do
     it "renders the link" do

--- a/spec/components/preview_link_component/view_spec.rb
+++ b/spec/components/preview_link_component/view_spec.rb
@@ -1,17 +1,19 @@
 require "rails_helper"
 
 RSpec.describe PreviewLinkComponent::View, type: :component do
+  let(:preview_url) { "https://example.com"}
+
   context "when the form has pages" do
     it "renders the link" do
-      render_inline(described_class.new([{ id: 183, question_text: "What is your address?", question_short_name: nil, hint_text: "", answer_type: "address", next_page: nil }], "https://example.com"))
-      expect(page).to have_link("Preview this form", href: "https://example.com")
+      render_inline(described_class.new([{ id: 183, question_text: "What is your address?", question_short_name: nil, hint_text: "", answer_type: "address", next_page: nil }], preview_url))
+      expect(page).to have_link("Preview this form", href: preview_url)
     end
   end
 
   context "when the form has no pages" do
     it "does not render the link" do
-      render_inline(described_class.new([], "https://example.com"))
-      expect(page).not_to have_link("Preview this form", href: "https://example.com")
+      render_inline(described_class.new([], preview_url))
+      expect(page).not_to have_link("Preview this form", href: preview_url)
     end
   end
 end

--- a/spec/components/preview_link_component/view_spec.rb
+++ b/spec/components/preview_link_component/view_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe PreviewLinkComponent::View, type: :component do
+  context "when the form has pages" do
+    it "renders the link" do
+      render_inline(described_class.new([{ id: 183, question_text: "What is your address?", question_short_name: nil, hint_text: "", answer_type: "address", next_page: nil }], "https://example.com"))
+      expect(page).to have_link("Preview this form", href: "https://example.com")
+    end
+  end
+
+  context "when the form has no pages" do
+    it "does not render the link" do
+      render_inline(described_class.new([], "https://example.com"))
+      expect(page).not_to have_link("Preview this form", href: "https://example.com")
+    end
+  end
+end

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -9,6 +9,7 @@ describe "forms/show.html.erb" do
 
   before do
     assign(:form, OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft"))
+    assign(:pages, [{ id: 183, question_text: "What is your address?", question_short_name: nil, hint_text: "", answer_type: "address", next_page: nil }])
     render template: "forms/show"
   end
 

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe "forms/show.html.erb" do
+  let(:pages) { [{ id: 183, question_text: "What is your address?", question_short_name: nil, hint_text: "", answer_type: "address", next_page: nil }] }
+
   around do |example|
     ClimateControl.modify RUNNER_BASE: "runner-host" do
       example.run
@@ -8,8 +10,7 @@ describe "forms/show.html.erb" do
   end
 
   before do
-    assign(:form, OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft"))
-    assign(:pages, [{ id: 183, question_text: "What is your address?", question_short_name: nil, hint_text: "", answer_type: "address", next_page: nil }])
+    assign(:form, OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", pages:))
     render template: "forms/show"
   end
 
@@ -28,13 +29,13 @@ describe "forms/show.html.erb" do
 
   describe "form states" do
     it "rendered draft tag " do
-      assign(:form, OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft"))
+      assign(:form, OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", pages: []))
       render template: "forms/show"
       expect(rendered).to have_css(".govuk-tag.govuk-tag--purple", text: "DRAFT")
     end
 
     it "rendered live tag" do
-      assign(:form, OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "live"))
+      assign(:form, OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "live", pages: []))
       render template: "forms/show"
       expect(rendered).to have_css(".govuk-tag.govuk-tag--blue", text: "LIVE")
     end


### PR DESCRIPTION
#### What problem does the pull request solve?
Moves the preview link into a view component, and only shows it when the form has pages.

Trello card: https://trello.com/c/EHyVdh6L/170-hide-preview-link-from-form-admin-users-if-their-form-does-not-have-any-questions

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


