### PR TITLE
Add mark complete to declaration page

### DIFF
--- a/app/components/mark_complete_component/view.html.erb
+++ b/app/components/mark_complete_component/view.html.erb
@@ -1,4 +1,4 @@
 <%= form_with model: @mark_complete_form, url: @path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-  <%= f.govuk_collection_radio_buttons :mark_complete, @mark_complete_options, :value, :name, legend: { size: 'm' } %>
+  <%= render :partial => 'forms/mark_complete/form', locals: { form: f, hint: @hint, legend: @legend} %>
   <%= f.govuk_submit t("save_and_continue") %>
 <% end %>

--- a/app/components/mark_complete_component/view.html.erb
+++ b/app/components/mark_complete_component/view.html.erb
@@ -1,4 +1,9 @@
-<%= form_with model: @mark_complete_form, url: @path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-  <%= render :partial => 'forms/mark_complete/form', locals: { form: f, hint: @hint, legend: @legend} %>
-  <%= f.govuk_submit t("save_and_continue") %>
+<% if @generate_form %>
+  <%= form_with model: @mark_complete_form, url: @path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= f.govuk_collection_radio_buttons :mark_complete, mark_complete_options, :value, :name, legend: { text: @legend, size: 'm' }, hint:{ text: @hint } %>
+    <%= f.govuk_submit t("save_and_continue") %>
+  <% end %>
+<% else %>
+  <%= @form_builder.govuk_collection_radio_buttons :mark_complete, mark_complete_options, :value, :name, legend: { text: @legend, size: 'm' }, hint:{ text: @hint } %>
 <% end %>
+

--- a/app/components/mark_complete_component/view.rb
+++ b/app/components/mark_complete_component/view.rb
@@ -2,16 +2,16 @@
 
 module MarkCompleteComponent
   class View < ViewComponent::Base
-    def initialize(pages, mark_complete_form, path)
+    def initialize(form:, path:, legend: t("mark_complete.legend"), hint: t("mark_complete.hint"))
       super
-      @pages = pages
-      @mark_complete_form = mark_complete_form
+      @mark_complete_form = form
       @path = path
-      @mark_complete_options = [OpenStruct.new(value: "true"), OpenStruct.new(value: "false")]
+      @legend = legend
+      @hint = hint
     end
 
     def render?
-      @pages.any? && FeatureService.enabled?(:task_list_statuses)
+      FeatureService.enabled?(:task_list_statuses)
     end
   end
 end

--- a/app/components/mark_complete_component/view.rb
+++ b/app/components/mark_complete_component/view.rb
@@ -2,16 +2,25 @@
 
 module MarkCompleteComponent
   class View < ViewComponent::Base
-    def initialize(form:, path:, legend: t("mark_complete.legend"), hint: t("mark_complete.hint"))
+    def initialize(form_model: nil, generate_form: true, form_builder: nil, path: nil, legend: t("mark_complete.legend"), hint: t("mark_complete.hint"))
       super
-      @mark_complete_form = form
-      @path = path
+      if generate_form
+        @mark_complete_form = form_model
+        @path = path
+      else
+        @form_builder = form_builder
+      end
+      @generate_form = generate_form
       @legend = legend
       @hint = hint
     end
 
     def render?
       FeatureService.enabled?(:task_list_statuses)
+    end
+
+    def mark_complete_options
+      [OpenStruct.new(value: "true", name: t("mark_complete.true")), OpenStruct.new(value: "false", name: t("mark_complete.false"))]
     end
   end
 end

--- a/app/controllers/forms/declaration_controller.rb
+++ b/app/controllers/forms/declaration_controller.rb
@@ -17,7 +17,7 @@ module Forms
   private
 
     def declaration_form_params
-      params.require(:forms_declaration_form).permit(:declaration_text).merge(form: current_form)
+      params.require(:forms_declaration_form).permit(:declaration_text, :mark_complete).merge(form: current_form)
     end
   end
 end

--- a/app/forms/forms/declaration_form.rb
+++ b/app/forms/forms/declaration_form.rb
@@ -2,19 +2,22 @@ class Forms::DeclarationForm
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :form, :declaration_text
+  attr_accessor :form, :declaration_text, :mark_complete
 
   validates :declaration_text, length: { maximum: 2000 }
+  validates :mark_complete, presence: true, if: -> { FeatureService.enabled?(:task_list_statuses) }
 
   def submit
     return false if invalid?
 
     form.declaration_text = declaration_text
+    form.declaration_section_completed = mark_complete
     form.save!
   end
 
   def assign_form_values
     self.declaration_text = form.declaration_text
