### PR TITLE
Add reorder page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,3 +3,4 @@ $govuk-fonts-path: "./fonts/";
 
 @import "govuk/all";
 @import "../../components/task_list_component/";
+@import "../../components/page_list_component/";

--- a/app/components/page_list_component/_index.scss
+++ b/app/components/page_list_component/_index.scss
@@ -1,0 +1,3 @@
+.govuk-button-group-right {
+  justify-content: end;
+}

--- a/app/components/page_list_component/_index.scss
+++ b/app/components/page_list_component/_index.scss
@@ -1,3 +1,9 @@
-.govuk-button-group-right {
+.app-page-list {
+  .govuk-summary-list:not(:last-child) {
+    margin-bottom: 0;
+  }
+}
+
+.app-page-list__button-group {
   justify-content: end;
 }

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -1,14 +1,50 @@
-<% @pages.each do |page| %>
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-      <%= question_text_with_optional_suffix(page) %>
-      </dt>
-      <dd class="govuk-summary-list__actions">
-      <%= govuk_link_to edit_page_path(@form_id, page) do %>
-        <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
-      <% end %>
-      </dd>
-    </div>
-  </dl>
+<%if FeatureService.enabled?(:reorder_pages) %>
+  <%= form_with url: move_page_url(@form_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <% @pages.each_with_index do |page, index| %>
+      <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+        <div class="govuk-summary-list__row">
+
+          <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+            <%= question_text_with_optional_suffix(page) %>
+          </dt>
+
+          <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
+
+            <div class="govuk-button-group form-action-group govuk-button-group-right" }">
+              <% if show_up_button(index) %>
+                <%= f.govuk_submit t("forms.form_overview.move_up"), secondary: true, name: 'move_direction[up]', value: page.id %>
+                <span class="govuk-visually-hidden"><%= page.question_text %></span>
+              <% end %>
+              <% if show_down_button(index)  %>
+                <%= f.govuk_submit t("forms.form_overview.move_down"), secondary: true, name: 'move_direction[down]', value: page.id  %>
+                <span class="govuk-visually-hidden"><%= page.question_text %></span>
+              <% end %>
+            </div>
+
+            <%= govuk_link_to edit_page_path(@form_id, page) do %>
+              <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
+            <% end %>
+
+          </dd>
+
+        </div>
+      </dl>
+
+    <% end %>
+  <% end %>
+  <% else %>
+  <% @pages.each do |page| %>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+        <%= question_text_with_optional_suffix(page) %>
+        </dt>
+        <dd class="govuk-summary-list__actions">
+        <%= govuk_link_to edit_page_path(@form_id, page) do %>
+          <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
+        <% end %>
+        </dd>
+      </div>
+    </dl>
+  <% end %>
 <% end %>

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -12,12 +12,10 @@
 
             <div class="govuk-button-group form-action-group govuk-button-group-right" }">
               <% if show_up_button(index) %>
-                <%= f.govuk_submit t("forms.form_overview.move_up"), secondary: true, name: 'move_direction[up]', value: page.id %>
-                <span class="govuk-visually-hidden"><%= page.question_text %></span>
+                <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page.question_text), secondary: true, name: 'move_direction[up]', value: page.id %>
               <% end %>
               <% if show_down_button(index)  %>
-                <%= f.govuk_submit t("forms.form_overview.move_down"), secondary: true, name: 'move_direction[down]', value: page.id  %>
-                <span class="govuk-visually-hidden"><%= page.question_text %></span>
+                <%= f.govuk_submit t("forms.form_overview.move_down_html", title: page.question_text), secondary: true, name: 'move_direction[down]', value: page.id %>
               <% end %>
             </div>
 

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -1,16 +1,17 @@
 <%if FeatureService.enabled?(:reorder_pages) %>
-  <%= form_with url: move_page_url(@form_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-    <% @pages.each_with_index do |page, index| %>
-      <dl class="govuk-summary-list govuk-!-margin-bottom-0">
-        <div class="govuk-summary-list__row">
+  <div class="app-page-list">
+    <%= form_with url: move_page_url(@form_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <% @pages.each_with_index do |page, index| %>
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
 
-          <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+            <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
             <%= question_text_with_optional_suffix(page) %>
-          </dt>
+            </dt>
 
-          <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
+            <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
 
-            <div class="govuk-button-group form-action-group govuk-button-group-right" }">
+            <div class="govuk-button-group form-action-group app-page-list__button-group" }">
               <% if show_up_button(index) %>
                 <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page.question_text), secondary: true, name: 'move_direction[up]', value: page.id %>
               <% end %>
@@ -23,12 +24,13 @@
               <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
             <% end %>
 
-          </dd>
+            </dd>
 
-        </div>
-      </dl>
+          </div>
+        </dl>
 
-    <% end %>
+      <% end %>
+  </div>
   <% end %>
   <% else %>
   <% @pages.each do |page| %>

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -7,5 +7,13 @@ module PageListComponent
       @pages = pages
       @form_id = form_id
     end
+
+    def show_up_button(index)
+      index != 0
+    end
+
+    def show_down_button(index)
+      index != @pages.length - 1
+    end
   end
 end

