### PR TITLE
Add task statuses

### DIFF
--- a/app/components/task_list_component/view.html.erb
+++ b/app/components/task_list_component/view.html.erb
@@ -16,7 +16,7 @@
                 <% end %>
               </span>
 
-              <% if row.status.present? %>
+              <% if FeatureService.enabled?(:task_list_statuses) && row.status.present? %>
                 <%= render GovukComponent::TagComponent.new(
                   text: "<span class='govuk-visually-hidden'>Status </span>".html_safe + I18n.t("task_statuses.#{row.status}"),
                   classes: "app-task-list__tag",

--- a/app/components/task_list_component/view.rb
+++ b/app/components/task_list_component/view.rb
@@ -62,7 +62,7 @@ module TaskListComponent
         incomplete: "grey",
         in_progress: "blue",
         cannot_start: "grey",
-        not_started: "grey"
+        not_started: "grey",
       }[status.downcase.to_sym]
     end
 

--- a/app/components/task_list_component/view.rb
+++ b/app/components/task_list_component/view.rb
@@ -57,7 +57,13 @@ module TaskListComponent
     end
 
     def get_status_colour
-      status == :completed ? nil : "grey" # passing nil, is standard govuk dark blue
+      {
+        completed: nil,
+        incomplete: "grey",
+        in_progress: "blue",
+        cannot_start: "grey",
+        not_started: "grey"
+      }[status.downcase.to_sym]
     end
 
     def status_id

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -47,11 +47,11 @@ class Form < ActiveResource::Base
 
     if FeatureService.enabled?(:task_list_statuses)
       task_list_statuses = TaskStatusService.new(form: self)
-      @missing_sections << :missing_pages unless task_list_statuses.is_complete?(:pages_status)
-      @missing_sections << :missing_submission_email unless task_list_statuses.is_complete?(:submission_email_status)
-      @missing_sections << :missing_privacy_policy_url unless task_list_statuses.is_complete?(:privacy_policy_status)
-      @missing_sections << :missing_contact_details unless task_list_statuses.is_complete?(:support_contact_details_status)
-      @missing_sections << :missing_what_happens_next unless task_list_statuses.is_complete?(:what_happens_next_status)
+      @missing_sections << :missing_pages unless task_list_statuses.pages_status == :completed
+      @missing_sections << :missing_submission_email unless task_list_statuses.submission_email_status == :completed
+      @missing_sections << :missing_privacy_policy_url unless task_list_statuses.privacy_policy_status == :completed
+      @missing_sections << :missing_contact_details unless task_list_statuses.support_contact_details_status == :completed
+      @missing_sections << :missing_what_happens_next unless task_list_statuses.what_happens_next_status == :completed
     else
       @missing_sections << :missing_pages unless pages.any?
       @missing_sections << :missing_submission_email if submission_email.blank?

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -44,11 +44,21 @@ class Form < ActiveResource::Base
 
   def ready_for_live?
     @missing_sections = []
-    @missing_sections << :missing_pages unless pages.any?
-    @missing_sections << :missing_submission_email if submission_email.blank?
-    @missing_sections << :missing_privacy_policy_url if privacy_policy_url.blank?
-    @missing_sections << :missing_contact_details unless support_email.present? || support_phone.present? || (support_url.present? && support_url_text.present?)
-    @missing_sections << :missing_what_happens_next if what_happens_next_text.blank?
+
+    if FeatureService.enabled?(:task_list_statuses)
+      task_list_statuses = TaskStatusService.new(form: self)
+      @missing_sections << :missing_pages unless task_list_statuses.is_complete?(:pages_status)
+      @missing_sections << :missing_submission_email unless task_list_statuses.is_complete?(:submission_email_status)
+      @missing_sections << :missing_privacy_policy_url unless task_list_statuses.is_complete?(:privacy_policy_status)
+      @missing_sections << :missing_contact_details unless task_list_statuses.is_complete?(:support_contact_details_status)
+      @missing_sections << :missing_what_happens_next unless task_list_statuses.is_complete?(:what_happens_next_status)
+    else
+      @missing_sections << :missing_pages unless pages.any?
+      @missing_sections << :missing_submission_email if submission_email.blank?
+      @missing_sections << :missing_privacy_policy_url if privacy_policy_url.blank?
+      @missing_sections << :missing_contact_details unless support_email.present? || support_phone.present? || (support_url.present? && support_url_text.present?)
+      @missing_sections << :missing_what_happens_next if what_happens_next_text.blank?
+    end
 
     if @missing_sections.any?
       false

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -39,7 +39,7 @@ private
   def section_2_tasks
     hint_text = I18n.t("forms.task_lists.section_2.hint_text", submission_email: @form.submission_email) if @form.submission_email.present?
 
-    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: section_2_statuses[0]  }]
+    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: section_2_statuses[0] }]
   end
 
   def section_3_tasks

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -31,8 +31,8 @@ private
     [
       { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id), status: section_1_statuses[0] },
       { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path, status: section_1_statuses[1] },
-      { task_name: I18n.t("forms.task_lists.section_1.declaration"), path: declaration_path(@form.id) },
-      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id), status: section_1_statuses[2]  },
+      { task_name: I18n.t("forms.task_lists.section_1.declaration"), path: declaration_path(@form.id), status: section_1_statuses[2] },
+      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id), status: section_1_statuses[3]  },
     ]
   end
 
@@ -57,11 +57,17 @@ private
   end
 
   def section_1_statuses
-    pages_statues = if @form.pages.empty?
-                      :incomplete
-                    else
+    pages_statues = if @form.question_section_completed
                       :completed
