### PR TITLE
Add custom declaration

### DIFF
--- a/app/controllers/forms/declaration_controller.rb
+++ b/app/controllers/forms/declaration_controller.rb
@@ -1,0 +1,23 @@
+module Forms
+  class DeclarationController < BaseController
+    def new
+      @declaration_form = DeclarationForm.new(form: current_form).assign_form_values
+    end
+
+    def create
+      @declaration_form = DeclarationForm.new(**declaration_form_params)
+
+      if @declaration_form.submit
+        redirect_to form_path(@declaration_form.form)
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def declaration_form_params
+      params.require(:forms_declaration_form).permit(:declaration_text).merge(form: current_form)
+    end
+  end
+end

--- a/app/forms/forms/declaration_form.rb
+++ b/app/forms/forms/declaration_form.rb
@@ -1,0 +1,20 @@
+class Forms::DeclarationForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :form, :declaration_text
+
+  validates :declaration_text, length: { maximum: 2000 }
+
+  def submit
+    return false if invalid?
+
+    form.declaration_text = declaration_text
+    form.save!
+  end
+
+  def assign_form_values
+    self.declaration_text = form.declaration_text
+    self
+  end
+end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -31,6 +31,7 @@ private
     [
       { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id) },
       { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path },
+      { task_name: I18n.t("forms.task_lists.section_1.declaration"), path: declaration_path(@form.id) },
       { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id) },
     ]
   end

--- a/app/views/forms/declaration/new.html.erb
+++ b/app/views/forms/declaration/new.html.erb
@@ -1,0 +1,24 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.declaration_form'), @declaration_form.errors.present?)) %>
+<% content_for :back_link, govuk_back_link_to(form_path(@declaration_form.form), "Back to create a form") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @declaration_form, url: declaration_create_path(@declaration_form.form)) do |f| %>
+      <% if @declaration_form&.errors&.present? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @declaration_form.form.name %></span>
+        <%= t("page_titles.declaration_form") %>
+      </h1>
+
+      <%= t("declaration_form.new.body_html") %>
+
+      <%= f.govuk_text_area :declaration_text, max_chars: 2000, label: {size: 'm' } %>
+
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,32 @@ en:
       hint: Select at least one option
       title: How can people get help with filling in this form?
   contact_govuk_forms: Contact the GOV.UK Forms team
+  declaration_form:
+    new:
+      body_html: |
+        <p class="govuk-body">
+          When someone has answered all the questions in
+          your form, they will be shown a page that lists all of their answers.
+          The page will ask them to check their answers before they submit the
+          form.
+        </p>
+        <p class="govuk-body">
+          You can add a declaration to this page. A declaration is some content
+          that people must confirm they understand and agree to before they
+          submit the form.
+        </p>
+        <p class="govuk-body">
+          You might want to add a declaration if you need people to confirm they
+          have provided accurate information, or that they understand the
+          consequences of providing false information.
+        </p>
+
+        <h2 class="govuk-heading-s">Example</h2>
+
+        <div class="govuk-inset-text">
+          By submitting this form you are confirming that, to the best of your
+          knowledge, the answers you are providing are correct.
+        </div>
   footer:
     accessibility_statement: Accessibility statement
     cookies: Cookies
@@ -45,6 +71,7 @@ en:
         add_or_edit_questions: Add and edit your questions
         add_what_happens_next: Add information about what happens next
         change_name: Edit the name of your form
+        declaration: Add a declaration for people to agree to
         title: Create your form
       section_2:
         submission_email: Set the email address completed forms will be sent to
@@ -144,6 +171,7 @@ en:
     change_email_form: What email address should form responses be sent to?
     change_name_form: Name your form
     contact_details_form: Provide contact details for support
+    declaration_form: Add a declaration
     error_prefix: 'Error: '
     forbidden: You cannot view this page
     home: Home

--- a/config/locales/forms/declaration.yml
+++ b/config/locales/forms/declaration.yml
@@ -1,0 +1,13 @@
+en:
+  helpers:
+    label:
+      forms_declaration_form:
+        declaration_text: Enter a declaration for people to agree to (optional)
+  activemodel:
+    errors:
+      models:
+        forms/declaration_form:
+          attributes:
+            declaration_text:
+              too_long: The declaration cannot be longer than 2,000 characters
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
     post "/what-happens-next" => "forms/what_happens_next#create", as: :what_happens_next_create
     get "/contact-details" => "forms/contact_details#new", as: :contact_details
     post "/contact-details" => "forms/contact_details#create", as: :contact_details_create
+    get "/declaration" => "forms/declaration#new", as: :declaration
+    post "/declaration" => "forms/declaration#create", as: :declaration_create
 
     scope "/pages" do
       get "/" => "pages#index", as: :form_pages

--- a/spec/forms/declaration_form_spec.rb
+++ b/spec/forms/declaration_form_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Forms::DeclarationForm, type: :model do
+  describe "validations" do
+    describe "Character length" do
+      it "is valid if less than 2000 characters" do
+        declaration_form = described_class.new(declaration_text: "a")
+
+        expect(declaration_form).to be_valid
+      end
+
+      it "is valid if 2000 characters" do
+        declaration_form = described_class.new(declaration_text: "a" * 2000)
+
+        expect(declaration_form).to be_valid
+      end
+
+      it "is invalid if more than 2000 characters" do
+        declaration_form = described_class.new(declaration_text: "a" * 2001)
+        error_message = I18n.t("activemodel.errors.models.forms/declaration_form.attributes.declaration_text.too_long")
+
+        expect(declaration_form).not_to be_valid
+
+        declaration_form.validate(:declaration_text)
+
+        expect(declaration_form.errors.full_messages_for(:declaration_text)).to include(
+          "Declaration text #{error_message}",
+        )
+      end
+    end
+
+    it "is valid if blank" do
+      declaration_form = described_class.new(declaration_text: "")
+
+      expect(declaration_form).to be_valid
+    end
+  end
+
+  describe "#submit" do
+    it "returns false if the data is invalid" do
+      form = described_class.new(declaration_text: ("abc" * 2001), form: { declaration_text: "" })
+      expect(form.submit).to eq false
+    end
+
+    it "sets the form's attribute value" do
+      form = OpenStruct.new(declaration_text: "abc")
+      declaration_form = described_class.new(form:)
+      declaration_form.declaration_text = "new declaration text"
+      declaration_form.submit
+      expect(declaration_form.form.declaration_text).to eq "new declaration text"
+    end
+  end
+end

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -37,9 +37,14 @@ describe FormTaskListService do
         expect(section_rows[1][:path]).to eq "/forms/1/pages"
       end
 
+      it "has a link to add/edit declaration" do
+        expect(section_rows[2][:task_name]).to eq "Add a declaration for people to agree to"
+        expect(section_rows[2][:path]).to eq "/forms/1/declaration"
+      end
+
       it "has a link to add/edit 'What happens next'" do
-        expect(section_rows[2][:task_name]).to eq "Add information about what happens next"
-        expect(section_rows[2][:path]).to eq "/forms/1/what-happens-next"
+        expect(section_rows[3][:task_name]).to eq "Add information about what happens next"
+        expect(section_rows[3][:path]).to eq "/forms/1/what-happens-next"
       end
     end
 


### PR DESCRIPTION
Allow form creators to add a custom declaration text to the check your answers page.

https://trello.com/c/23IXa1As/197-allow-form-creators-to-customise-the-declaration-on-the-check-your-answers-page

#### What problem does the pull request solve?
#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