--- a/app/controllers/page_list_controller.rb
+++ b/app/controllers/page_list_controller.rb
@@ -29,7 +29,20 @@ class PageListController < ApplicationController
     render :edit, status: :unprocessable_entity
   end
 
+  def move_page
+    Page.find(move_params[:page_id], params: { form_id: move_params[:form_id] }).move_page(move_params[:direction])
+    redirect_to form_pages_path
+  end
+
 private
+
+  def move_params
+    form_id = params.require(:form_id)
+    p = params.require(:move_direction).permit(%i[up down])
+    direction = p[:up] ? :up : :down
+    page_id = p[direction]
+    @move_params ||= { form_id:, page_id:, direction: }
+  end
 
   def mark_complete_options
     [OpenStruct.new(value: "true"), OpenStruct.new(value: "false")]

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -26,6 +26,12 @@ class Page < ActiveResource::Base
     self.is_optional = is_optional_value
   end
 
+  def move_page(direction)
+    return false unless %i[up down].include? direction
+
+    put(direction)
+  end
+
 private
 
   def is_optional_value

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,8 +74,8 @@ en:
     form_overview:
       edit: Edit
       live_title: Your form
-      move_down: Move down
-      move_up: Move up
+      move_down_html: Move down <span class="govuk-visually-hidden">%{title}</span>
+      move_up_html: Move up <span class="govuk-visually-hidden">%{title}</span>
       title: Create a form
       your_questions: Your questions
     task_lists:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,8 @@ en:
     form_overview:
       edit: Edit
       live_title: Your form
+      move_down: Move down
+      move_up: Move up
       title: Create a form
       your_questions: Your questions
     task_lists:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
       post "/" => "page_list#update"
       get "/:page_id/edit" => "pages#edit", as: :edit_page
       patch "/:page_id/edit" => "pages#update", as: :update_page
+      post "/move-page" => "page_list#move_page", as: :move_page
       get "/new" => "pages#new", as: :new_page
       post "/new" => "pages#create", as: :create_page
       get "/:page_id/delete" => "forms/delete_confirmation#delete", as: :delete_page

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,7 @@
 features:
   task_list_statuses: true
   submission_email_confirmation: true
+  reorder_pages: false
 
 # Settings for GOV.UK Notify api & email templates
 govuk_notify:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -2,3 +2,4 @@
 features:
   task_list_statuses: true
   submission_email_confirmation: true
+  reorder_pages: true

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe PageListComponent::View, type: :component do
     end
   end
 
-  context "when the form has pages" do
-    let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name")] }
+  context "when the form has a single page" do
+    let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?")] }
 
     it "renders question title" do
       render_inline(described_class.new(pages:, form_id: 0))
@@ -21,6 +21,30 @@ RSpec.describe PageListComponent::View, type: :component do
     it "renders link" do
       render_inline(described_class.new(pages:, form_id: 0))
       expect(page).to have_link("Edit")
+    end
+
+    context "when re-ordering pages feature is enabled", feature_reorder_pages: true do
+      it "does not have re-ordering buttons" do
+        render_inline(described_class.new(pages:, form_id: 0))
+        expect(page).not_to have_button("Move up")
+        expect(page).not_to have_button("Move down")
+      end
+    end
+  end
+
+  context "when the form has multiple pages" do
+    let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?"), OpenStruct.new(id: 2, question_text: "What is you pet's name?")] }
+
+    context "when re-ordering pages feature is enabled", feature_reorder_pages: true do
+      it "renders a move up link" do
+        render_inline(described_class.new(pages:, form_id: 0))
+        expect(page).to have_button("Move up")
+      end
+
+      it "renders a move down link" do
+        render_inline(described_class.new(pages:, form_id: 0))
+        expect(page).to have_button("Move down")
+      end
     end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -30,4 +30,24 @@ describe Page do
       end
     end
   end
+
+  describe "#move_page" do
+    it "when given :up calls put(:up)" do
+      page = described_class.new
+      allow(page).to receive(:put).with(:up).and_return(true)
+      expect(page.move_page(:up)).to eq(true)
+    end
+
+    it "when given :down calls put(:down)" do
+      page = described_class.new
+      allow(page).to receive(:put).with(:down).and_return(true)
+      expect(page.move_page(:down)).to eq(true)
+    end
+
+    it "when given anything else returns false and does not call put" do
+      page = described_class.new
+      allow(page).to receive(:put).and_return(true)
+      expect(page.move_page(:invalid_direction)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
# Add Page reordering to the page list

Page reordering has been added to the admin, though hidden behind a feature flag for now.

'Move up' and 'Move down' buttons are added to the current page_list component. The component may be better off using a list or table element but that change can be implemented in another ticket.

The API changes required for actually moving pages are in [https://github.com/alphagov/forms-api/pull/116](in this PR)

Trello card: https://trello.com/c/vUh413Cv/296-add-reordering-questions-to-admin

<img width="1027" alt="image" src="https://user-images.githubusercontent.com/11035856/204275536-ba535f6b-78bc-4456-9b59-cce7641db0a4.png">

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
