### PR TITLE
Email confirmation tasklist

### DIFF
--- a/app/components/task_list_component/view.html.erb
+++ b/app/components/task_list_component/view.html.erb
@@ -27,7 +27,7 @@
 
             <% if row.hint_text.present? %>
               <br>
-              <span class="app-task-list__hint govuk-hint"><%= row.hint_text %></span>
+              <span class="app-task-list__hint govuk-hint"><%= row.hint_text.html_safe %></span>
             <% end %>
 
           </li>

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -66,4 +66,23 @@ class Form < ActiveResource::Base
       true
     end
   end
+
+  def form_submission_email
+    FormSubmissionEmail.find_by_form_id(id)
+  end
+
+  def email_confirmation_status
+    # Email set before confirmation feature introduced
+    return :email_set_without_confirmation if submission_email.present? && form_submission_email.blank?
+
+    if form_submission_email.present?
+      if form_submission_email.confirmed? || submission_email == form_submission_email.temporary_submission_email
+        :confirmed
+      else
+        :sent
+      end
+    else
+      :not_started
+    end
+  end
 end

--- a/app/models/form_submission_email.rb
+++ b/app/models/form_submission_email.rb
@@ -1,3 +1,8 @@
 class FormSubmissionEmail < ApplicationRecord
   validates :form_id, presence: true
+
+  def confirmed?
+    # confirmation_code is blanked when the email code has been confirmed
+    confirmation_code.blank?
+  end
 end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -38,7 +38,7 @@ private
   end
 
   def section_2_tasks
-    hint_text = I18n.t("forms.task_lists.section_2.hint_text", submission_email: @form.submission_email) if @form.submission_email.present?
+    hint_text = I18n.t("forms.task_lists.section_2.hint_text_html", submission_email: @form.submission_email) if @form.submission_email.present?
 
     if FeatureService.enabled?(:submission_email_confirmation)
       [{ task_name: I18n.t("forms.task_lists.section_2.set_email"), path: submission_email_form_path(@form.id), hint_text: },

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -41,8 +41,8 @@ private
     hint_text = I18n.t("forms.task_lists.section_2.hint_text_html", submission_email: @form.submission_email) if @form.submission_email.present?
 
     if FeatureService.enabled?(:submission_email_confirmation)
-      [{ task_name: I18n.t("forms.task_lists.section_2.set_email"), path: submission_email_form_path(@form.id), hint_text: },
-       { task_name: I18n.t("forms.task_lists.section_2.confirm_email"), path: submission_email_code_path(@form.id) }]
+      [{ task_name: I18n.t("forms.task_lists.section_2.set_email"), path: submission_email_form_path(@form.id), hint_text:, status: @task_list_statuses.submission_email_status },
+       { task_name: I18n.t("forms.task_lists.section_2.confirm_email"), path: submission_email_code_path(@form.id), status: @task_list_statuses.confirm_submission_email_status, active: @task_list_statuses.can_enter_submission_email_code }]
     else
       [{ task_name: I18n.t("forms.task_lists.section_2.submission_email"), path: change_form_email_path(@form.id), hint_text:, status: @task_list_statuses.submission_email_status }]
     end

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -36,11 +36,28 @@ class TaskStatusService
   end
 
   def submission_email_status
-    if @form.submission_email.present?
+    if FeatureService.enabled?(:submission_email_confirmation)
+      {
+        email_set_without_confirmation: :completed,
+        not_started: :not_started,
+        sent: :in_progress,
+        confirmed: :completed,
+      }[@form.email_confirmation_status]
+    # without submission_email_confirmation feature
+    elsif @form.submission_email.present?
       :completed
     else
       :not_started
     end
+  end
+
+  def confirm_submission_email_status
+    {
+      email_set_without_confirmation: :completed,
+      not_started: :cannot_start,
+      sent: :not_started,
+      confirmed: :completed,
+    }[@form.email_confirmation_status]
   end
 
   def privacy_policy_status
@@ -73,5 +90,9 @@ class TaskStatusService
      submission_email_status,
      privacy_policy_status,
      support_contact_details_status].all? { |task| task == :completed }
+  end
+
+  def can_enter_submission_email_code
+    @form.email_confirmation_status == :sent
   end
 end

--- a/app/views/forms/submission_email/submission_email_confirmed.html.erb
+++ b/app/views/forms/submission_email/submission_email_confirmed.html.erb
@@ -5,4 +5,4 @@
 
 <%= t('email_code_success.body_html', submission_email: @submission_email_form.form.submission_email) %>
 
-<%= govuk_link_to(t('email_code_success.continue'), form_path) %>
+<p class="govuk-body"><%= govuk_link_to(t('email_code_success.continue'), form_path) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,7 +85,7 @@ en:
         title: Create your form
       section_2:
         confirm_email: Enter the email address confirmation code
