### PR TITLE
Remove catchall route to fix 404 issue

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,4 @@ Rails.application.routes.draw do
   match "/403", to: "errors#forbidden", as: :error_403, via: :all
   match "/404", to: "errors#not_found", as: :error_404, via: :all
   match "/500", to: "errors#internal_server_error", as: :error_500, via: :all
-
-  match "*path", to: "errors#not_found", via: :all
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -2,21 +2,16 @@ require "rails_helper"
 
 RSpec.describe "Errors", type: :request do
   describe "Page not found" do
-    it "returns http code 404" do
+    before do
       get "/404"
+    end
+
+    it "returns http code 404" do
       expect(response).to have_http_status(:not_found)
     end
 
-    describe "random non-exist path" do
-      it "returns http code 404" do
-        get "/random/string/"
-        expect(response).to have_http_status(:not_found)
-      end
-
-      it "renders the not found template" do
-        get "/random/string/"
-        expect(response.body).to include(I18n.t("not_found.title"))
-      end
+    it "renders the not found template" do
+      expect(response.body).to include(I18n.t("not_found.title"))
     end
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
This removes the catchall route from `routes.rb`. I believe this was the cause of the 404 issue when logging in via signon as it was overriding the routes in the GDS-SSO gem. I think something along these lines was happening:

1. Go to the admin when logged out
2. Get redirected to signon
3. Enter signon login details
4. Successfully get authenticated by Signon
5. Signon sets the appropriate session cookie
6. Get redirected to https://admin.forms.service.gov.uk/auth/gds/callback?code={code id}&state={state id}

Expected behaviour:
7\. this route should go to the signon gem's authentication controller, which should redirect the user to the page they were originally trying to access
Bug behaviour:
7\. the catchall route renders the 404 page. Since the user has been correctly authenticated and given a cookie in step 4/5, navigating back to the forms-admin homepage allows the user to use the application from this point onwards.

The offending catchall route wasn't really doing anything - default Rails behaviour is to redirect to /404 on a RoutingError, so any route not captured in `routes.rb` will render a 404. It does have a couple of small impacts on us:
- On our local machines, we'll see a Rails error page for routing errors instead of the custom 404 page, because in the development config we have `consider_all_requests_local = true`. On other environments, we will still see the custom 404 page.
- We can no longer test this behaviour, so I've removed the relevant test. This is a slight risk, but since we're now relying on default Rails behaviour we can probably live with this.

Trello card: https://trello.com/c/JfHIJrjb/129-investigate-occasional-404-error-when-navigating-to-admin-from-signon

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


