### PR TITLE
Make what happens next a required section

### DIFF
--- a/app/forms/forms/make_live_form.rb
+++ b/app/forms/forms/make_live_form.rb
@@ -47,5 +47,15 @@ private
     if form.missing_sections.include?(:missing_privacy_policy_url)
       errors.add(:confirm_make_live, :missing_privacy_policy_url)
     end
+
+    if form.missing_sections.include?(:missing_contact_details)
+      errors.add(:confirm_make_live, :missing_contact_details)
+      return false
+    end
+
+    if form.missing_sections.include?(:missing_what_happens_next)
+      errors.add(:confirm_make_live, :missing_what_happens_next)
+      false
+    end
   end
 end

--- a/app/forms/forms/what_happens_next_form.rb
+++ b/app/forms/forms/what_happens_next_form.rb
@@ -4,6 +4,7 @@ class Forms::WhatHappensNextForm
 
   attr_accessor :form, :what_happens_next_text
 
+  validates :what_happens_next_text, presence: true, if: -> { form.live? }
   validates :what_happens_next_text, length: { maximum: 2000 }
 
   def submit

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -48,6 +48,7 @@ class Form < ActiveResource::Base
     @missing_sections << :missing_submission_email if submission_email.blank?
     @missing_sections << :missing_privacy_policy_url if privacy_policy_url.blank?
     @missing_sections << :missing_contact_details unless support_email.present? || support_phone.present? || (support_url.present? && support_url_text.present?)
+    @missing_sections << :missing_what_happens_next if what_happens_next_text.blank?
 
     if @missing_sections.any?
       false

--- a/config/locales/forms/make_live.yml
+++ b/config/locales/forms/make_live.yml
@@ -15,3 +15,5 @@ en:
               missing_pages: You cannot make your form live because it does not have any questions. Answer ‘No’ and add one or more questions.
               missing_privacy_policy_url: You cannot make your form live because it does not have a link to privacy information. Answer ‘No’ and add a link.
               missing_submission_email: You cannot make your form live because it does not have an email address to send completed forms to. Answer ‘No’ and add an email address.
+              missing_what_happens_next: You cannot make your form live because it does not have information about what happens next. Answer ‘No’ and add information about what happens next.
+              missing_contact_details: You cannot make your form live because it does not have contact details. Answer ‘No’ and add contact details.

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :form, class: "Form" do
     sequence(:name) { |n| "Form #{n}" }
+    sequence(:form_slug) { |n| "form-#{n}" }
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
     org { "test-org" }
@@ -10,6 +11,7 @@ FactoryBot.define do
     support_phone { nil }
     support_url { nil }
     support_url_text { nil }
+    what_happens_next_text { nil }
 
     trait :new_form do
       submission_email { "" }
@@ -17,9 +19,15 @@ FactoryBot.define do
       pages { [] }
     end
 
+    trait :ready_for_live do
+      support_email { Faker::Internet.email(domain: "example.gov.uk") }
+      what_happens_next_text { "We usually respond to applications within 10 working days." }
+    end
+
     trait :live do
       live_at { Time.zone.now }
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
+      what_happens_next_text { "We usually respond to applications within 10 working days." }
     end
 
     trait :with_pages do

--- a/spec/forms/make_live_form_spec.rb
+++ b/spec/forms/make_live_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
   end
 
   describe "#submit" do
-    let(:make_live_form) { described_class.new(form: build(:form, :with_pages)) }
+    let(:make_live_form) { described_class.new(form: build(:form, :with_pages, :with_support, what_happens_next_text: "We usually respond to applications within 10 working days.")) }
 
     context "when form is invalid" do
       it "returns false" do

--- a/spec/forms/what_happens_next_form_spec.rb
+++ b/spec/forms/what_happens_next_form_spec.rb
@@ -1,54 +1,117 @@
 require "rails_helper"
 
 RSpec.describe Forms::WhatHappensNextForm, type: :model do
-  describe "validations" do
-    describe "Character length" do
-      it "is valid if less than 2000 characters" do
-        what_happens_next_form = described_class.new(what_happens_next_text: "a")
+  context "when form is live" do
+    let(:form) do
+      build(:form, :live)
+    end
 
-        expect(what_happens_next_form).to be_valid
+    describe "validations" do
+      describe "Character length" do
+        it "is valid if less than 2000 characters" do
+          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a")
+
+          expect(what_happens_next_form).to be_valid
+        end
+
+        it "is valid if 2000 characters" do
+          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a" * 2000)
+
+          expect(what_happens_next_form).to be_valid
+        end
+
+        it "is invalid if more than 2000 characters" do
+          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a" * 2001)
+          error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
+
+          expect(what_happens_next_form).not_to be_valid
+
+          what_happens_next_form.validate(:what_happens_next_text)
+
+          expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
+            "What happens next text #{error_message}",
+          )
+        end
       end
 
