### PR TITLE
Add Email confirmation

### DIFF
--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -1,0 +1,47 @@
+module Forms
+  class SubmissionEmailController < BaseController
+    before_action :submission_email_form, except: %i[create confirm_submission_email_code]
+
+    def new; end
+
+    def create
+      @submission_email_form = SubmissionEmailForm.new(set_email_form_params)
+
+      if @submission_email_form.submit
+        redirect_to submission_email_code_sent_path(@submission_email_form.form)
+      else
+        render :new
+      end
+    end
+
+    def submission_email_code_sent; end
+
+    def submission_email_code; end
+
+    def confirm_submission_email_code
+      @submission_email_form = SubmissionEmailForm.new(set_email_code_form_params).assign_form_values
+
+      if @submission_email_form.confirm_confirmation_code
+        redirect_to submission_email_confirmed_path(@submission_email_form.form)
+      else
+        render :submission_email_code
+      end
+    end
+
+    def submission_email_confirmed; end
+
+  private
+
+    def set_email_form_params
+      params.require(:forms_submission_email_form).permit(:temporary_submission_email).merge(form: current_form).merge(current_user:)
+    end
+
+    def set_email_code_form_params
+      params.require(:forms_submission_email_form).permit(:email_code).merge(form: current_form).merge(current_user:)
+    end
+
+    def submission_email_form
+      @submission_email_form ||= SubmissionEmailForm.new(form: current_form).assign_form_values
+    end
+  end
+end

--- a/app/forms/forms/submission_email_form.rb
+++ b/app/forms/forms/submission_email_form.rb
@@ -8,8 +8,8 @@ class Forms::SubmissionEmailForm
   GOVUK_EMAIL_REGEX = /\.gov\.uk\z/i
 
   validates :temporary_submission_email, presence: true
-  validates :temporary_submission_email, format: { with: EMAIL_REGEX, message: :invalid_email }, if: -> { temporary_submission_email.present? }
-  validates :temporary_submission_email, format: { with: GOVUK_EMAIL_REGEX, message: :non_govuk_email }, if: -> { temporary_submission_email.present? }
+  validates :temporary_submission_email, format: { with: EMAIL_REGEX, message: :invalid_email }
+  validates :temporary_submission_email, format: { with: GOVUK_EMAIL_REGEX, message: :non_govuk_email }
 
   EMAIL_CODE_REGEX = /[0-9]{6}/
   validates :email_code, format: { with: EMAIL_CODE_REGEX, message: :invalid_email_code }, if: -> { email_code.present? }

