### PR TITLE
Add text settings form

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -26,5 +26,18 @@
           row.action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
+
+
+    <% end %>
+
+      <% if (@page_object.answer_type == "text") %>
+        <%= summary_list.row do |row|
+          row.key(text: "Input type")
+          row.value(text: t("helpers.label.page.text_settings_options.names.#{@page_object.answer_settings.input_type}"))
+          row.action(text: "Change",
+                    href: @change_text_settings_path,
+                    visually_hidden_text: "input type") end %>
+
+
     <% end %>
   <% end %>

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -2,11 +2,12 @@
 
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
-    def initialize(page_object, change_answer_type_path = "", change_selections_settings_path = "")
+    def initialize(page_object, change_answer_type_path = "", change_selections_settings_path = "", change_text_settings_path = "")
       super
       @page_object = page_object
       @change_answer_type_path = change_answer_type_path
       @change_selections_settings_path = change_selections_settings_path
+      @change_text_settings_path = change_text_settings_path
     end
   end
 end

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -1,0 +1,52 @@
+class Pages::TextSettingsController < PagesController
+  def new
+    # TODO: Load from session
+    @text_settings_form = Forms::TextSettingsForm.new
+    @input_types = Forms::TextSettingsForm::INPUT_TYPES
+    @text_settings_path = text_settings_create_path(@form)
+    render "pages/text_settings"
+  end
+
+  def create
+    @text_settings_form = Forms::TextSettingsForm.new(text_settings_form_params)
+    @input_types = Forms::TextSettingsForm::INPUT_TYPES
+    @text_settings_path = text_settings_create_path(@form)
+
+    if @text_settings_form.submit(session)
+      redirect_to new_page_path(@form)
+    else
+      render "pages/text_settings"
+    end
+  end
+
+  def edit
+    @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    input_type = @page&.answer_settings&.input_type ? @page.answer_settings&.input_type : ""
+    @text_settings_form = Forms::TextSettingsForm.new(input_type:, page: @page)
+    @input_types = Forms::TextSettingsForm::INPUT_TYPES
+    @text_settings_path = text_settings_update_path(@form)
+    render "pages/text_settings"
+  end
+
+  def update
+    @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    @text_settings_form = Forms::TextSettingsForm.new(text_settings_form_params)
+    @input_types = Forms::TextSettingsForm::INPUT_TYPES
+    @text_settings_path = text_settings_update_path(@form)
+
+    @text_settings_form.assign_values_to_page(@page)
+
+    if @page.save!
+      redirect_to edit_page_path(@form)
+    else
+      render "pages/text_settings"
+    end
+  end
+
+private
+
+  def text_settings_form_params
+    form = Form.find(params[:form_id])
+    params.require(:forms_text_settings_form).permit(:input_type).merge(form:)
+  end
+end

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -1,6 +1,6 @@
 class Pages::TextSettingsController < PagesController
   def new
-    input_type = session[:page]["answer_settings"]["input_type"] if session[:page]["answer_settings"].present?
+    input_type = session.dig(:page, "answer_settings", "input_type")
     @text_settings_form = Forms::TextSettingsForm.new(input_type:)
     @text_settings_path = text_settings_create_path(@form)
     render "pages/text_settings"
@@ -19,7 +19,7 @@ class Pages::TextSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    input_type = @page&.answer_settings&.input_type ? @page.answer_settings&.input_type : ""
+    input_type = @page&.answer_settings&.input_type
     @text_settings_form = Forms::TextSettingsForm.new(input_type:, page: @page)
     @text_settings_path = text_settings_update_path(@form)
     render "pages/text_settings"

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -3,12 +3,14 @@ class Pages::TextSettingsController < PagesController
     input_type = session.dig(:page, "answer_settings", "input_type")
     @text_settings_form = Forms::TextSettingsForm.new(input_type:)
     @text_settings_path = text_settings_create_path(@form)
