### PR TITLE
382 address implementation of autofill work in production

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -46,4 +46,12 @@
                     visually_hidden_text: "input type") end %>
       <% end %>
 
+      <% if (@page_object.answer_type == "address") %>
+        <%= summary_list.row do |row|
+          row.key(text: "Input type")
+          row.value(text: t("helpers.label.page.address_settings_options.input_types.#{@page_object.answer_settings.input_type}"))
+          row.action(text: "Change",
+                     href: @change_address_settings_path,
+                     visually_hidden_text: "input type") end %>
+      <% end %>
   <% end %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -46,7 +46,7 @@
                     visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if (@page_object.answer_type == "address") %>
+      <% if (@page_object.answer_type == "address") && @page_object&.answer_settings&.input_type %>
         <%= summary_list.row do |row|
           row.key(text: "Input type")
           row.value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -49,7 +49,7 @@
       <% if (@page_object.answer_type == "address") %>
         <%= summary_list.row do |row|
           row.key(text: "Input type")
-          row.value(text: t("helpers.label.page.address_settings_options.input_types.#{@page_object.answer_settings.input_type}"))
+          row.value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
           row.action(text: "Change",
                      href: @change_address_settings_path,
                      visually_hidden_text: "input type") end %>

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -12,6 +12,7 @@ module PageSettingsSummaryComponent
       @change_address_settings_path = change_address_settings_path
     end
 
+  private
     def address_input_type_to_string
       input_type = @page_object.answer_settings.input_type
       if input_type.uk_address == "true" && input_type.international_address == "true"

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -2,13 +2,14 @@
 
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
-    def initialize(page_object, change_answer_type_path: "", change_selections_settings_path: "", change_text_settings_path: "", change_date_settings_path: "")
+    def initialize(page_object, change_answer_type_path: "", change_selections_settings_path: "", change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "")
       super
       @page_object = page_object
       @change_answer_type_path = change_answer_type_path
       @change_selections_settings_path = change_selections_settings_path
       @change_text_settings_path = change_text_settings_path
       @change_date_settings_path = change_date_settings_path
+      @change_address_settings_path = change_address_settings_path
     end
   end
 end

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -13,6 +13,7 @@ module PageSettingsSummaryComponent
     end
 
   private
+
     def address_input_type_to_string
       input_type = @page_object.answer_settings.input_type
       if input_type.uk_address == "true" && input_type.international_address == "true"

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -11,5 +11,16 @@ module PageSettingsSummaryComponent
       @change_date_settings_path = change_date_settings_path
       @change_address_settings_path = change_address_settings_path
     end
+
+    def address_input_type_to_string
+      input_type = @page_object.answer_settings.input_type
+      if input_type.uk_address == "true" && input_type.international_address == "true"
+        "uk_and_international_addresses"
+      elsif input_type.uk_address == "true"
+        "uk_addresses"
+      else
+        "international_addresses"
+      end
+    end
   end
 end

--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -2,7 +2,7 @@ class Pages::AddressSettingsController < PagesController
   def new
     uk_address = session.dig(:page, "answer_settings", "input_type", "uk_address")
     international_address = session.dig(:page, "answer_settings", "input_type", "international_address")
-    @address_settings_form = Forms::AddressSettingsForm.new(uk_address: uk_address, international_address: international_address)
+    @address_settings_form = Forms::AddressSettingsForm.new(uk_address:, international_address:)
     @address_settings_path = address_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
     render "pages/address_settings"
@@ -23,7 +23,9 @@ class Pages::AddressSettingsController < PagesController
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     input_type = @page&.answer_settings&.input_type
-    @address_settings_form = Forms::AddressSettingsForm.new(uk_address: input_type["uk_address"], international_address: input_type["international_address"], page: @page)
+    uk_address = input_type&.uk_address
+    international_address = input_type&.international_address
+    @address_settings_form = Forms::AddressSettingsForm.new(uk_address:, international_address:, page: @page)
     @address_settings_path = address_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render "pages/address_settings"

--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -1,7 +1,8 @@
 class Pages::AddressSettingsController < PagesController
   def new
-    input_type = session.dig(:page, "answer_settings", "input_type")
-    @address_settings_form = Forms::AddressSettingsForm.new(input_type:)
+    uk_address = session.dig(:page, "answer_settings", "input_type", "uk_address")
+    international_address = session.dig(:page, "answer_settings", "input_type", "international_address")
+    @address_settings_form = Forms::AddressSettingsForm.new(uk_address: uk_address, international_address: international_address)
     @address_settings_path = address_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
     render "pages/address_settings"
@@ -22,7 +23,7 @@ class Pages::AddressSettingsController < PagesController
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     input_type = @page&.answer_settings&.input_type
-    @address_settings_form = Forms::AddressSettingsForm.new(input_type:, page: @page)
+    @address_settings_form = Forms::AddressSettingsForm.new(uk_address: input_type["uk_address"], international_address: input_type["international_address"], page: @page)
     @address_settings_path = address_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render "pages/address_settings"
@@ -45,6 +46,6 @@ private
 
   def address_settings_form_params
     form = Form.find(params[:form_id])
-    params.require(:forms_address_settings_form).permit(:input_type).merge(form:)
+    params.require(:forms_address_settings_form).permit(:uk_address, :international_address).merge(form:)
   end
 end

--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -5,7 +5,7 @@ class Pages::AddressSettingsController < PagesController
     @address_settings_form = Forms::AddressSettingsForm.new(uk_address:, international_address:)
     @address_settings_path = address_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
-    render "pages/address_settings"
+    render address_settings_view
   end
 
   def create
@@ -16,7 +16,7 @@ class Pages::AddressSettingsController < PagesController
     if @address_settings_form.submit(session)
       redirect_to new_page_path(@form)
     else
-      render "pages/address_settings"
+      render address_settings_view
     end
   end
 
@@ -28,7 +28,7 @@ class Pages::AddressSettingsController < PagesController
     @address_settings_form = Forms::AddressSettingsForm.new(uk_address:, international_address:, page: @page)
     @address_settings_path = address_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
-    render "pages/address_settings"
+    render address_settings_view
   end
 
   def update