--- a/app/forms/forms/submission_email_form.rb
+++ b/app/forms/forms/submission_email_form.rb
@@ -1,0 +1,94 @@
+class Forms::SubmissionEmailForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :form, :temporary_submission_email, :email_code, :confirmation_code, :current_user
+
+  EMAIL_REGEX = /.*@.*/
+  GOVUK_EMAIL_REGEX = /\.gov\.uk\z/i
+
+  validates :temporary_submission_email, presence: true
+  validates :temporary_submission_email, format: { with: EMAIL_REGEX, message: :invalid_email }, if: -> { temporary_submission_email.present? }
+  validates :temporary_submission_email, format: { with: GOVUK_EMAIL_REGEX, message: :non_govuk_email }, if: -> { temporary_submission_email.present? }
+
+  EMAIL_CODE_REGEX = /[0-9]{6}/
+  validates :email_code, format: { with: EMAIL_CODE_REGEX, message: :invalid_email_code }, if: -> { email_code.present? }
+  validate :email_code_matches_confirmation_code
+
+  def submit
+    return false if invalid?
+
+    confirmation_code = generate_confirmation_code
+
+    form_submission_email = FormSubmissionEmail.find_by_form_id(form.id)
+
+    form_processed = if form_submission_email.nil?
+                       create_submission_email_record(confirmation_code)
+                     else
+                       update_submission_email_record(confirmation_code, form_submission_email)
+                     end
+
+    if form_processed
+      # send notify email?
+      Rails.logger.info "Email sent to #{temporary_submission_email} with code #{confirmation_code}"
+      true
+    else
+      false
+    end
+  end
+
+  def confirm_confirmation_code
+    return false if invalid?
+
+    # Update the submission email in the form
+    form.submission_email = temporary_submission_email
+    form.save!
+    mark_submission_email_as_confirmed
+  end
+
+  def mark_submission_email_as_confirmed
+    self.confirmation_code = nil
+    form_submission_email = FormSubmissionEmail.find_by_form_id(form.id)
+    form_submission_email.update!(confirmation_code: nil, updated_by_name: current_user.name, updated_by_email: current_user.email)
+  end
+
+  def assign_form_values
+    form_submission_email = FormSubmissionEmail.find_by_form_id(form.id)
+
+    if form_submission_email.nil?
+      self.temporary_submission_email = form.submission_email
+    else
+      self.temporary_submission_email = form_submission_email.temporary_submission_email
+      self.confirmation_code = form_submission_email.confirmation_code
+    end
+
+    self
+  end
+
+private
+
+  def generate_confirmation_code
+    SecureRandom.random_number(10**6).to_s.rjust(6, "0")
+  end
+
+  def email_code_matches_confirmation_code
+    if confirmation_code.present? && email_code != confirmation_code
+      errors.add(:email_code, :email_code_mismatch)
+    end
+  end
+
+  def create_submission_email_record(confirmation_code)
+    FormSubmissionEmail.create!(form_id: form.id,
+                                temporary_submission_email:,
+                                confirmation_code:,
+                                created_by_name: current_user.name,
+                                created_by_email: current_user.email)
+  end
+
+  def update_submission_email_record(confirmation_code, form)
+    form.update(temporary_submission_email:,
+                confirmation_code:,
+                updated_by_name: current_user.name,
+                updated_by_email: current_user.email)
+  end
+end

--- a/app/models/form_submission_email.rb
+++ b/app/models/form_submission_email.rb
@@ -1,0 +1,3 @@
+class FormSubmissionEmail < ApplicationRecord
+  validates :form_id, presence: true
+end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -40,7 +40,12 @@ private
   def section_2_tasks
     hint_text = I18n.t("forms.task_lists.section_2.hint_text", submission_email: @form.submission_email) if @form.submission_email.present?
 
-    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: @task_list_statuses.submission_email_status }]
+    if FeatureService.enabled?(:submission_email_confirmation)
+      [{ task_name: I18n.t("forms.task_lists.section_2.set_email"), path: submission_email_form_path(@form.id), hint_text: },
+       { task_name: I18n.t("forms.task_lists.section_2.confirm_email"), path: submission_email_code_path(@form.id) }]
+    else
+      [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: @task_list_statuses.submission_email_status }]
+    end
   end
 
   def section_3_tasks

--- a/app/views/forms/submission_email/new.html.erb
+++ b/app/views/forms/submission_email/new.html.erb
@@ -1,0 +1,20 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.set_email_form'), @submission_email_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(form_path(@submission_email_form.form), "Back to create a form") %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @submission_email_form, url: submission_email_form_path) do |f| %>
+      <% if @submission_email_form&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @submission_email_form.form.name %></span>
+        <%= t("page_titles.set_email_form") %>
+      </h1>
+
+      <%= t("set_email_form.new.body_html") %>
+      <%= f.govuk_text_field :temporary_submission_email, label: {  tag: 'h2', size: 'm' } %>
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/forms/submission_email/submission_email_code.html.erb
+++ b/app/views/forms/submission_email/submission_email_code.html.erb
@@ -1,0 +1,13 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.confirm_email_form'), @submission_email_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(form_path(@submission_email_form.form), "Back to create a form") %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @submission_email_form, url: confirm_submission_email_code_path) do |f| %>
+      <% if @submission_email_form&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+      <%= f.govuk_text_field :email_code, width: 10, label: {  tag: 'h1', size: 'l' } %>
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/forms/submission_email/submission_email_code_sent.html.erb
+++ b/app/views/forms/submission_email/submission_email_code_sent.html.erb
@@ -1,0 +1,8 @@
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%=  @submission_email_form.form.name %></span>
+  <%= t("page_titles.email_code_sent") %>
+</h1>
+<%= t('email_code_sent.body_html', temp_email:  @submission_email_form.temporary_submission_email) %>
+
+<p class="govuk-body"><%= govuk_link_to "Enter the email address confirmation code", submission_email_code_path( @submission_email_form.form) %></p>
+<p class="govuk-body"><%= govuk_link_to(t('email_code_sent.continue'), form_path) %></p>