+    @back_link_url = type_of_answer_new_path(@form)
     render "pages/text_settings"
   end
 
   def create
     @text_settings_form = Forms::TextSettingsForm.new(text_settings_form_params)
     @text_settings_path = text_settings_create_path(@form)
+    @back_link_url = type_of_answer_new_path(@form)
 
     if @text_settings_form.submit(session)
       redirect_to new_page_path(@form)
@@ -22,6 +24,7 @@ class Pages::TextSettingsController < PagesController
     input_type = @page&.answer_settings&.input_type
     @text_settings_form = Forms::TextSettingsForm.new(input_type:, page: @page)
     @text_settings_path = text_settings_update_path(@form)
+    @back_link_url = type_of_answer_edit_path(@form)
     render "pages/text_settings"
   end
 
@@ -29,6 +32,7 @@ class Pages::TextSettingsController < PagesController
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     @text_settings_form = Forms::TextSettingsForm.new(text_settings_form_params)
     @text_settings_path = text_settings_update_path(@form)
+    @back_link_url = type_of_answer_edit_path(@form)
 
     if @text_settings_form.assign_values_to_page(@page) && @page.save!
       redirect_to edit_page_path(@form)

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -2,14 +2,12 @@ class Pages::TextSettingsController < PagesController
   def new
     input_type = session[:page]["answer_settings"]["input_type"] if session[:page]["answer_settings"].present?
     @text_settings_form = Forms::TextSettingsForm.new(input_type:)
-    @input_types = Forms::TextSettingsForm::INPUT_TYPES
     @text_settings_path = text_settings_create_path(@form)
     render "pages/text_settings"
   end
 
   def create
     @text_settings_form = Forms::TextSettingsForm.new(text_settings_form_params)
-    @input_types = Forms::TextSettingsForm::INPUT_TYPES
     @text_settings_path = text_settings_create_path(@form)
 
     if @text_settings_form.submit(session)
@@ -23,7 +21,6 @@ class Pages::TextSettingsController < PagesController
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     input_type = @page&.answer_settings&.input_type ? @page.answer_settings&.input_type : ""
     @text_settings_form = Forms::TextSettingsForm.new(input_type:, page: @page)
-    @input_types = Forms::TextSettingsForm::INPUT_TYPES
     @text_settings_path = text_settings_update_path(@form)
     render "pages/text_settings"
   end
@@ -31,7 +28,6 @@ class Pages::TextSettingsController < PagesController
   def update
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     @text_settings_form = Forms::TextSettingsForm.new(text_settings_form_params)
-    @input_types = Forms::TextSettingsForm::INPUT_TYPES
     @text_settings_path = text_settings_update_path(@form)
 
     if @text_settings_form.assign_values_to_page(@page) && @page.save!

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -34,6 +34,7 @@ class Pages::TextSettingsController < PagesController
     @input_types = Forms::TextSettingsForm::INPUT_TYPES
     @text_settings_path = text_settings_update_path(@form)
 
+    # TODO: validation issue
     @text_settings_form.assign_values_to_page(@page)
 
     if @page.save!

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -1,7 +1,7 @@
 class Pages::TextSettingsController < PagesController
   def new
-    # TODO: Load from session
-    @text_settings_form = Forms::TextSettingsForm.new
+    input_type = session[:page]["answer_settings"]["input_type"] if session[:page]["answer_settings"].present?
+    @text_settings_form = Forms::TextSettingsForm.new(input_type:)
     @input_types = Forms::TextSettingsForm::INPUT_TYPES
     @text_settings_path = text_settings_create_path(@form)
     render "pages/text_settings"
@@ -34,10 +34,7 @@ class Pages::TextSettingsController < PagesController
     @input_types = Forms::TextSettingsForm::INPUT_TYPES
     @text_settings_path = text_settings_update_path(@form)
 
