### PR TITLE
Fix broken profile link

### DIFF
--- a/app/components/header_component/view.rb
+++ b/app/components/header_component/view.rb
@@ -6,7 +6,7 @@ module HeaderComponent
       super
       @current_user = current_user
       @show_profile_link = current_user&.name.present?
-      @user_profile_url = "#{GDS::SSO::Config.oauth_root_url}/users/#{current_user&.uid}/edit"
+      @user_profile_url = GDS::SSO::Config.oauth_root_url
     end
   end
 end

--- a/spec/components/header_component/header_component_preview.rb
+++ b/spec/components/header_component/header_component_preview.rb
@@ -4,7 +4,7 @@ class HeaderComponent::HeaderComponentPreview < ViewComponent::Preview
   end
 
   def with_user
-    current_user = OpenStruct.new(name: "A User", uid: "123456")
+    current_user = OpenStruct.new(name: "A User")
     render(HeaderComponent::View.new(current_user))
   end
 end

--- a/spec/components/header_component/view_spec.rb
+++ b/spec/components/header_component/view_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe HeaderComponent::View, type: :component do
     end
 
     it "does not contain the profile link" do
-      expect(page).not_to have_link(user.name, href: "http://signon.dev.gov.uk/users/#{user.uid}/edit")
+      expect(page).not_to have_link(user.name, href: "http://signon.dev.gov.uk")
     end
 
     it "does not contain the sign out link" do
@@ -33,7 +33,7 @@ RSpec.describe HeaderComponent::View, type: :component do
     end
 
     it "contains the profile link" do
-      expect(page).to have_link(user.name, href: "http://signon.dev.gov.uk/users/#{user.uid}/edit")
+      expect(page).to have_link(user.name, href: "http://signon.dev.gov.uk")
     end
 
     it "contains the sign out link" do

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :user, class: "User" do
     email { Faker::Internet.email(domain: "example.gov.uk") }
     name { Faker::Name.name }
-    uid { Faker::Number.number(digits: 6) }
+    uid { Faker::Internet.uuid }
     organisation_slug { "test-org" }
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
The previous PR used the gds-sso gem's user `uid` field to generate a direct link to the user's profile. Unfortunately, `uid` doesn't do what I thought it did - it's a UUID rather than the number that appears in the profile link. This means that the profile link 404s, and it also means that the GDS-SSO gem doesn't actually provide us with any way to link to the user profile.

In this PR I've made the link point to the Signon home page. This isn't ideal behaviour as it makes the link text confusing, but it's consistent with the other apps that use Signon. We're also about to review our use of Signon anyway so this may be a temporary fix.

Trello card: https://trello.com/c/KFF7AYq9/251-forms-admin-add-signout-link

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


