### PR TITLE
update text on make live page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,7 +113,7 @@ en:
         </p>
 
         <p class="govuk-body">
-        After you have made your form live, completed forms will be sent to %{submission_email}.
+          After you have made your form live, completed forms will be sent to %{submission_email}.
         </p>
   not_found:
     body: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,13 +113,8 @@ en:
         </p>
 
         <p class="govuk-body">
-          Make sure you are happy with the form before you make it live. After you
-          have made your form live:
+        After you have made your form live, completed forms will be sent to %{submission_email}.
         </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>completed forms will be sent to %{submission_email}</li>
-          <li>you will not be able to change the name of the form</li>
-        </ul>
   not_found:
     body: |
       If you typed the web address, check it is correct.
@@ -132,7 +127,7 @@ en:
     error_prefix: 'Error: '
     home: Home
     internal_server_error: Sorry, there is a problem with the service
-    make_live_form: Make form live
+    make_live_form: Make your form live
     new_page_form: Edit question
     not_found: Page not found
     privacy_policy_form: Provide a link to privacy information for this form


### PR DESCRIPTION
#### What problem does the pull request solve?
Originally it was thought that we may have to stop users from editing a live form’s name because it would be needed for the form slug and changing the title would break links.

But our URLs now rely on the form ID, so changing the name and slug will not break links.

So we should update the warning content on the ‘Make your form live’ page to remove the wording about not being able to change the name of a live form.

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