-    # TODO: validation issue
-    @text_settings_form.assign_values_to_page(@page)
-
-    if @page.save!
+    if @text_settings_form.assign_values_to_page(@page) && @page.save!
       redirect_to edit_page_path(@form)
     else
       render "pages/text_settings"

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -28,6 +28,7 @@ class Pages::TypeOfAnswerController < PagesController
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     @type_of_answer_form = Forms::TypeOfAnswerForm.new(answer_type_form_params)
     @page.answer_type = @type_of_answer_form.answer_type if @type_of_answer_form.valid?
+    # TODO: Can we only do this if the answer type changes?
     @page.answer_settings = nil if @type_of_answer_form.valid?
 
     if @type_of_answer_form.valid? && @page.save!
@@ -41,16 +42,13 @@ class Pages::TypeOfAnswerController < PagesController
 private
 
   def next_page_path(form, answer_type, action)
-    if answer_type == "selection"
-      if action == :create
-        selections_settings_new_path(form)
-      else
-        selections_settings_edit_path(form)
-      end
-    elsif action == :create
-      new_page_path(@form)
+    case answer_type
+    when "selection"
+      action == :create ? selections_settings_new_path(form) : selections_settings_edit_path(form)
+    when "text"
+      action == :create ? text_settings_new_path(form) : text_settings_edit_path(form)
     else
-      edit_page_path(@form)
+      action == :create ? new_page_path(@form) : edit_page_path(@form)
     end
   end
 

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -27,8 +27,9 @@ class Pages::TypeOfAnswerController < PagesController
   def update
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     @type_of_answer_form = Forms::TypeOfAnswerForm.new(answer_type_form_params)
+    return redirect_to edit_page_path(@form) unless answer_type_changed?
+
     @page.answer_type = @type_of_answer_form.answer_type if @type_of_answer_form.valid?
-    # TODO: Can we only do this if the answer type changes?
     @page.answer_settings = nil if @type_of_answer_form.valid?
 
     if @type_of_answer_form.valid? && @page.save!
@@ -55,5 +56,9 @@ private
   def answer_type_form_params
     form = Form.find(params[:form_id])
     params.require(:forms_type_of_answer_form).permit(:answer_type).merge(form:)
+  end
+
+  def answer_type_changed?
+    @type_of_answer_form.answer_type != @page.answer_type
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -63,6 +63,10 @@ private
   end
 
   def answer_types
-    @answer_types = Page::ANSWER_TYPES
+    @answer_types = if FeatureService.enabled?(:autocomplete_answer_types)
+                      Page::ANSWER_TYPES.reject { |e| %w[single_line long_text].include?(e) }
+                    else
+                      Page::ANSWER_TYPES.reject { |e| %w[organisation_name text].include?(e) }
+                    end
   end
 end

--- a/app/forms/forms/text_settings_form.rb
+++ b/app/forms/forms/text_settings_form.rb
@@ -1,0 +1,22 @@
+class Forms::TextSettingsForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :input_type, :form, :page
+
+  INPUT_TYPES = %w[single_line long_text].freeze
+
+  validates :input_type, presence: true, inclusion: { in: INPUT_TYPES }
+
+  def submit(session)
+    return false if invalid?
+
+    session[:page][:answer_settings] = { input_type: }
+  end
+
+  def assign_values_to_page(page)
+    return false if invalid?
+
+    page.answer_settings = { input_type: }
+  end
+end

--- a/app/forms/forms/text_settings_form.rb
+++ b/app/forms/forms/text_settings_form.rb
@@ -11,6 +11,7 @@ class Forms::TextSettingsForm
   def submit(session)
     return false if invalid?
 
+    session[:page] = {} if session[:page].blank?
     session[:page][:answer_settings] = { input_type: }
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,10 +44,11 @@ module ApplicationHelper
   end
 
   def translation_key_for_answer_type(answer_type, answer_settings)
-    # TODO: add logic for text inputs
     case answer_type
     when "selection"
       answer_settings.only_one_option == "true" ? "radio" : "checkbox"
+    when "text"
+      answer_settings.input_type
     else
       answer_type
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,6 +44,7 @@ module ApplicationHelper
   end
 
   def translation_key_for_answer_type(answer_type, answer_settings)
