### PR TITLE
Restrict users from just making an incomplete form live

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,10 @@ gem "validate_url"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]
+
+  gem "factory_bot_rails"
+  gem "faker"
+
   gem "pry"
   gem "rspec-rails", ">= 3.9.0"
   # gem "rubocop", "~> 1.26"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,13 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.11.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
+    faker (2.23.0)
+      i18n (>= 1.8.11, < 2)
     faraday (2.5.2)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -415,6 +422,8 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  factory_bot_rails
+  faker
   gds-sso
   govuk-components (= 3.2.1)
   govuk_design_system_formbuilder (= 3.1.2)

--- a/app/components/task_list_component/view.html.erb
+++ b/app/components/task_list_component/view.html.erb
@@ -1,37 +1,39 @@
 <%= tag.ol(**html_attributes) do %>
   <% sections.each do |section| %>
-    <li>
-      <h2 class="app-task-list__section">
-        <span class="app-task-list__section-number"><%= section.number %>. </span> <%= section.title %>
-      </h2>
-      <ul class="app-task-list__items">
-        <% section.rows.each do |row| %>
-          <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-              <% if row.active %>
-                <%= govuk_link_to row.task_name, row.get_path, aria_describedby: row.status_id %>
-              <% else %>
-                <%= row.task_name %>
-              <% end %>
-            </span>
+    <% unless section.rows.empty? %>
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number"><%= section.number %>. </span> <%= section.title %>
+        </h2>
+        <ul class="app-task-list__items">
+          <% section.rows.each do |row| %>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <% if row.active %>
+                  <%= govuk_link_to row.task_name, row.get_path, aria_describedby: row.status_id %>
+                <% else %>
+                  <%= row.task_name %>
+                <% end %>
+              </span>
 
-            <% if row.status.present? %>
-              <%= render GovukComponent::TagComponent.new(
-                text: "<span class='govuk-visually-hidden'>Status </span>".html_safe + I18n.t("task_statuses.#{row.status}"),
-                classes: "app-task-list__tag",
-                colour: row.get_status_colour,
-                html_attributes: { id: row.status_id },
-              ) %>
-          <% end %>
+              <% if row.status.present? %>
+                <%= render GovukComponent::TagComponent.new(
+                  text: "<span class='govuk-visually-hidden'>Status </span>".html_safe + I18n.t("task_statuses.#{row.status}"),
+                  classes: "app-task-list__tag",
+                  colour: row.get_status_colour,
+                  html_attributes: { id: row.status_id },
+                ) %>
+            <% end %>
 
-          <% if row.hint_text.present? %>
-            <br>
-            <span class="app-task-list__hint govuk-hint"><%= row.hint_text %></span>
-          <% end %>
+            <% if row.hint_text.present? %>
+              <br>
+              <span class="app-task-list__hint govuk-hint"><%= row.hint_text %></span>
+            <% end %>
 
-        </li>
-      <% end %>
-      </ul>
-    </li>
+          </li>
+        <% end %>
+        </ul>
+      </li>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -5,42 +5,12 @@ class FormsController < ApplicationController
 
   def show
     @form = Form.find(params[:id])
-    create_form_task_list
+    @task_list = FormTaskListService.call(form: @form).all_tasks
   end
 
 private
 
   def form_params
     params.require(:form).permit(:name, :submission_email)
-  end
-
-  def create_form_task_list
-    @question_path = if @form.pages.any?
-                       form_pages_path(@form)
-                     else
-                       new_page_path(@form)
-                     end
-
-    @task_list = [{ title: t("forms.task_lists.section_1.title"),
-                    rows: [
-                      { task_name: t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form) },
-                      { task_name: t("forms.task_lists.section_1.add_or_edit_questions"), path: @question_path },
-                      { task_name: t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id) },
-                    ] },
-                  { title: t("forms.task_lists.section_2.title"),
-                    rows: [
-                      { task_name: t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id) },
-                    ] },
-                  { title: t("forms.task_lists.section_3.title"),
-                    rows: [
-                      { task_name: t("forms.task_lists.section_3.privacy_policy"), path: privacy_policy_path(@form.id) },
-                    ] }]
-
-    unless @form.live?
-      @task_list.append({ title: t("forms.task_lists.section_4.title"),
-                          rows: [
-                            { task_name: t("forms.task_lists.section_4.make_live"), path: make_live_path(@form.id) },
-                          ] })
-    end
   end
 end