@@ -40,7 +40,7 @@ class Pages::AddressSettingsController < PagesController
     if @address_settings_form.assign_values_to_page(@page) && @page.save!
       redirect_to edit_page_path(@form)
     else
-      render "pages/address_settings"
+      render address_settings_view
     end
   end
 
@@ -49,5 +49,9 @@ private
   def address_settings_form_params
     form = Form.find(params[:form_id])
     params.require(:forms_address_settings_form).permit(:uk_address, :international_address).merge(form:)
+  end
+
+  def address_settings_view
+    "pages/address_settings"
   end
 end

--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -1,0 +1,50 @@
+class Pages::AddressSettingsController < PagesController
+  def new
+    input_type = session.dig(:page, "answer_settings", "input_type")
+    @address_settings_form = Forms::AddressSettingsForm.new(input_type:)
+    @address_settings_path = address_settings_create_path(@form)
+    @back_link_url = type_of_answer_new_path(@form)
+    render "pages/address_settings"
+  end
+
+  def create
+    @address_settings_form = Forms::AddressSettingsForm.new(address_settings_form_params)
+    @address_settings_path = address_settings_create_path(@form)
+    @back_link_url = type_of_answer_new_path(@form)
+
+    if @address_settings_form.submit(session)
+      redirect_to new_page_path(@form)
+    else
+      render "pages/address_settings"
+    end
+  end
+
+  def edit
+    @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    input_type = @page&.answer_settings&.input_type
+    @address_settings_form = Forms::AddressSettingsForm.new(input_type:, page: @page)
+    @address_settings_path = address_settings_update_path(@form)
+    @back_link_url = type_of_answer_edit_path(@form)
+    render "pages/address_settings"
+  end
+
+  def update
+    @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    @address_settings_form = Forms::AddressSettingsForm.new(address_settings_form_params)
+    @address_settings_path = address_settings_update_path(@form)
+    @back_link_url = type_of_answer_edit_path(@form)
+
+    if @address_settings_form.assign_values_to_page(@page) && @page.save!
+      redirect_to edit_page_path(@form)
+    else
+      render "pages/address_settings"
+    end
+  end
+
+private
+
+  def address_settings_form_params
+    form = Form.find(params[:form_id])
+    params.require(:forms_address_settings_form).permit(:input_type).merge(form:)
+  end
+end

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -50,6 +50,8 @@ private
       action == :create ? text_settings_new_path(form) : text_settings_edit_path(form)
     when "date"
       action == :create ? date_settings_new_path(form) : date_settings_edit_path(form)
+    when "address"
+      action == :create ? address_settings_new_path(form) : address_settings_edit_path(form)
     else
       action == :create ? new_page_path(@form) : edit_page_path(@form)
     end

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -42,18 +42,38 @@ class Pages::TypeOfAnswerController < PagesController
 
 private
 
+  def selection_path(form, action)
+    action == :create ? selections_settings_new_path(form) : selections_settings_edit_path(form)
+  end
+
+  def text_path(form, action)
+    action == :create ? text_settings_new_path(form) : text_settings_edit_path(form)
+  end
+
+  def date_path(form, action)
+    action == :create ? date_settings_new_path(form) : date_settings_edit_path(form)
+  end
+
+  def address_path(form, action)
+    action == :create ? address_settings_new_path(form) : address_settings_edit_path(form)
+  end
+
+  def default_path(_form, action)
+    action == :create ? new_page_path(@form) : edit_page_path(@form)
+  end
+
   def next_page_path(form, answer_type, action)
     case answer_type
     when "selection"
-      action == :create ? selections_settings_new_path(form) : selections_settings_edit_path(form)
+      selection_path(form, action)
     when "text"
-      action == :create ? text_settings_new_path(form) : text_settings_edit_path(form)
+      text_path(form, action)
     when "date"
-      action == :create ? date_settings_new_path(form) : date_settings_edit_path(form)
+      date_path(form, action)
     when "address"
-      action == :create ? address_settings_new_path(form) : address_settings_edit_path(form)
+      address_path(form, action)
     else
-      action == :create ? new_page_path(@form) : edit_page_path(@form)
+      default_path(form, action)
     end
   end
 

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -58,8 +58,8 @@ private
     action == :create ? address_settings_new_path(form) : address_settings_edit_path(form)
   end
 
-  def default_path(_form, action)
-    action == :create ? new_page_path(@form) : edit_page_path(@form)
+  def default_path(form, action)
+    action == :create ? new_page_path(form) : edit_page_path(form)
   end
 
   def next_page_path(form, answer_type, action)

--- a/app/forms/forms/address_settings_form.rb
+++ b/app/forms/forms/address_settings_form.rb
@@ -2,22 +2,29 @@ class Forms::AddressSettingsForm
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :input_type, :form, :page
+  attr_accessor :uk_address, :international_address, :form, :page, :input_type
 
   INPUT_TYPES = %w[uk_address international_address].freeze
 
-  validates :input_type, presence: true, inclusion: { in: INPUT_TYPES }
+  # validate :any_present?
+  # validates :input_type, presence: true
+  validates :uk_address, inclusion: { in: %w[true false] }
+  # validates :international_address, inclusion: { in: %w[true false] }
 
   def submit(session)
     return false if invalid?
 
     session[:page] = {} if session[:page].blank?
-    session[:page][:answer_settings] = { input_type: }
+    session[:page][:answer_settings] = { input_type: { uk_address:, international_address: } }
   end
 
   def assign_values_to_page(page)
     return false if invalid?
 
-    page.answer_settings = { input_type: }
+    page.answer_settings = { input_type: { uk_address:, international_address: } }
+  end
+
+  def any_present?
+    return errors.add(:uk_address, :blank) if uk_address == "false" && international_address == "false"
   end
 end

--- a/app/forms/forms/address_settings_form.rb
+++ b/app/forms/forms/address_settings_form.rb
@@ -2,14 +2,13 @@ class Forms::AddressSettingsForm
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :uk_address, :international_address, :form, :page, :input_type
+  attr_accessor :uk_address, :international_address, :form, :page
 
   INPUT_TYPES = %w[uk_address international_address].freeze
 
   validate :at_least_one_selected?
-  # validates :input_type, presence: true
   validates :uk_address, inclusion: { in: %w[true false] }