--- a/app/views/forms/submission_email/submission_email_confirmed.html.erb
+++ b/app/views/forms/submission_email/submission_email_confirmed.html.erb
@@ -1,0 +1,8 @@
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @submission_email_form.form.name %></span>
+  <%= t("page_titles.confirm_email_success") %>
+</h1>
+
+<%= t('email_code_success.body_html', submission_email: @submission_email_form.form.submission_email) %>
+
+<%= govuk_link_to(t('email_code_success.continue'), form_path) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,16 @@ en:
           By submitting this form you are confirming that, to the best of your
           knowledge, the answers you are providing are correct.
         </div>
+  email_code_sent:
+    body_html: |
+      <p class="govuk-body">We've sent a confirmation code and your email address to %{temp_email}.</p>
+      <p class="govuk-body">The recipient will be asked to give you the code. You need to enter the code to confirm the email address.</p>
+    continue: Continue creating a form
+  email_code_success:
+    body_html: '<p class="govuk-body">Completed forms will be sent to %{submission_email}.</p>
+
+      '
+    continue: Continue creating a form
   footer:
     accessibility_statement: Accessibility statement
     cookies: Cookies
@@ -74,7 +84,9 @@ en:
         declaration: Add a declaration for people to agree to
         title: Create your form
       section_2:
+        confirm_email: Enter the email address confirmation code
         hint_text: Completed forms will be sent to %{submission_email}
+        set_email: Set the email address completed forms will be sent to
         submission_email: Set the email address completed forms will be sent to
         title: Set email address for completed forms
       section_3:
@@ -181,8 +193,11 @@ en:
   page_titles:
     change_email_form: What email address should form responses be sent to?
     change_name_form: Name your form
+    confirm_email_form: Enter the confirmation code
+    confirm_email_success: Email address confirmed
     contact_details_form: Provide contact details for support
     declaration_form: Add a declaration
+    email_code_sent: Confirmation code sent
     error_prefix: 'Error: '
     forbidden: You cannot view this page
     home: Home
@@ -192,6 +207,7 @@ en:
     not_found: Page not found
     privacy_policy_form: Provide a link to privacy information for this form
     service_unavailable: Sorry, the service is unavailable
+    set_email_form: Set the email address for completed forms
     what_happens_next_form: Form submitted page
     your_form_is_live: Your form is live
   pages:
@@ -252,6 +268,20 @@ en:
   service_unavailable:
     body_html: "%{link} if you need to make changes to your forms or speak to someone about the service."
     title: Sorry, the service is unavailable
+  set_email_form:
+    new:
+      body_html: |
+        <p class="govuk-body">
+          You need to provide an email address for completed forms to be sent to for processing. It should be a shared government email inbox.
+        </p>
+
+        <p class="govuk-body">
+          To make sure the email address you provide is correct, we’ll send an email to it with a confirmation code and your email address.
+        </p>
+
+        <p class="govuk-body">
+          The recipient will be asked to tell you the code. You will then need to enter the code to confirm the email address.
+        </p>
   skip_to_main_content: Skip to main content
   task_statuses:
     cannot_start: cannot start yet

