### PR TITLE
Add answer type specific hint text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,4 +42,18 @@ module ApplicationHelper
   def question_text_with_optional_suffix(page)
     page.is_optional ? t("pages.optional", question_text: page.question_text) : page.question_text
   end
+
+  def translation_key_for_answer_type(answer_type, answer_settings)
+    case answer_type
+    when "selection"
+      answer_settings.only_one_option == "true" ? "radio" : "checkbox"
+    else
+      answer_type
+    end
+  end
+
+  def hint_for_edit_page_field(field, answer_type, answer_settings)
+    key = translation_key_for_answer_type(answer_type, answer_settings)
+    t("helpers.hint.page.#{field}.#{key}", default: t("helpers.hint.page.question_text.default"))
+  end
 end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -3,11 +3,11 @@
 
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_text_field :question_text, label: { size: 'm' } %>
+  <%= f.govuk_text_field :question_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("question_text", page_object.answer_type, page_object.answer_settings) } %>
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
-  <%= f.govuk_text_field :hint_text, label: { size: 'm' } %>
+  <%= f.govuk_text_field :hint_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("hint_text", page_object.answer_type, page_object.answer_settings) } %>
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,11 +106,33 @@ en:
     hint:
       page:
         answer_type: The answer will be checked to make sure it’s in the selected format.
-        hint_text: Use hint text to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for.
+        hint_text:
+          address: You could use hint text to tell people how you will use their address. For example, ‘We’ll send your licence to this address.’
+          checkbox: Use hint text to help people answer the question. For a question where people can select more than one answer you might want to use ‘Select all that apply’.
+          date: Use hint text to help people answer the question. For a date question you could use ‘For example, 27 3 2007’.
+          default: Use hint text to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for.
+          email: You could use hint text to tell people how you will use their email address. For example, ‘We’ll only use your email address to contact you about your application.’
+          long_text: Use hint text to help people answer the question. For example, you could give a bit more detail about the information you need.
+          national_insurance_number: Use hint text to help people answer the question. For example, ‘It’s on your National Insurance card, benefit letter, payslip or P60. For example, QQ 12 34 56 C.’
+          number: Use hint text to help people answer the question. For example, ‘Do not include bank holidays’.
+          organisation_name: Use hint text to help people answer the question. For example, you might need to ask people to enter the registered name of their company.
+          phone_number: Use hint text to help people answer the question. For example, ‘You can provide either a home or mobile phone number.’
+          radio: Use hint text to help people answer the question. For a question where people can only select one answer you might want to use ‘Select one option’.
+          single_line: Use hint text to help people answer the question. For example, you could say what format the answer should be in or where to find it.
         question_short_name: The short name will be used when the form’s questions are all displayed in a list. Use a short descriptive name. For example ‘Address’.
-        question_text: |-
-          Ask a question the way you would in person. For example ‘What is your
-          address?’
+        question_text:
+          address: Ask the question the way you would in person. For example, ‘What’s your address?’
+          checkbox: Ask the question the way you would in person. For example, ‘Which of these countries have you lived in?’
+          date: Ask the question the way you would in person. For example, ‘What date was your passport issued?’
+          default: Ask a question the way you would in person. For example ‘What is your address?’
+          email: Ask the question the way you would in person. For example, ‘What’s your email address?’
+          long_text: Ask the question the way you would in person. For example, ‘Why do you want to apply for this role?’
+          national_insurance_number: Ask the question the way you would in person. For example, ‘What’s your National Insurance number?’
+          number: Ask the question the way you would in person. For example, ‘How many holiday days do you get a year?’
+          organisation_name: Ask the question the way you would in person. For example, ‘What’s the name of the organisation?’
+          phone_number: Ask the question the way you would in person. For example, ‘What’s your phone number?’
+          radio: Ask the question the way you would in person. For example, ‘What country do you live in?’
+          single_line: Ask the question the way you would in person. For example, ‘What’s your reference number?’
     label:
       forms_make_live_form:
         confirm_make_live: Are you sure you want to make your form live?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -52,4 +52,55 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "translation_key_for_answer_type" do
+    let(:answer_type) { "email" }
+    let(:answer_settings) { {} }
+
+    context "with a non-selection answer type" do
+      it "returns the answer type" do
+        expect(helper.translation_key_for_answer_type(answer_type, answer_settings)).to eq "email"
+      end
+    end
+
+    context "with selection answer type" do
+      context "and 'only_one_option' set to 'true'" do
+        let(:answer_type) { "selection" }
+        let(:answer_settings) { OpenStruct.new(only_one_option: "true") }
+
+        it "returns the answer subtype" do
+          expect(helper.translation_key_for_answer_type(answer_type, answer_settings)).to eq "radio"
+        end
+      end
+
+      context "and 'only_one_option' set to 'false'" do
+        let(:answer_type) { "selection" }
+        let(:answer_settings) { OpenStruct.new(only_one_option: false) }
+
+        it "returns the answer subtype" do
+          expect(helper.translation_key_for_answer_type(answer_type, answer_settings)).to eq "checkbox"
+        end
+      end
+    end
+  end
+
+  describe "hint_for_edit_page_field" do
+    context "with an answer type that has custom text" do
+      let(:answer_type) { "email" }
+      let(:answer_settings) { {} }
+
+      it "returns the custom hint text for the answer type" do
+        expect(helper.hint_for_edit_page_field("question_text", answer_type, answer_settings)).to eq(I18n.t("helpers.hint.page.question_text.email"))
+      end
+    end
+
+    context "with an answer type that does not have custom text" do
+      let(:answer_type) { "some_random_string" }
+      let(:answer_settings) { {} }
+
+      it "returns the default hint text" do
+        expect(helper.hint_for_edit_page_field("question_text", answer_type, answer_settings)).to eq(I18n.t("helpers.hint.page.question_text.default"))
+      end
+    end
+  end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Work address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          answer_settings: nil,
         }].to_json
       end
 
@@ -39,6 +40,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Work address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          answer_settings: nil,
         }.to_json
       end
 

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe "pages/edit.html.erb" do
 
   before do
     # Initialize models
-    page = Page.new(id: 1, question_text:, form_id: 1, answer_type: "email")
+    page = Page.new(id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil)
     form = Form.new(id: 1, name: "Form 1", form_id: 1, pages: [page])
     current_user = OpenStruct.new(uid: "123456")
 


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds ansdwer-specific hint text for all existing answer types. Uses the current hint text as a sensible default if we add other answer types later.

I pulled this out of the autocomplete PR because I think this makes sense independently of the autocomplete changes.

Trello card: https://trello.com/c/2SL7oeph/372-add-answer-specific-hints-to-edit-question-page

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