-  # validates :international_address, inclusion: { in: %w[true false] }
+  validates :international_address, inclusion: { in: %w[true false] }
 
   def submit(session)
     return false if invalid?
@@ -25,6 +24,6 @@ class Forms::AddressSettingsForm
   end
 
   def at_least_one_selected?
-    return errors.add(:uk_address, :blank) if uk_address == "false" && international_address == "false"
+    errors.add(:base, :blank) if uk_address == "false" && international_address == "false"
   end
 end

--- a/app/forms/forms/address_settings_form.rb
+++ b/app/forms/forms/address_settings_form.rb
@@ -1,0 +1,23 @@
+class Forms::AddressSettingsForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :input_type, :form, :page
+
+  INPUT_TYPES = %w[uk_address international_address].freeze
+
+  validates :input_type, presence: true, inclusion: { in: INPUT_TYPES }
+
+  def submit(session)
+    return false if invalid?
+
+    session[:page] = {} if session[:page].blank?
+    session[:page][:answer_settings] = { input_type: }
+  end
+
+  def assign_values_to_page(page)
+    return false if invalid?
+
+    page.answer_settings = { input_type: }
+  end
+end

--- a/app/forms/forms/address_settings_form.rb
+++ b/app/forms/forms/address_settings_form.rb
@@ -6,7 +6,7 @@ class Forms::AddressSettingsForm
 
   INPUT_TYPES = %w[uk_address international_address].freeze
 
-  # validate :any_present?
+  validate :at_least_one_selected?
   # validates :input_type, presence: true
   validates :uk_address, inclusion: { in: %w[true false] }
   # validates :international_address, inclusion: { in: %w[true false] }
@@ -24,7 +24,7 @@ class Forms::AddressSettingsForm
     page.answer_settings = { input_type: { uk_address:, international_address: } }
   end
 
-  def any_present?
+  def at_least_one_selected?
     return errors.add(:uk_address, :blank) if uk_address == "false" && international_address == "false"
   end
 end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -23,7 +23,7 @@
     <% end %>
   <% end %>
 
-  <%= render PageSettingsSummaryComponent::View.new(page_object, change_answer_type_path:, change_selections_settings_path:, change_text_settings_path:, change_date_settings_path:) %>
+  <%= render PageSettingsSummaryComponent::View.new(page_object, change_answer_type_path:, change_selections_settings_path:, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/app/views/pages/address_settings.html.erb
+++ b/app/views/pages/address_settings.html.erb
@@ -1,0 +1,19 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.address_settings"), @address_settings_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(@back_link_url) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: [@form, @address_settings_form], url: @address_settings_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(
+            :input_type,
+            Forms::AddressSettingsForm::INPUT_TYPES,
+            ->(option) { option },
+            ->(option) { I18n.t('helpers.label.page.address_settings_options.names.' + option) },
+            legend: { text: t('page_titles.address_settings'), size: 'l', tag: 'h1' },
+            caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' },
+          )  %>
+      <%= f.govuk_submit t('save_and_continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pages/address_settings.html.erb
+++ b/app/views/pages/address_settings.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [@form, @address_settings_form], url: @address_settings_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_check_boxes_fieldset 'address_types', multiple: false, legend: { text: t("page_titles.address_settings") }, caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' }, hint: { text: t("address_settings.hint")} do %>
+      <%= f.govuk_check_boxes_fieldset 'address_types', multiple: false, legend: { text: t("page_titles.address_settings"), tag: "h1", size: "l" }, caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' }, hint: { text: t("address_settings.hint")} do %>
         <%= f.govuk_check_box 'uk_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.uk_addresses") }%>
         <%= f.govuk_check_box 'international_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.international_addresses") }%>
       <% end %>

--- a/app/views/pages/address_settings.html.erb
+++ b/app/views/pages/address_settings.html.erb
@@ -5,15 +5,12 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [@form, @address_settings_form], url: @address_settings_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_collection_radio_buttons(
-            :input_type,
-            Forms::AddressSettingsForm::INPUT_TYPES,
-            ->(option) { option },
-            ->(option) { I18n.t('helpers.label.page.address_settings_options.names.' + option) },
-            legend: { text: t('page_titles.address_settings'), size: 'l', tag: 'h1' },
-            caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' },
-          )  %>
+      <%= f.govuk_check_boxes_fieldset 'address_types', multiple: false, legend: { text: t("page_titles.address_settings") }, caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' }, hint: { text: t("address_settings.hint")} do %>
+        <%= f.govuk_check_box 'uk_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.uk_address") }%>
+        <%= f.govuk_check_box 'international_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.international_address") }%>
+      <% end %>
       <%= f.govuk_submit t('save_and_continue') %>
     <% end %>
   </div>
 </div>
+

--- a/app/views/pages/address_settings.html.erb
+++ b/app/views/pages/address_settings.html.erb
@@ -6,8 +6,8 @@
     <%= form_with model: [@form, @address_settings_form], url: @address_settings_path do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_check_boxes_fieldset 'address_types', multiple: false, legend: { text: t("page_titles.address_settings") }, caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' }, hint: { text: t("address_settings.hint")} do %>
-        <%= f.govuk_check_box 'uk_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.uk_address") }%>
-        <%= f.govuk_check_box 'international_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.international_address") }%>
+        <%= f.govuk_check_box 'uk_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.uk_addresses") }%>
+        <%= f.govuk_check_box 'international_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.international_addresses") }%>
       <% end %>
       <%= f.govuk_submit t('save_and_continue') %>
     <% end %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -16,7 +16,8 @@
                                              change_answer_type_path: type_of_answer_edit_path(@form),
                                              change_selections_settings_path: selections_settings_edit_path(@form),
                                              change_text_settings_path: text_settings_edit_path(@form),
-                                             change_date_settings_path: date_settings_edit_path(@form)
+                                             change_date_settings_path: date_settings_edit_path(@form),
+                                             change_address_settings_path: address_settings_edit_path(@form)
     } %>
 
     <p class="govuk-body">

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -16,7 +16,8 @@
                                              change_answer_type_path: type_of_answer_new_path(@form),
                                              change_selections_settings_path: selections_settings_new_path(@form),
                                              change_text_settings_path: text_settings_new_path(@form),
