### PR TITLE
Enable email confirmation feature flag

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
   task_list_statuses: true
-  submission_email_confirmation: false
+  submission_email_confirmation: true
 
 # Settings for GOV.UK Notify api & email templates
 govuk_notify:

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -86,9 +86,11 @@ describe FormTaskListService do
           expect(section_rows.first[:hint_text]).to be_nil
         end
 
-        it "has link to set submission email" do
-          expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
-          expect(section_rows.first[:path]).to eq "/forms/1/change-email"
+        context "when task list statuses are enabled", feature_submission_email_confirmation: false do
+          it "has link to set submission email" do
+            expect(section_rows.first[:task_name]).to eq "Set the email address completed forms will be sent to"
+            expect(section_rows.first[:path]).to eq "/forms/1/change-email"
+          end
         end
 
         context "when task list statuses are enabled", feature_task_list_statuses: true do


### PR DESCRIPTION
# Enable the email confirmation loop in staging and production

This commit will enable the email confirmation loop.

Trello card:
https://trello.com/c/d4bc6tiC/344-front-end-build-the-confirmation-code-loop-for-setting-an-email-address-for-completed-forms-to-go-to-should-have

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