--- a/app/forms/forms/make_live_form.rb
+++ b/app/forms/forms/make_live_form.rb
@@ -8,6 +8,8 @@ class Forms::MakeLiveForm
 
   validates :confirm_make_live, presence: true, inclusion: { in: CONFIRM_LIVE_VALUES.values }
 
+  validate :required_parts_of_form_completed
+
   def submit
     return false if invalid?
     # we are valid and didn't need to save
@@ -23,5 +25,29 @@ class Forms::MakeLiveForm
 
   def values
     CONFIRM_LIVE_VALUES.keys
+  end
+
+private
+
+  def required_parts_of_form_completed
+    # we are valid and didn't need to save
+    return unless made_live?
+
+    if form.pages.blank?
+      errors.add(:confirm_make_live, :missing_pages)
+      return false
+    end
+
+    if form.submission_email.blank?
+      errors.add(:confirm_make_live, :missing_submission_email)
+      return false
+    end
+
+    if form.privacy_policy_url.blank?
+      return false
+      errors.add(:confirm_make_live, :missing_privacy_policy_url)
+    end
+
+
   end
 end

--- a/app/forms/forms/make_live_form.rb
+++ b/app/forms/forms/make_live_form.rb
@@ -32,22 +32,20 @@ private
   def required_parts_of_form_completed
     # we are valid and didn't need to save
     return unless made_live?
+    return if form.ready_for_live?
 
-    if form.pages.blank?
+    if form.missing_sections.include?(:missing_pages)
       errors.add(:confirm_make_live, :missing_pages)
       return false
     end
 
-    if form.submission_email.blank?
+    if form.missing_sections.include?(:missing_submission_email)
       errors.add(:confirm_make_live, :missing_submission_email)
       return false
     end
 
-    if form.privacy_policy_url.blank?
-      return false
+    if form.missing_sections.include?(:missing_privacy_policy_url)
       errors.add(:confirm_make_live, :missing_privacy_policy_url)
     end
-
-
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -7,6 +7,8 @@ class Form < ActiveResource::Base
 
   has_many :pages
 
+  attr_accessor :missing_sections
+
   def last_page
     pages.find { |p| !p.has_next_page? }
   end
@@ -38,5 +40,18 @@ class Form < ActiveResource::Base
     current_last_page = last_page
     current_last_page.next_page = page.id
     current_last_page.save!
+  end
+
+  def ready_for_live?
+    @missing_sections = []
+    @missing_sections << :missing_pages unless pages.any?
+    @missing_sections << :missing_submission_email if submission_email.blank?
+    @missing_sections << :missing_privacy_policy_url if privacy_policy_url.blank?
+
+    if @missing_sections.any?
+      false
+    else
+      true
+    end
   end
 end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -1,0 +1,52 @@
+class FormTaskListService
+  include Rails.application.routes.url_helpers
+
+  class << self
+    def call(**args)
+      new(**args)
+    end
+  end
+
+  def initialize(form:)
+    @form = form
+  end
+
+  def all_tasks
+    [
+      { title: I18n.t("forms.task_lists.section_1.title"), rows: section_1_tasks },
+      { title: I18n.t("forms.task_lists.section_2.title"), rows: section_2_tasks },
+      { title: I18n.t("forms.task_lists.section_3.title"), rows: section_3_tasks },
+      { title: I18n.t("forms.task_lists.section_4.title"), rows: section_4_tasks },
+    ]
+  end
+
+private
+
+  def section_1_tasks
+    question_path = if @form.pages.any?
+                      form_pages_path(@form.id)
+                    else
+                      new_page_path(@form.id)
+                    end
+    [
+      { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id) },
+      { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path },
+      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id) },
+    ]
+  end
+
+  def section_2_tasks
+    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id) }]
+  end
+
+  def section_3_tasks
+    [{ task_name: I18n.t("forms.task_lists.section_3.privacy_policy"), path: privacy_policy_path(@form.id) }]
+  end
+
+  def section_4_tasks
+    return [] if @form.live?
+    return [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: make_live_path(@form.id) }] if @form.ready_for_live?
+
+    [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: "", active: false }]
+  end
+end

--- a/config/locales/forms/make_live.yml
+++ b/config/locales/forms/make_live.yml
@@ -12,3 +12,6 @@ en:
           attributes:
             confirm_make_live:
               blank: You must choose an option