+                    else
+                      :incomplete
                     end
+
+    declaration_statues = if @form.declaration_section_completed
+                            :completed
+                          else
+                            :incomplete
+                          end
 
     what_happens_next_status = if @form.what_happens_next_text.present?
                                  :completed
@@ -71,6 +77,7 @@ private
     results = []
     results << :completed
     results << pages_statues
+    results << declaration_statues
     results << what_happens_next_status
 
     results

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -9,6 +9,7 @@ class FormTaskListService
 
   def initialize(form:)
     @form = form
+    @task_list_statuses = TaskStatusService.new(form: @form).statuses
   end
 
   def all_tasks
@@ -29,23 +30,23 @@ private
                       new_page_path(@form.id)
                     end
     [
-      { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id), status: section_1_statuses[0] },
-      { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path, status: section_1_statuses[1] },
-      { task_name: I18n.t("forms.task_lists.section_1.declaration"), path: declaration_path(@form.id), status: section_1_statuses[2] },
-      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id), status: section_1_statuses[3] },
+      { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id), status: @task_list_statuses[:name_status] },
+      { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path, status: @task_list_statuses[:pages_status] },
+      { task_name: I18n.t("forms.task_lists.section_1.declaration"), path: declaration_path(@form.id), status: @task_list_statuses[:declaration_status] },
+      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id), status: @task_list_statuses[:what_happens_next_status] },
     ]
   end
 
   def section_2_tasks
     hint_text = I18n.t("forms.task_lists.section_2.hint_text", submission_email: @form.submission_email) if @form.submission_email.present?
 
-    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: section_2_statuses[0] }]
+    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: @task_list_statuses[:submission_email_status] }]
   end
 
   def section_3_tasks
     [
-      { task_name: I18n.t("forms.task_lists.section_3.privacy_policy"), path: privacy_policy_path(@form.id), status: section_3_statuses[0] },
-      { task_name: I18n.t("forms.task_lists.section_3.contact_details"), path: contact_details_path(@form.id), status: section_3_statuses[1] },
+      { task_name: I18n.t("forms.task_lists.section_3.privacy_policy"), path: privacy_policy_path(@form.id), status: @task_list_statuses[:privacy_policy_status] },
+      { task_name: I18n.t("forms.task_lists.section_3.contact_details"), path: contact_details_path(@form.id), status: @task_list_statuses[:support_contact_details_status] },
     ]
   end
 
@@ -54,65 +55,5 @@ private
     return [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: make_live_path(@form.id), status: :not_started }] if @form.ready_for_live?
 
     [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: "", active: false, status: :cannot_start }]
-  end
-
-  def section_1_statuses
-    pages_status = if @form.question_section_completed
-                     :completed
-                   elsif @form.pages.any?
-                     :in_progress
-                   else
-                     :incomplete
-                   end
-
-    declaration_status = if @form.declaration_section_completed
-                           :completed
-                         else
-                           :incomplete
-                         end
-
-    what_happens_next_status = if @form.what_happens_next_text.present?
-                                 :completed
-                               else
-                                 :incomplete
-                               end
-    results = []
-    results << :completed
-    results << pages_status
-    results << declaration_status
-    results << what_happens_next_status
-
-    results
-  end
-
-  def section_2_statuses
-    submission_status = if @form.submission_email.present?
-                          :completed
-                        else
-                          :incomplete
-                        end
-
-    results = []
-    results << submission_status
-    results
-  end
-
-  def section_3_statuses
-    privacy_policy_status = if @form.privacy_policy_url.present?
-                              :completed
-                            else
-                              :incomplete
-                            end
-
-    support_contact_details = if @form.support_email.present? || @form.support_phone.present? || (@form.support_url_text.present? && @form.support_url)
-                                :completed
-                              else
-                                :incomplete
-                              end
-
-    results = []
-    results << privacy_policy_status
-    results << support_contact_details
-    results
   end
 end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -29,23 +29,23 @@ private
                       new_page_path(@form.id)
                     end
     [
-      { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id) },
-      { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path },
+      { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id), status: section_1_statuses[0] },
+      { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path, status: section_1_statuses[1] },
       { task_name: I18n.t("forms.task_lists.section_1.declaration"), path: declaration_path(@form.id) },
-      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id) },
+      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id), status: section_1_statuses[2]  },
     ]
   end
 
   def section_2_tasks
     hint_text = I18n.t("forms.task_lists.section_2.hint_text", submission_email: @form.submission_email) if @form.submission_email.present?
 
-    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text: }]
+    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: section_2_statuses[0]  }]
   end
 
   def section_3_tasks
     [
-      { task_name: I18n.t("forms.task_lists.section_3.privacy_policy"), path: privacy_policy_path(@form.id) },
-      { task_name: I18n.t("forms.task_lists.section_3.contact_details"), path: contact_details_path(@form.id) },
+      { task_name: I18n.t("forms.task_lists.section_3.privacy_policy"), path: privacy_policy_path(@form.id), status: section_3_statuses[0] },
+      { task_name: I18n.t("forms.task_lists.section_3.contact_details"), path: contact_details_path(@form.id), status: section_3_statuses[1] },
     ]
   end
 
@@ -55,4 +55,55 @@ private
 
     [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: "", active: false }]
   end
