### PR TITLE
Restrict form viewing by org

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,4 +6,8 @@ class ErrorsController < ApplicationController
   def internal_server_error
     render status: :internal_server_error
   end
+
+  def forbidden
+    render status: :forbidden
+  end
 end

--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -1,4 +1,6 @@
 class Forms::BaseController < ApplicationController
+  include CheckFormOrganisation
+
   def current_form
     Form.find(params[:form_id])
   end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,4 +1,6 @@
 class FormsController < ApplicationController
+  include CheckFormOrganisation
+
   rescue_from ActiveResource::ResourceNotFound do
     render template: "errors/not_found", status: :not_found
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
+  include CheckFormOrganisation
   before_action :fetch_form, :answer_types
 
   def new

--- a/app/lib/check_form_organisation.rb
+++ b/app/lib/check_form_organisation.rb
@@ -6,6 +6,8 @@ module CheckFormOrganisation
 private
 
   def check_form_organisation
+    return nil unless params[:form_id].present?
+
     form = Form.find(params[:form_id])
     if form.org == current_user.organisation_slug
       nil

--- a/app/lib/check_form_organisation.rb
+++ b/app/lib/check_form_organisation.rb
@@ -1,0 +1,15 @@
+module CheckFormOrganisation
+  def self.included(base)
+    base.before_action :check_form_organisation
+  end
+
+private
+  def check_form_organisation
+    form = Form.find(params[:form_id])
+    if form.org == current_user.organisation_slug
+      return
+    else
+      render "errors/forbidden", status: :forbidden, formats: :html
+    end
+  end
+end

--- a/app/lib/check_form_organisation.rb
+++ b/app/lib/check_form_organisation.rb
@@ -4,10 +4,11 @@ module CheckFormOrganisation
   end
 
 private
+
   def check_form_organisation
     form = Form.find(params[:form_id])
     if form.org == current_user.organisation_slug
-      return
+      nil
     else
       render "errors/forbidden", status: :forbidden, formats: :html
     end

--- a/app/lib/check_form_organisation.rb
+++ b/app/lib/check_form_organisation.rb
@@ -6,7 +6,7 @@ module CheckFormOrganisation
 private
 
   def check_form_organisation
-    return nil unless params[:form_id].present?
+    return nil if params[:form_id].blank?
 
     form = Form.find(params[:form_id])
     if form.org == current_user.organisation_slug

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,8 @@
+<% set_page_title(t("page_titles.forbidden")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('forbidden.title') %></h1>
+    <%= simple_format(t('forbidden.body'), class: 'govuk-body') %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,9 @@ en:
     cookies: Cookies
     helpful_links: Helpful links
     privacy: Privacy
+  forbidden:
+    body: You do not have permission to view this page as it does not belong to your organisation. Contact the GOV.UK Forms team if you think this is incorrect.
+    title: You cannot view this page
   form_url_component:
     copy_to_clipboard: Copy URL to clipboard
     url_is: 'The URL for your form is:'
@@ -139,6 +142,7 @@ en:
     change_name_form: Name your form
     contact_details_form: Provide contact details for support
     error_prefix: 'Error: '
+    forbidden: You cannot view this page
     home: Home
     internal_server_error: Sorry, there is a problem with the service
     make_live_form: Make your form live

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
   end
 
   # Page routes
+  match "/403", to: "errors#forbidden", as: :error_403, via: :all
   match "/404", to: "errors#not_found", as: :error_404, via: :all
   match "/500", to: "errors#internal_server_error", as: :error_500, via: :all
 

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Form #{n}" }
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
+    org { "test-org" }
     live_at { nil }
     missing_sections { nil }
     support_email { nil }

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -38,5 +38,9 @@ FactoryBot.define do
       support_url { Faker::Internet.url(host: "gov.uk") }
       support_url_text { Faker::Lorem.sentence(word_count: 1, random_words_to_add: 4) }
     end
+
+    trait :from_other_org do
+      org { "another-org" }
+    end
   end
 end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -38,9 +38,5 @@ FactoryBot.define do
       support_url { Faker::Internet.url(host: "gov.uk") }
       support_url_text { Faker::Lorem.sentence(word_count: 1, random_words_to_add: 4) }
     end
-
-    trait :from_other_org do
-      org { "another-org" }
-    end
   end
 end

--- a/spec/requests/change_name_spec.rb
+++ b/spec/requests/change_name_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "ChangeName controller", type: :request do
     before do
       ActiveResource::HttpMock.reset!
       ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/", req_headers, form_response_data, 200
         mock.get "/api/v1/forms/2", req_headers, form_response_data, 200
         mock.put "/api/v1/forms/2", post_headers
         mock.post "/api/v1/forms", post_headers, { id: 2 }.to_json, 200
@@ -78,7 +79,7 @@ RSpec.describe "ChangeName controller", type: :request do
       post change_form_name_path(form_id: 2), params: { forms_change_name_form: { name: "new_form_name" } }
       expected_request = ActiveResource::Request.new(:put, "/api/v1/forms/2", { "id": 2, "name": "new_form_name", "submission_email": "submission@email.com", "start_page": 1, org: "test-org" }.to_json, post_headers)
       expect(ActiveResource::HttpMock.requests).to include expected_request
-      expect(ActiveResource::HttpMock.requests[1].body).to eq expected_request.body
+      expect(ActiveResource::HttpMock.requests[2].body).to eq expected_request.body
       expect(response).to redirect_to(form_path(form_id: 2))
     end
   end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Forms", type: :request do
 
     context "with a form from another organisation" do
       let(:form) do
-        build :form, :from_other_org, id: 2
+        build :form, org: "another-org", id: 2
       end
 
       before do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Forms", type: :request do
           submission_email: "submission@email.com",
           privacy_policy_url: "https://example.com/privacy_policy",
           live_at: "",
+          org: "test-org",
           support_email: "test@example.gov.uk",
           support_phone: nil,
           support_url: nil,
@@ -134,6 +135,7 @@ RSpec.describe "Forms", type: :request do
           name: "Form name",
           form_slug: "form-name",
           submission_email: "submission@email.com",
+          org: "test-org",
           id: 2,
         )
       end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Pages", type: :request do
           form_slug: "form-name",
           submission_email: "submission@email.com",
           live_at: "",
+          org: "test-org",
         })
       end
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Pages", type: :request do
 
     context "with a form from another organisation" do
       let(:form) do
-        build :form, :from_other_org, id: 2
+        build :form, org: "another-org", id: 2
       end
 
       before do


### PR DESCRIPTION
#### What problem does the pull request solve?
For pages that request a form from the API, this will check if the form is from the user's organisation. If not, it renders a 403 page.

Trello card: https://trello.com/c/gvazDV8a/149-add-basic-authorisation-to-protect-forms-from-being-changed-by-other-organisations

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


