### PR TITLE
Copy Public Assets To Correct Directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,7 @@ COPY --chown=ruby:ruby bin/ ./bin
 RUN chmod 0755 bin/*
 
 COPY --chown=ruby:ruby --from=build /usr/local/bundle /usr/local/bundle
-COPY --chown=ruby:ruby --from=build /app/public /public
-COPY --chown=ruby:ruby . .
+COPY --chown=ruby:ruby --from=build /app /app
 
 EXPOSE 3000
 


### PR DESCRIPTION
When building the docker image copy the public assets into /app/public rather than into /public. This fixes an issue where the sever cannot find the necessary public assets.

### Notes
This is the same fix applied to forms-runner: https://github.com/alphagov/forms-runner/pull/178

It has been deployed to our AWS development environment and it works as expected.