+    self.mark_complete = form.try(:declaration_section_completed)
     self
   end
 end

--- a/app/views/forms/declaration/new.html.erb
+++ b/app/views/forms/declaration/new.html.erb
@@ -17,6 +17,10 @@
 
       <%= f.govuk_text_area :declaration_text, max_chars: 2000, label: {size: 'm' } %>
 
+      <% if FeatureService.enabled?(:task_list_statuses) %>
+        <%= render :partial => 'forms/mark_complete/form', locals: { form: f, legend: t("mark_complete.legend"), hint: t("mark_complete.hint")} %>
+      <% end %>
+
       <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>

--- a/app/views/forms/declaration/new.html.erb
+++ b/app/views/forms/declaration/new.html.erb
@@ -18,7 +18,7 @@
       <%= f.govuk_text_area :declaration_text, max_chars: 2000, label: {size: 'm' } %>
 
       <% if FeatureService.enabled?(:task_list_statuses) %>
-        <%= render :partial => 'forms/mark_complete/form', locals: { form: f, legend: t("mark_complete.legend"), hint: t("mark_complete.hint")} %>
+        <%= render MarkCompleteComponent::View.new(generate_form: false, form_builder: f, form_model: @declaration_form) %>
       <% end %>
 
       <%= f.govuk_submit "Save and continue" %>

--- a/app/views/forms/mark_complete/_form.html.erb
+++ b/app/views/forms/mark_complete/_form.html.erb
@@ -1,0 +1,1 @@
+<%= form.govuk_collection_radio_buttons :mark_complete, [OpenStruct.new(value: "true", name: t("mark_complete.true")), OpenStruct.new(value: "false", name: t("mark_complete.false"))], :value, :name, legend: { text: legend, size: 'm' }, hint:{ text: hint } %>

--- a/app/views/forms/mark_complete/_form.html.erb
+++ b/app/views/forms/mark_complete/_form.html.erb
@@ -1,1 +1,0 @@
-<%= form.govuk_collection_radio_buttons :mark_complete, [OpenStruct.new(value: "true", name: t("mark_complete.true")), OpenStruct.new(value: "false", name: t("mark_complete.false"))], :value, :name, legend: { text: legend, size: 'm' }, hint:{ text: hint } %>

--- a/app/views/page_list/edit.html.erb
+++ b/app/views/page_list/edit.html.erb
@@ -47,7 +47,9 @@
         </dl>
       <% end %>
 
-      <%= render MarkCompleteComponent::View.new(@form.pages, @mark_complete_form, form_pages_path(@form)) %>
+      <% if @pages.any? %>
+        <%= render MarkCompleteComponent::View.new(form: @mark_complete_form, path: form_pages_path(@form), legend: t("pages.index.mark_complete.legend")) %>
+      <% end %>
     <% end %>
 
   </div>

--- a/app/views/page_list/edit.html.erb
+++ b/app/views/page_list/edit.html.erb
@@ -48,7 +48,7 @@
       <% end %>
 
       <% if @pages.any? %>
-        <%= render MarkCompleteComponent::View.new(form: @mark_complete_form, path: form_pages_path(@form), legend: t("pages.index.mark_complete.legend")) %>
+        <%= render MarkCompleteComponent::View.new(form_model: @mark_complete_form, path: form_pages_path(@form), legend: t("pages.index.mark_complete.legend")) %>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,6 +166,11 @@ en:
         <p class="govuk-body">
           After you have made your form live, completed forms will be sent to %{submission_email}.
         </p>
+  mark_complete:
+    'false': No, I'll come back later
+    hint: Selecting 'Yes' will mark this task as complete. You will still be able to make changes if you need to.
+    legend: Do you want to mark this task as complete?
+    'true': 'Yes'
   not_found:
     body: |
       If you typed the web address, check it is correct.
@@ -195,6 +200,8 @@ en:
     heading: Edit question
     index:
       add_question: Add a question
+      mark_complete:
+        legend: Have you finished editing your questions?
       title: Add and edit your questions
     make_optional_hint: "‘(optional)’ will be added to the end of the question text"
     make_optional_text: Make this question optional

--- a/config/locales/forms/declaration.yml
+++ b/config/locales/forms/declaration.yml
@@ -10,4 +10,5 @@ en:
           attributes:
             declaration_text:
               too_long: The declaration cannot be longer than 2,000 characters
-
+            mark_complete:
+              blank: You must choose an option

--- a/config/locales/forms/mark_complete.yml
+++ b/config/locales/forms/mark_complete.yml
@@ -1,16 +1,4 @@
 en:
-  helpers:
-    legend:
-      forms_mark_complete_form:
-        mark_complete: Have you finished editing your questions?
-    hint:
-      forms_mark_complete_form:
-        mark_complete: Selecting 'Yes' will mark this task as complete. You will still be able to make changes if you need to.
-    label:
-      forms_mark_complete_form:
-        mark_complete_options:
-          true: "Yes"
-          false: "No, I'll come back later"
   activemodel:
     errors:
       models:

--- a/spec/components/mark_complete_component/mark_complete_component_preview.rb
+++ b/spec/components/mark_complete_component/mark_complete_component_preview.rb
@@ -1,8 +1,16 @@
 require "factory_bot"
 class MarkCompleteComponent::MarkCompleteComponentPreview < ViewComponent::Preview
   def default
-    form = FactoryBot.build(:form, :new_form, id: 1)
+    form = FactoryBot.build(:form, id: 1)
     mark_complete_form = Forms::MarkCompleteForm.new(form:).assign_form_values
-    render(MarkCompleteComponent::View.new(form: mark_complete_form, path: "/", legend: "Have you finished editing your questions?"))
+    render(MarkCompleteComponent::View.new(form_model: mark_complete_form, path: "/", legend: "Have you finished editing your questions?"))
+  end
+
+  def excluding_form
+    form = FactoryBot.build(:form, id: 1)
+    mark_complete_form = Forms::MarkCompleteForm.new(form:).assign_form_values
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, mark_complete_form,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+    render(MarkCompleteComponent::View.new(form_builder:, generate_form: false))
   end
 end

--- a/spec/components/mark_complete_component/mark_complete_component_preview.rb
+++ b/spec/components/mark_complete_component/mark_complete_component_preview.rb
@@ -1,14 +1,8 @@
 require "factory_bot"
 class MarkCompleteComponent::MarkCompleteComponentPreview < ViewComponent::Preview
-  def without_pages
+  def default
     form = FactoryBot.build(:form, :new_form, id: 1)
     mark_complete_form = Forms::MarkCompleteForm.new(form:).assign_form_values
-    render(MarkCompleteComponent::View.new(form.pages, mark_complete_form, "/"))
-  end
-
-  def with_pages
-    form = FactoryBot.build(:form, :with_pages, id: 2)
-    mark_complete_form = Forms::MarkCompleteForm.new(form:).assign_form_values
-    render(MarkCompleteComponent::View.new(form.pages, mark_complete_form, "/"))
+    render(MarkCompleteComponent::View.new(form: mark_complete_form, path: "/", legend: "Have you finished editing your questions?"))
   end
 end

--- a/spec/components/mark_complete_component/view_spec.rb
+++ b/spec/components/mark_complete_component/view_spec.rb
@@ -3,32 +3,29 @@ require "rails_helper"
 RSpec.describe MarkCompleteComponent::View, type: :component do
   let(:mark_complete_form) { Forms::MarkCompleteForm.new(form:).assign_form_values }
 
-  context "when the form has pages" do
-    let(:form) { build(:form, :with_pages, id: 2) }
+  let(:form) { build(:form, :with_pages, id: 2) }
 
-    context "when the task status feature is enabled", feature_task_list_statuses: true do
-      it "renders the form" do
-        render_inline(described_class.new(form.pages, mark_complete_form, "/"))
+  context "when the task status feature is enabled", feature_task_list_statuses: true do
+    it "renders the form" do
+      render_inline(described_class.new(form: mark_complete_form, path: "/"))
 
-        expect(page.text).to have_text("Have you finished editing your questions?")
-      end
+      expect(page.text).to have_text("Do you want to mark this task as complete?")
     end
 
-    context "when the task status feature is disabled", feature_task_list_statuses: false do
-      it "renders the form" do
-        render_inline(described_class.new(form.pages, mark_complete_form, "/"))
+    it "the label and hint text cna be overridden" do
+      render_inline(described_class.new(form: mark_complete_form, path: "/", legend: "Have you finished editing your questions?", hint: "You can come back to your questions later"))
 
-        expect(page.text).not_to have_text("Have you finished editing your questions?")
-      end
+      expect(page.text).not_to have_text("Do you want to mark this task as complete?")
+      expect(page.text).to have_text("Have you finished editing your questions?")
+      expect(page.text).to have_text("You can come back to your questions later")
     end
   end
 
-  context "when the form has no pages" do
-    let(:form) { build(:form, :new_form, id: 2) }
+  context "when the task status feature is disabled", feature_task_list_statuses: false do
+    it "renders the form" do
+      render_inline(described_class.new(form: mark_complete_form, path: "/"))
 
