### PR TITLE
Fix issue with input type playback

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -28,22 +28,24 @@
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
       <% end %>
 
-      <% if (@page_object.answer_type == "text") %>
-        <%= summary_list.row do |row|
-          row.key(text: "Input type")
-          row.value(text: t("helpers.label.page.text_settings_options.names.#{@page_object.answer_settings.input_type}"))
-          row.action(text: "Change",
-                    href: @change_text_settings_path,
-                    visually_hidden_text: "input type") end %>
-      <% end %>
+      <% if @page_object&.answer_settings&.input_type %>
+        <% if (@page_object.answer_type == "text") %>
+          <%= summary_list.row do |row|
+            row.key(text: "Input type")
+            row.value(text: t("helpers.label.page.text_settings_options.names.#{@page_object.answer_settings.input_type}"))
+            row.action(text: "Change",
+                      href: @change_text_settings_path,
+                      visually_hidden_text: "input type") end %>
+        <% end %>
 
-      <% if (@page_object.answer_type == "date") %>
-        <%= summary_list.row do |row|
-          row.key(text: "Input type")
-          row.value(text: t("helpers.label.page.date_settings_options.input_types.#{@page_object.answer_settings.input_type}"))
-          row.action(text: "Change",
-                    href: @change_date_settings_path,
-                    visually_hidden_text: "input type") end %>
+        <% if (@page_object.answer_type == "date") %>
+          <%= summary_list.row do |row|
+            row.key(text: "Input type")
+            row.value(text: t("helpers.label.page.date_settings_options.input_types.#{@page_object.answer_settings.input_type}"))
+            row.action(text: "Change",
+                      href: @change_date_settings_path,
+                      visually_hidden_text: "input type") end %>
+        <% end %>
       <% end %>
 
   <% end %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -28,24 +28,22 @@
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
       <% end %>
 
-      <% if @page_object&.answer_settings&.input_type %>
-        <% if (@page_object.answer_type == "text") %>
-          <%= summary_list.row do |row|
-            row.key(text: "Input type")
-            row.value(text: t("helpers.label.page.text_settings_options.names.#{@page_object.answer_settings.input_type}"))
-            row.action(text: "Change",
-                      href: @change_text_settings_path,
-                      visually_hidden_text: "input type") end %>
-        <% end %>
+      <% if (@page_object.answer_type == "text") && @page_object&.answer_settings&.input_type%>
+        <%= summary_list.row do |row|
+          row.key(text: "Input type")
+          row.value(text: t("helpers.label.page.text_settings_options.names.#{@page_object.answer_settings.input_type}"))
+          row.action(text: "Change",
+                    href: @change_text_settings_path,
+                    visually_hidden_text: "input type") end %>
+      <% end %>
 
-        <% if (@page_object.answer_type == "date") %>
-          <%= summary_list.row do |row|
-            row.key(text: "Input type")
-            row.value(text: t("helpers.label.page.date_settings_options.input_types.#{@page_object.answer_settings.input_type}"))
-            row.action(text: "Change",
-                      href: @change_date_settings_path,
-                      visually_hidden_text: "input type") end %>
-        <% end %>
+      <% if (@page_object.answer_type == "date") && @page_object&.answer_settings&.input_type %>
+        <%= summary_list.row do |row|
+          row.key(text: "Input type")
+          row.value(text: t("helpers.label.page.date_settings_options.input_types.#{@page_object.answer_settings.input_type}"))
+          row.action(text: "Change",
+                    href: @change_date_settings_path,
+                    visually_hidden_text: "input type") end %>
       <% end %>
 
   <% end %>

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -28,4 +28,12 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     change_date_settings_path = "https://example.com/change_date_settings"
     render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
   end
+
+  def with_legacy_date_answer_type
+    page = FactoryBot.build(:page, :with_date_settings, id: 1)
+    page.answer_settings = nil
+    change_answer_type_path = "https://example.com/change_answer_type"
+    change_date_settings_path = "https://example.com/change_date_settings"
+    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
+  end
 end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       expect(page).to have_link("Change Answer type Date", href: change_answer_type_path)
     end
 
-    it "has links to change the selection options" do
+    it "has a link to change the input type" do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_date_settings_path:))
       expect(page).to have_link("Change input type", href: change_date_settings_path)
     end
@@ -100,6 +100,19 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_date_settings_path:))
       expect(page).to have_text "Input type"
       expect(page).to have_text I18n.t("helpers.label.page.date_settings_options.input_types.#{page_object.answer_settings.input_type}")
+    end
+
+    context "when the date has no answer settings" do
+      let(:page_object) do
+        page = FactoryBot.build(:page, :with_date_settings, id: 1)
+        page.answer_settings = nil
+        page
+      end
+
+      it "has no link to change the input type" do
+        render_inline(described_class.new(page_object, change_answer_type_path:, change_date_settings_path:))
+        expect(page).not_to have_link("Change input type", href: change_date_settings_path)
+      end
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
Editing a question page with an exisitng date field (i.e. one without an answer settings field) will result in an error, since the page_settings_summary component is expecting the input type to be present. The same will be true of address fields if that it merged before this change.

This PR adds a check for this. This should be a temporary solution - the proper solution is to migrate the existing date (and address) fields. There is a ticket for this in the backlog which should be done in the next sprint.

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
