### PR TITLE
Set default builder GOVUKDesignSystemFormBuilder

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,9 @@ module FormsAdmin
     # config.eager_load_paths << Rails.root.join("extras")
     config.exceptions_app = routes
 
+    # All forms should use GOVUKDesignSystemFormBuilder by default
+    config.action_view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
+
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/preview"
     # Replace with value which will be true in local dev and PAAS dev


### PR DESCRIPTION
Set the default form builder in the application config.

This reduces the number of places we need to specify it and matches the runner config.

More work can be done to remove it, for example from applicationController and view tests.

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