+
+  def section_1_statuses
+    pages_statues = if @form.pages.empty?
+                      :incomplete
+                    else
+                      :completed
+                    end
+
+    what_happens_next_status = if @form.what_happens_next_text.present?
+                                 :completed
+                               else
+                                 :incomplete
+                               end
+    results = []
+    results << :completed
+    results << pages_statues
+    results << what_happens_next_status
+
+    results
+  end
+  def section_2_statuses
+    submission_status = if @form.submission_email.present?
+                          :completed
+                        else
+                          :incomplete
+                        end
+
+    results = []
+    results << submission_status
+    results
+  end
+
+  def section_3_statuses
+    privacy_policy_status = if @form.privacy_policy_url.present?
+                              :completed
+                            else
+                              :incomplete
+                            end
+
+    support_contact_details = if @form.support_email.present? || @form.support_phone.present? || (@form.support_url_text.present? && @form.support_url)
+                                :completed
+                              else
+                                :incomplete
+                              end
+
+    results = []
+    results << privacy_policy_status
+    results << support_contact_details
+    results
+  end
+
 end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -32,7 +32,7 @@ private
       { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id), status: section_1_statuses[0] },
       { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path, status: section_1_statuses[1] },
       { task_name: I18n.t("forms.task_lists.section_1.declaration"), path: declaration_path(@form.id), status: section_1_statuses[2] },
-      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id), status: section_1_statuses[3]  },
+      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id), status: section_1_statuses[3] },
     ]
   end
 
@@ -51,23 +51,25 @@ private
 
   def section_4_tasks
     return [] if @form.live?
-    return [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: make_live_path(@form.id) }] if @form.ready_for_live?
+    return [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: make_live_path(@form.id), status: :not_started }] if @form.ready_for_live?
 
-    [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: "", active: false }]
+    [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: "", active: false, status: :cannot_start }]
   end
 
   def section_1_statuses
-    pages_statues = if @form.question_section_completed
-                      :completed
-                    else
-                      :incomplete
-                    end
+    pages_status = if @form.question_section_completed
+                     :completed
+                   elsif @form.pages.any?
+                     :in_progress
+                   else
+                     :incomplete
+                   end
 
-    declaration_statues = if @form.declaration_section_completed
-                            :completed
-                          else
-                            :incomplete
-                          end
+    declaration_status = if @form.declaration_section_completed
+                           :completed
+                         else
+                           :incomplete
+                         end
 
     what_happens_next_status = if @form.what_happens_next_text.present?
                                  :completed
@@ -76,12 +78,13 @@ private
                                end
     results = []
     results << :completed
-    results << pages_statues
-    results << declaration_statues
+    results << pages_status
+    results << declaration_status
     results << what_happens_next_status
 
     results
   end
+
   def section_2_statuses
     submission_status = if @form.submission_email.present?
                           :completed
@@ -112,5 +115,4 @@ private
     results << support_contact_details
     results
   end
-
 end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -9,7 +9,7 @@ class FormTaskListService
 
   def initialize(form:)
     @form = form
-    @task_list_statuses = TaskStatusService.new(form: @form).statuses
+    @task_list_statuses = TaskStatusService.new(form: @form)
   end
 
   def all_tasks
@@ -30,23 +30,23 @@ private
                       new_page_path(@form.id)
                     end
     [
-      { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id), status: @task_list_statuses[:name_status] },
-      { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path, status: @task_list_statuses[:pages_status] },
-      { task_name: I18n.t("forms.task_lists.section_1.declaration"), path: declaration_path(@form.id), status: @task_list_statuses[:declaration_status] },
-      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id), status: @task_list_statuses[:what_happens_next_status] },
+      { task_name: I18n.t("forms.task_lists.section_1.change_name"), path: change_form_name_path(@form.id), status: @task_list_statuses.name_status },
+      { task_name: I18n.t("forms.task_lists.section_1.add_or_edit_questions"), path: question_path, status: @task_list_statuses.pages_status },
+      { task_name: I18n.t("forms.task_lists.section_1.declaration"), path: declaration_path(@form.id), status: @task_list_statuses.declaration_status },
+      { task_name: I18n.t("forms.task_lists.section_1.add_what_happens_next"), path: what_happens_next_path(@form.id), status: @task_list_statuses.what_happens_next_status },
     ]
   end
 
   def section_2_tasks
     hint_text = I18n.t("forms.task_lists.section_2.hint_text", submission_email: @form.submission_email) if @form.submission_email.present?
 
-    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: @task_list_statuses[:submission_email_status] }]
+    [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: @task_list_statuses.submission_email_status }]
   end
 
   def section_3_tasks
     [
-      { task_name: I18n.t("forms.task_lists.section_3.privacy_policy"), path: privacy_policy_path(@form.id), status: @task_list_statuses[:privacy_policy_status] },
-      { task_name: I18n.t("forms.task_lists.section_3.contact_details"), path: contact_details_path(@form.id), status: @task_list_statuses[:support_contact_details_status] },
+      { task_name: I18n.t("forms.task_lists.section_3.privacy_policy"), path: privacy_policy_path(@form.id), status: @task_list_statuses.privacy_policy_status },
+      { task_name: I18n.t("forms.task_lists.section_3.contact_details"), path: contact_details_path(@form.id), status: @task_list_statuses.support_contact_details_status },
     ]
   end
 
@@ -56,8 +56,8 @@ private
     [{
       task_name: I18n.t("forms.task_lists.section_4.make_live"),
       path: @form.ready_for_live? ? make_live_path(@form.id) : "",
-      status: @task_list_statuses[:make_live_status],
-      active: @form.ready_for_live?,
+      status: @task_list_statuses.make_live_status,
+      active: @task_list_statuses.mandatory_tasks_completed?,
     }]
   end
 end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -52,8 +52,12 @@ private
 
   def section_4_tasks
     return [] if @form.live?