-    it "does not render the form" do
-      render_inline(described_class.new(form.pages, mark_complete_form, "/"))
-      expect(page).not_to have_text("Have you finished editing your questions?")
+      expect(page.text).not_to have_text("Do you want to mark this task as complete?")
     end
   end
 end

--- a/spec/components/mark_complete_component/view_spec.rb
+++ b/spec/components/mark_complete_component/view_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe MarkCompleteComponent::View, type: :component do
     it "renders the form" do
       render_inline(described_class.new(form: mark_complete_form, path: "/"))
 
-      expect(page.text).to have_text("Do you want to mark this task as complete?")
+      expect(page.text).to have_text(I18n.t("mark_complete.legend"))
     end
 
-    it "the label and hint text cna be overridden" do
-      render_inline(described_class.new(form: mark_complete_form, path: "/", legend: "Have you finished editing your questions?", hint: "You can come back to your questions later"))
+    it "the label and hint text can be overridden" do
+      render_inline(described_class.new(form: mark_complete_form, path: "/", legend: I18n.t("pages.index.mark_complete.legend"), hint: "You can come back to your questions later"))
 
-      expect(page.text).not_to have_text("Do you want to mark this task as complete?")
-      expect(page.text).to have_text("Have you finished editing your questions?")
+      expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
+      expect(page.text).to have_text(I18n.t("pages.index.mark_complete.legend"))
       expect(page.text).to have_text("You can come back to your questions later")
     end
   end
@@ -25,7 +25,7 @@ RSpec.describe MarkCompleteComponent::View, type: :component do
     it "renders the form" do
       render_inline(described_class.new(form: mark_complete_form, path: "/"))
 
-      expect(page.text).not_to have_text("Do you want to mark this task as complete?")
+      expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
     end
   end
 end

--- a/spec/components/mark_complete_component/view_spec.rb
+++ b/spec/components/mark_complete_component/view_spec.rb
@@ -1,29 +1,53 @@
 require "rails_helper"
 
+def generate_form_builder(model)
+  GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, model,
+                                                ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+end
+
 RSpec.describe MarkCompleteComponent::View, type: :component do
+  let(:form) { build(:form, :with_pages, id: 2) }
   let(:mark_complete_form) { Forms::MarkCompleteForm.new(form:).assign_form_values }
 
-  let(:form) { build(:form, :with_pages, id: 2) }
-
   context "when the task status feature is enabled", feature_task_list_statuses: true do
-    it "renders the form" do
-      render_inline(described_class.new(form: mark_complete_form, path: "/"))
+    context "when using the generate_form option" do
+      it "renders the form" do
+        render_inline(described_class.new(form_model: mark_complete_form, path: "/"))
 
-      expect(page.text).to have_text(I18n.t("mark_complete.legend"))
+        expect(page.text).to have_text(I18n.t("mark_complete.legend"))
+      end
+
+      it "the label and hint text can be overridden" do
+        render_inline(described_class.new(form_model: mark_complete_form, path: "/", legend: I18n.t("pages.index.mark_complete.legend"), hint: "You can come back to your questions later"))
+
+        expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
+        expect(page.text).to have_text(I18n.t("pages.index.mark_complete.legend"))
+        expect(page.text).to have_text("You can come back to your questions later")
+      end
     end
 
-    it "the label and hint text can be overridden" do
-      render_inline(described_class.new(form: mark_complete_form, path: "/", legend: I18n.t("pages.index.mark_complete.legend"), hint: "You can come back to your questions later"))
+    context "when not using the generate_form option" do
+      let(:form_builder) { generate_form_builder(mark_complete_form) }
 
-      expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
-      expect(page.text).to have_text(I18n.t("pages.index.mark_complete.legend"))
-      expect(page.text).to have_text("You can come back to your questions later")
+      it "renders the form" do
+        render_inline(described_class.new(form_builder:, generate_form: false))
+
+        expect(page.text).to have_text(I18n.t("mark_complete.legend"))
+      end
+
+      it "the label and hint text can be overridden" do
+        render_inline(described_class.new(form_builder:, generate_form: false, legend: I18n.t("pages.index.mark_complete.legend"), hint: "You can come back to your questions later"))
+
+        expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
+        expect(page.text).to have_text(I18n.t("pages.index.mark_complete.legend"))
+        expect(page.text).to have_text("You can come back to your questions later")
+      end
     end
   end
 
   context "when the task status feature is disabled", feature_task_list_statuses: false do
     it "renders the form" do
-      render_inline(described_class.new(form: mark_complete_form, path: "/"))
+      render_inline(described_class.new(form_model: mark_complete_form, path: "/"))
 
       expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
     end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -12,6 +12,8 @@ FactoryBot.define do
     support_url { nil }
     support_url_text { nil }
     what_happens_next_text { nil }