+    # TODO: add logic for text inputs
     case answer_type
     when "selection"
       answer_settings.only_one_option == "true" ? "radio" : "checkbox"

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,7 +5,7 @@ class Page < ActiveResource::Base
   headers["X-API-Token"] = ENV["API_KEY"]
 
   ANSWER_TYPES = if FeatureService.enabled?(:autocomplete_answer_types)
-                   %w[organisation_name email phone_number national_insurance_number address date selection number single_line long_text].freeze
+                   %w[organisation_name email phone_number national_insurance_number address date selection number text].freeze
                  else
                    %w[single_line number address date email national_insurance_number phone_number long_text selection].freeze
                  end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,11 +4,7 @@ class Page < ActiveResource::Base
   self.include_format_in_path = false
   headers["X-API-Token"] = ENV["API_KEY"]
 
-  ANSWER_TYPES = if FeatureService.enabled?(:autocomplete_answer_types)
-                   %w[organisation_name email phone_number national_insurance_number address date selection number text].freeze
-                 else
-                   %w[single_line number address date email national_insurance_number phone_number long_text selection].freeze
-                 end
+  ANSWER_TYPES = %w[single_line number address date email national_insurance_number phone_number long_text selection organisation_name text].freeze
 
   belongs_to :form
   validates :question_text, presence: true

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -23,7 +23,7 @@
     <% end %>
   <% end %>
 
-  <%= render PageSettingsSummaryComponent::View.new(page_object, change_answer_type_path, change_selections_settings_path) %>
+  <%= render PageSettingsSummaryComponent::View.new(page_object, change_answer_type_path, change_selections_settings_path, change_text_settings_path) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -14,7 +14,8 @@
                                              page_object: @page,
                                              action_path: update_page_path(@form, @page) ,
                                              change_answer_type_path: type_of_answer_edit_path(@form),
-                                             change_selections_settings_path: selections_settings_edit_path(@form)
+                                             change_selections_settings_path: selections_settings_edit_path(@form),
+                                             change_text_settings_path: text_settings_edit_path(@form)
     } %>
 
     <p class="govuk-body">

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -14,7 +14,8 @@
                                              page_object: @page,
                                              action_path: create_page_path(@form),
                                              change_answer_type_path: type_of_answer_new_path(@form),
-                                             change_selections_settings_path: selections_settings_new_path(@form)
+                                             change_selections_settings_path: selections_settings_new_path(@form),
+                                             change_text_settings_path: text_settings_new_path(@form)
     } %>
 
     <p class="govuk-body">

--- a/app/views/pages/text_settings.html.erb
+++ b/app/views/pages/text_settings.html.erb
@@ -1,5 +1,5 @@
 <% set_page_title(title_with_error_prefix(t("page_titles.text_settings"), @text_settings_form.errors.any?)) %>
-<% content_for :back_link, govuk_back_link_to(type_of_answer_new_path(@form)) %>
+<% content_for :back_link, govuk_back_link_to(@back_link_url) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/text_settings.html.erb
+++ b/app/views/pages/text_settings.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
             :input_type,
-            @input_types,
+            Forms::TextSettingsForm::INPUT_TYPES,
             ->(option) { option },
             ->(option) { I18n.t('helpers.label.page.text_settings_options.names.' + option) },
             legend: { text: t('page_titles.text_settings'), size: 'l', tag: 'h1' },

--- a/app/views/pages/text_settings.html.erb
+++ b/app/views/pages/text_settings.html.erb
@@ -1,0 +1,19 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.text_settings"), @text_settings_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(type_of_answer_new_path(@form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: [@form, @text_settings_form], url: @text_settings_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(
+            :input_type,
+            @input_types,
+            ->(option) { option },
+            ->(option) { I18n.t('helpers.label.page.text_settings_options.names.' + option) },
+            legend: { text: t('page_titles.text_settings'), size: 'l', tag: 'h1' },
+            caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' },
+          )  %>
+      <%= f.govuk_submit t('save_and_continue') %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,9 +159,14 @@ en:
             phone_number: Phone number
             selection: Selection from a list
             single_line: Single line of text
