### PR TITLE
Update GOV.UK Frontend to v4.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,8 +59,8 @@ gem "bootsnap", require: false
 gem "gds-sso"
 
 # Use govuk-components for displaying govuk themed forms
-gem "govuk-components", "3.2.2"
-gem "govuk_design_system_formbuilder", "3.2.0"
+gem "govuk-components", "~> 3.3.0"
+gem "govuk_design_system_formbuilder", "~> 3.3.0"
 
 # For structured logging
 gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,14 +176,11 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk-components (3.2.2)
-      actionpack (>= 6.1)
-      activemodel (>= 6.1)
+    govuk-components (3.3.0)
       html-attributes-utils (~> 0.9, >= 0.9.2)
       pagy (~> 5.10.1)
-      railties (>= 6.1)
       view_component (~> 2.74.1)
-    govuk_design_system_formbuilder (3.2.0)
+    govuk_design_system_formbuilder (3.3.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -467,8 +464,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   gds-sso
-  govuk-components (= 3.2.2)
-  govuk_design_system_formbuilder (= 3.2.0)
+  govuk-components (~> 3.3.0)
+  govuk_design_system_formbuilder (~> 3.3.0)
   govuk_notify_rails
   i18n-tasks (~> 1.0.11)
   jbuilder

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "stylelint-config-gds": "^0.2.0"
   },
   "dependencies": {
-    "govuk-frontend": "4.3.1"
+    "govuk-frontend": "~4.4.0"
   },
   "standard": {
     "globals": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3954,10 +3954,10 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-govuk-frontend@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.3.1.tgz#d9c581aca3d23bbfe9bd27c25fee65322b276393"
-  integrity sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==
+govuk-frontend@~4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.4.0.tgz#36531ae3b12798267e5a72409c7e4b3b10565102"
+  integrity sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA==
 
 graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
   version "4.2.10"


### PR DESCRIPTION
#### What problem does the pull request solve?

- Updates GOV.UK Frontend to v4.4.0
- Updates the component and form builder gems to the corresponding version (3.3.0)
- Sets both the gems and the govuk-frontend npm package to update bug fixes but not minor versions

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