--- a/config/locales/forms/submission_email_form.yml
+++ b/config/locales/forms/submission_email_form.yml
@@ -1,0 +1,18 @@
+en:
+  helpers:
+    label:
+      forms_submission_email_form:
+        temporary_submission_email: What email address should completed forms be sent to?
+        email_code: Enter the confirmation code
+  activemodel:
+    errors:
+      models:
+        forms/submission_email_form:
+          attributes:
+            temporary_submission_email:
+              blank: Enter an email address for the form
+              invalid_email: Enter an email address in the correct format, like name@example.com
+              non_govuk_email: Enter an email address ending in .gov.uk
+            email_code:
+              invalid_email_code: The code should be 6 characters long
+              email_code_mismatch: This code is not correct - double check the code or send a new one

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,14 @@ Rails.application.routes.draw do
     post "/change-name" => "forms/change_name#update"
     get "/change-email" => "forms/change_email#new", as: :change_form_email
     post "/change-email" => "forms/change_email#create"
+
+    get "/submission-email" => "forms/submission_email#new", as: :submission_email_form
+    post "/submission-email" => "forms/submission_email#create"
+    get "/confirm-submission-email" => "forms/submission_email#submission_email_code", as: :submission_email_code
+    post "/confirm-submission-email" => "forms/submission_email#confirm_submission_email_code", as: :confirm_submission_email_code
+    get "/submission-email-confirmed" => "forms/submission_email#submission_email_confirmed", as: :submission_email_confirmed
+    get "/email-code-sent" => "forms/submission_email#submission_email_code_sent", as: :submission_email_code_sent
+
     get "/delete" => "forms/delete_confirmation#delete", as: :delete_form
     delete "/delete" => "forms/delete_confirmation#destroy", as: :destroy_form
     get "/privacy-policy" => "forms/privacy_policy#new", as: :privacy_policy

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,3 +2,4 @@
 features:
   make_question_optional: true
   task_list_statuses: true
+  submission_email_confirmation: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -2,3 +2,4 @@
 features:
   make_question_optional: true
   task_list_statuses: true
+  submission_email_confirmation: true

--- a/db/migrate/20221103162118_create_form_submission_email.rb
+++ b/db/migrate/20221103162118_create_form_submission_email.rb
@@ -1,0 +1,14 @@
+class CreateFormSubmissionEmail < ActiveRecord::Migration[7.0]
+  def change
+    create_table :form_submission_emails do |t|
+      t.integer :form_id, index: true, foreign_key: true
+      t.string :temporary_submission_email
+      t.string :confirmation_code
+      t.string :created_by_name
+      t.string :created_by_email
+      t.string :updated_by_name
+      t.string :updated_by_email
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_13_111847) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_03_162118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "form_submission_emails", force: :cascade do |t|
+    t.integer "form_id"
+    t.string "temporary_submission_email"
+    t.string "confirmation_code"
+    t.string "created_by_name"
+    t.string "created_by_email"
+    t.string "updated_by_name"
+    t.string "updated_by_email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["form_id"], name: "index_form_submission_emails_on_form_id"
+  end
 
   create_table "forms", id: :bigint, default: nil, force: :cascade do |t|
     t.text "name"

--- a/spec/factories/forms/submission_email_form.rb
+++ b/spec/factories/forms/submission_email_form.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :submission_email_form, class: "Forms::SubmissionEmailForm" do
+    temporary_submission_email { "submit@example.gov.uk" }
+    form { build :form }
+
+    trait :with_user do
+      current_user { OpenStruct.new(name: "User", email: "user@gov.uk") }
+    end
+  end
+end

--- a/spec/factories/models/form_submission_email.rb
+++ b/spec/factories/models/form_submission_email.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :form_submission_email, class: "FormSubmissionEmail" do
+    sequence(:form_id) { |n| "Form #{n}" }
+  end
+end