-                                             change_date_settings_path: date_settings_new_path(@form)
+                                             change_date_settings_path: date_settings_new_path(@form),
+                                             change_address_settings_path: address_settings_new_path(@form)
     } %>
 
     <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,13 @@ en:
       forms_make_live_form:
         confirm_make_live: Are you sure you want to make your form live?
       page:
+        address_settings_options:
+          input_types:
+            international_address: International addresses
+            uk_address: UK addresses
+          names:
+            international_address: 'No'
+            uk_address: 'Yes'
         answer_type_options:
           descriptions:
             address: To collect an address with separate fields for line 1, line 2, town or city, county and postcode
@@ -225,6 +232,7 @@ en:
       If you pasted the web address, check you copied the entire address.
     title: Page not found
   page_titles:
+    address_settings: What kind of addresses do you expect to receive?
     change_email_form: What email address should form responses be sent to?
     change_name_form: Name your form
     confirm_email_form: Enter the confirmation code

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,8 +144,9 @@ en:
             international_address: International address
             uk_address: UK address
           names:
-            international_address: International addresses
-            uk_address: UK addresses
+            international_addresses: International addresses
+            uk_addresses: UK addresses
+            uk_and_international_addresses: UK and international addresses
         answer_type_options:
           descriptions:
             address: To collect an address with separate fields for line 1, line 2, town or city, county and postcode

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,8 @@ en:
           attributes:
             question_text:
               blank: Question text cannot be blank
+  address_settings:
+    hint: Select all that apply
   contact_details:
     new:
       body_html: |
@@ -139,11 +141,11 @@ en:
       page:
         address_settings_options:
           input_types:
+            international_address: International address
+            uk_address: UK address
+          names:
             international_address: International addresses
             uk_address: UK addresses
-          names:
-            international_address: 'No'
-            uk_address: 'Yes'
         answer_type_options:
           descriptions:
             address: To collect an address with separate fields for line 1, line 2, town or city, county and postcode

--- a/config/locales/forms/address_settings.yml
+++ b/config/locales/forms/address_settings.yml
@@ -4,6 +4,9 @@ en:
       models:
         forms/address_settings_form:
           attributes:
-            input_type:
+            uk_address:
+              blank: Select the kind of addresses you expect to receive
+              inclusion: Select ‘UK addresses’ or ‘International addresses’
+            international_address:
               blank: Select the kind of addresses you expect to receive
               inclusion: Select ‘UK addresses’ or ‘International addresses’

--- a/config/locales/forms/address_settings.yml
+++ b/config/locales/forms/address_settings.yml
@@ -1,0 +1,9 @@
+en:
+  activemodel:
+    errors:
+      models:
+        forms/address_settings_form:
+          attributes:
+            input_type:
+              blank: Select the kind of addresses you expect to receive
+              inclusion: Select ‘UK addresses’ or ‘International addresses’

--- a/config/locales/forms/address_settings.yml
+++ b/config/locales/forms/address_settings.yml
@@ -4,9 +4,9 @@ en:
       models:
         forms/address_settings_form:
           attributes:
-            uk_address:
+            base:
               blank: Select the kind of addresses you expect to receive
+            uk_address:
               inclusion: Select ‘UK addresses’ or ‘International addresses’
             international_address:
-              blank: Select the kind of addresses you expect to receive
               inclusion: Select ‘UK addresses’ or ‘International addresses’

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
         post "/date-settings" => "pages/date_settings#create", as: :date_settings_create
         get "/selections-settings" => "pages/selections_settings#new", as: :selections_settings_new
         post "/selections-settings" => "pages/selections_settings#create", as: :selections_settings_create
+        get "/address-settings" => "pages/address_settings#new", as: :address_settings_new
+        post "/address-settings" => "pages/address_settings#create", as: :address_settings_create
         get "/" => "pages#new", as: :new_page
         post "/" => "pages#create", as: :create_page
       end
@@ -65,6 +67,8 @@ Rails.application.routes.draw do
           post "/date-settings" => "pages/date_settings#update", as: :date_settings_update
           get "/selections-settings" => "pages/selections_settings#edit", as: :selections_settings_edit
           post "/selections-settings" => "pages/selections_settings#update", as: :selections_settings_update
+          get "/address-settings" => "pages/address_settings#edit", as: :address_settings_edit
+          post "/address-settings" => "pages/address_settings#update", as: :address_settings_update
           get "/" => "pages#edit", as: :edit_page
           patch "/" => "pages#update", as: :update_page
         end

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -37,19 +37,11 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
   end
 
-  def with_text_answer_type
-    page = FactoryBot.build(:page, :with_text_settings, id: 1)
+  def with_address_answer_type
+    page = FactoryBot.build(:page, :with_address_settings, id: 1)
     page.answer_settings = OpenStruct.new(page.answer_settings)
     change_answer_type_path = "https://example.com/change_answer_type"
-    change_text_settings_path = "https://example.com/change_text_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_text_settings_path:))
-  end
-
-  def with_date_answer_type
-    page = FactoryBot.build(:page, :with_date_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
-    change_answer_type_path = "https://example.com/change_answer_type"
-    change_date_settings_path = "https://example.com/change_date_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
+    change_address_settings_path = "https://example.com/change_address_settings"
+    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_address_settings_path:))
   end
 end

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -42,7 +42,7 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     page.answer_settings = OpenStruct.new(page.answer_settings)
     change_answer_type_path = "https://example.com/change_answer_type"
     change_text_settings_path = "https://example.com/change_text_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path, "", change_text_settings_path))
+    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_text_settings_path:))
   end
 
   def with_date_answer_type
@@ -50,6 +50,6 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     page.answer_settings = OpenStruct.new(page.answer_settings)
     change_answer_type_path = "https://example.com/change_answer_type"
     change_date_settings_path = "https://example.com/change_date_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path, "", "", change_date_settings_path))
+    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
   end
 end

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -37,6 +37,14 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
   end
 
+  def with_text_answer_type
+    page = FactoryBot.build(:page, :with_text_settings, id: 1)
+    page.answer_settings = OpenStruct.new(page.answer_settings)
+    change_answer_type_path = "https://example.com/change_answer_type"
+    change_text_settings_path = "https://example.com/change_text_settings"
+    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path, "", change_text_settings_path))
+  end
+
   def with_date_answer_type
     page = FactoryBot.build(:page, :with_date_settings, id: 1)
     page.answer_settings = OpenStruct.new(page.answer_settings)
