### PR TITLE
Enable admins to make optional questions in production

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,3 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
-  make_question_optional: false
+  make_question_optional: true

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -21,6 +21,6 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    include_examples expected_value_test, :make_question_optional, features, false
+    include_examples expected_value_test, :make_question_optional, features, true
   end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Work address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          is_optional: false,
         })]
       end
 
@@ -160,6 +161,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Work address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          is_optional: false,
         }].to_json
       end
 
@@ -171,6 +173,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Work address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          is_optional: false,
         }.to_json
       end
 
@@ -180,6 +183,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Home address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          is_optional: false,
         }
       end
 
@@ -280,6 +284,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Home address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          is_optional: false,
         } }
       end
 
@@ -316,6 +321,7 @@ RSpec.describe "Pages", type: :request do
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
           next_page: nil,
+          is_optional: false,
         })
       end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

- Updates the feature flag to allow users to create optional questions

##### Optional changes
If you are confident that this feature is ready, you can remove the settings in the various settings.yml files and remove the condition in the view here https://github.com/alphagov/forms-admin/blob/e1135814274d7045e85670b835b4efec26e4d8b5/app/views/pages/_form.html.erb#L12

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


