### PR TITLE
Add logging user_ip in production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,7 @@ class ApplicationController < ActionController::Base
       payload[:user_organisation_slug] = current_user.organisation_slug
     end
     payload[:request_id] = request.request_id
+    payload[:remote_ip] = request.remote_ip
     payload[:form_id] = params[:form_id] if params[:form_id].present?
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
       payload[:user_organisation_slug] = current_user.organisation_slug
     end
     payload[:request_id] = request.request_id
-    payload[:remote_ip] = request.remote_ip
+    payload[:user_ip] = request.remote_ip
     payload[:form_id] = params[:form_id] if params[:form_id].present?
   end
 

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -7,6 +7,7 @@ Rails.application.configure do
       h[:user_id] = event.payload[:user_id]
       h[:user_email] = event.payload[:user_email]
       h[:user_organisation_slug] = event.payload[:user_organisation_slug]
+      h[:user_ip] = event.payload[:remote_ip]
       h[:request_id] = event.payload[:request_id]
       h[:user_id] = event.payload[:user_id]
       h[:form_id] = event.payload[:form_id] if event.payload[:form_id]

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
       h[:user_id] = event.payload[:user_id]
       h[:user_email] = event.payload[:user_email]
       h[:user_organisation_slug] = event.payload[:user_organisation_slug]
-      h[:user_ip] = event.payload[:remote_ip]
+      h[:user_ip] = event.payload[:user_ip]
       h[:request_id] = event.payload[:request_id]
       h[:user_id] = event.payload[:user_id]
       h[:form_id] = event.payload[:form_id] if event.payload[:form_id]


### PR DESCRIPTION
We currently don't log the ip address of the user accesssing the admin.

This commit adds a new entry in the logs for user_ip, which in turn uses the rails remote_ip call. The client ip is picked from the X-forwarded-for header, which is passed through the PaaS router to the application. This may or may not be the right thing to log - it's not clear from running the code on localhost that the correct ip is picked up.

We'll merge this and check the logs in staging to check we have the correct value.

See documentation from MDN and rails for more details.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

https://api.rubyonrails.org/v5.1/classes/ActionDispatch/Request.html#method-i-remote_ip-3D


Trello card: https://trello.com/c/bgLy2njq/355-implement-basic-protective-monitoring-of-govuk-forms

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
