### PR TITLE
Make email validation case insensitive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN apk update
 RUN apk upgrade --available
-RUN apk add libc6-compat openssl-dev build-base libpq-dev yarn nodejs=16.16.0-r0
+RUN apk add libc6-compat openssl-dev build-base libpq-dev yarn nodejs=16.17.1-r0
 RUN adduser -D ruby
 RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 

--- a/app/forms/forms/change_email_form.rb
+++ b/app/forms/forms/change_email_form.rb
@@ -5,7 +5,7 @@ class Forms::ChangeEmailForm
   attr_accessor :form, :submission_email
 
   EMAIL_REGEX = /.*@.*/
-  GOVUK_EMAIL_REGEX = /\.gov\.uk\z/
+  GOVUK_EMAIL_REGEX = /\.gov\.uk\z/i
   validates :submission_email, presence: true, format: { with: EMAIL_REGEX, message: :invalid_email }
   validates :submission_email, format: { with: GOVUK_EMAIL_REGEX, message: :non_govuk_email }
 

--- a/spec/forms/change_email_form_spec.rb
+++ b/spec/forms/change_email_form_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe Forms::ChangeEmailForm, type: :model do
       )
     end
 
+    it "domain validation is case insensitive" do
+      change_email_form = described_class.new(submission_email: "laura.mipsum@juggling.GOV.UK")
+
+      change_email_form.validate(:submission_email)
+
+      expect(change_email_form).to be_valid
+    end
+
     # More tests are required here -  e.g. that a valid submission updates the Form object
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

Trello card: https://trello.com/c/yIZUnKea/212-validation-for-emails-only-accept-lower-case-values

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


