### PR TITLE
Fix intermittently breaking test

### DIFF
--- a/spec/factories/forms/type_of_answer_form.rb
+++ b/spec/factories/forms/type_of_answer_form.rb
@@ -4,7 +4,11 @@ FactoryBot.define do
     form { build :form }
 
     trait :without_selection_answer_type do
-      answer_type { %w[single_line number address date email national_insurance_number phone_number long_text organisation_name].sample }
+      if FeatureService.enabled?(:autocomplete_answer_types)
+        answer_type { %w[single_line number address date email national_insurance_number phone_number long_text organisation_name].sample }
+      else
+        answer_type { %w[single_line number address date email national_insurance_number phone_number long_text].sample }
+      end
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
My previous PR intermittently breaks the rspec tests if `organisation_name` appears in the sample in `spec/factories/forms/type_of_answer_form.rb`.

This removes it from that sample if the relevant feature flag is not present.

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