+            text: Text
         hint_text: Hint text (optional)
         question_short_name: Question short name (optional)
         question_text: Question text
+        text_settings_options:
+          names:
+            long_text: More than a single line of text
+            single_line: Single line of text
   home:
     create_a_form: Create a form
     form_name_heading: Form name
@@ -230,6 +235,7 @@ en:
     privacy_policy_form: Provide a link to privacy information for this form
     service_unavailable: Sorry, the service is unavailable
     set_email_form: Set the email address for completed forms
+    text_settings: How much text will people need to provide?
     type_of_answer: What kind of answer do you need to this question?
     what_happens_next_form: Form submitted page
     your_form_is_live: Your form is live

--- a/config/locales/forms/text_settings.yml
+++ b/config/locales/forms/text_settings.yml
@@ -1,0 +1,9 @@
+en:
+  activemodel:
+    errors:
+      models:
+        forms/text_settings_form:
+          attributes:
+            input_type:
+              blank: Select how much text people will need to provide
+              inclusion: Select ‘Single line of text’ or ‘More than a single line of text’

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
       scope "/new" do
         get "/type-of-answer" => "pages/type_of_answer#new", as: :type_of_answer_new
         post "/type-of-answer" => "pages/type_of_answer#create", as: :type_of_answer_create
+        get "/text-settings" => "pages/text_settings#new", as: :text_settings_new
+        post "/text-settings" => "pages/text_settings#create", as: :text_settings_create
         get "/selections-settings" => "pages/selections_settings#new", as: :selections_settings_new
         post "/selections-settings" => "pages/selections_settings#create", as: :selections_settings_create
         get "/" => "pages#new", as: :new_page
@@ -55,6 +57,8 @@ Rails.application.routes.draw do
         scope "/edit" do
           get "/type-of-answer" => "pages/type_of_answer#edit", as: :type_of_answer_edit
           post "/type-of-answer" => "pages/type_of_answer#update", as: :type_of_answer_update
+          get "/text-settings" => "pages/text_settings#edit", as: :text_settings_edit
+          post "/text-settings" => "pages/text_settings#update", as: :text_settings_update
           get "/selections-settings" => "pages/selections_settings#edit", as: :selections_settings_edit
           post "/selections-settings" => "pages/selections_settings#update", as: :selections_settings_update
           get "/" => "pages#edit", as: :edit_page

--- a/spec/factories/forms/text_settings_form.rb
+++ b/spec/factories/forms/text_settings_form.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :text_settings_form, class: "Forms::TextSettingsForm" do
+    input_type { Forms::TextSettingsForm::INPUT_TYPES.sample }
+  end
+end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -21,5 +21,10 @@ FactoryBot.define do
       answer_type { "selection" }
       answer_settings { { only_one_option: "true", selection_options: [Forms::SelectionOption.new({ name: "Option 1" }), Forms::SelectionOption.new({ name: "Option 2" })] } }
     end
+
+    trait :with_text_settings do
+      answer_type { "text" }
+      answer_settings { { input_type: Forms::TextSettingsForm::INPUT_TYPES.sample } }
+    end
   end
 end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :page, class: "Page" do
     question_text { Faker::Lorem.question }
-    answer_type { %w[single_line number address date email national_insurance_number phone_number long_text selection organisation_name].sample }
+    answer_type { Page::ANSWER_TYPES.sample }
     is_optional { nil }
     answer_settings { nil }
 
@@ -10,7 +10,11 @@ FactoryBot.define do
     end
 
     trait :without_selection_answer_type do
