### PR TITLE
Add organisation name answer type

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,7 +4,11 @@ class Page < ActiveResource::Base
   self.include_format_in_path = false
   headers["X-API-Token"] = ENV["API_KEY"]
 
-  ANSWER_TYPES = %w[single_line number address date email national_insurance_number phone_number long_text selection].freeze
+  ANSWER_TYPES = if FeatureService.enabled?(:autocomplete_answer_types)
+                   %w[organisation_name email phone_number national_insurance_number address date selection number single_line long_text].freeze
+                 else
+                   %w[single_line number address date email national_insurance_number phone_number long_text selection].freeze
+                 end
 
   belongs_to :form
   validates :question_text, presence: true

--- a/app/views/pages/type-of-answer.html.erb
+++ b/app/views/pages/type-of-answer.html.erb
@@ -5,15 +5,28 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [@form, @type_of_answer_form], url: @type_of_answer_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_collection_radio_buttons(
-            :answer_type,
-            @answer_types,
-            ->(option) { option },
-            ->(option) { I18n.t('helpers.label.page.answer_type_options.names.' + option) },
-            ->(option) { I18n.t('helpers.label.page.answer_type_options.descriptions.' + option) },
-            legend: { text: t('page_titles.type_of_answer'), size: 'l', tag: 'h1' },
-            caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' },
-          )  %>
+
+      <% if FeatureService.enabled?(:autocomplete_answer_types) %>
+        <%= f.govuk_collection_radio_buttons(
+              :answer_type,
+              @answer_types,
+              ->(option) { option },
+              ->(option) { I18n.t('helpers.label.page.answer_type_options.names.' + option) },
+              legend: { text: t('page_titles.type_of_answer'), size: 'l', tag: 'h1' },
+              caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' },
+            )  %>
+      <% else %>
+        <%= f.govuk_collection_radio_buttons(
+              :answer_type,
+              @answer_types,
+              ->(option) { option },
+              ->(option) { I18n.t('helpers.label.page.answer_type_options.names.' + option) },
+              ->(option) { I18n.t('helpers.label.page.answer_type_options.descriptions.' + option) },
+              legend: { text: t('page_titles.type_of_answer'), size: 'l', tag: 'h1' },
+              caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' },
+            )  %>
+      <% end %>
+
       <%= f.govuk_submit t('save_and_continue'), value: "true", name: :set_answer_type %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,7 @@ en:
             long_text: Multiple lines of text
             national_insurance_number: National Insurance number
             number: Number
+            organisation_name: Company or organisation’s name
             phone_number: Phone number
             selection: Selection from a list
             single_line: Single line of text

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,7 @@ features:
   task_list_statuses: true
   submission_email_confirmation: true
   reorder_pages: true
-  autocomplete_answer_types: true
+  autocomplete_answer_types: false
 
 # Settings for GOV.UK Notify api & email templates
 govuk_notify:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,7 @@ features:
   task_list_statuses: true
   submission_email_confirmation: true
   reorder_pages: true
+  autocomplete_answer_types: true
 
 # Settings for GOV.UK Notify api & email templates
 govuk_notify:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,3 +3,4 @@ features:
   task_list_statuses: true
   submission_email_confirmation: true
   reorder_pages: true
+  autocomplete_answer_types: true

--- a/spec/factories/forms/type_of_answer_form.rb
+++ b/spec/factories/forms/type_of_answer_form.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     form { build :form }
 
     trait :without_selection_answer_type do
-      answer_type { %w[single_line number address date email national_insurance_number phone_number long_text].sample }
+      answer_type { %w[single_line number address date email national_insurance_number phone_number long_text organisation_name].sample }
     end
   end
 end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :page, class: "Page" do
     question_text { Faker::Lorem.question }
-    answer_type { %w[single_line number address date email national_insurance_number phone_number long_text selection].sample }
+    answer_type { %w[single_line number address date email national_insurance_number phone_number long_text selection organisation_name].sample }
     is_optional { nil }
     answer_settings { nil }
 
@@ -10,7 +10,7 @@ FactoryBot.define do
     end
 
     trait :without_selection_answer_type do
-      answer_type { %w[single_line number address date email national_insurance_number phone_number long_text].sample }
+      answer_type { %w[single_line number address date email national_insurance_number phone_number long_text organisation_name].sample }
     end
 
     trait :with_selections_settings do


### PR DESCRIPTION
#### What problem does the pull request solve?

Adds an 'organisation_name' answer type to the admin.

Includes:
- a new feature flag for the autocomplete work. The changes to the answer type page, and any new answer types added as part of this work, will only be displayed if this is set to `true`

Doesn't include:
- the answer-type specifc hint text xhanges. I think this makes sense independedntly of the autocomplete bit of these cards so I'm going to separate PR for them.

Trello card: https://trello.com/c/jRKIbnBl/369-org-name-implementation-of-autofill-work-in-production

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