-    return [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: make_live_path(@form.id), status: :not_started }] if @form.ready_for_live?
 
-    [{ task_name: I18n.t("forms.task_lists.section_4.make_live"), path: "", active: false, status: :cannot_start }]
+    [{
+      task_name: I18n.t("forms.task_lists.section_4.make_live"),
+      path: @form.ready_for_live? ? make_live_path(@form.id) : "",
+      status: @task_list_statuses[:make_live_status],
+      active: @form.ready_for_live?,
+    }]
   end
 end

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -3,61 +3,73 @@ class TaskStatusService
     @form = form
   end
 
-  def statuses
-    name_status = :completed
-
-    pages_status = if @form.question_section_completed && @form.pages.any?
-                     :completed
-                   elsif @form.pages.any?
-                     :in_progress
-                   else
-                     :incomplete
-                   end
-
-    declaration_status = if @form.declaration_section_completed
-                           :completed
-                         else
-                           :incomplete
-                         end
-
-    what_happens_next_status = if @form.what_happens_next_text.present?
-                                 :completed
-                               else
-                                 :incomplete
-                               end
-
-    submission_email_status = if @form.submission_email.present?
-                                :completed
-                              else
-                                :incomplete
-                              end
-
-    privacy_policy_status = if @form.privacy_policy_url.present?
-                              :completed
-                            else
-                              :incomplete
-                            end
-
-    support_contact_details_status = if @form.support_email.present? || @form.support_phone.present? || (@form.support_url_text.present? && @form.support_url)
-                                       :completed
-                                     else
-                                       :incomplete
-                                     end
-
-    make_live_status = if [pages_status,
-                           what_happens_next_status,
-                           submission_email_status,
-                           privacy_policy_status,
-                           support_contact_details_status].all? { |task| task == :completed }
-                         :not_started
-                       else
-                         :cannot_start
-                       end
-
-    { name_status:, pages_status:, declaration_status:, what_happens_next_status:, submission_email_status:, privacy_policy_status:, support_contact_details_status:, make_live_status: }
+  def name_status
+    :completed
   end
 
-  def is_complete?(task)
-    statuses[task] == :completed
+  def pages_status
+    if @form.question_section_completed && @form.pages.any?
+      :completed
+    elsif @form.pages.any?
+      :in_progress
+    else
+      :incomplete
+    end
+  end
+
+  def declaration_status
+    if @form.declaration_section_completed
+      :completed
+    else
+      :incomplete
+    end
+  end
+
+  def what_happens_next_status
+    if @form.what_happens_next_text.present?
+      :completed
+    else
+      :incomplete
+    end
+  end
+
+  def submission_email_status
+    if @form.submission_email.present?
+      :completed
+    else
+      :incomplete
+    end
+  end
+
+  def privacy_policy_status
+    if @form.privacy_policy_url.present?
+      :completed
+    else
+      :incomplete
+    end
+  end
+
+  def support_contact_details_status
+    if @form.support_email.present? || @form.support_phone.present? || (@form.support_url_text.present? && @form.support_url)
+      :completed
+    else
+      :incomplete
+    end
+  end
+
+  def make_live_status
+    if mandatory_tasks_completed?
+      :not_started
+    else
+      :cannot_start
+    end
+  end
+
+  def mandatory_tasks_completed?
+    [pages_status,
+     what_happens_next_status,
+     submission_email_status,
+     privacy_policy_status,
+     support_contact_details_status].all? { |task| task == :completed }
   end
 end

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -1,0 +1,52 @@
+class TaskStatusService
+  def initialize(form:)
+    @form = form
+  end
+
+  def statuses
+    name_status = :completed
+
+    pages_status = if @form.question_section_completed && @form.pages.any?
+                     :completed
+                   elsif @form.pages.any?
+                     :in_progress
+                   else
+                     :incomplete
+                   end
+
+    declaration_status = if @form.declaration_section_completed
+                           :completed
+                         else
+                           :incomplete
+                         end
+
+    what_happens_next_status = if @form.what_happens_next_text.present?
+                                 :completed
+                               else
+                                 :incomplete
+                               end
+
+    submission_email_status = if @form.submission_email.present?
+                                :completed
+                              else
+                                :incomplete
+                              end
+
+    privacy_policy_status = if @form.privacy_policy_url.present?
+                              :completed
+                            else
+                              :incomplete
+                            end
+
+    support_contact_details_status = if @form.support_email.present? || @form.support_phone.present? || (@form.support_url_text.present? && @form.support_url)
+                                       :completed
+                                     else
+                                       :incomplete
+                                     end
+    { name_status:, pages_status:, declaration_status:, what_happens_next_status:, submission_email_status:, privacy_policy_status:, support_contact_details_status: }
+  end
+
+  def is_complete?(task)
+    statuses[task] == :completed
+  end
+end

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -43,7 +43,18 @@ class TaskStatusService
                                      else
                                        :incomplete
                                      end
-    { name_status:, pages_status:, declaration_status:, what_happens_next_status:, submission_email_status:, privacy_policy_status:, support_contact_details_status: }
+
+    make_live_status = if [pages_status,
+                           what_happens_next_status,
+                           submission_email_status,
+                           privacy_policy_status,
+                           support_contact_details_status].all? { |task| task == :completed }
+                         :not_started
+                       else
+                         :cannot_start
+                       end
+
+    { name_status:, pages_status:, declaration_status:, what_happens_next_status:, submission_email_status:, privacy_policy_status:, support_contact_details_status:, make_live_status: }
   end
 
   def is_complete?(task)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,5 +256,6 @@ en:
   task_statuses:
     cannot_start: cannot start yet
     completed: completed
