### PR TITLE
Disable sentry transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+# Vim swap files
+*.swp

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,7 +2,7 @@ Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
   config.debug = true
-  config.traces_sample_rate = 1.0
+  config.traces_sample_rate = 0.0
   config.environment = ENV["PAAS_ENVIRONMENT"] || "local"
 end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
    Disable Sentry Transactions

    Sentry Transactions can be used to monitor application performance by
    sampling transaction data. We are not using this aspect of Sentry and
    have decided to turn it off.


### Notes
Setting this to `0.0` or removing it all together will disable transaction data: https://docs.sentry.io/platforms/ruby/guides/rails/configuration/options/#tracing-options

I've opted to set it to `0.0` so there is some on-going record for the future that we have intentionally disabled this feature.