@@ -44,6 +52,4 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     change_date_settings_path = "https://example.com/change_date_settings"
     render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path, "", "", change_date_settings_path))
   end
-
-  # TODO: Add preview for date and text inputs
 end

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -36,4 +36,14 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     change_date_settings_path = "https://example.com/change_date_settings"
     render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
   end
+
+  def with_date_answer_type
+    page = FactoryBot.build(:page, :with_date_settings, id: 1)
+    page.answer_settings = OpenStruct.new(page.answer_settings)
+    change_answer_type_path = "https://example.com/change_answer_type"
+    change_date_settings_path = "https://example.com/change_date_settings"
+    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path, "", "", change_date_settings_path))
+  end
+
+  # TODO: Add preview for date and text inputs
 end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -96,6 +96,11 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       expect(page).to have_link("Change input type", href: change_date_settings_path)
     end
 
+    it "has links to change the selection options" do
+      render_inline(described_class.new(page_object, change_answer_type_path:, change_date_settings_path:))
+      expect(page).to have_link("Change input type", href: change_date_settings_path)
+    end
+
     it "renders the input type" do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_date_settings_path:))
       expect(page).to have_text "Input type"

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
   let(:change_selections_settings_path) { "https://example.com/change_selections_settings" }
   let(:change_text_settings_path) { "https://example.com/change_text_settings" }
   let(:change_date_settings_path) { "https://example.com/change_date_settings" }
+  let(:change_address_settings_path) { "https://example.com/change_address_settings" }
 
   context "when the page is not a selection page" do
     it "has a link to change the answer type" do
@@ -118,6 +119,30 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         render_inline(described_class.new(page_object, change_answer_type_path:, change_date_settings_path:))
         expect(page).not_to have_link("Change input type", href: change_date_settings_path)
       end
+    end
+  end
+
+  context "when the page is an address page" do
+    let(:page_object) do
+      page = FactoryBot.build(:page, :with_address_settings, id: 1)
+      page.answer_settings = OpenStruct.new(page.answer_settings)
+      page
+    end
+
+    it "has a link to change the answer type" do
+      render_inline(described_class.new(page_object, change_answer_type_path:, change_address_settings_path:))
+      expect(page).to have_link("Change Answer type Address", href: change_answer_type_path)
+    end
+
+    it "has links to change the selection options" do
+      render_inline(described_class.new(page_object, change_answer_type_path:, change_address_settings_path:))
+      expect(page).to have_link("Change input type", href: change_address_settings_path)
+    end
+
+    it "renders the input type" do
+      render_inline(described_class.new(page_object, change_answer_type_path:, change_address_settings_path:))
+      expect(page).to have_text "Input type"
+      expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.input_types.#{page_object.answer_settings.input_type}")
     end
   end
 end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -126,8 +126,13 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:page_object) do
       page = FactoryBot.build(:page, :with_address_settings, id: 1)
       page.answer_settings = OpenStruct.new(page.answer_settings)
+      page.answer_settings.input_type = input_type
       page
     end
+
+    let(:input_type){ OpenStruct.new({ uk_address:, international_address: }) }
+    let(:uk_address){ "true" }
+    let(:international_address) { "true" }
 
     it "has a link to change the answer type" do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_address_settings_path:))
@@ -142,7 +147,27 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     it "renders the input type" do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_address_settings_path:))
       expect(page).to have_text "Input type"
-      expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.input_types.#{page_object.answer_settings.input_type}")
+      expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.uk_and_international_addresses")
+    end
+
+    context "when the input type is uk addresses only" do
+      let(:uk_address){ "true" }
+      let(:international_address) { "false" }
+
+      it "renders the input type as uk addresses" do
+        render_inline(described_class.new(page_object, change_answer_type_path:, change_address_settings_path:))
+        expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.uk_addresses")
+      end
+    end
+
+    context "when the input type is international addresses only" do
+      let(:uk_address){ "false" }
+      let(:international_address) { "true" }
+
+      it "renders the input type as international addresses" do
+        render_inline(described_class.new(page_object, change_answer_type_path:, change_address_settings_path:))
+        expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.international_addresses")
+      end
     end
   end
 end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       page
     end
 
-    let(:input_type){ OpenStruct.new({ uk_address:, international_address: }) }
-    let(:uk_address){ "true" }
+    let(:input_type) { OpenStruct.new({ uk_address:, international_address: }) }
+    let(:uk_address) { "true" }
     let(:international_address) { "true" }
 
     it "has a link to change the answer type" do
@@ -151,7 +151,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     end
 
     context "when the input type is uk addresses only" do
-      let(:uk_address){ "true" }
+      let(:uk_address) { "true" }
       let(:international_address) { "false" }
 
       it "renders the input type as uk addresses" do
@@ -161,7 +161,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     end
 
     context "when the input type is international addresses only" do
-      let(:uk_address){ "false" }
+      let(:uk_address) { "false" }
       let(:international_address) { "true" }
 
       it "renders the input type as international addresses" do

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -97,11 +97,6 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       expect(page).to have_link("Change input type", href: change_date_settings_path)
     end
 
-    it "has links to change the selection options" do
-      render_inline(described_class.new(page_object, change_answer_type_path:, change_date_settings_path:))
-      expect(page).to have_link("Change input type", href: change_date_settings_path)
-    end
-
     it "renders the input type" do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_date_settings_path:))
       expect(page).to have_text "Input type"

--- a/spec/factories/forms/address_settings_form.rb
+++ b/spec/factories/forms/address_settings_form.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :address_settings_form, class: "Forms::AddressSettingsForm" do
-    input_type { Forms::AddressSettingsForm::INPUT_TYPES.sample }
+    uk_address { "true" }
+    international_address { "true" }
   end
 end

--- a/spec/factories/forms/address_settings_form.rb
+++ b/spec/factories/forms/address_settings_form.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address_settings_form, class: "Forms::AddressSettingsForm" do
+    input_type { Forms::AddressSettingsForm::INPUT_TYPES.sample }
+  end
+end