+    in_progress: in progress
     incomplete: incomplete
-    not_started: not started yet
+    not_started: not started

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,4 +256,5 @@ en:
   task_statuses:
     cannot_start: cannot start yet
     completed: completed
+    incomplete: incomplete
     not_started: not started yet

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
   make_question_optional: true
-  task_list_statuses: false
+  task_list_statuses: true

--- a/spec/factories/forms/make_live_forms.rb
+++ b/spec/factories/forms/make_live_forms.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :make_live_form, class: "Forms::MakeLiveForm" do
     confirm_make_live { %w[made_live not_made_live].sample }
 
-    form { build :form, :with_pages }
+    form { build :form, :with_pages, :ready_for_live }
   end
 end

--- a/spec/factories/forms/make_live_forms.rb
+++ b/spec/factories/forms/make_live_forms.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :make_live_form, class: "Forms::MakeLiveForm" do
     confirm_make_live { %w[made_live not_made_live].sample }
 
-    form { build :form, :with_pages, :ready_for_live }
+    form { build :form, :ready_for_live }
   end
 end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -24,12 +24,16 @@ FactoryBot.define do
     trait :ready_for_live do
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
       what_happens_next_text { "We usually respond to applications within 10 working days." }
+      question_section_completed { true }
+      declaration_section_completed { true }
     end
 
     trait :live do
       live_at { Time.zone.now }
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
       what_happens_next_text { "We usually respond to applications within 10 working days." }
+      question_section_completed { true }
+      declaration_section_completed { true }
     end
 
     trait :with_pages do
@@ -40,6 +44,8 @@ FactoryBot.define do
       pages do
         Array.new(pages_count) { association(:page) }
       end
+
+      question_section_completed { true }
     end
 
     trait :with_support do

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     end
 
     trait :ready_for_live do
+      with_pages
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
       what_happens_next_text { "We usually respond to applications within 10 working days." }
       question_section_completed { true }

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -12,8 +12,8 @@ FactoryBot.define do
     support_url { nil }
     support_url_text { nil }
     what_happens_next_text { nil }
-    question_section_completed { "false" }
-    declaration_section_completed { "false" }
+    question_section_completed { false }
+    declaration_section_completed { false }
 
     trait :new_form do
       submission_email { "" }

--- a/spec/forms/declaration_form_spec.rb
+++ b/spec/forms/declaration_form_spec.rb
@@ -3,39 +3,68 @@ require "rails_helper"
 RSpec.describe Forms::DeclarationForm, type: :model do
   describe "validations" do
     describe "Character length" do
-      it "is valid if less than 2000 characters" do
-        declaration_form = described_class.new(declaration_text: "a")
+      context "when the task status feature is not enabled", feature_task_list_statuses: false do
+        it "is valid if less than 2000 characters" do
+          declaration_form = described_class.new(declaration_text: "a")
 
-        expect(declaration_form).to be_valid
+          expect(declaration_form).to be_valid
+        end
+
+        it "is valid if 2000 characters" do
+          declaration_form = described_class.new(declaration_text: "a" * 2000)
+
+          expect(declaration_form).to be_valid
+        end
+
+        it "is invalid if more than 2000 characters" do
+          declaration_form = described_class.new(declaration_text: "a" * 2001)
+          error_message = I18n.t("activemodel.errors.models.forms/declaration_form.attributes.declaration_text.too_long")
+
+          expect(declaration_form).not_to be_valid
+
+          declaration_form.validate(:declaration_text)
+
+          expect(declaration_form.errors.full_messages_for(:declaration_text)).to include(
+            "Declaration text #{error_message}",
+          )
+        end
       end
 
-      it "is valid if 2000 characters" do
-        declaration_form = described_class.new(declaration_text: "a" * 2000)
+      context "when the task status feature is enabled", feature_task_list_statuses: true do
+        it "is valid if less than 2000 characters" do
+          declaration_form = described_class.new(declaration_text: "a", mark_complete: true)
 
-        expect(declaration_form).to be_valid
+          expect(declaration_form).to be_valid
+        end
+
+        it "is valid if 2000 characters" do
+          declaration_form = described_class.new(declaration_text: "a" * 2000, mark_complete: true)
+
+          expect(declaration_form).to be_valid
+        end
+
+        it "is invalid if more than 2000 characters" do
+          declaration_form = described_class.new(declaration_text: "a" * 2001, mark_complete: true)
+          error_message = I18n.t("activemodel.errors.models.forms/declaration_form.attributes.declaration_text.too_long")
+
+          expect(declaration_form).not_to be_valid
+
+          declaration_form.validate(:declaration_text)
+
+          expect(declaration_form.errors.full_messages_for(:declaration_text)).to include(
+            "Declaration text #{error_message}",
+          )
+        end
       end
-
-      it "is invalid if more than 2000 characters" do
-        declaration_form = described_class.new(declaration_text: "a" * 2001)
-        error_message = I18n.t("activemodel.errors.models.forms/declaration_form.attributes.declaration_text.too_long")
-
-        expect(declaration_form).not_to be_valid
-
-        declaration_form.validate(:declaration_text)
-
-        expect(declaration_form.errors.full_messages_for(:declaration_text)).to include(
-          "Declaration text #{error_message}",
-        )
-      end
-    end
-
-    it "is valid if declaration text is blank" do
-      declaration_form = described_class.new(declaration_text: "")
-
-      expect(declaration_form).to be_valid
     end
 
     context "when the task status feature is not enabled", feature_task_list_statuses: false do