-      answer_type { %w[single_line number address date email national_insurance_number phone_number long_text organisation_name].sample }
+      if FeatureService.enabled?(:autocomplete_answer_types)
+        answer_type { %w[single_line number address date email national_insurance_number phone_number long_text organisation_name].sample }
+      else
+        answer_type { %w[single_line number address date email national_insurance_number phone_number long_text].sample }
+      end
     end
 
     trait :with_selections_settings do

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -25,14 +25,29 @@ feature "Add/editing a single line question", type: :feature do
 
   context "when a form has no existing pages" do
     let(:pages) { [] }
+    let(:answer_types) { %w[single_line number address date email national_insurance_number phone_number long_text selection] }
 
     scenario "add a question for each type of answer" do
-      Page::ANSWER_TYPES.each do |answer_type|
+      answer_types.each do |answer_type|
         when_i_viewing_an_existing_form
         and_i_want_to_create_or_edit_a_page
         and_i_select_a_type_of_answer_option(answer_type)
         and_i_provide_a_question_text
         and_i_save_and_create_another
+      end
+    end
+
+    context "with the autocomplete_answer_types flag enabled", feature_autocomplete_answer_types: true do
+      let(:answer_types) { %w[organisation_name email phone_number national_insurance_number address date selection number text] }
+
+      scenario "add a question for each type of answer" do
+        answer_types.each do |answer_type|
+          when_i_viewing_an_existing_form
+          and_i_want_to_create_or_edit_a_page
+          and_i_select_a_type_of_answer_option(answer_type)
+          and_i_provide_a_question_text
+          and_i_save_and_create_another
+        end
       end
     end
   end
@@ -43,9 +58,10 @@ feature "Add/editing a single line question", type: :feature do
       5.times { |id| existing_pages.push(build(:page, id:, form_id: 1)) }
       existing_pages
     end
+    let(:answer_types) { %w[single_line number address date email national_insurance_number phone_number long_text selection] }
 
     scenario "add a question for each type of answer" do
-      Page::ANSWER_TYPES.each do |answer_type|
+      answer_types.each do |answer_type|
         when_i_viewing_an_existing_form
         and_i_want_to_create_or_edit_a_page
         and_i_can_see_a_list_of_existing_pages
@@ -53,6 +69,22 @@ feature "Add/editing a single line question", type: :feature do
         and_i_select_a_type_of_answer_option(answer_type)
         and_i_provide_a_question_text
         and_i_save_and_create_another
+      end
+    end
+
+    context "with the autocomplete_answer_types flag enabled", feature_autocomplete_answer_types: true do
+      let(:answer_types) { %w[organisation_name email phone_number national_insurance_number address date selection number text] }
+
+      scenario "add a question for each type of answer" do
+        answer_types.each do |answer_type|
+          when_i_viewing_an_existing_form
+          and_i_want_to_create_or_edit_a_page
+          and_i_can_see_a_list_of_existing_pages
+          and_i_start_adding_a_new_question
+          and_i_select_a_type_of_answer_option(answer_type)
+          and_i_provide_a_question_text
+          and_i_save_and_create_another
+        end
       end
     end
   end
@@ -72,6 +104,7 @@ private
     choose I18n.t("helpers.label.page.answer_type_options.names.#{answer_type}")
     click_button "Save and continue"
     fill_in_selection_settings if answer_type == "selection"
+    fill_in_text_settings if answer_type == "text"
     expect(page.find("h1")).to have_content "Edit question"
   end
 
@@ -109,6 +142,12 @@ private
     click_button "Remove option 3"
     fill_in "Option 1", with: "Radio option 1"
     fill_in "Option 2", with: "Radio option 2"
+    click_button "Save and continue"
+  end
+
+  def fill_in_text_settings
+    expect(page.find("h1")).to have_text "How much text will people need to provide?"
+    choose "Single line of text"
     click_button "Save and continue"
   end
 end

