### PR TITLE
Remove trailing characters from pagelist

### DIFF
--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -11,7 +11,7 @@
 
             <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
 
-            <div class="govuk-button-group form-action-group app-page-list__button-group" }">
+            <div class="govuk-button-group form-action-group app-page-list__button-group">
               <% if show_up_button(index) %>
                 <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page.question_text), secondary: true, name: 'move_direction[up]', value: page.id %>
               <% end %>


### PR DESCRIPTION
Some extra characters in the page_list_component view cause invalid markup.

Removed.

#### What problem does the pull request solve?

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
