### PR TITLE
Make privacy and email fields optional when in draft

### DIFF
--- a/app/forms/forms/change_email_form.rb
+++ b/app/forms/forms/change_email_form.rb
@@ -6,8 +6,9 @@ class Forms::ChangeEmailForm
 
   EMAIL_REGEX = /.*@.*/
   GOVUK_EMAIL_REGEX = /\.gov\.uk\z/i
-  validates :submission_email, presence: true, format: { with: EMAIL_REGEX, message: :invalid_email }
-  validates :submission_email, format: { with: GOVUK_EMAIL_REGEX, message: :non_govuk_email }
+  validates :submission_email, presence: true, if: -> { form.live? }
+  validates :submission_email, format: { with: EMAIL_REGEX, message: :invalid_email }, if: -> { submission_email.present? }
+  validates :submission_email, format: { with: GOVUK_EMAIL_REGEX, message: :non_govuk_email }, if: -> { submission_email.present? }
 
   def submit
     return false if invalid?

--- a/app/forms/forms/privacy_policy_form.rb
+++ b/app/forms/forms/privacy_policy_form.rb
@@ -6,7 +6,8 @@ class Forms::PrivacyPolicyForm
 
   attr_accessor :form, :privacy_policy_url
 
-  validates :privacy_policy_url, presence: true, url: true
+  validates :privacy_policy_url, presence: true, if: -> { form.live? }
+  validates :privacy_policy_url, url: true, if: -> { privacy_policy_url.present? }
 
   def submit
     return false if invalid?

--- a/spec/forms/change_email_form_spec.rb
+++ b/spec/forms/change_email_form_spec.rb
@@ -1,48 +1,102 @@
 require "rails_helper"
 
 RSpec.describe Forms::ChangeEmailForm, type: :model do
-  describe "Email" do
-    it "is invalid if blank" do
-      change_email_form = described_class.new(submission_email: "")
-      error_message = I18n.t("activemodel.errors.models.forms/change_email_form.attributes.submission_email.blank")
+  context "when the form is live" do
+    describe "Email" do
+      let(:form) do
+        build(:form, :live)
+      end
 
-      change_email_form.validate(:submission_email)
+      it "is invalid if blank" do
+        change_email_form = described_class.new(form:, submission_email: "")
+        error_message = I18n.t("activemodel.errors.models.forms/change_email_form.attributes.submission_email.blank")
 
-      expect(change_email_form.errors.full_messages_for(:submission_email)).to include(
-        "Submission email #{error_message}",
-      )
+        change_email_form.validate(:submission_email)
+
+        expect(change_email_form.errors.full_messages_for(:submission_email)).to include(
+          "Submission email #{error_message}",
+        )
+      end
+
+      it "is invalid if email address is not in the correct format" do
+        change_email_form = described_class.new(form:, submission_email: "laura.mipsum")
+        error_message = I18n.t("activemodel.errors.models.forms/change_email_form.attributes.submission_email.invalid_email")
+
+        change_email_form.validate(:submission_email)
+
+        expect(change_email_form.errors.full_messages_for(:submission_email)).to include(
+          "Submission email #{error_message}",
+        )
+      end
+
+      it "is invalid if email address does not end in .gov.uk" do
+        change_email_form = described_class.new(form:, submission_email: "laura.mipsum@gmail.com")
+        error_message = I18n.t("activemodel.errors.models.forms/change_email_form.attributes.submission_email.non_govuk_email")
+
+        change_email_form.validate(:submission_email)
+
+        expect(change_email_form.errors.full_messages_for(:submission_email)).to include(
+          "Submission email #{error_message}",
+        )
+      end
+
+      it "domain validation is case insensitive" do
+        change_email_form = described_class.new(form:, submission_email: "laura.mipsum@juggling.GOV.UK")
+
+        change_email_form.validate(:submission_email)
+
+        expect(change_email_form).to be_valid
+      end
+
+      # More tests are required here -  e.g. that a valid submission updates the Form object
     end
+  end
 
-    it "is invalid if email address is not in the correct format" do
-      change_email_form = described_class.new(submission_email: "laura.mipsum")
-      error_message = I18n.t("activemodel.errors.models.forms/change_email_form.attributes.submission_email.invalid_email")
+  context "when the form is not live" do
+    describe "Email" do
+      let(:form) do
+        build(:form)
+      end
 
-      change_email_form.validate(:submission_email)
+      it "is invalid if blank" do
+        change_email_form = described_class.new(form:, submission_email: "")
 
