### PR TITLE
Remove obsolete db tables

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,25 +27,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_03_162118) do
     t.index ["form_id"], name: "index_form_submission_emails_on_form_id"
   end
 
-  create_table "forms", id: :bigint, default: nil, force: :cascade do |t|
-    t.text "name"
-    t.text "submission_email"
-    t.text "org"
-  end
-
-  create_table "pages", id: :bigint, default: nil, force: :cascade do |t|
-    t.bigint "form_id"
-    t.text "question_text"
-    t.text "question_short_name"
-    t.text "hint_text"
-    t.text "answer_type"
-    t.text "next"
-  end
-
-  create_table "schema_info", id: false, force: :cascade do |t|
-    t.integer "version", default: 0, null: false
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -60,5 +41,4 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_03_162118) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "pages", "forms", name: "pages_form_id_fkey"
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

These were some how added to schema.db back in August last year but we shouldn't be using them directly. 
The only two tables forms-admin uses are as follows

- Users, to store signed in signon users 
- form_submission_emails, used when confirming form submission email addresses and checking if they have been verified.



Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