-      it "is valid if 2000 characters" do
-        what_happens_next_form = described_class.new(what_happens_next_text: "a" * 2000)
-
-        expect(what_happens_next_form).to be_valid
-      end
-
-      it "is invalid if more than 2000 characters" do
-        what_happens_next_form = described_class.new(what_happens_next_text: "a" * 2001)
-        error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
+      it "is invalid if blank" do
+        what_happens_next_form = described_class.new(form:, what_happens_next_text: "")
 
         expect(what_happens_next_form).not_to be_valid
+      end
+      # More tests are required here -  e.g. that a valid submission updates the Form object
+    end
 
-        what_happens_next_form.validate(:what_happens_next_text)
+    describe "#submit" do
+      it "returns false if the data is invalid" do
+        what_happens_next_form = described_class.new(form:, what_happens_next_text: ("abc" * 2001))
+        expect(what_happens_next_form.submit).to eq false
+      end
 
-        expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
-          "What happens next text #{error_message}",
-        )
+      it "sets the form's attribute value" do
+        form = OpenStruct.new(what_happens_next_text: "abc")
+        what_happens_next_form = described_class.new(form:)
+        what_happens_next_form.what_happens_next_text = "Thank you for submitting"
+        what_happens_next_form.submit
+        expect(what_happens_next_form.form.what_happens_next_text).to eq "Thank you for submitting"
       end
     end
-
-    it "is valid if blank" do
-      what_happens_next_form = described_class.new(what_happens_next_text: "")
-
-      expect(what_happens_next_form).to be_valid
-    end
-    # More tests are required here -  e.g. that a valid submission updates the Form object
   end
 
-  describe "#submit" do
-    it "returns false if the data is invalid" do
-      form = described_class.new(what_happens_next_text: ("abc" * 2001), form: { what_happens_next_text: "" })
-      expect(form.submit).to eq false
+  context "when form is not live" do
+    let(:form) do
+      build(:form)
     end
 
-    it "sets the form's attribute value" do
-      form = OpenStruct.new(what_happens_next_text: "abc")
-      what_happens_next_form = described_class.new(form:)
-      what_happens_next_form.what_happens_next_text = "Thank you for submitting"
-      what_happens_next_form.submit
-      expect(what_happens_next_form.form.what_happens_next_text).to eq "Thank you for submitting"
+    describe "validations" do
+      describe "Character length" do
+        it "is valid if less than 2000 characters" do
+          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a")
+
+          expect(what_happens_next_form).to be_valid
+        end
+
+        it "is valid if 2000 characters" do
+          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a" * 2000)
+
+          expect(what_happens_next_form).to be_valid
+        end
+
+        it "is invalid if more than 2000 characters" do
+          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a" * 2001)
+          error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
+
+          expect(what_happens_next_form).not_to be_valid
+
+          what_happens_next_form.validate(:what_happens_next_text)
+
+          expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
+            "What happens next text #{error_message}",
+          )
+        end
+      end
+
+      it "is valid if blank" do
+        what_happens_next_form = described_class.new(form:, what_happens_next_text: "")
+
+        expect(what_happens_next_form).to be_valid
+      end
+      # More tests are required here -  e.g. that a valid submission updates the Form object
+    end
+
+    describe "#submit" do
+      it "returns false if the data is invalid" do
+        what_happens_next_form = described_class.new(form:, what_happens_next_text: ("abc" * 2001))
+        expect(what_happens_next_form.submit).to eq false
+      end
+
+      it "sets the form's attribute value" do
+        form = OpenStruct.new(what_happens_next_text: "abc")
+        what_happens_next_form = described_class.new(form:)
+        what_happens_next_form.what_happens_next_text = "Thank you for submitting"
+        what_happens_next_form.submit
+        expect(what_happens_next_form.form.what_happens_next_text).to eq "Thank you for submitting"
+      end
     end
   end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -71,7 +71,7 @@ describe Form do
         results = new_form
         results.ready_for_live?
 
-        expect(results.missing_sections).to eq %i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details]
+        expect(results.missing_sections).to eq %i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details missing_what_happens_next]
       end
     end
   end

--- a/spec/requests/forms/what_happens_next/what_happens_next_spec.rb
+++ b/spec/requests/forms/what_happens_next/what_happens_next_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "WhatHappensNext controller", type: :request do
       start_page: 1,
       org: "test-org",
       what_happens_next_text: "Good things come to those who wait",
+      live_at: nil,
     }.to_json
   end
 
@@ -19,6 +20,7 @@ RSpec.describe "WhatHappensNext controller", type: :request do
       id: 2,
       org: "test-org",
       what_happens_next_text: "",
+      live_at: nil,
     )
   end
 