-      expect(change_email_form.errors.full_messages_for(:submission_email)).to include(
-        "Submission email #{error_message}",
-      )
+        change_email_form.validate(:submission_email)
+
+        expect(change_email_form.errors.full_messages_for(:submission_email)).to be_empty
+      end
+
+      it "is invalid if email address is not in the correct format" do
+        change_email_form = described_class.new(form:, submission_email: "laura.mipsum")
+        error_message = I18n.t("activemodel.errors.models.forms/change_email_form.attributes.submission_email.invalid_email")
+
+        change_email_form.validate(:submission_email)
+
+        expect(change_email_form.errors.full_messages_for(:submission_email)).to include(
+          "Submission email #{error_message}",
+        )
+      end
+
+      it "is invalid if email address does not end in .gov.uk" do
+        change_email_form = described_class.new(form:, submission_email: "laura.mipsum@gmail.com")
+        error_message = I18n.t("activemodel.errors.models.forms/change_email_form.attributes.submission_email.non_govuk_email")
+
+        change_email_form.validate(:submission_email)
+
+        expect(change_email_form.errors.full_messages_for(:submission_email)).to include(
+          "Submission email #{error_message}",
+        )
+      end
+
+      it "domain validation is case insensitive" do
+        change_email_form = described_class.new(form:, submission_email: "laura.mipsum@juggling.GOV.UK")
+
+        change_email_form.validate(:submission_email)
+
+        expect(change_email_form).to be_valid
+      end
+
+      # More tests are required here -  e.g. that a valid submission updates the Form object
     end
-
-    it "is invalid if email address does not end in .gov.uk" do
-      change_email_form = described_class.new(submission_email: "laura.mipsum@gmail.com")
-      error_message = I18n.t("activemodel.errors.models.forms/change_email_form.attributes.submission_email.non_govuk_email")
-
-      change_email_form.validate(:submission_email)
-
-      expect(change_email_form.errors.full_messages_for(:submission_email)).to include(
-        "Submission email #{error_message}",
-      )
-    end
-
-    it "domain validation is case insensitive" do
-      change_email_form = described_class.new(submission_email: "laura.mipsum@juggling.GOV.UK")
-
-      change_email_form.validate(:submission_email)
-
-      expect(change_email_form).to be_valid
-    end
-
-    # More tests are required here -  e.g. that a valid submission updates the Form object
   end
 end

--- a/spec/forms/privacy_policy_form_spec.rb
+++ b/spec/forms/privacy_policy_form_spec.rb
@@ -2,19 +2,58 @@ require "rails_helper"
 
 RSpec.describe Forms::PrivacyPolicyForm, type: :model do
   describe "Privacy policy URL" do
-    it "is invalid if blank" do
-      privacy_policy_form = described_class.new(privacy_policy_url: "")
-      error_message = I18n.t("activemodel.errors.models.forms/privacy_policy_form.attributes.privacy_policy_url.blank")
+    context "when form is live" do
+      let(:form) do
+        build(:form, :live)
+      end
 
-      privacy_policy_form.validate(:privacy_policy_url)
+      it "is invalid if blank" do
+        privacy_policy_form = described_class.new(form:, privacy_policy_url: "")
+        error_message = I18n.t("activemodel.errors.models.forms/privacy_policy_form.attributes.privacy_policy_url.blank")
 
-      expect(privacy_policy_form.errors.full_messages_for(:privacy_policy_url)).to include(
-        "Privacy policy url #{error_message}",
-      )
+        privacy_policy_form.validate(:privacy_policy_url)
+
+        expect(privacy_policy_form.errors.full_messages_for(:privacy_policy_url)).to include(
+          "Privacy policy url #{error_message}",
+        )
+      end
+
+      it "validates the URL" do
+        privacy_policy_form = described_class.new(form:, privacy_policy_url: "gov.uk")
+        error_message = I18n.t("errors.messages.url")
+
+        privacy_policy_form.validate(:privacy_policy_url)
+
+        expect(privacy_policy_form.errors.full_messages_for(:privacy_policy_url)).to include(
+          "Privacy policy url #{error_message}",
+        )
+      end
     end
 
-    it { is_expected.to validate_url_of(:privacy_policy_url) }
+    context "when form is not live" do
+      let(:form) do
+        build(:form)
+      end
 
+      it "is valid if blank" do
+        privacy_policy_form = described_class.new(form:, privacy_policy_url: "")
+
+        privacy_policy_form.validate(:privacy_policy_url)
+
+        expect(privacy_policy_form.errors.full_messages_for(:privacy_policy_url)).to be_empty
+      end
+
+      it "validates the URL" do
+        privacy_policy_form = described_class.new(form:, privacy_policy_url: "gov.uk")
+        error_message = I18n.t("errors.messages.url")
+
+        privacy_policy_form.validate(:privacy_policy_url)
+
+        expect(privacy_policy_form.errors.full_messages_for(:privacy_policy_url)).to include(
+          "Privacy policy url #{error_message}",
+        )
+      end
+    end
     # More tests are required here -  e.g. that a valid submission updates the Form object
   end
 end