+      it "is valid if declaration text is blank" do
+        declaration_form = described_class.new(declaration_text: "")
+
+        expect(declaration_form).to be_valid
+      end
+
       it "is valid if mark complete is blank" do
         declaration_form = described_class.new(mark_complete: "")
 
@@ -45,6 +74,12 @@ RSpec.describe Forms::DeclarationForm, type: :model do
     end
 
     context "when the task status feature is enabled", feature_task_list_statuses: true do
+      it "is valid if declaration text is blank" do
+        declaration_form = described_class.new(declaration_text: "", mark_complete: true)
+
+        expect(declaration_form).to be_valid
+      end
+
       it "is not valid if mark complete is blank" do
         declaration_form = described_class.new(mark_complete: nil)
 

--- a/spec/requests/make_form_live_spec.rb
+++ b/spec/requests/make_form_live_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "MakeLive controller", type: :request do
   let(:form) do
     build(:form,
-          :with_pages,
           :ready_for_live,
           id: 2)
   end

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe FormTaskListService do
   describe "#all_tasks" do
-    let(:form) { build(:form, id: 1) }
+    let(:form) { build(:form, :new_form, id: 1) }
 
     it "returns array of tasks objects for a given form" do
       expect(described_class.call(form:).all_tasks).to be_an_instance_of(Array)
@@ -46,6 +46,15 @@ describe FormTaskListService do
         expect(section_rows[3][:task_name]).to eq "Add information about what happens next"
         expect(section_rows[3][:path]).to eq "/forms/1/what-happens-next"
       end
+
+      context "when task list statuses are enabled", feature_task_list_statuses: true do
+        it "has the correct default statuses" do
+          expect(section_rows.first[:status]).to eq :completed
+          expect(section_rows[1][:status]).to eq :incomplete
+          expect(section_rows[2][:status]).to eq :incomplete
+          expect(section_rows[3][:status]).to eq :incomplete
+        end
+      end
     end
 
     describe "section 2 tasks" do
@@ -55,26 +64,33 @@ describe FormTaskListService do
 
       let(:section_rows) { section[:rows] }
 
-      it "has link to set submission email" do
-        expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
-        expect(section_rows.first[:path]).to eq "/forms/1/change-email"
-      end
-
-      it "has hint text explaining where completed forms will be sent to" do
-        expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_lists.section_2.hint_text", submission_email: form.submission_email)
-      end
-    end
-
-    describe "section 2 tasks - with no submission email" do
-      let(:section) do
-        form.submission_email = nil
-        described_class.call(form:).all_tasks[1]
-      end
-
-      let(:section_rows) { section[:rows] }
-
       it "has no hint text explaining where completed forms will be sent to" do
         expect(section_rows.first[:hint_text]).to be_nil
+      end
+
+      context "when task list statuses are enabled", feature_task_list_statuses: true do
+        it "has the correct default status" do
+          expect(section_rows.first[:status]).to eq :incomplete
+        end
+      end
+
+      context "with email set" do
+        let(:form) { build(:form, id: 1) }
+
+        it "has link to set submission email" do
+          expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
+          expect(section_rows.first[:path]).to eq "/forms/1/change-email"
+        end
+
+        it "has hint text explaining where completed forms will be sent to" do
+          expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_lists.section_2.hint_text", submission_email: form.submission_email)
+        end
+
+        context "when task list statuses are enabled", feature_task_list_statuses: true do
+          it "has the correct default status" do
+            expect(section_rows.first[:status]).to eq :completed
+          end
+        end
       end
     end
 
@@ -94,6 +110,13 @@ describe FormTaskListService do
         expect(section_rows[1][:task_name]).to eq "Provide contact details for support"
         expect(section_rows[1][:path]).to eq "/forms/1/contact-details"
       end
+
+      context "when task list statuses are enabled", feature_task_list_statuses: true do
+        it "has the correct default statuses" do
+          expect(section_rows.first[:status]).to eq :incomplete
+          expect(section_rows[1][:status]).to eq :incomplete
+        end
+      end
     end
 
     describe "section 4 tasks" do
@@ -108,7 +131,13 @@ describe FormTaskListService do
         expect(section_rows.first[:path]).to be_empty
       end
 
-      describe "when form is ready to make live" do
+      context "when task list statuses are enabled", feature_task_list_statuses: true do
+        it "has the correct default status" do
+          expect(section_rows.first[:status]).to eq :cannot_start
+        end
+      end
+
+      context "when form is ready to make live" do
         let(:section) do
           allow(form).to receive(:ready_for_live?).and_return(true)
           described_class.call(form:).all_tasks[3]
@@ -120,9 +149,15 @@ describe FormTaskListService do
           expect(section_rows.first[:task_name]).to eq "Make your form live"
           expect(section_rows.first[:path]).to eq "/forms/1/make-live"
         end
+
+        context "when task list statuses are enabled", feature_task_list_statuses: true do
+          it "has the correct default status" do
+            expect(section_rows.first[:status]).to eq :not_started
+          end
+        end
       end
 
-      describe "when form is live" do
+      context "when form is live" do
         let(:section) do
           allow(form).to receive(:live?).and_return(true)
           described_class.call(form:).all_tasks[3]

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -138,8 +138,8 @@ describe FormTaskListService do
       end
 
       context "when form is ready to make live" do