--- a/spec/forms/submission_email_form_spec.rb
+++ b/spec/forms/submission_email_form_spec.rb
@@ -1,0 +1,161 @@
+require "rails_helper"
+
+RSpec.describe Forms::SubmissionEmailForm, type: :model do
+  it "has a valid factory" do
+    submission_email_form = build :submission_email_form
+    expect(submission_email_form).to be_valid
+  end
+
+  describe "validations" do
+    it "is invalid if not given an email address ending with .gov.uk" do
+      submission_email_form = build :submission_email_form, temporary_submission_email: "a@example.org"
+      expect(submission_email_form).to be_invalid
+    end
+
+    it "is invalid if not given an email address" do
+      submission_email_form = build :submission_email_form, temporary_submission_email: nil
+      expect(submission_email_form).to be_invalid
+    end
+
+    it "is invalid if email_code is in the wrong format" do
+      submission_email_form = build :submission_email_form, email_code: "abcdef", confirmation_code: "abcdef"
+      expect(submission_email_form).to be_invalid
+    end
+
+    it "is invalid if email_code does not match confirmation code" do
+      submission_email_form = build :submission_email_form, email_code: "000000", confirmation_code: "123456"
+      expect(submission_email_form).to be_invalid
+    end
+  end
+
+  describe "#assign_form_values" do
+    context "when FormSubmissionEmail does not exist for form" do
+      it "sets temporary_submission_email to form submission_email" do
+        form = build :form, submission_email: "curent_value@gds.gov.uk"
+        submission_email_form = build :submission_email_form, form: form
+
+        submission_email_form.assign_form_values
+        expect(submission_email_form.temporary_submission_email).to eq("curent_value@gds.gov.uk")
+      end
+    end
+
+    context "when FormSubmissionEmail exists for form" do
+      it "sets temporary_submission_email and confirmation_code from model" do
+        form = build :form, id: 1, submission_email: "curent_value@gds.gov.uk"
+        create :form_submission_email, form_id: form.id, temporary_submission_email: "test@test.gov.uk", confirmation_code: "654321"
+        submission_email_form = build :submission_email_form, form: form
+
+        submission_email_form.assign_form_values
+        expect(submission_email_form.temporary_submission_email).to eq("test@test.gov.uk")
+        expect(submission_email_form.confirmation_code).to eq("654321")
+      end
+    end
+  end
+
+  describe "#submit" do
+    it "returns false if invalid" do
+      submission_email_form = build :submission_email_form, temporary_submission_email: ""
+      expect(submission_email_form.submit).to be_falsy
+    end
+
+    context "when FormSubmissionEmail does not exist for form" do
+      it "creates a FormSubmissionEmail object with form_id" do
+        form = build :form, submission_email: "curent_value@gds.gov.uk", id: 1
+        submission_email_form = build :submission_email_form, :with_user, form: form, temporary_submission_email: "test@test.gov.uk", current_user: OpenStruct.new(name: "User", email: "user@gov.uk")
+
+        result = submission_email_form.submit
+        expect(result).to be_truthy
+        form_submission_email = FormSubmissionEmail.find_by_form_id(1)
+        expect(form_submission_email).to be_present
+        expect(form_submission_email.temporary_submission_email).to eq("test@test.gov.uk")
+        expect(form_submission_email.confirmation_code).not_to be_nil
+        expect(form_submission_email.created_by_name).to eq("User")
+        expect(form_submission_email.created_by_email).to eq("user@gov.uk")
+      end
+    end
+
+    context "when FormSubmissionEmail does exist for form" do
+      it "updates a FormSubmissionEmail object with form_id" do
+        form = build :form, submission_email: "curent_value@gds.gov.uk", id: 1
+        create :form_submission_email, form_id: form.id
+        submission_email_form = build :submission_email_form, :with_user, form: form, temporary_submission_email: "test@test.gov.uk", current_user: OpenStruct.new(name: "User", email: "user@gov.uk")
+
+        result = submission_email_form.submit
+        expect(result).to be_truthy
+        form_submission_email = FormSubmissionEmail.find_by_form_id(1)
+        expect(form_submission_email).to be_present
+        expect(form_submission_email.temporary_submission_email).to eq("test@test.gov.uk")
+        expect(form_submission_email.confirmation_code).not_to be_nil
+        expect(form_submission_email.updated_by_name).to eq("User")
+        expect(form_submission_email.updated_by_email).to eq("user@gov.uk")
+      end
+    end
+  end
+
+  describe "#confirm_confirmation_code" do
+    it "returns false if invalid" do
+      submission_email_form = build :submission_email_form, temporary_submission_email: ""
+      expect(submission_email_form.confirm_confirmation_code).to be_falsy
+    end
+
+    it "returns false and does not update form if confirmation code does not match" do
+      form = build :form, submission_email: "curent_value@gds.gov.uk", id: 1
+      allow(form).to receive(:save!).and_return(true)
+      create :form_submission_email, form_id: form.id, confirmation_code: "654321"
+      submission_email_form = build :submission_email_form, :with_user, form: form, temporary_submission_email: "test@test.gov.uk", email_code: "123456"
+      submission_email_form.assign_form_values
+      expect(submission_email_form.confirm_confirmation_code).to be_falsy
+      # Returns form's submission email is unchanged
+      expect(form.submission_email).to eq("curent_value@gds.gov.uk")
+    end
+
+    it "returns true and updates form if confirmation code does not match" do
+      form = build :form, submission_email: "curent_value@gds.gov.uk", id: 1
+      allow(form).to receive(:save!).and_return(true)
+      create :form_submission_email, form_id: form.id, confirmation_code: "123456", temporary_submission_email: "test@test.gov.uk"
+      submission_email_form = build :submission_email_form, :with_user, form: form, email_code: "123456"
+      submission_email_form.assign_form_values
+      # Returns true and updates the form's submission email
+      expect(submission_email_form.confirm_confirmation_code).to be_truthy
+      expect(form.submission_email).to eq("test@test.gov.uk")
+
+      # updates the FormSubmissionEmail to show cleared
+      expect(FormSubmissionEmail.find_by_form_id(form.id).confirmation_code).to be_nil
+      expect(FormSubmissionEmail.find_by_form_id(form.id).updated_by_name).not_to be_nil
+      expect(FormSubmissionEmail.find_by_form_id(form.id).updated_by_email).not_to be_nil
+    end
+
+    context "when FormSubmissionEmail does not exist for form" do
+      it "creates a FormSubmissionEmail object with form_id" do
+        form = build :form, submission_email: "curent_value@gds.gov.uk", id: 1
+        submission_email_form = build :submission_email_form, :with_user, form: form, temporary_submission_email: "test@test.gov.uk", current_user: OpenStruct.new(name: "User", email: "user@gov.uk")
+
+        result = submission_email_form.submit
+        expect(result).to be_truthy
+        form_submission_email = FormSubmissionEmail.find_by_form_id(1)
+        expect(form_submission_email).to be_present
+        expect(form_submission_email.temporary_submission_email).to eq("test@test.gov.uk")
+        expect(form_submission_email.confirmation_code).not_to be_nil
+        expect(form_submission_email.created_by_name).to eq("User")
+        expect(form_submission_email.created_by_email).to eq("user@gov.uk")
+      end
+    end
+
+    context "when FormSubmissionEmail does exist for form" do
+      it "updates a FormSubmissionEmail object with form_id" do
+        form = build :form, submission_email: "curent_value@gds.gov.uk", id: 1
+        create :form_submission_email, form_id: form.id
+        submission_email_form = build :submission_email_form, :with_user, form: form, temporary_submission_email: "test@test.gov.uk", current_user: OpenStruct.new(name: "User", email: "user@gov.uk")
+
+        result = submission_email_form.submit
+        expect(result).to be_truthy
+        form_submission_email = FormSubmissionEmail.find_by_form_id(1)
+        expect(form_submission_email).to be_present
+        expect(form_submission_email.temporary_submission_email).to eq("test@test.gov.uk")
+        expect(form_submission_email.confirmation_code).not_to be_nil
+        expect(form_submission_email.updated_by_name).to eq("User")
+        expect(form_submission_email.updated_by_email).to eq("user@gov.uk")
+      end
+    end
+  end
+end