-        hint_text: Completed forms will be sent to %{submission_email}
+        hint_text_html: Completed forms will be sent to:<br> %{submission_email}
         set_email: Set the email address completed forms will be sent to
         submission_email: Set the email address completed forms will be sent to
         title: Set email address for completed forms

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -71,7 +71,7 @@ describe FormTaskListService do
         end
 
         it "has hint text explaining where completed forms will be sent to" do
-          expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_lists.section_2.hint_text", submission_email: form.submission_email)
+          expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_lists.section_2.hint_text_html", submission_email: form.submission_email)
         end
 
         context "when task list statuses are enabled", feature_task_list_statuses: true do

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -81,8 +81,21 @@ describe FormTaskListService do
         end
       end
 
-      it "has no hint text explaining where completed forms will be sent to" do
-        expect(section_rows.first[:hint_text]).to be_nil
+      context "when submission_email is not set" do
+        it "has no hint text explaining where completed forms will be sent to" do
+          expect(section_rows.first[:hint_text]).to be_nil
+        end
+
+        it "has link to set submission email" do
+          expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
+          expect(section_rows.first[:path]).to eq "/forms/1/change-email"
+        end
+
+        context "when task list statuses are enabled", feature_task_list_statuses: true do
+          it "has the correct default status" do
+            expect(section_rows.first[:status]).to eq :not_started
+          end
+        end
       end
 
       context "when submission_email_confirmation flag is true", feature_submission_email_confirmation: true do
@@ -95,18 +108,68 @@ describe FormTaskListService do
           expect(section_rows[1][:task_name]).to eq "Enter the email address confirmation code"
           expect(section_rows[1][:path]).to eq "/forms/1/confirm-submission-email"
         end
-      end
 
-      context "when submission_email_confirmation flag is false", feature_submission_email_confirmation: false do
-        it "has link to set submission email" do
-          expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
-          expect(section_rows.first[:path]).to eq "/forms/1/change-email"
-        end
-      end
+        context "when task list statuses are enabled", feature_task_list_statuses: true do
+          context "and submission_email is set and no code sent" do
+            before do
+              form.submission_email = "test@example.gov.uk"
+            end
 
-      context "when task list statuses are enabled", feature_task_list_statuses: true do
-        it "has the correct default status" do
-          expect(section_rows.first[:status]).to eq :not_started
+            it "enter email has status of completed" do
+              expect(section_rows.first[:status]).to eq :completed
+            end
+
+            it "enter code has status of completed" do
+              expect(section_rows[1][:status]).to eq :completed
+            end
+          end
+
+          context "and submission_email is not set and no code sent" do
+            it "enter email has status of not_started" do
+              expect(section_rows.first[:status]).to eq :not_started
+            end
+
+            it "enter code has status of cannot_start" do
+              expect(section_rows[1][:status]).to eq :cannot_start
+            end
+
+            it "enter code is not active" do
+              expect(section_rows[1][:active]).to be_falsy
+            end
+          end
+
+          context "and submission_email is not set and code sent" do
+            before do
+              create :form_submission_email, form_id: form.id, confirmation_code: form.id
+            end
+
+            it "enter email has status of in_progress" do
+              expect(section_rows.first[:status]).to eq :in_progress
+            end
+
+            it "enter code has status of incomplete" do
+              expect(section_rows[1][:status]).to eq :not_started
+            end
+
+            it "enter code is active" do
+              expect(section_rows[1][:active]).to be_truthy
+            end
+          end
+
+          context "and submission_email is set and code blank" do
+            before do
+              form.submission_email = "test@example.gov.uk"
+              create :form_submission_email, form_id: form.id, confirmation_code: nil
+            end
+
+            it "enter email has status of completed" do
+              expect(section_rows.first[:status]).to eq :completed
+            end
+
+            it "enter code has status of completed" do
+              expect(section_rows[1][:status]).to eq :completed
+            end
+          end
         end
       end
     end

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -108,6 +108,14 @@ describe TaskStatusService do
           expect(task_status_service.submission_email_status).to eq :completed
         end
       end
+
+      context "when task list statuses are enabled", feature_submission_email_confirmation: true do
+        let(:form) { OpenStruct.new(email_confirmation_status: :email_set_without_confirmation) }
+
+        it "returns correct values based on email_confirmation_status" do
+          expect(task_status_service.submission_email_status).to eq :completed
+        end
+      end
     end
 
     describe "privacy policy status" do


### PR DESCRIPTION
## Add tasklist status for the email confirmation loop

This includes two small change to copy:
- adding a break between the text and email address in the email hint text on the tasklist
- adding a missing paragraph tag to the email code sent page

It also add's the email confirmation loop task status.

There are two email confirmation tasks which need status:
- sending a code
- confirming a code

Forms which already have a submission email set have both status set to
completed.

The second task status is dependent on the first. If the first task is
complete, the confirmation tasks is active and marked as not started.

When the confirmation task is done, both are marked as complete.

If the user tries to change the email to an address which matches the
current submission email address, both tasks are marked as complete.

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