+        let(:form) { build(:form, :ready_for_live, id: 1) }
         let(:section) do
-          allow(form).to receive(:ready_for_live?).and_return(true)
           described_class.call(form:).all_tasks[3]
         end
 

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+describe TaskStatusService do
+  let(:task_status_service) do
+    described_class.new(form:)
+  end
+
+  describe "statuses" do
+    let(:statuses) do
+      task_status_service.statuses
+    end
+
+    describe "name status" do
+      let(:form) { build(:form, :new_form, id: 1) }
+
+      it "returns the correct default value" do
+        expect(statuses[:name_status]).to eq :completed
+      end
+    end
+
+    describe "pages status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, id: 1) }
+
+        it "returns the correct default value" do
+          expect(statuses[:pages_status]).to eq :incomplete
+        end
+      end
+
+      context "with a form which has pages" do
+        let(:form) { build(:form, :new_form, :with_pages, id: 1, question_section_completed: false) }
+
+        it "returns the in progress status" do
+          expect(statuses[:pages_status]).to eq :in_progress
+        end
+
+        context "and questions marked completed" do
+          let(:form) { build(:form, :new_form, :with_pages, id: 1, question_section_completed: true) }
+
+          it "returns the completed status" do
+            expect(statuses[:pages_status]).to eq :completed
+          end
+        end
+      end
+    end
+
+    describe "declaration status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, id: 1) }
+
+        it "returns the correct default value" do
+          expect(statuses[:declaration_status]).to eq :incomplete
+        end
+      end
+
+      context "with a form which has a declaration marked incomplete" do
+        let(:form) { build(:form, id: 1, declaration_section_completed: false) }
+
+        it "returns the incomplete status" do
+          expect(statuses[:declaration_status]).to eq :incomplete
+        end
+      end
+
+      context "with a form which has a declaration marked complete" do
+        let(:form) { build(:form, id: 1, declaration_section_completed: true) }
+
+        it "returns the completed status" do
+          expect(statuses[:declaration_status]).to eq :completed
+        end
+      end
+    end
+
+    describe "what happens next status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, id: 1) }
+
+        it "returns the correct default value" do
+          expect(statuses[:what_happens_next_status]).to eq :incomplete
+        end
+      end
+
+      context "with a form which has a what happens next section" do
+        let(:form) { build(:form, :new_form, id: 1, what_happens_next_text: "We usually respond to applications within 10 working days.") }
+
+        it "returns the in progress status" do
+          expect(statuses[:what_happens_next_status]).to eq :completed
+        end
+      end
+    end
+
+    describe "submission email status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, id: 1) }
+
+        it "returns the correct default value" do
+          expect(statuses[:submission_email_status]).to eq :incomplete
+        end
+      end
+
+      context "with a form which has an email set" do
+        let(:form) { build(:form, :new_form, id: 1, submission_email: Faker::Internet.email(domain: "example.gov.uk")) }
+
+        it "returns the in progress status" do
+          expect(statuses[:submission_email_status]).to eq :completed
+        end
+      end
+    end
+
+    describe "privacy policy status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, id: 1) }
+
+        it "returns the correct default value" do
+          expect(statuses[:privacy_policy_status]).to eq :incomplete
+        end
+      end
+
+      context "with a form which has a privacy policy section" do
+        let(:form) { build(:form, :new_form, id: 1, privacy_policy_url: Faker::Internet.url(host: "gov.uk")) }
+
+        it "returns the in progress status" do
+          expect(statuses[:privacy_policy_status]).to eq :completed
+        end
+      end
+    end
+
+    describe "support contact details status status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, id: 1) }
+
+        it "returns the correct default value" do
+          expect(statuses[:support_contact_details_status]).to eq :incomplete
+        end
+      end
+
+      context "with a form which has contact details set" do
+        let(:form) { build(:form, :new_form, :with_support, id: 1) }
+
+        it "returns the in progress status" do
+          expect(statuses[:support_contact_details_status]).to eq :completed
+        end
+      end
+    end
+
+    describe "make live status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, id: 1) }
+
+        it "returns the correct default value" do
+          expect(statuses[:make_live_status]).to eq :cannot_start
+        end
+      end
+
+      context "with a form which is ready to go live" do
+        let(:form) { build(:form, :ready_for_live, id: 1) }
+
+        it "returns the not started status" do
+          expect(statuses[:make_live_status]).to eq :not_started
+        end
+      end
+    end
+  end
+
+  describe "#is_complete?" do
+    let(:form) { build(:form, :new_form, :with_pages, question_section_completed: false) }
+
+    it "returns true for a complete task" do
+      expect(task_status_service.is_complete?(:name_status)).to eq true
+    end
+
+    it "returns false for an in progress task" do
+      expect(task_status_service.is_complete?(:pages_status)).to eq false
+    end
+
+    it "returns false for an incomplete task" do
+      expect(task_status_service.is_complete?(:support_contact_details_status)).to eq false
+    end
+  end
+end

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -6,15 +6,11 @@ describe TaskStatusService do
   end
 
   describe "statuses" do
-    let(:statuses) do
-      task_status_service.statuses
-    end
-
     describe "name status" do
       let(:form) { build(:form, :new_form, id: 1) }
 
       it "returns the correct default value" do
-        expect(statuses[:name_status]).to eq :completed
+        expect(task_status_service.name_status).to eq :completed
       end
     end
 
@@ -23,7 +19,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1) }
 
         it "returns the correct default value" do