+    question_section_completed { "false" }
+    declaration_section_completed { "false" }
 
     trait :new_form do
       submission_email { "" }

--- a/spec/forms/declaration_form_spec.rb
+++ b/spec/forms/declaration_form_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe Forms::DeclarationForm, type: :model do
     context "when the task status feature is not enabled", feature_task_list_statuses: false do
       it "sets the form's attribute value" do
         form = OpenStruct.new(declaration_text: "abc")
-        declaration_form = described_class.new(form:)
-        declaration_form.declaration_text = "new declaration text"
+        declaration_form = described_class.new(form:, declaration_text: "new declaration text")
         declaration_form.submit
         expect(declaration_form.form.declaration_text).to eq "new declaration text"
       end
@@ -73,9 +72,7 @@ RSpec.describe Forms::DeclarationForm, type: :model do
     context "when the task status feature is enabled", feature_task_list_statuses: true do
       it "sets the form's attribute values" do
         form = OpenStruct.new(declaration_text: "abc", declaration_section_completed: "false")
-        declaration_form = described_class.new(form:)
-        declaration_form.declaration_text = "new declaration text"
-        declaration_form.mark_complete = "true"
+        declaration_form = described_class.new(form:, declaration_text: "new declaration text", mark_complete: "true")
         declaration_form.submit
         expect(declaration_form.form.declaration_text).to eq "new declaration text"
         expect(declaration_form.form.declaration_section_completed).to eq "true"

--- a/spec/forms/declaration_form_spec.rb
+++ b/spec/forms/declaration_form_spec.rb
@@ -29,10 +29,28 @@ RSpec.describe Forms::DeclarationForm, type: :model do
       end
     end
 
-    it "is valid if blank" do
+    it "is valid if declaration text is blank" do
       declaration_form = described_class.new(declaration_text: "")
 
       expect(declaration_form).to be_valid
+    end
+
+    context "when the task status feature is not enabled", feature_task_list_statuses: false do
+      it "is valid if mark complete is blank" do
+        declaration_form = described_class.new(mark_complete: "")
+
+        expect(declaration_form).to be_valid
+        expect(declaration_form.errors.full_messages_for(:mark_complete)).not_to include "Mark complete #{I18n.t('activemodel.errors.models.forms/declaration_form.attributes.mark_complete.blank')}"
+      end
+    end
+
+    context "when the task status feature is enabled", feature_task_list_statuses: true do
+      it "is not valid if mark complete is blank" do
+        declaration_form = described_class.new(mark_complete: nil)
+
+        expect(declaration_form).not_to be_valid
+        expect(declaration_form.errors.full_messages_for(:mark_complete)).to include "Mark complete #{I18n.t('activemodel.errors.models.forms/declaration_form.attributes.mark_complete.blank')}"
+      end
     end
   end
 
@@ -42,12 +60,26 @@ RSpec.describe Forms::DeclarationForm, type: :model do
       expect(form.submit).to eq false
     end
 
-    it "sets the form's attribute value" do
-      form = OpenStruct.new(declaration_text: "abc")
-      declaration_form = described_class.new(form:)
-      declaration_form.declaration_text = "new declaration text"
-      declaration_form.submit
-      expect(declaration_form.form.declaration_text).to eq "new declaration text"
+    context "when the task status feature is not enabled", feature_task_list_statuses: false do
+      it "sets the form's attribute value" do
+        form = OpenStruct.new(declaration_text: "abc")
+        declaration_form = described_class.new(form:)
+        declaration_form.declaration_text = "new declaration text"
+        declaration_form.submit
+        expect(declaration_form.form.declaration_text).to eq "new declaration text"
+      end
+    end
+
+    context "when the task status feature is enabled", feature_task_list_statuses: true do
+      it "sets the form's attribute values" do
+        form = OpenStruct.new(declaration_text: "abc", declaration_section_completed: "false")
+        declaration_form = described_class.new(form:)
+        declaration_form.declaration_text = "new declaration text"
+        declaration_form.mark_complete = "true"
+        declaration_form.submit
+        expect(declaration_form.form.declaration_text).to eq "new declaration text"
+        expect(declaration_form.form.declaration_section_completed).to eq "true"
+      end
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
Allows the user to mark the declaration as complete. Includes some changes to the existing mark complete component to reduce duplication.

Trello card: https://trello.com/c/6kzPVxj1/286-add-are-you-finished-section-to-the-form-admin-add-a-declaration-task
Related API PR: https://github.com/alphagov/forms-api/pull/112

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