+              missing_pages: You cannot make your form live because it does not have any questions. Answer ‘No’ and add one or more questions.
+              missing_privacy_policy_url: You cannot make your form live because it does not have a link to privacy information. Answer ‘No’ and add a link.
+              missing_submission_email: You cannot make your form live because it does not have an email address to send completed forms to. Answer ‘No’ and add an email address.

--- a/spec/components/task_list_component/view_spec.rb
+++ b/spec/components/task_list_component/view_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe TaskListComponent::View, type: :component do
       ]))
     end
 
-    it "renders" do
-      expect(page).to have_text("section title")
+    it "does not render section without rows" do
+      expect(page).not_to have_text("section title")
     end
   end
 

--- a/spec/factories/forms/make_live_forms.rb
+++ b/spec/factories/forms/make_live_forms.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :make_live_form, class: "Forms::MakeLiveForm" do
     confirm_make_live { %w[made_live not_made_live].sample }
 
-    form { build :form }
+    form { build :form, :with_pages }
   end
 end

--- a/spec/factories/forms/make_live_forms.rb
+++ b/spec/factories/forms/make_live_forms.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :make_live_form, class: "Forms::MakeLiveForm" do
+    confirm_make_live { %w[made_live not_made_live].sample }
+
+    form { build :form }
+  end
+end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -3,16 +3,20 @@ FactoryBot.define do
     sequence(:name) { |n| "Form #{n}" }
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
-
     live_at { nil }
+    missing_sections { nil }
 
     trait :new_form do
-      submission_email { nil }
-      privacy_policy_url { nil }
+      submission_email { "" }
+      privacy_policy_url { "" }
       pages { [] }
     end
 
-    factory :form_with_pages do
+    trait :live do
+      live_at { Time.zone.now }
+    end
+
+    trait :with_pages do
       transient do
         pages_count { 5 }
       end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :form, class: "Form" do
+    sequence(:name) { |n| "Form #{n}" }
+    submission_email { Faker::Internet.email(domain: "example.gov.uk") }
+    privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
+
+    live_at { nil }
+
+    trait :new_form do
+      submission_email { nil }
+      privacy_policy_url { nil }
+      pages { [] }
+    end
+
+    factory :form_with_pages do
+      transient do
+        pages_count { 5 }
+      end
+
+      pages do
+        Array.new(pages_count) { association(:page) }
+      end
+    end
+  end
+end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :page, class: "Page" do
+    question_text { Faker::Lorem.question }
+    answer_type { %w[single_line address date email national_insurance_number phone_number].sample }
+
+    trait :with_hints do
+      hint_text { Faker::Quote.yoda }
+    end
+  end
+end

--- a/spec/forms/make_live_form_spec.rb
+++ b/spec/forms/make_live_form_spec.rb
@@ -15,15 +15,14 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
   end
 
   describe "#submit" do
-    let(:form) { described_class.new(form: OpenStruct.new(live_at: nil)) }
+    let(:make_live_form) { described_class.new(form: OpenStruct.new(live_at: nil)) }
 
     context "when form is invalid" do
       it "returns false" do
-        expect(form.submit).to eq false
+        expect(make_live_form.submit).to eq false
       end
 
       it "sets error messages" do