-          expect(statuses[:pages_status]).to eq :incomplete
+          expect(task_status_service.pages_status).to eq :incomplete
         end
       end
 
@@ -31,14 +27,14 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, :with_pages, id: 1, question_section_completed: false) }
 
         it "returns the in progress status" do
-          expect(statuses[:pages_status]).to eq :in_progress
+          expect(task_status_service.pages_status).to eq :in_progress
         end
 
         context "and questions marked completed" do
           let(:form) { build(:form, :new_form, :with_pages, id: 1, question_section_completed: true) }
 
           it "returns the completed status" do
-            expect(statuses[:pages_status]).to eq :completed
+            expect(task_status_service.pages_status).to eq :completed
           end
         end
       end
@@ -49,7 +45,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1) }
 
         it "returns the correct default value" do
-          expect(statuses[:declaration_status]).to eq :incomplete
+          expect(task_status_service.declaration_status).to eq :incomplete
         end
       end
 
@@ -57,7 +53,7 @@ describe TaskStatusService do
         let(:form) { build(:form, id: 1, declaration_section_completed: false) }
 
         it "returns the incomplete status" do
-          expect(statuses[:declaration_status]).to eq :incomplete
+          expect(task_status_service.declaration_status).to eq :incomplete
         end
       end
 
@@ -65,7 +61,7 @@ describe TaskStatusService do
         let(:form) { build(:form, id: 1, declaration_section_completed: true) }
 
         it "returns the completed status" do
-          expect(statuses[:declaration_status]).to eq :completed
+          expect(task_status_service.declaration_status).to eq :completed
         end
       end
     end
@@ -75,7 +71,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1) }
 
         it "returns the correct default value" do
-          expect(statuses[:what_happens_next_status]).to eq :incomplete
+          expect(task_status_service.what_happens_next_status).to eq :incomplete
         end
       end
 
@@ -83,7 +79,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1, what_happens_next_text: "We usually respond to applications within 10 working days.") }
 
         it "returns the in progress status" do
-          expect(statuses[:what_happens_next_status]).to eq :completed
+          expect(task_status_service.what_happens_next_status).to eq :completed
         end
       end
     end
@@ -93,7 +89,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1) }
 
         it "returns the correct default value" do
-          expect(statuses[:submission_email_status]).to eq :incomplete
+          expect(task_status_service.submission_email_status).to eq :incomplete
         end
       end
 
@@ -101,7 +97,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1, submission_email: Faker::Internet.email(domain: "example.gov.uk")) }
 
         it "returns the in progress status" do
-          expect(statuses[:submission_email_status]).to eq :completed
+          expect(task_status_service.submission_email_status).to eq :completed
         end
       end
     end
@@ -111,7 +107,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1) }
 
         it "returns the correct default value" do
-          expect(statuses[:privacy_policy_status]).to eq :incomplete
+          expect(task_status_service.privacy_policy_status).to eq :incomplete
         end
       end
 
@@ -119,7 +115,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1, privacy_policy_url: Faker::Internet.url(host: "gov.uk")) }
 
         it "returns the in progress status" do
-          expect(statuses[:privacy_policy_status]).to eq :completed
+          expect(task_status_service.privacy_policy_status).to eq :completed
         end
       end
     end
@@ -129,7 +125,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1) }
 
         it "returns the correct default value" do
-          expect(statuses[:support_contact_details_status]).to eq :incomplete
+          expect(task_status_service.support_contact_details_status).to eq :incomplete
         end
       end
 
@@ -137,7 +133,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, :with_support, id: 1) }
 
         it "returns the in progress status" do
-          expect(statuses[:support_contact_details_status]).to eq :completed
+          expect(task_status_service.support_contact_details_status).to eq :completed
         end
       end
     end
@@ -147,7 +143,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, id: 1) }
 
         it "returns the correct default value" do
-          expect(statuses[:make_live_status]).to eq :cannot_start
+          expect(task_status_service.make_live_status).to eq :cannot_start
         end
       end
 
@@ -155,25 +151,27 @@ describe TaskStatusService do
         let(:form) { build(:form, :ready_for_live, id: 1) }
 
         it "returns the not started status" do
-          expect(statuses[:make_live_status]).to eq :not_started
+          expect(task_status_service.make_live_status).to eq :not_started
         end
       end
     end
   end
 
-  describe "#is_complete?" do
-    let(:form) { build(:form, :new_form, :with_pages, question_section_completed: false) }
+  describe "#mandatory_tasks_completed" do
+    context "when mandatory tasks have not been completed" do
+      let(:form) { build(:form, :new_form) }
 
-    it "returns true for a complete task" do
-      expect(task_status_service.is_complete?(:name_status)).to eq true
+      it "returns false" do
+        expect(task_status_service.mandatory_tasks_completed?).to eq false
+      end
     end
 
-    it "returns false for an in progress task" do
-      expect(task_status_service.is_complete?(:pages_status)).to eq false
-    end
+    context "when mandatory tasks have been completed" do
+      let(:form) { build(:form, :ready_for_live) }
 
-    it "returns false for an incomplete task" do
-      expect(task_status_service.is_complete?(:support_contact_details_status)).to eq false
+      it "returns true" do
+        expect(task_status_service.mandatory_tasks_completed?).to eq true
+      end
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds task statuses to the task list page, so that users can easily see their progress in making a form live.

Hidden behind the `task_list_statuses` feature flag, which I've set to `true` in this PR since this is the last thing we need for it.

Trello card: https://trello.com/c/omFTuinM/50-epic-adding-status-to-each-section-should-have

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