@@ -29,6 +31,7 @@ RSpec.describe "WhatHappensNext controller", type: :request do
       id: 2,
       org: "test-org",
       what_happens_next_text: "Wait until you get a reply",
+      live_at: nil,
     })
   end
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -11,19 +11,7 @@ RSpec.describe "Forms", type: :request do
 
     describe "Given a form" do
       let(:form) do
-        Form.new({
-          id: 2,
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          privacy_policy_url: "https://example.com/privacy_policy",
-          live_at: "",
-          org: "test-org",
-          support_email: "test@example.gov.uk",
-          support_phone: nil,
-          support_url: nil,
-          support_url_text: nil,
-        })
+        build(:form, :live, id: 2)
       end
 
       let(:pages) do
@@ -111,15 +99,7 @@ RSpec.describe "Forms", type: :request do
   describe "Deleting an existing form" do
     describe "Given a valid form" do
       let(:form) do
-        Form.new({
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          id: 2,
-          org: "test-org",
-          start_page: 1,
-          live_at: "",
-        })
+        build(:form, id: 2)
       end
 
       let(:req_headers) do
@@ -153,13 +133,7 @@ RSpec.describe "Forms", type: :request do
   describe "Destroying an existing form" do
     describe "Given a valid form" do
       let(:form) do
-        Form.new(
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          org: "test-org",
-          id: 2,
-        )
+        build(:form, id: 2)
       end
 
       before do

--- a/spec/requests/make_form_live_spec.rb
+++ b/spec/requests/make_form_live_spec.rb
@@ -1,63 +1,23 @@
 require "rails_helper"
 
 RSpec.describe "MakeLive controller", type: :request do
-  let(:form_response_data) do
-    {
-      id: 2,
-      name: "Form name",
-      form_slug: "form-name",
-      submission_email: "submission@email.com",
-      start_page: 1,
-      org: "test-org",
-      privacy_policy_url: "https://www.example.gov.uk/privacy-policy",
-      live_at: "",
-      support_email: nil,
-      support_phone: nil,
-      support_url: nil,
-      support_url_text: nil,
-    }.to_json
-  end
-
-  let(:page_data) do
-    build(:page, form_id: 2).to_json
-  end
-
   let(:form) do
-    page = build(:page)
-
-    Form.new(
-      name: "Form name",
-      form_slug: "form-name",
-      submission_email: "submission@email.com",
-      id: 2,
-      org: "test-org",
-      privacy_policy_url: "https://www.example.gov.uk/privacy-policy",
-      live_at: "",
-      support_email: "test@example.gov.uk",
-      support_phone: nil,
-      support_url: nil,
-      support_url_text: nil,
-      pages: [page],
-    )
+    build(:form,
+          :with_pages,
+          :ready_for_live,
+          id: 2)
   end
 
   let(:updated_form) do
-    page = form.pages
-
-    Form.new({
-      name: "Form name",
-      form_slug: "form-name",
-      submission_email: "submission@email.com",
-      id: 2,
-      org: "test-org",
-      privacy_policy_url: "https://www.example.gov.uk/privacy-policy",
-      live_at: "2021-01-01T00:00:00.000Z",
-      support_email: "test@example.gov.uk",
-      support_phone: nil,
-      support_url: nil,
-      support_url_text: nil,
-      pages: page,
-    })
+    build(:form,
+          :live,
+          id: 2,
+          name: form.name,
+          form_slug: form.form_slug,
+          submission_email: form.submission_email,
+          privacy_policy_url: form.privacy_policy_url,
+          support_email: form.support_email,
+          pages: form.pages)
   end
 
   let(:req_headers) do
@@ -107,15 +67,9 @@ RSpec.describe "MakeLive controller", type: :request do
 
     context "when the form is already live" do
       let(:form) do
-        Form.new(
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          id: 2,
-          org: "test-org",
-          privacy_policy_url: "https://www.example.com",
-          live_at: "2021-01-01T00:00:00.000Z",
-        )
+        build(:form,
+              :live,
+              id: 2)
       end
 
       it "Reads the form from the API" do
@@ -147,6 +101,7 @@ RSpec.describe "MakeLive controller", type: :request do
           org: "test-org",
           privacy_policy_url: "https://www.example.com",
           live_at: "2021-01-01T00:00:00.000Z",
+          what_happens_next_text: "We usually respond to applications within 10 working days.",
         )
       end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

- Makes the 'What happens next' section mandatory for going live
- Makes the 'What happens next' section mandatory when the form is already live
- 'What happens next' remains optional when the form is still in Draft.

Also includes:
- Making the Contact details mandatory for going Live - previously the 'make form live' link wasn't active if contact details weren't filled in, but a user could bypass this by going to the make live URL.
- Updating a few tests to use FactoryBot instead of manually creating form data.

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


