### PR TITLE
Configure number of instances

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,4 +45,5 @@ jobs:
             --var SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
             --var API_BASE=${{ secrets.API_BASE }} \
             --var RUNNER_BASE=${{ secrets.RUNNER_BASE }} \
+            --var INSTANCES=2 \
             --var API_KEY=${{ secrets.API_KEY }} 

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,7 @@ applications:
   - name: forms-admin-((PAAS_ENVIRONMENT))
     memory: 256M
     command: rake db:migrate && bin/rails server
+    instances: ((INSTANCES))
     services:
       - forms-admin-((PAAS_ENVIRONMENT))-db
       - forms-admin-((PAAS_ENVIRONMENT))-splunk


### PR DESCRIPTION
Allow the number of app instances to be configurable when deploying to PaaS. Set the number of instances to 2 in development.

#### What problem does the pull request solve?
We should run at least two instances to avoid down time to PaaS maintenance and if an application instance crashes. The number of instances can be configured per environment should more than two be necessary for capacity planning reasons. 

Dev has been set to 2 because often issues arise when going from a single to multiple instances and this will allow us to see such problems in dev environments.

This will require changes to each of the forms-admin deploy jobs in forms-deploy before they will be able to deploy this change. Those are linked below:
https://github.com/alphagov/forms-deploy/compare/increase_instances?expand=1

Cloudfoundry manifest documentation for instances: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#instances


#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


