### PR TITLE
Turn on reorder_pages feature flag

### DIFF
--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -1,37 +1,39 @@
 <%if FeatureService.enabled?(:reorder_pages) %>
-  <div class="app-page-list">
-    <%= form_with url: move_page_url(@form_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <% @pages.each_with_index do |page, index| %>
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
+  <%if @pages.present?  %>
+    <div class="app-page-list">
+      <%= form_with url: move_page_url(@form_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <% @pages.each_with_index do |page, index| %>
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
 
-            <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-            <%= question_text_with_optional_suffix(page) %>
-            </dt>
+              <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+              <%= question_text_with_optional_suffix(page) %>
+              </dt>
 
-            <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
+              <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
 
-            <div class="govuk-button-group form-action-group app-page-list__button-group">
-              <% if show_up_button(index) %>
-                <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page.question_text), secondary: true, name: 'move_direction[up]', value: page.id %>
+              <div class="govuk-button-group form-action-group app-page-list__button-group">
+                <% if show_up_button(index) %>
+                  <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page.question_text), secondary: true, name: 'move_direction[up]', value: page.id %>
+                <% end %>
+                <% if show_down_button(index)  %>
+                  <%= f.govuk_submit t("forms.form_overview.move_down_html", title: page.question_text), secondary: true, name: 'move_direction[down]', value: page.id %>
+                <% end %>
+              </div>
+
+              <%= govuk_link_to edit_page_path(@form_id, page) do %>
+                <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
               <% end %>
-              <% if show_down_button(index)  %>
-                <%= f.govuk_submit t("forms.form_overview.move_down_html", title: page.question_text), secondary: true, name: 'move_direction[down]', value: page.id %>
-              <% end %>
+
+              </dd>
+
             </div>
+          </dl>
 
-            <%= govuk_link_to edit_page_path(@form_id, page) do %>
-              <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
-            <% end %>
-
-            </dd>
-
-          </div>
-        </dl>
-
-      <% end %>
-  </div>
+        <% end %>
+    </div>
   <% end %>
+<% end %>
   <% else %>
   <% @pages.each do |page| %>
     <dl class="govuk-summary-list">

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -7,44 +7,43 @@
             <div class="govuk-summary-list__row">
 
               <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-              <%= question_text_with_optional_suffix(page) %>
+                <%= question_text_with_optional_suffix(page) %>
               </dt>
 
               <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
 
-              <div class="govuk-button-group form-action-group app-page-list__button-group">
-                <% if show_up_button(index) %>
-                  <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page.question_text), secondary: true, name: 'move_direction[up]', value: page.id %>
-                <% end %>
-                <% if show_down_button(index)  %>
-                  <%= f.govuk_submit t("forms.form_overview.move_down_html", title: page.question_text), secondary: true, name: 'move_direction[down]', value: page.id %>
-                <% end %>
-              </div>
+                <div class="govuk-button-group form-action-group app-page-list__button-group">
+                  <% if show_up_button(index) %>
+                    <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page.question_text), secondary: true, name: 'move_direction[up]', value: page.id %>
+                  <% end %>
+                  <% if show_down_button(index)  %>
+                    <%= f.govuk_submit t("forms.form_overview.move_down_html", title: page.question_text), secondary: true, name: 'move_direction[down]', value: page.id %>
+                  <% end %>
+                </div>
 
-              <%= govuk_link_to edit_page_path(@form_id, page) do %>
-                <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
-              <% end %>
+                <%= govuk_link_to edit_page_path(@form_id, page) do %>
+                  <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
+                <% end %>
 
               </dd>
 
             </div>
           </dl>
-
         <% end %>
+      <% end %>
     </div>
   <% end %>
-<% end %>
-  <% else %>
+<% else %>
   <% @pages.each do |page| %>
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-        <%= question_text_with_optional_suffix(page) %>
+          <%= question_text_with_optional_suffix(page) %>
         </dt>
         <dd class="govuk-summary-list__actions">
-        <%= govuk_link_to edit_page_path(@form_id, page) do %>
-          <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
-        <% end %>
+          <%= govuk_link_to edit_page_path(@form_id, page) do %>
+            <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
+          <% end %>
         </dd>
       </div>
     </dl>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,7 +2,7 @@
 features:
   task_list_statuses: true
   submission_email_confirmation: true
-  reorder_pages: false
+  reorder_pages: true
 
 # Settings for GOV.UK Notify api & email templates
 govuk_notify:


### PR DESCRIPTION
This commit turns on the feature falg for allowing form creators to reorder pages from within the page list.

#### What problem does the pull request solve?

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
