### PR TITLE
Change radio size to comply with Design System guidance

### DIFF
--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -25,6 +25,5 @@
       @answer_types,
       ->(option) { option },
       ->(option) { I18n.t('helpers.label.page.answer_type_options.names.' + option) },
-      ->(option) { I18n.t('helpers.label.page.answer_type_options.descriptions.' + option) },
-      small: true
+      ->(option) { I18n.t('helpers.label.page.answer_type_options.descriptions.' + option) }
 )  %>


### PR DESCRIPTION
#### What problem does the pull request solve?
We're currently using the 'small radios' variant with hint text - [the design system team recommend against this](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/radios/_index.scss#L284-L291).

This changes it to use the normal sized radio buttons.

Trello card: https://trello.com/c/mckzboCP/193-using-hints-with-small-radios-isnt-recommended-by-the-design-system

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


