### PR TITLE
Fix Rspec deprecation warning for using .stub

### DIFF
--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe HostingEnvironment do
     end
 
     context "when in local development" do
-      before { Rails.env.stub(production?: false) }
+      before { allow(Rails.env).to receive(:production?).and_return(false) }
 
       it "returns true" do
         expect(described_class.test_environment?).to be(true)
@@ -36,7 +36,7 @@ RSpec.describe HostingEnvironment do
     end
 
     context "when in production" do
-      before { Rails.env.stub(production?: true) }
+      before { allow(Rails.env).to receive(:production?).and_return(true) }
 
       it "returns false" do
         expect(described_class.test_environment?).to be(false)


### PR DESCRIPTION
When running the hosting_environment_spec.rb tests, rspec complains about the use of stub.

This commit changes stub to use the newer allow().to receive() syntax.

#### What problem does the pull request solve?

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