-        make_live_form = form
         make_live_form.submit
         expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include(
           "Confirm make live #{error_message}",
@@ -33,15 +32,14 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
 
     context "when admin user decides not to make form live" do
       before do
-        form.confirm_make_live = "not_made_live"
+        make_live_form.confirm_make_live = "not_made_live"
       end
 
       it "returns true" do
-        expect(form.submit).to eq true
+        expect(make_live_form.submit).to eq true
       end
 
       it "sets no error messages" do
-        make_live_form = form
         make_live_form.submit
         expect(make_live_form.errors).to be_empty
       end
@@ -68,6 +66,37 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
         make_live_form = form
         make_live_form.submit
         expect(make_live_form.errors).to be_empty
+      end
+    end
+
+    context "when form is being made live but not all the required sections have been completed" do
+      before(:each) do
+        make_live_form.confirm_make_live = "made_live"
+        make_live_form.form = build(:form)
+      end
+
+      it "is invalid if submission_email is blank" do
+        error_message = "You cannot make your form live because it does not have an email address to send completed forms to. Answer ‘No’ and add an email address."
+        make_live_form.form.submission_email = nil
+        expect(make_live_form).not_to be_valid
+
+        expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include("Confirm make live #{error_message}")
+      end
+
+      it "is invalid is no privacy_policy" do
+        error_message = "You cannot make your form live because it does not have a link to privacy information. Answer ‘No’ and add a link."
+        make_live_form.form.privacy_policy_url = nil
+        expect(make_live_form).not_to be_valid
+
+        expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include("Confirm make live #{error_message}")
+      end
+
+      it "is invalid if no questions have been added" do
+        error_message = "You cannot make your form live because it does not have any questions. Answer ‘No’ and add one or more questions."
+        make_live_form.form.pages = []
+        expect(make_live_form).not_to be_valid
+
+        expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include("Confirm make live #{error_message}")
       end
     end
   end

--- a/spec/forms/make_live_form_spec.rb
+++ b/spec/forms/make_live_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
   end
 
   describe "#submit" do
-    let(:make_live_form) { described_class.new(form: OpenStruct.new(live_at: nil)) }
+    let(:make_live_form) { described_class.new(form: build(:form, :with_pages)) }
 
     context "when form is invalid" do
       it "returns false" do
@@ -53,26 +53,26 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
       end
 
       before do
-        form.confirm_make_live = "made_live"
+        allow(make_live_form.form).to receive(:save!).and_return(1)
+        make_live_form.confirm_make_live = "made_live"
       end
 
       it "sets live_at to current date/time" do
-        make_form = form
-        form.submit
-        expect(make_form.form.live_at).to eq " 2021-01-01 04:30:00.000000000 +0000"
+        make_live_form.submit
+        expect(make_live_form.form.live_at).to eq " 2021-01-01 04:30:00.000000000 +0000"
       end
 
       it "sets no error messages" do
-        make_live_form = form
         make_live_form.submit
         expect(make_live_form.errors).to be_empty
       end
     end
 
     context "when form is being made live but not all the required sections have been completed" do
-      before(:each) do
+      let(:make_live_form) { build :make_live_form }
+
+      before do
         make_live_form.confirm_make_live = "made_live"
-        make_live_form.form = build(:form)
       end
 
       it "is invalid if submission_email is blank" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -41,4 +41,38 @@ describe Form do
       end
     end
   end
+
+  describe "#ready_for_live?" do
+    context "when a form is complete and ready to be made live" do
+      let(:completed_form) { build :form, :with_pages, :live }
+
+      it "returns true" do
+        expect(completed_form.ready_for_live?).to eq true
+      end
+
+      it "returns no missing fields" do
+        results = completed_form
+        results.ready_for_live?
+
+        expect(results.missing_sections).to be_empty
+      end
+    end
+
+    context "when a form is incomplete and should still be in draft state" do
+      let(:new_form) { build :form, :new_form }
+
+      it "returns false" do
+        new_form.pages = []
+        expect(new_form.ready_for_live?).to eq false
+      end
+
+      it "returns a set of keys related to missing fields" do
+        new_form.pages = []
+        results = new_form
+        results.ready_for_live?
+
+        expect(results.missing_sections).to eq %i[missing_pages missing_submission_email missing_privacy_policy_url]
+      end
+    end
+  end
 end

--- a/spec/requests/make_form_live_spec.rb
+++ b/spec/requests/make_form_live_spec.rb
@@ -14,7 +14,13 @@ RSpec.describe "MakeLive controller", type: :request do
     }.to_json
   end
 
+  let(:page_data) do
+    build(:page, form_id: 2).to_json
+  end
+
   let(:form) do
+    page = build(:page)
+
     Form.new(
       name: "Form name",
       form_slug: "form-name",
@@ -23,10 +29,13 @@ RSpec.describe "MakeLive controller", type: :request do
       org: "test-org",
       privacy_policy_url: "https://www.example.gov.uk/privacy-policy",
       live_at: "",
+      pages: [page],
     )
   end
 
   let(:updated_form) do
+    page = form.pages
+
     Form.new({
       name: "Form name",
       form_slug: "form-name",
@@ -35,6 +44,7 @@ RSpec.describe "MakeLive controller", type: :request do
       org: "test-org",
       privacy_policy_url: "https://www.example.gov.uk/privacy-policy",
       live_at: "2021-01-01T00:00:00.000Z",
+      pages: page,
     })
   end
 
@@ -169,7 +179,7 @@ RSpec.describe "MakeLive controller", type: :request do
     end
 
     context "when making a form live" do
