### PR TITLE
Add submission_email to form task list hint text

### DIFF
--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -37,7 +37,9 @@ private
   end
 
   def section_2_tasks
-    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id) }]
+    hint_text = I18n.t("forms.task_lists.section_2.hint_text", submission_email: @form.submission_email) if @form.submission_email.present?
+
+    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text: }]
   end
 
   def section_3_tasks

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,7 @@ en:
         declaration: Add a declaration for people to agree to
         title: Create your form
       section_2:
+        hint_text: Completed forms will be sent to %{submission_email}
         submission_email: Set the email address completed forms will be sent to
         title: Set email address for completed forms
       section_3:

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -59,6 +59,23 @@ describe FormTaskListService do
         expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
         expect(section_rows.first[:path]).to eq "/forms/1/change-email"
       end
+
+      it "has hint text explaining where completed forms will be sent to" do
+        expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_lists.section_2.hint_text", submission_email: form.submission_email)
+      end
+    end
+
+    describe "section 2 tasks - with no submission email" do
+      let(:section) do
+        form.submission_email = nil
+        described_class.call(form:).all_tasks[1]
+      end
+
+      let(:section_rows) { section[:rows] }
+
+      it "has no hint text explaining where completed forms will be sent to" do
+        expect(section_rows.first[:hint_text]).to be_nil
+      end
     end
 
     describe "section 3 tasks" do


### PR DESCRIPTION
#### What problem does the pull request solve?
This is to help confirm which email address completed forms will be sent it. The hint text will only display when the form has an actual submission email address.

This feature becomes more important when we have added confirmation code loop for submission where the form could potentially have a temp submission email that will eventually replace a confirmed submission email address.


Trello card: https://trello.com/c/PmOBtGP2/303-add-submission-email-address-to-task-list

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