--- a/spec/models/form_submission_email_spec.rb
+++ b/spec/models/form_submission_email_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe FormSubmissionEmail, type: :model do
+  subject(:form_submission_email) { described_class.new }
+
+  describe "validations" do
+    it "requires a form_id" do
+      form_submission_email.form_id = 123_456
+      expect(form_submission_email).to be_valid
+    end
+  end
+end

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -64,22 +64,10 @@ describe FormTaskListService do
 
       let(:section_rows) { section[:rows] }
 
-      it "has no hint text explaining where completed forms will be sent to" do
-        expect(section_rows.first[:hint_text]).to be_nil
-      end
-
-      context "when task list statuses are enabled", feature_task_list_statuses: true do
-        it "has the correct default status" do
-          expect(section_rows.first[:status]).to eq :incomplete
-        end
-      end
-
-      context "with email set" do
-        let(:form) { build(:form, id: 1) }
-
-        it "has link to set submission email" do
-          expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
-          expect(section_rows.first[:path]).to eq "/forms/1/change-email"
+      context "when submission_email is set" do
+        let(:section) do
+          form.submission_email = "test@example.gov.uk"
+          described_class.call(form:).all_tasks[1]
         end
 
         it "has hint text explaining where completed forms will be sent to" do
@@ -90,6 +78,35 @@ describe FormTaskListService do
           it "has the correct default status" do
             expect(section_rows.first[:status]).to eq :completed
           end