-      let(:form_params) { { forms_make_live_form: { confirm_make_live: :made_live } } }
+      let(:form_params) { { forms_make_live_form: { confirm_make_live: :made_live, form: } } }
 
       it "Reads the form from the API" do
         expect(form).to have_been_read

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+describe FormTaskListService do
+  describe "#all_tasks" do
+    let(:form) { build(:form, id: 1) }
+
+    it "returns array of tasks objects for a given form" do
+      expect(described_class.call(form:).all_tasks).to be_an_instance_of(Array)
+    end
+
+    it "returns 4 sections" do
+      expected_sections = [{ title: "Task 1" }, { title: "Task 2" }, { title: "Task 3" }, { title: "Task 4" }]
+      expect(described_class.call(form:).all_tasks.count).to eq expected_sections.count
+    end
+
+    describe "section 1 tasks" do
+      let(:section) do
+        described_class.call(form:).all_tasks.first
+      end
+
+      let(:section_rows) { section[:rows] }
+
+      it "has links to edit form name" do
+        expect(section_rows.first[:task_name]).to eq "Edit the name of your form"
+        expect(section_rows.first[:path]).to eq "/forms/1/change-name"
+      end
+
+      it "has a link to add new pages/questions (if no pages/questions exist)" do
+        expect(section_rows[1][:task_name]).to eq "Add and edit your questions"
+        expect(section_rows[1][:path]).to eq "/forms/1/pages/new"
+      end
+
+      it "has a link to add/edit existing pages (if pages/questions exist)" do
+        page = build :page
+        form.pages = [page]
+        expect(section_rows[1][:task_name]).to eq "Add and edit your questions"
+        expect(section_rows[1][:path]).to eq "/forms/1/pages"
+      end
+
+      it "has a link to add/edit 'What happens next'" do
+        expect(section_rows[2][:task_name]).to eq "Add information about what happens next"
+        expect(section_rows[2][:path]).to eq "/forms/1/what-happens-next"
+      end
+    end
+
+    describe "section 2 tasks" do
+      let(:section) do
+        described_class.call(form:).all_tasks[1]
+      end
+
+      let(:section_rows) { section[:rows] }
+
+      it "has link to set submission email" do
+        expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
+        expect(section_rows.first[:path]).to eq "/forms/1/change-email"
+      end
+    end
+
+    describe "section 3 tasks" do
+      let(:section) do
+        described_class.call(form:).all_tasks[2]
+      end
+
+      let(:section_rows) { section[:rows] }
+
+      it "has link to set privacy policy url" do
+        expect(section_rows.first[:task_name]).to eq "Provide a link to privacy information for this form"
+        expect(section_rows.first[:path]).to eq "/forms/1/privacy_policy"
+      end
+    end
+
+    describe "section 4 tasks" do
+      let(:section) do
+        described_class.call(form:).all_tasks[3]
+      end
+
+      let(:section_rows) { section[:rows] }
+
+      it "has text to make the form live (no link)" do
+        expect(section_rows.first[:task_name]).to eq "Make your form live"
+        expect(section_rows.first[:path]).to be_empty
+      end
+
+      describe "when form is ready to make live" do
+        let(:section) do
+          allow(form).to receive(:ready_for_live?).and_return(true)
+          described_class.call(form:).all_tasks[3]
+        end
+
+        let(:section_rows) { section[:rows] }
+
+        it "has link to make the form live" do
+          expect(section_rows.first[:task_name]).to eq "Make your form live"
+          expect(section_rows.first[:path]).to eq "/forms/1/make_live"
+        end
+      end
+
+      describe "when form is live" do
+        let(:section) do
+          allow(form).to receive(:live?).and_return(true)
+          described_class.call(form:).all_tasks[3]
+        end
+
+        let(:section_rows) { section[:rows] }
+
+        it "has no tasks" do
+          expect(section_rows).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "capybara/rspec"
 
 require_relative "support/active_resource_mock"
+require_relative "support/factorybot"
 require_relative "support/matchers/active_resource/have_been_created"
 require_relative "support/matchers/active_resource/have_been_updated"
 require_relative "support/matchers/active_resource/have_been_read"

--- a/spec/support/factorybot.rb
+++ b/spec/support/factorybot.rb
@@ -1,0 +1,5 @@
+require "factory_bot"
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
- introduces factory_bot and faker
- adds method to form model to check if the form as a whole is ready to be made live
- refactors the forms task list by abstraction the code from controller into a new service called FormTaskListService

Users will now either see "Make your form live" as either text (if form is not ready to be made live), as link (if all the required parts of the form are completed) or not at all (if the form is live)

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


