### PR TITLE
Move page settings summary into component

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -1,0 +1,30 @@
+<%= govuk_summary_list do |summary_list| %>
+    <%= summary_list.row do |row|
+      row.key(text: "Answer type")
+      row.value(text: t("helpers.label.page.answer_type_options.names.#{@page_object.answer_type}"))
+      row.action(text: "Change",
+                 href: @change_answer_type_path,
+                 visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{@page_object.answer_type}")
+      ) end %>
+
+      <% if (@page_object.answer_type == "selection") %>
+        <%= summary_list.row do |row|
+          row.key(text: "Options")
+          row.value(text: @page_object.show_selection_options)
+          row.action(text: "Change",
+                    href: @change_selections_settings_path,
+                    visually_hidden_text: "Options") end %>
+        <%= summary_list.row do |row|
+          row.key(text: t("selections_settings.only_one_option"))
+          row.value(text: @page_object.answer_settings.only_one_option == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.action(text: "Change",
+                    href: @change_selections_settings_path,
+                    visually_hidden_text: t("selections_settings.only_one_option")) end %>
+        <%= summary_list.row do |row|
+          row.key(text: t("selections_settings.include_none_of_the_above"))
+          row.value(text: @page_object.is_optional? ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.action(text: "Change",
+                    href: @change_selections_settings_path,
+                    visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
+    <% end %>
+  <% end %>

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PageSettingsSummaryComponent
+  class View < ViewComponent::Base
+    def initialize(page_object, change_answer_type_path = "", change_selections_settings_path = "")
+      super
+      @page_object = page_object
+      @change_answer_type_path = change_answer_type_path
+      @change_selections_settings_path = change_selections_settings_path
+    end
+  end
+end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -23,37 +23,7 @@
     <% end %>
   <% end %>
 
-  <%# TODO: move to component? %>
-  <%= govuk_summary_list do |summary_list| %>
-    <%= summary_list.row do |row|
-      row.key(text: "Answer type")
-      row.value(text: t("helpers.label.page.answer_type_options.names.#{page_object.answer_type}"))
-      row.action(text: "Change",
-                 href: change_answer_type_path,
-                 visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{page_object.answer_type}")
-      ) end %>
-
-      <% if (page_object.answer_type == "selection") %>
-        <%= summary_list.row do |row|
-          row.key(text: "Options")
-          row.value(text: page_object.show_selection_options)
-          row.action(text: "Change",
-                    href: change_selections_settings_path,
-                    visually_hidden_text: "Options") end %>
-        <%= summary_list.row do |row|
-          row.key(text: t("selections_settings.only_one_option"))
-          row.value(text: page_object.answer_settings.only_one_option == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
-          row.action(text: "Change",
-                    href: change_selections_settings_path,
-                    visually_hidden_text: t("selections_settings.only_one_option")) end %>
-        <%= summary_list.row do |row|
-          row.key(text: t("selections_settings.include_none_of_the_above"))
-          row.value(text: page_object.is_optional? ? t("selections_settings.yes") : t("selections_settings.no"))
-          row.action(text: "Change",
-                    href: change_selections_settings_path,
-                    visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
-    <% end %>
-  <% end %>
+  <%= render PageSettingsSummaryComponent::View.new(page_object, change_answer_type_path, change_selections_settings_path) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -1,0 +1,15 @@
+class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewComponent::Preview
+  def with_non_selection_answer_type
+    page = FactoryBot.build(:page, :without_selection_answer_type, id: 1)
+    change_answer_type_path = "https://example.com/change_answer_type"
+    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path))
+  end
+
+  def with_selection_answer_type
+    page = FactoryBot.build(:page, :with_selections_settings, id: 1)
+    page.answer_settings = OpenStruct.new(page.answer_settings)
+    change_answer_type_path = "https://example.com/change_answer_type"
+    change_selections_settings_path = "https://example.com/change_selections_settings"
+    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path, change_selections_settings_path))
+  end
+end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe PageSettingsSummaryComponent::View, type: :component do
+  let(:page_object) { build :page, :without_selection_answer_type, id: 1 }
+  let(:change_answer_type_path) { "https://example.com/change_answer_type" }
+  let(:change_selections_settings_path) { "https://example.com/change_selections_settings" }
+
+  context "when the page is not a selection page" do
+    it "has a link to change the answer type" do
+      render_inline(described_class.new(page_object, change_answer_type_path))
+      expect(page).to have_link("Change Answer type", href: change_answer_type_path)
+    end
+
+    it "does not have links to change the selection options" do
+      render_inline(described_class.new(page_object, change_answer_type_path, change_selections_settings_path))
+      expect(page).not_to have_link("Change Options", href: change_selections_settings_path)
+      expect(page).not_to have_link("Change People can only select one option", href: change_selections_settings_path)
+      expect(page).not_to have_link("Change Include an option for ‘None of the above’", href: change_selections_settings_path)
+    end
+
+    it "does not render the selection settings" do
+      render_inline(described_class.new(page_object, change_answer_type_path, change_selections_settings_path))
+      expect(page).not_to have_text "Selection from a list"
+      expect(page).not_to have_text "Option 1, Option 2"
+    end
+  end
+
+  context "when the page is a selection page" do
+    let(:page_object) do
+      page = FactoryBot.build(:page, :with_selections_settings, id: 1)
+      page.answer_settings = OpenStruct.new(page.answer_settings)
+      page
+    end
+
+    it "has a link to change the answer type" do
+      render_inline(described_class.new(page_object, change_answer_type_path, change_selections_settings_path))
+      expect(page).to have_link("Change Answer type Selection from a list", href: change_answer_type_path)
+    end
+
+    it "has links to change the selection options" do
+      render_inline(described_class.new(page_object, change_answer_type_path, change_selections_settings_path))
+      expect(page).to have_link("Change Options", href: change_selections_settings_path)
+      expect(page).to have_link("Change People can only select one option", href: change_selections_settings_path)
+      expect(page).to have_link("Change Include an option for ‘None of the above’", href: change_selections_settings_path)
+    end
+
+    it "renders the selection settings" do
+      render_inline(described_class.new(page_object, change_answer_type_path, change_selections_settings_path))
+      expect(page).to have_text "Selection from a list"
+      expect(page).to have_text "Option 1, Option 2"
+      expect(page).to have_text "Yes"
+      expect(page).to have_text "No"
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
Moves the page settings summary out of the _form partial and into its own component, so it can be previewed and tested more easily.

Trello card: https://trello.com/c/7g5U8XFx/359-move-page-settings-summary-into-a-component

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