--- a/spec/factories/forms/type_of_answer_form.rb
+++ b/spec/factories/forms/type_of_answer_form.rb
@@ -5,9 +5,9 @@ FactoryBot.define do
 
     trait :with_simple_answer_type do
       if FeatureService.enabled?(:autocomplete_answer_types)
-        answer_type { %w[single_line number address email national_insurance_number phone_number long_text organisation_name].sample }
+        answer_type { %w[single_line number email national_insurance_number phone_number long_text organisation_name].sample }
       else
-        answer_type { %w[single_line number address email national_insurance_number phone_number long_text].sample }
+        answer_type { %w[single_line number email national_insurance_number phone_number long_text].sample }
       end
     end
   end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -11,9 +11,9 @@ FactoryBot.define do
 
     trait :with_simple_answer_type do
       if FeatureService.enabled?(:autocomplete_answer_types)
-        answer_type { %w[single_line number address email national_insurance_number phone_number long_text organisation_name].sample }
+        answer_type { %w[single_line number email national_insurance_number phone_number long_text organisation_name].sample }
       else
-        answer_type { %w[single_line number address email national_insurance_number phone_number long_text].sample }
+        answer_type { %w[single_line number email national_insurance_number phone_number long_text].sample }
       end
     end
 
@@ -30,6 +30,11 @@ FactoryBot.define do
     trait :with_date_settings do
       answer_type { "date" }
       answer_settings { { input_type: Forms::DateSettingsForm::INPUT_TYPES.sample } }
+    end
+
+    trait :with_address_settings do
+      answer_type { "address" }
+      answer_settings { { input_type: Forms::AddressSettingsForm::INPUT_TYPES.sample } }
     end
   end
 end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
 
     trait :with_address_settings do
       answer_type { "address" }
-      answer_settings { { input_type: Forms::AddressSettingsForm::INPUT_TYPES.sample } }
+      answer_settings { { input_type: { "uk_address": "true", "international_address": "true" } } }
     end
   end
 end

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -106,6 +106,7 @@ private
     fill_in_selection_settings if answer_type == "selection"
     fill_in_text_settings if answer_type == "text"
     fill_in_date_settings if answer_type == "date"
+    fill_in_address_settings if answer_type == "address"
     expect(page.find("h1")).to have_content "Edit question"
   end
 
@@ -155,6 +156,12 @@ private
   def fill_in_date_settings
     expect(page.find("h1")).to have_text "Are you asking for someone's date of birth?"
     choose "No"
