### PR TITLE
Add contact link to error page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,4 +30,12 @@ module ApplicationHelper
     mode_segment = live ? "form" : "preview-form"
     "#{runner_url}/#{mode_segment}/#{form_id}/#{form_slug}"
   end
+
+  def contact_url
+    "mailto:govuk-forms@digital.cabinet-office.gov.uk"
+  end
+
+  def contact_link(text = t("contact_govuk_forms"))
+    govuk_link_to(text, contact_url)
+  end
 end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('forbidden.title') %></h1>
-    <%= simple_format(t('forbidden.body'), class: 'govuk-body') %>
+    <%= simple_format(t('forbidden.body_html', link: contact_link), class: 'govuk-body') %>
   </div>
 </div>

--- a/app/views/errors/service_unavailable.html.erb
+++ b/app/views/errors/service_unavailable.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('service_unavailable.title') %></h1>
-    <%= simple_format(t('service_unavailable.body'), class: 'govuk-body') %>
+    <%= simple_format(t('service_unavailable.body_html', link: contact_link), class: 'govuk-body') %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
     <div class="govuk-width-container ">
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>
         <%= t("phase_banner.before_link") %>
-        <%= govuk_link_to(t("phase_banner.link"), "mailto:govuk-forms@digital.cabinet-office.gov.uk") %>
+        <%= contact_link(t("phase_banner.link")) %>
         <%= t("phase_banner.after_link") %>
       <% end %>
       <%= yield :back_link %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
         </p>
       hint: Select at least one option
       title: How can people get help with filling in this form?
+  contact_govuk_forms: Contact the GOV.UK Forms team
   footer:
     accessibility_statement: Accessibility statement
     cookies: Cookies
@@ -202,7 +203,7 @@ en:
     submit_button: Save and continue
   save_and_continue: Save and continue
   service_unavailable:
-    body: Contact the GOV.UK Forms team if you need to make changes to your forms or speak to someone about the service.
+    body_html: "%{link} if you need to make changes to your forms or speak to someone about the service."
     title: Sorry, the service is unavailable
   skip_to_main_content: Skip to main content
   task_statuses:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
     helpful_links: Helpful links
     privacy: Privacy
   forbidden:
-    body: You do not have permission to view this page as it does not belong to your organisation. Contact the GOV.UK Forms team if you think this is incorrect.
+    body_html: You do not have permission to view this page as it does not belong to your organisation. %{link} if you think this is incorrect.
     title: You cannot view this page
   form_url_component:
     copy_to_clipboard: Copy URL to clipboard

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -20,4 +20,20 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "contact_url" do
+    it "returns a link to the contact email address" do
+      expect(helper.contact_url).to eq "mailto:govuk-forms@digital.cabinet-office.gov.uk"
+    end
+  end
+
+  describe "contact_link" do
+    it "returns a link to the contact email address with default text" do
+      expect(helper.contact_link).to eq '<a class="govuk-link" href="mailto:govuk-forms@digital.cabinet-office.gov.uk">Contact the GOV.UK Forms team</a>'
+    end
+
+    it "returns a link to the contact email address with custom text" do
+      expect(helper.contact_link("test")).to eq '<a class="govuk-link" href="mailto:govuk-forms@digital.cabinet-office.gov.uk">test</a>'
+    end
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
- Adds a contact link to the Forbidden error page (rather than unlinked text saying 'Contact the GOV.UK Forms team')
- Adds a helper to make adding contact links (and changing the link in future) easier.

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


