### PR TITLE
Run Migrations on Start Up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,4 @@ COPY --chown=ruby:ruby . .
 
 EXPOSE 3000
 
-CMD ["rails", "s", "-b", "0.0.0.0"]
+CMD ["/bin/sh", "-c", "rake db:migrate && rails s -b 0.0.0.0"]


### PR DESCRIPTION
The database migrations have been running when the app starts on PaaS. For consistency run them on ECS when the app starts.

#### What problem does the pull request solve?
Ensures the database migrations run when the app starts on ECS as they currently do on PaaS. Also note that the forms-api runs its migration each time it starts.

### Notes
This has been deployed to our AWS development environment and its running. It also ran the migrations and created the necessary tables:
