### PR TITLE
Add number answer type

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -63,6 +63,6 @@ private
   end
 
   def answer_types
-    @answer_types = %w[single_line number address date email national_insurance_number phone_number]
+    @answer_types = Page::ANSWER_TYPES
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -63,6 +63,6 @@ private
   end
 
   def answer_types
-    @answer_types = %w[single_line address date email national_insurance_number phone_number]
+    @answer_types = %w[single_line number address date email national_insurance_number phone_number]
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,9 +4,11 @@ class Page < ActiveResource::Base
   self.include_format_in_path = false
   headers["X-API-Token"] = ENV["API_KEY"]
 
+  ANSWER_TYPES = %w[single_line number address date email national_insurance_number phone_number].freeze
+
   belongs_to :form
   validates :question_text, presence: true
-  validates :answer_type, presence: true, inclusion: { in: %w[single_line number address date email national_insurance_number phone_number] }
+  validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
   before_validation :convert_is_optional_to_boolean
 
   def has_next_page?

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,7 +6,7 @@ class Page < ActiveResource::Base
 
   belongs_to :form
   validates :question_text, presence: true
-  validates :answer_type, presence: true, inclusion: { in: %w[single_line address date email national_insurance_number phone_number] }
+  validates :answer_type, presence: true, inclusion: { in: %w[single_line number address date email national_insurance_number phone_number] }
   before_validation :convert_is_optional_to_boolean
 
   def has_next_page?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
             date: Requires a day, month and year
             email: Requires an answer in the format of an email address
             national_insurance_number: Requires an answer in the format of a National Insurance number
+            number: Requires a numerical answer
             phone_number: Requires an answer in the format of a phone number
             single_line: For a short answer
           names:
@@ -85,6 +86,7 @@ en:
             date: Date
             email: Email address
             national_insurance_number: National Insurance number
+            number: Number
             phone_number: Phone number
             single_line: Single line of text
         hint_text: Hint text (optional)

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :page, class: "Page" do
     question_text { Faker::Lorem.question }
-    answer_type { %w[single_line address date email national_insurance_number phone_number].sample }
+    answer_type { %w[single_line number address date email national_insurance_number phone_number].sample }
     is_optional { nil }
 
     trait :with_hints do


### PR DESCRIPTION
#### What problem does the pull request solve?
Lets form creators choose the 'number' answer type.

Trello card: https://trello.com/c/Vs9UtbVF/221-add-number-answer-to-a-question-in-the-admin

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