+    click_button "Save and continue"
+  end
+
+  def fill_in_address_settings
+    expect(page.find("h1")).to have_text "What kind of addresses do you expect to receive?"
+    choose "Yes"
     click_button "Save and continue"
   end
 end

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Add/editing a single line question", type: :feature do
+feature "Add/editing a single question", type: :feature do
   let(:form) { build :form, id: 1 }
   let(:req_headers) do
     {
@@ -161,7 +161,9 @@ private
 
   def fill_in_address_settings
     expect(page.find("h1")).to have_text "What kind of addresses do you expect to receive?"
-    choose "Yes"
+    check "UK addresses"
+    check "International addresses"
     click_button "Save and continue"
+    expect(page.find(".govuk-summary-list")).to have_text "UK and international addresses"
   end
 end

--- a/spec/forms/address_settings_form_spec.rb
+++ b/spec/forms/address_settings_form_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Forms::AddressSettingsForm, type: :model do
+  let(:form) { build :form, id: 1 }
+  let(:address_settings_form) { described_class.new }
+
+  it "has a valid factory" do
+    address_settings_form = build :address_settings_form
+    expect(address_settings_form).to be_valid
+  end
+
+  describe "validations" do
+    it "is invalid if not given an input type" do
+      error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.input_type.blank")
+      address_settings_form.input_type = nil
+      expect(address_settings_form).to be_invalid
+      expect(address_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
+    end
+
+    it "is invalid given an empty string input_type" do
+      error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.input_type.blank")
+      address_settings_form.input_type = ""
+      expect(address_settings_form).to be_invalid
+      expect(address_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
+    end
+
+    it "is invalid given an input_type which is not in the list" do
+      error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.input_type.inclusion")
+      address_settings_form.input_type = "some_random_string"
+      expect(address_settings_form).to be_invalid
+      expect(address_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
+    end
+
+    it "is valid if input type is a valid input type" do
+      described_class::INPUT_TYPES.each do |input_type|
+        address_settings_form.input_type = input_type
+        expect(address_settings_form).to be_valid "#{input_type} is not an input type"
+      end
+    end
+  end
+
+  describe "#submit" do
+    let(:session_mock) { {} }
+
+    it "returns false if the form is invalid" do
+      expect(address_settings_form.submit(session_mock)).to be_falsey
+    end
+
+    it "sets a session key called 'page' as a hash with the answer type in it" do
+      address_settings_form.input_type = "uk_address"
+      address_settings_form.submit(session_mock)
+      expect(session_mock[:page][:answer_settings]).to include(input_type: "uk_address")
+    end
+  end
+end

--- a/spec/forms/address_settings_form_spec.rb
+++ b/spec/forms/address_settings_form_spec.rb
@@ -10,31 +10,34 @@ RSpec.describe Forms::AddressSettingsForm, type: :model do
   end
 
   describe "validations" do
-    it "is invalid if not given an input type" do
-      error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.input_type.blank")
-      address_settings_form.input_type = nil
+    it "is invalid if no options are selected" do
+      error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.base.blank")
+      address_settings_form.uk_address = "false"
+      address_settings_form.international_address = "false"
       expect(address_settings_form).to be_invalid
-      expect(address_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
+      expect(address_settings_form.errors.full_messages_for(:base)).to include(error_message)
     end
 
-    it "is invalid given an empty string input_type" do
-      error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.input_type.blank")
-      address_settings_form.input_type = ""
+    it "is invalid given a value which is neither true nor false" do
+      uk_error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.uk_address.inclusion")
+      international_error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.international_address.inclusion")
+      address_settings_form.uk_address = "maybe"
+      address_settings_form.international_address = "possibly"
       expect(address_settings_form).to be_invalid
-      expect(address_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
+      expect(address_settings_form.errors.full_messages_for(:uk_address)).to include("Uk address #{uk_error_message}")
+      expect(address_settings_form.errors.full_messages_for(:international_address)).to include("International address #{international_error_message}")
     end
 
-    it "is invalid given an input_type which is not in the list" do
-      error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.input_type.inclusion")
-      address_settings_form.input_type = "some_random_string"
-      expect(address_settings_form).to be_invalid
-      expect(address_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
-    end
-
-    it "is valid if input type is a valid input type" do
-      described_class::INPUT_TYPES.each do |input_type|
-        address_settings_form.input_type = input_type
-        expect(address_settings_form).to be_valid "#{input_type} is not an input type"
+    it "is valid if address settings are valid" do
+      valid_combinations = [
+        { uk_address: "true", international_address: "true" },
+        { uk_address: "true", international_address: "false" },
+        { uk_address: "false", international_address: "true" },
+      ]
+      valid_combinations.each do |combination|
+        address_settings_form.uk_address = combination[:uk_address]
+        address_settings_form.international_address = combination[:international_address]
+        expect(address_settings_form).to be_valid
       end
     end
   end
@@ -47,9 +50,9 @@ RSpec.describe Forms::AddressSettingsForm, type: :model do
     end
 
     it "sets a session key called 'page' as a hash with the answer type in it" do
-      address_settings_form.input_type = "uk_address"
+      address_settings_form = build :address_settings_form
       address_settings_form.submit(session_mock)
-      expect(session_mock[:page][:answer_settings]).to include(input_type: "uk_address")
+      expect(session_mock[:page][:answer_settings]).to include(input_type: { international_address: "true", uk_address: "true" })
     end
   end
 end

--- a/spec/requests/pages/address_settings_spec.rb
+++ b/spec/requests/pages/address_settings_spec.rb
@@ -1,0 +1,165 @@
+require "rails_helper"
+
+RSpec.describe "AddressSettings controller", type: :request, feature_autocomplete_answer_types: true do
+  let(:form) { build :form, id: 1 }
+  let(:pages) { build_list :page, 5, form_id: form.id }
+
+  let(:address_settings_form) { build :address_settings_form, form: }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Content-Type" => "application/json",
+    }
+  end
+
+  describe "#new" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+
+      get address_settings_new_path(form_id: address_settings_form.form.id)
+    end
+
+    it "reads the existing form" do
+      expect(form).to have_been_read
+    end
+
+    it "sets an instance variable for address_settings_path" do
+      path = assigns(:address_settings_path)
+      expect(path).to eq address_settings_new_path(address_settings_form.form.id)
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("pages/address_settings")
+    end
+  end
+
+  describe "#create" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+    end
+
+    context "when form is invalid" do
+      before do
+        post address_settings_create_path form_id: form.id, params: { forms_address_settings_form: { input_type: nil } }
+      end
+
+      it "renders the address settings view if there are errors" do
+        expect(response).to have_rendered("pages/address_settings")
+      end
+    end
+
+    context "when form is valid and ready to store" do
+      before do
+        post address_settings_create_path form_id: form.id, params: { forms_address_settings_form: { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address } }
+      end
+
+      let(:address_settings_form) { build :address_settings_form, form: }
+
+      it "saves the input type to session" do
+        expect(session[:page][:answer_settings]).to eq({ "input_type": { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address } })
+      end
+
+      it "redirects the user to the edit question page" do
+        expect(response).to redirect_to new_page_path(form.id)
+      end
+    end
+  end
+
+  describe "#edit" do
+    let(:page) { build :page, :with_address_settings, id: 2, form_id: form.id }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/2", req_headers, page.to_json, 200
+      end
+
+      get address_settings_edit_path(form_id: page.form_id, page_id: page.id)
+    end
+
+    it "reads the existing form" do
+      expect(form).to have_been_read
+    end
+
+    it "returns the existing page input type" do
+      form = assigns(:address_settings_form)
+      expect(form.uk_address).to eq page.answer_settings["input_type"]["uk_address"]
+      expect(form.international_address).to eq page.answer_settings["input_type"]["international_address"]
+    end
+
+    it "sets an instance variable for address_settings_path" do
+      path = assigns(:address_settings_path)
+      expect(path).to eq address_settings_edit_path(address_settings_form.form.id)
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("pages/address_settings")
+    end
+  end
+
+  describe "#update" do
+    let(:page) do
+      new_page = build :page, :with_address_settings, id: 2, form_id: form.id
+      new_page.answer_settings = OpenStruct.new(input_type: OpenStruct.new(uk_address: "false", international_address: "true"))
+      new_page
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/2", req_headers, page.to_json, 200
+        mock.put "/api/v1/forms/1/pages/2", post_headers
+      end
+    end
+
+    context "when form is valid and ready to update in the DB" do
+      let(:input_type) { { uk_address:, international_address: } }
+      let(:uk_address) { page.answer_settings.input_type.uk_address }
+      let(:international_address) { page.answer_settings.input_type.international_address }
+
+      before do
+        post address_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_address_settings_form: { uk_address: "true", international_address: "false" } }
+      end
+
+      it "loads the updated input type from the page params" do
+        form_instance_variable = assigns(:address_settings_form)
+        expect(form_instance_variable.uk_address).to eq "true"
+        expect(form_instance_variable.international_address).to eq "false"
+        page_instance_variable = assigns(:page)
+        expect(page_instance_variable.answer_settings["input_type"]).to eq({ "international_address" => "false", "uk_address" => "true" })
+      end
+
+      it "redirects the user to the edit question page" do
+        expect(response).to redirect_to edit_page_path(form.id, page.id)
+      end
+    end
+
+    context "when form is invalid" do
+      let(:input_type) { nil }
+
+      before do
+        post address_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_address_settings_form: { input_type: } }
+      end
+
+      it "renders the address settings view if there are errors" do
+        expect(response).to have_rendered("pages/address_settings")
+      end
+    end
+  end
+end

--- a/spec/requests/pages/date_settings_spec.rb
+++ b/spec/requests/pages/date_settings_spec.rb
@@ -1,0 +1,161 @@
+require "rails_helper"
+
+RSpec.describe "DateSettings controller", type: :request, feature_autocomplete_answer_types: true do
+  let(:form) { build :form, id: 1 }
+  let(:pages) { build_list :page, 5, form_id: form.id }
+
+  let(:date_settings_form) { build :date_settings_form, form: }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => ENV["API_KEY"],
+      "Content-Type" => "application/json",
+    }
+  end
+
+  describe "#new" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+
+      get date_settings_new_path(form_id: date_settings_form.form.id)
+    end
+
+    it "reads the existing form" do
+      expect(form).to have_been_read
+    end
+
+    it "sets an instance variable for date_settings_path" do
+      path = assigns(:date_settings_path)
+      expect(path).to eq date_settings_new_path(date_settings_form.form.id)
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("pages/date_settings")
+    end
+  end
+
+  describe "#create" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+    end
+
+    context "when form is invalid" do
+      before do
+        post date_settings_create_path form_id: form.id, params: { forms_date_settings_form: { input_type: nil } }
+      end
+
+      it "renders the date settings view if there are errors" do
+        expect(response).to have_rendered("pages/date_settings")
+      end
+    end
+
+    context "when form is valid and ready to store" do
+      before do
+        post date_settings_create_path form_id: form.id, params: { forms_date_settings_form: { input_type: "date_of_birth" } }
+      end
+
+      let(:date_settings_form) { build :date_settings_form, form: }
+
+      it "saves the input type to session" do
+        expect(session[:page][:answer_settings]).to eq({ "input_type": "date_of_birth" })
+      end
+
+      it "redirects the user to the edit question page" do
+        expect(response).to redirect_to new_page_path(form.id)
+      end
+    end
+  end
+
+  describe "#edit" do
+    let(:page) { build :page, :with_date_settings, id: 2, form_id: form.id }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/2", req_headers, page.to_json, 200
+      end
+
+      get date_settings_edit_path(form_id: page.form_id, page_id: page.id)
+    end
+
+    it "reads the existing form" do
+      expect(form).to have_been_read
+    end
+
+    it "returns the existing page input type" do
+      form = assigns(:date_settings_form)
+      expect(form.input_type).to eq page.answer_settings["input_type"]
+    end
+
+    it "sets an instance variable for date_settings_path" do
+      path = assigns(:date_settings_path)
+      expect(path).to eq date_settings_edit_path(date_settings_form.form.id)
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("pages/date_settings")
+    end
+  end
+
+  describe "#update" do
+    let(:page) do
+      new_page = build :page, :with_date_settings, id: 2, form_id: form.id
+      new_page.answer_settings = OpenStruct.new(input_type: OpenStruct.new(uk_date: "false", international_date: "true"))
+      new_page
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/2", req_headers, page.to_json, 200
+        mock.put "/api/v1/forms/1/pages/2", post_headers
+      end
+    end
+
+    context "when form is valid and ready to update in the DB" do
+      let(:input_type) { "date_of_birth" }
+
+      before do
+        post date_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_date_settings_form: { input_type: "other_date" } }
+      end
+
+      it "loads the updated input type from the page params" do
+        form_instance_variable = assigns(:date_settings_form)
+        expect(form_instance_variable.input_type).to eq "other_date"
+        page_instance_variable = assigns(:page)
+        expect(page_instance_variable.answer_settings["input_type"]).to eq "other_date"
+      end
+
+      it "redirects the user to the edit question page" do
+        expect(response).to redirect_to edit_page_path(form.id, page.id)
+      end
+    end
+
+    context "when form is invalid" do
+      let(:input_type) { nil }
+
+      before do
+        post date_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_date_settings_form: { input_type: } }
+      end
+
+      it "renders the date settings view if there are errors" do
+        expect(response).to have_rendered("pages/date_settings")
+      end
+    end
+  end
+end

--- a/spec/requests/pages/type_of_answer_spec.rb
+++ b/spec/requests/pages/type_of_answer_spec.rb
@@ -116,6 +116,22 @@ RSpec.describe "TypeOfAnswer controller", type: :request do
           expect(response).to redirect_to date_settings_new_path(form.id)
         end
       end
+
+      context "when answer type is address" do
+        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "address", form: }
+
+        before do
+          post type_of_answer_create_path form_id: form.id, params: { forms_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
+        end
+
+        it "saves the answer type to session" do
+          expect(session[:page]).to eq({ "answer_type": type_of_answer_form.answer_type })
+        end
+
+        it "redirects the user to the question details page" do
+          expect(response).to redirect_to address_settings_new_path(form.id)
+        end
+      end
     end
 
     context "when form is invalid" do

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -14,7 +14,7 @@ describe "pages/_form.html.erb", type: :view do
                                             change_selections_settings_path: "http://change-me-please.com",
                                             change_text_settings_path: "http://change-me-please.com",
                                             change_date_settings_path: "http://change-me-please.com",
-                                            change_address_settings_path: "http://change-me-please.com", }
+                                            change_address_settings_path: "http://change-me-please.com" }
   end
 
   it "has a form with correct action" do

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -13,7 +13,8 @@ describe "pages/_form.html.erb", type: :view do
                                             change_answer_type_path: "http://change-me-please.com",
                                             change_selections_settings_path: "http://change-me-please.com",
                                             change_text_settings_path: "http://change-me-please.com",
-                                            change_date_settings_path: "http://change-me-please.com" }
+                                            change_date_settings_path: "http://change-me-please.com",
+                                            change_address_settings_path: "http://change-me-please.com", }
   end
 
   it "has a form with correct action" do

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -16,6 +16,7 @@ describe "pages/edit.html.erb" do
     allow(view).to receive(:selections_settings_edit_path).and_return("/selections_settings")
     allow(view).to receive(:text_settings_edit_path).and_return("/text-settings")
     allow(view).to receive(:date_settings_edit_path).and_return("/date-settings")
+    allow(view).to receive(:address_settings_edit_path).and_return("/address-settings")
 
     # Assign instance variables so they can be accessed from views
     assign(:form, form)


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds a new settings page to the address input, allowing form creators to set the address to allow UK addresses, international addresses, or both. 

Trello card: https://trello.com/c/zdoo448d/382-address-implementation-of-autofill-work-in-production

Prerequisite PRs:
- API: https://github.com/alphagov/forms-api/pull/168
- Runner: https://github.com/alphagov/forms-runner/pull/229

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