+        end
+      end
+
+      it "has no hint text explaining where completed forms will be sent to" do
+        expect(section_rows.first[:hint_text]).to be_nil
+      end
+
+      context "when submission_email_confirmation flag is true", feature_submission_email_confirmation: true do
+        it "has link to set submission email" do
+          expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
+          expect(section_rows.first[:path]).to eq "/forms/1/submission-email"
+        end
+
+        it "has link to confirm submission email" do
+          expect(section_rows[1][:task_name]).to eq "Enter the email address confirmation code"
+          expect(section_rows[1][:path]).to eq "/forms/1/confirm-submission-email"
+        end
+      end
+
+      context "when submission_email_confirmation flag is false", feature_submission_email_confirmation: false do
+        it "has link to set submission email" do
+          expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
+          expect(section_rows.first[:path]).to eq "/forms/1/change-email"
+        end
+      end
+
+      context "when task list statuses are enabled", feature_task_list_statuses: true do
+        it "has the correct default status" do
+          expect(section_rows.first[:status]).to eq :incomplete
         end
       end
     end


### PR DESCRIPTION
# Add email confirmation when setting form submission email

Trello cards: [frontend](https://trello.com/c/d4bc6tiC/344-front-end-build-the-confirmation-code-loop-for-setting-an-email-address-for-completed-forms-to-go-to-should-have) and [backend](https://trello.com/c/acUPDM7v/498-back-end-build-the-loop-for-setting-an-email-address-for-completed-forms-to-go-to-moving-to-github)

This PR adds a new method of setting the submission email for a form. It's a fairly large feature and this PR doesn't implement all functionality (no emails are sent!). It's behind a feature flag in production, which still uses the current journey.

It adds:
 - database table and model to store unconfirmed email addresses along with a six digit code and some auditing data
 - new routes to allow a user to generate a new unconfirmed email address
 - new routes to allow a user to confirm an email address by entering a code. If the code matches, we know the email is controlled by the user and so the form is updated to set the email
 
Points to note:
- This PR doesn't implement the notify integration which sends the code to users
- Only one unconfirmed email address can be created per form. If the user changes it, the old one is lost
- There is no way to resend an email, the user would have to change the email again to get the code emailed again
- Confirmed emails are not remembered - if a users wants to change the submission email to one which was previously used, they must send and enter a code again
- There are no request tests yet. These will be added in another PR to keep the size of this one controllable

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