--- a/spec/requests/change_email_spec.rb
+++ b/spec/requests/change_email_spec.rb
@@ -1,35 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "ChangeEmail controller", type: :request do
-  let(:form_response_data) do
-    {
-      id: 2,
-      name: "Form name",
-      submission_email: "submission@test-org.gov.uk",
-      start_page: 1,
-      org: "test-org",
-      live_at: Time.zone.now,
-    }.to_json
-  end
-
   let(:form) do
-    Form.new(
-      name: "Form name",
-      submission_email: "submission@test-org.gov.uk",
-      id: 2,
-      org: "test-org",
-      live_at: Time.zone.now,
-    )
+    build(:form, :live, id: 2)
   end
 
   let(:updated_form) do
-    Form.new({
-      id: 2,
-      name: "Form name",
-      submission_email: "new_submission@test-org.gov.uk",
-      org: "test-org",
-      live_at: Time.zone.now,
-    })
+    new_form = form
+    new_form.submission_email = "new_submission@test-org.gov.uk"
+    new_form
   end
 
   let(:req_headers) do

--- a/spec/requests/change_email_spec.rb
+++ b/spec/requests/change_email_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "ChangeEmail controller", type: :request do
       submission_email: "submission@test-org.gov.uk",
       start_page: 1,
       org: "test-org",
+      live_at: Time.zone.now,
     }.to_json
   end
 
@@ -17,6 +18,7 @@ RSpec.describe "ChangeEmail controller", type: :request do
       submission_email: "submission@test-org.gov.uk",
       id: 2,
       org: "test-org",
+      live_at: Time.zone.now,
     )
   end
 
@@ -26,6 +28,7 @@ RSpec.describe "ChangeEmail controller", type: :request do
       name: "Form name",
       submission_email: "new_submission@test-org.gov.uk",
       org: "test-org",
+      live_at: Time.zone.now,
     })
   end
 

--- a/spec/requests/privacy_policy_spec.rb
+++ b/spec/requests/privacy_policy_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "PrivacyPolicy controller", type: :request do
       start_page: 1,
       org: "test-org",
       privacy_policy_url: "https://www.example.com",
+      live_at: Time.zone.now,
     }.to_json
   end
 
@@ -19,6 +20,7 @@ RSpec.describe "PrivacyPolicy controller", type: :request do
       id: 2,
       org: "test-org",
       privacy_policy_url: "https://www.example.com",
+      live_at: Time.zone.now,
     )
   end
 
@@ -29,6 +31,7 @@ RSpec.describe "PrivacyPolicy controller", type: :request do
       id: 2,
       org: "test-org",
       privacy_policy_url: "https://www.example.gov.uk/privacy-policy",
+      live_at: Time.zone.now,
     })
   end
 

--- a/spec/requests/privacy_policy_spec.rb
+++ b/spec/requests/privacy_policy_spec.rb
@@ -1,38 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "PrivacyPolicy controller", type: :request do
-  let(:form_response_data) do
-    {
-      id: 2,
-      name: "Form name",
-      submission_email: "submission@email.com",
-      start_page: 1,
-      org: "test-org",
-      privacy_policy_url: "https://www.example.com",
-      live_at: Time.zone.now,
-    }.to_json
-  end
-
   let(:form) do
-    Form.new(
-      name: "Form name",
-      submission_email: "submission@email.com",
-      id: 2,
-      org: "test-org",
-      privacy_policy_url: "https://www.example.com",
-      live_at: Time.zone.now,
-    )
+    build(:form, :live, id: 2, privacy_policy_url: "https://www.example.com")
   end
 
   let(:updated_form) do
-    Form.new({
-      name: "Form name",
-      submission_email: "submission@email.com",
-      id: 2,
-      org: "test-org",
-      privacy_policy_url: "https://www.example.gov.uk/privacy-policy",
-      live_at: Time.zone.now,
-    })
+    new_form = form
+    new_form.privacy_policy_url = "https://www.example.gov.uk/privacy-policy"
+    new_form
   end
 
   let(:req_headers) do


### PR DESCRIPTION
#### What problem does the pull request solve?
Makes the submission_email and privacy_policy fields optional for a draft form. If the user puts anything into these fields, the normal validations on format will still apply.

Trello card: https://trello.com/c/Cub5Mrk1/188-form-admin-allow-form-tasks-to-be-empty-while-form-is-in-draft

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