--- a/spec/forms/text_settings_form_spec.rb
+++ b/spec/forms/text_settings_form_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Forms::TextSettingsForm, type: :model do
+  let(:form) { build :form, id: 1 }
+  let(:text_settings_form) { described_class.new }
+
+  it "has a valid factory" do
+    text_settings_form = build :text_settings_form
+    expect(text_settings_form).to be_valid
+  end
+
+  describe "validations" do
+    it "is invalid if not given an input type" do
+      error_message = I18n.t("activemodel.errors.models.forms/text_settings_form.attributes.input_type.blank")
+      text_settings_form.input_type = nil
+      expect(text_settings_form).to be_invalid
+      expect(text_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
+    end
+
+    it "is invalid given an empty string input_type" do
+      error_message = I18n.t("activemodel.errors.models.forms/text_settings_form.attributes.input_type.blank")
+      text_settings_form.input_type = ""
+      expect(text_settings_form).to be_invalid
+      expect(text_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
+    end
+
+    it "is invalid given an input_type which is not in the list" do
+      error_message = I18n.t("activemodel.errors.models.forms/text_settings_form.attributes.input_type.inclusion")
+      text_settings_form.input_type = "some_random_string"
+      expect(text_settings_form).to be_invalid
+      expect(text_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
+    end
+
+    it "is valid if input type is a valid input type" do
+      described_class::INPUT_TYPES.each do |input_type|
+        text_settings_form.input_type = input_type
+        expect(text_settings_form).to be_valid "#{input_type} is not an input type"
+      end
+    end
+  end
+
+  describe "#submit" do
+    let(:session_mock) { {} }
+
+    it "returns false if the form is invalid" do
+      expect(text_settings_form.submit(session_mock)).to be_falsey
+    end
+
+    it "sets a session key called 'page' as a hash with the answer type in it" do
+      text_settings_form.input_type = "single_line"
+      text_settings_form.submit(session_mock)
+      expect(session_mock[:page][:answer_settings]).to include(input_type: "single_line")
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -64,8 +64,9 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     context "with selection answer type" do
+      let(:answer_type) { "selection" }
+
       context "and 'only_one_option' set to 'true'" do
-        let(:answer_type) { "selection" }
         let(:answer_settings) { OpenStruct.new(only_one_option: "true") }
 
         it "returns the answer subtype" do
@@ -74,11 +75,23 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       context "and 'only_one_option' set to 'false'" do
-        let(:answer_type) { "selection" }
         let(:answer_settings) { OpenStruct.new(only_one_option: false) }
 
         it "returns the answer subtype" do
           expect(helper.translation_key_for_answer_type(answer_type, answer_settings)).to eq "checkbox"
+        end
+      end
+    end
+
+    context "with text answer type" do
+      let(:answer_type) { "text" }
+      let(:answer_settings) { OpenStruct.new(input_type:) }
+
+      context "and 'input_type' set to a valid value" do
+        let(:input_type) { Forms::TextSettingsForm::INPUT_TYPES.sample }
+
+        it "returns the answer subtype" do
+          expect(helper.translation_key_for_answer_type(answer_type, answer_settings)).to eq input_type
         end
       end
     end

--- a/spec/requests/pages/text_settings_spec.rb
+++ b/spec/requests/pages/text_settings_spec.rb
@@ -1,0 +1,157 @@
+require "rails_helper"
+
+RSpec.describe "TextSettings controller", type: :request, feature_autocomplete_answer_types: true do
+  let(:form) { build :form, id: 1 }
+  let(:pages) { build_list :page, 5, form_id: form.id }
+
+  let(:text_settings_form) { build :text_settings_form, form: }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Content-Type" => "application/json",
+    }
+  end
+
+  describe "#new" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+
+      get text_settings_new_path(form_id: text_settings_form.form.id)
+    end
+
+    it "reads the existing form" do
+      expect(form).to have_been_read
+    end
+
+    it "sets an instance variable for text_settings_path" do
+      path = assigns(:text_settings_path)
+      expect(path).to eq text_settings_new_path(text_settings_form.form.id)
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("pages/text_settings")
+    end
+  end
+
+  describe "#create" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+    end
+
+    context "when form is invalid" do
+      before do
+        post text_settings_create_path form_id: form.id, params: { forms_text_settings_form: { input_type: nil } }
+      end
+
+      it "renders the text settings view if there are errors" do
+        expect(response).to have_rendered("pages/text_settings")
+      end
+    end
+
+    context "when form is valid and ready to store" do
+      before do
+        post text_settings_create_path form_id: form.id, params: { forms_text_settings_form: { input_type: text_settings_form.input_type } }
+      end
+
+      let(:text_settings_form) { build :text_settings_form, form: }
+
+      it "saves the input type to session" do
+        expect(session[:page][:answer_settings]).to eq({ "input_type": text_settings_form.input_type })
+      end
+
+      it "redirects the user to the edit question page" do
+        expect(response).to redirect_to new_page_path(form.id)
+      end
+    end
+  end
+
+  describe "#edit" do
+    let(:page) { build :page, :with_text_settings, id: 2, form_id: form.id }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/2", req_headers, page.to_json, 200
+      end
+
+      get text_settings_edit_path(form_id: page.form_id, page_id: page.id)
+    end
+
+    it "reads the existing form" do
+      expect(form).to have_been_read
+    end
+
+    it "returns the existing page input type" do
+      form = assigns(:text_settings_form)
+      expect(form.input_type).to eq page.answer_settings["input_type"]
+    end
+
+    it "sets an instance variable for text_settings_path" do
+      path = assigns(:text_settings_path)
+      expect(path).to eq text_settings_edit_path(text_settings_form.form.id)
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("pages/text_settings")
+    end
+  end
+
+  describe "#update" do
+    let(:page) { build :page, :with_text_settings, id: 2, form_id: form.id }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/2", req_headers, page.to_json, 200
+        mock.put "/api/v1/forms/1/pages/2", post_headers
+      end
+    end
+
+    context "when form is valid and ready to update in the DB" do
+      let(:input_type) { "single_line" }
+
+      before do
+        post text_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_text_settings_form: { input_type: } }
+      end
+
+      it "saves the updated input type to DB" do
+        form_instance_variable = assigns(:text_settings_form)
+        expect(form_instance_variable.input_type).to eq input_type
+        page_instance_variable = assigns(:page)
+        expect(page_instance_variable.answer_settings["input_type"]).to eq input_type
+      end
+
+      it "redirects the user to the edit question page" do
+        expect(response).to redirect_to edit_page_path(form.id, page.id)
+      end
+    end
+
+    context "when form is invalid" do
+      let(:input_type) { nil }
+
+      before do
+        post text_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_text_settings_form: { input_type: } }
+      end
+
+      it "renders the text settings view if there are errors" do
+        expect(response).to have_rendered("pages/text_settings")
+      end
+    end
+  end
+end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -11,7 +11,8 @@ describe "pages/_form.html.erb", type: :view do
                                             page_object: question,
                                             action_path: "http://example.com",
                                             change_answer_type_path: "http://change-me-please.com",
-                                            change_selections_settings_path: "http://change-me-please.com" }
+                                            change_selections_settings_path: "http://change-me-please.com",
+                                            change_text_settings_path: "http://change-me-please.com" }
   end
 
   it "has a form with correct action" do

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -14,6 +14,7 @@ describe "pages/edit.html.erb" do
     allow(form).to receive(:persisted?).and_return(true)
     allow(view).to receive(:type_of_answer_edit_path).and_return("/type-of-answer")
     allow(view).to receive(:selections_settings_edit_path).and_return("/selections_settings")
+    allow(view).to receive(:text_settings_edit_path).and_return("/text-settings")
 
     # Assign instance variables so they can be accessed from views
     assign(:form, form)


### PR DESCRIPTION
Co-authored-by: Samuel Culley <SamJamCul@users.noreply.github.com>

#### What problem does the pull request solve?
Allows the user to select a 'text' answer type, which then has an additional options page where the user chooses between long and short text types.

Trello card: https://trello.com/c/hiSdqQBI/375-text-implementation-of-autofill-work-in-production

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
