### PR TITLE
Annotate view with the path of the template being used

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  # config.action_view.annotate_rendered_view_with_filenames = true
+  config.action_view.annotate_rendered_view_with_filenames = true
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true


### PR DESCRIPTION
#### What problem does the pull request solve?
This config change allows use to easily identify with view component/partial was used to render parts of the page

For example this screenshot shows which two templates were used to produce part of the forms details page.
This is really useful when you start having components nested within other components.
<img width="1286" alt="image" src="https://user-images.githubusercontent.com/3441519/193129079-e4d9e530-a831-47ab-a4a0-9df31bbe1c32.png">

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


