### PR TITLE
Change IP logging in production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,11 @@
+require "resolv"
+
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
+  before_action :set_request_id
   before_action :authenticate_user!
   before_action :set_user_instance_variable
   before_action :check_service_unavailable
-  before_action :set_request_id
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :clear_questions_session_data
@@ -27,7 +29,7 @@ class ApplicationController < ActionController::Base
       payload[:user_organisation_slug] = current_user.organisation_slug
     end
     payload[:request_id] = request.request_id
-    payload[:user_ip] = request.remote_ip
+    payload[:user_ip] = user_ip(request.env.fetch("HTTP_X_FORWARDED_FOR", ""))
     payload[:form_id] = params[:form_id] if params[:form_id].present?
   end
 
@@ -36,10 +38,35 @@ class ApplicationController < ActionController::Base
   end
 
   def set_request_id
+    request.request_id = request_id
+
+    # Pass the request id to the API to enable tracing
     if Rails.env.production?
       [Form, Page].each do |active_resource_model|
         active_resource_model.headers["X-Request-ID"] = request.request_id
       end
     end
+  end
+
+  # PaaS uses a different header to pass on the request_id
+  # https://github.com/cloudfoundry/gorouter/issues/148 If PaaS header exists,
+  # use it, otherwise use standard header or generate new value
+  def request_id
+    vcap_request_id = request.env.fetch("HTTP_X_VCAP_REQUEST_ID", false)
+    if vcap_request_id
+      # This is a user input so take basic precautions by limiting chars to
+      # range and length
+      vcap_request_id.gsub(/[^\w\-@]/, "").first(255)
+    else
+      request.request_id
+    end
+  end
+
+  # Becuase determining the clients real IP is hard, simply return the first
+  # value of the x-forwarded_for, checking it's an IP. This will probably be
+  # enough for out basic monitoring in PaaS
+  def user_ip(forwarded_for = "")
+    first_ip_string = forwarded_for.split(",").first
+    Regexp.union([Resolv::IPv4::Regex, Resolv::IPv6::Regex]).match(first_ip_string) && first_ip_string
   end
 end

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe ApplicationController do
+  subject(:application_controller) { described_class.new }
+
+  describe "#user_ip" do
+    [
+      ["", nil],
+      ["127.0.0.1", "127.0.0.1"],
+      ["127.0.0.1, 192.168.0.128", "127.0.0.1"],
+      ["185.93.3.65, 15.158.44.215, 10.0.1.94", "185.93.3.65"],
+      ["    185.93.3.65, 15.158.44.215, 10.0.1.94", nil],
+      ["invalid value, 192.168.0.128", nil],
+      ["192.168.0.128.123.2981", nil],
+      ["2001:db8::, 2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF, ::1234:5678", "2001:db8::"],
+      [",,,,,,,,,,,,,,,,,,,,,,,,", nil],
+    ].each do |value, expected|
+      it "returns #{expected.inspect} when given forwarded_for #{value.inspect}" do
+        expect(application_controller.user_ip(value)).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Change PaaS client_ip logging logic

Client IP logging for protective monitoring currently uses the value returned from rails `request.remote_ip` which uses the rails configuration for trusted proxies to work out the most reasonable value for client IP based on the `X-forwarded_for` headers. The logic for  getting the clients real IP isn't as simple as using the socket IP as in PaaS clients are always connecting through a router and we also  can't trust the value of `X-forwarded_for` as the client may be spoofing the value.

https://github.com/rack/rack/blob/main/lib/rack/request.rb

We don't set any values for trusted_proxies - we would set these to amazon cloud-front values, for example see the following gist:

https://gist.github.com/mrk21/f25b22528d69d0cfdd2426e8470a8ee6

In this commit instead of tackling this, we simply log the first value set in `X-forwarded_for` after basic sanitisation to protect against malicious input.

This commit also picks up request_id using the PaaS specific value, to help debugging and observing the above behaviour.

Trello card: https://trello.com/c/bgLy2njq/355-implement-basic-protective-monitoring-of-govuk-forms

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
