### PR TITLE
Prevent incomplete page data by putting answer type and settings data in session

### DIFF
--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -22,8 +22,7 @@ class Pages::AddressSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    @page.load_from_session(session, "answer_type")
-    @page.load_from_session(session, "answer_settings")
+    @page.load_from_session(session, %w[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
     uk_address = input_type&.uk_address
     international_address = input_type&.international_address

--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -22,6 +22,9 @@ class Pages::AddressSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    answer_type = session.dig(:page, "answer_type") || @page.answer_type
+    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
+    @page.load(answer_type:, answer_settings:)
     input_type = @page&.answer_settings&.input_type
     uk_address = input_type&.uk_address
     international_address = input_type&.international_address
@@ -37,7 +40,7 @@ class Pages::AddressSettingsController < PagesController
     @address_settings_path = address_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
 
-    if @address_settings_form.assign_values_to_page(@page) && @page.save!
+    if @address_settings_form.submit(session)
       redirect_to edit_page_path(@form)
     else
       render address_settings_view

--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -22,9 +22,8 @@ class Pages::AddressSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type") || @page.answer_type
-    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
-    @page.load(answer_type:, answer_settings:)
+    @page.load_from_session(session, "answer_type")
+    @page.load_from_session(session, "answer_settings")
     input_type = @page&.answer_settings&.input_type
     uk_address = input_type&.uk_address
     international_address = input_type&.international_address

--- a/app/controllers/pages/date_settings_controller.rb
+++ b/app/controllers/pages/date_settings_controller.rb
@@ -21,8 +21,7 @@ class Pages::DateSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    @page.load_from_session(session, "answer_type")
-    @page.load_from_session(session, "answer_settings")
+    @page.load_from_session(session, %w[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
     @date_settings_form = Forms::DateSettingsForm.new(input_type:, page: @page)
     @date_settings_path = date_settings_update_path(@form)

--- a/app/controllers/pages/date_settings_controller.rb
+++ b/app/controllers/pages/date_settings_controller.rb
@@ -21,9 +21,8 @@ class Pages::DateSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type") || @page.answer_type
-    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
-    @page.load(answer_type:, answer_settings:)
+    @page.load_from_session(session, "answer_type")
+    @page.load_from_session(session, "answer_settings")
     input_type = @page&.answer_settings&.input_type
     @date_settings_form = Forms::DateSettingsForm.new(input_type:, page: @page)
     @date_settings_path = date_settings_update_path(@form)

--- a/app/controllers/pages/date_settings_controller.rb
+++ b/app/controllers/pages/date_settings_controller.rb
@@ -21,6 +21,9 @@ class Pages::DateSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    answer_type = session.dig(:page, "answer_type") || @page.answer_type
+    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
+    @page.load(answer_type:, answer_settings:)
     input_type = @page&.answer_settings&.input_type
     @date_settings_form = Forms::DateSettingsForm.new(input_type:, page: @page)
     @date_settings_path = date_settings_update_path(@form)
@@ -34,7 +37,7 @@ class Pages::DateSettingsController < PagesController
     @date_settings_path = date_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
 
-    if @date_settings_form.assign_values_to_page(@page) && @page.save!
+    if @date_settings_form.submit(session)
       redirect_to edit_page_path(@form)
     else
       render "pages/date_settings"

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -28,11 +28,10 @@ class Pages::SelectionsSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type") || @page.answer_type
-    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
-    is_optional = session.dig(:page, "is_optional") || @page.is_optional
+    @page.load_from_session(session, "answer_type")
+    @page.load_from_session(session, "answer_settings")
+    @page.load_from_session(session, "is_optional")
 
-    @page.load(answer_type:, answer_settings:, is_optional:)
     @selections_settings_path = selections_settings_update_path(@form)
     @selections_settings_form = Forms::SelectionsSettingsForm.new(load_answer_settings_from_page_object(@page))
     @back_link_url = edit_page_path(@form, @page)

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -28,9 +28,9 @@ class Pages::SelectionsSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type")
-    answer_settings = session.dig(:page, "answer_settings")
-    is_optional = session.dig(:page, "is_optional")
+    answer_type = session.dig(:page, "answer_type") || @page.answer_type
+    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
+    is_optional = session.dig(:page, "is_optional") || @page.is_optional
 
     @page.load(answer_type:, answer_settings:, is_optional:)
     @selections_settings_path = selections_settings_update_path(@form)
@@ -91,7 +91,7 @@ private
   end
 
   def load_answer_settings_from_page_object(page)
-    if page.answer_settings.present?
+    if page.answer_settings.present? && page.answer_settings.attributes.include?(:only_one_option) && page.answer_settings.attributes.include?(:selection_options)
       only_one_option = page.answer_settings.only_one_option
       include_none_of_the_above = page.is_optional
       selection_options = page.answer_settings.selection_options

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -28,6 +28,10 @@ class Pages::SelectionsSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    answer_type = session.dig(:page, "answer_type")
+    answer_settings = session.dig(:page, "answer_settings")
+
+    @page.load(answer_type:, answer_settings:)
     @selections_settings_path = selections_settings_update_path(@form)
     @selections_settings_form = Forms::SelectionsSettingsForm.new(load_answer_settings_from_page_object(@page))
     @back_link_url = edit_page_path(@form, @page)
@@ -47,14 +51,11 @@ class Pages::SelectionsSettingsController < PagesController
     elsif params[:remove]
       @selections_settings_form.remove(params[:remove].to_i)
       render selection_settings_view
-    else
-      @selections_settings_form.assign_values_to_page(@page)
+    elsif @selections_settings_form.valid? && @selections_settings_form.submit(session)
 
-      if @selections_settings_form.valid? && @page.save!
-        redirect_to edit_page_path(@form)
-      else
-        render selection_settings_view
-      end
+      redirect_to edit_page_path(@form)
+    else
+      render selection_settings_view
     end
   end
 

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -65,10 +65,6 @@ private
     Forms::SelectionOption.new(hash)
   end
 
-  def default_options
-    { selection_options: [{ name: "" }, { name: "" }].map(&method(:convert_to_selection_option)), only_one_option: false, include_none_of_the_above: false }
-  end
-
   def load_answer_settings_from_params(params)
     selection_options = params[:selection_options] ? params[:selection_options].values.map(&method(:convert_to_selection_option)) : []
     only_one_option = params[:only_one_option]
@@ -85,20 +81,16 @@ private
 
       { only_one_option:, selection_options:, include_none_of_the_above: }
     else
-      default_options
+      Forms::SelectionsSettingsForm.new.default_options
     end
   end
 
   def load_answer_settings_from_page_object(page)
-    if page.answer_settings.present? && page.answer_settings.attributes.include?(:only_one_option) && page.answer_settings.attributes.include?(:selection_options)
-      only_one_option = page.answer_settings.only_one_option
-      include_none_of_the_above = page.is_optional
-      selection_options = page.answer_settings.selection_options
+    only_one_option = page.answer_settings.only_one_option
+    include_none_of_the_above = page.is_optional
+    selection_options = page.answer_settings.selection_options
 
-      { only_one_option:, selection_options:, include_none_of_the_above: }
-    else
-      default_options
-    end
+    { only_one_option:, selection_options:, include_none_of_the_above: }
   end
 
   def selections_settings_form_params

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -30,8 +30,9 @@ class Pages::SelectionsSettingsController < PagesController
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     answer_type = session.dig(:page, "answer_type")
     answer_settings = session.dig(:page, "answer_settings")
+    is_optional = session.dig(:page, "is_optional")
 
-    @page.load(answer_type:, answer_settings:)
+    @page.load(answer_type:, answer_settings:, is_optional:)
     @selections_settings_path = selections_settings_update_path(@form)
     @selections_settings_form = Forms::SelectionsSettingsForm.new(load_answer_settings_from_page_object(@page))
     @back_link_url = edit_page_path(@form, @page)

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -78,7 +78,7 @@ private
 
       { only_one_option:, selection_options:, include_none_of_the_above: }
     else
-      Forms::SelectionsSettingsForm.new.default_options
+      Forms::SelectionsSettingsForm::DEFAULT_OPTIONS
     end
   end
 

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -28,10 +28,7 @@ class Pages::SelectionsSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    @page.load_from_session(session, "answer_type")
-    @page.load_from_session(session, "answer_settings")
-    @page.load_from_session(session, "is_optional")
-
+    @page.load_from_session(session, %w[answer_type answer_settings is_optional])
     @selections_settings_path = selections_settings_update_path(@form)
     @selections_settings_form = Forms::SelectionsSettingsForm.new(load_answer_settings_from_page_object(@page))
     @back_link_url = edit_page_path(@form, @page)

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -21,8 +21,7 @@ class Pages::TextSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    @page.load_from_session(session, "answer_type")
-    @page.load_from_session(session, "answer_settings")
+    @page.load_from_session(session, %w[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
     @text_settings_form = Forms::TextSettingsForm.new(input_type:, page: @page)
     @text_settings_path = text_settings_update_path(@form)

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -21,6 +21,9 @@ class Pages::TextSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    answer_type = session.dig(:page, "answer_type")
+    answer_settings = session.dig(:page, "answer_settings")
+    @page.load(answer_type:, answer_settings:)
     input_type = @page&.answer_settings&.input_type
     @text_settings_form = Forms::TextSettingsForm.new(input_type:, page: @page)
     @text_settings_path = text_settings_update_path(@form)
@@ -34,7 +37,7 @@ class Pages::TextSettingsController < PagesController
     @text_settings_path = text_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
 
-    if @text_settings_form.assign_values_to_page(@page) && @page.save!
+    if @text_settings_form.submit(session)
       redirect_to edit_page_path(@form)
     else
       render "pages/text_settings"

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -21,9 +21,8 @@ class Pages::TextSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type") || @page.answer_type
-    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
-    @page.load(answer_type:, answer_settings:)
+    @page.load_from_session(session, "answer_type")
+    @page.load_from_session(session, "answer_settings")
     input_type = @page&.answer_settings&.input_type
     @text_settings_form = Forms::TextSettingsForm.new(input_type:, page: @page)
     @text_settings_path = text_settings_update_path(@form)

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -21,8 +21,8 @@ class Pages::TextSettingsController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type")
-    answer_settings = session.dig(:page, "answer_settings")
+    answer_type = session.dig(:page, "answer_type") || @page.answer_type
+    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
     @page.load(answer_type:, answer_settings:)
     input_type = @page&.answer_settings&.input_type
     @text_settings_form = Forms::TextSettingsForm.new(input_type:, page: @page)

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -19,7 +19,7 @@ class Pages::TypeOfAnswerController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type")
+    answer_type = session.dig(:page, "answer_type") || @page.answer_type
 
     @page.load(answer_type:)
     @type_of_answer_form = Forms::TypeOfAnswerForm.new(answer_type: @page.answer_type, page: @page)

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -19,7 +19,7 @@ class Pages::TypeOfAnswerController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    @page.load_from_session(session, "answer_type")
+    @page.load_from_session(session, %w[answer_type])
 
     @type_of_answer_form = Forms::TypeOfAnswerForm.new(answer_type: @page.answer_type, page: @page)
     @type_of_answer_path = type_of_answer_update_path(@form)

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -83,9 +83,20 @@ private
     @type_of_answer_form.answer_type != @page.answer_type
   end
 
+  def default_answer_settings_for_answer_type(answer_type)
+    case answer_type
+    when "selection"
+      Forms::SelectionsSettingsForm.new.default_options
+    when "text", "date", "address"
+      { input_type: nil }
+    else
+      {}
+    end
+  end
+
   def save_to_session(session)
     if @type_of_answer_form.submit(session)
-      session[:page]["answer_settings"] = nil
+      session[:page]["answer_settings"] = default_answer_settings_for_answer_type(@type_of_answer_form.answer_type)
       redirect_to next_page_path(@form, @type_of_answer_form.answer_type, :update)
     else
       @type_of_answer_path = type_of_answer_update_path(@form)

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -19,9 +19,8 @@ class Pages::TypeOfAnswerController < PagesController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type") || @page.answer_type
+    @page.load_from_session(session, "answer_type")
 
-    @page.load(answer_type:)
     @type_of_answer_form = Forms::TypeOfAnswerForm.new(answer_type: @page.answer_type, page: @page)
     @type_of_answer_path = type_of_answer_update_path(@form)
     render "pages/type-of-answer"

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -86,7 +86,7 @@ private
   def default_answer_settings_for_answer_type(answer_type)
     case answer_type
     when "selection"
-      Forms::SelectionsSettingsForm.new.default_options
+      Forms::SelectionsSettingsForm::DEFAULT_OPTIONS
     when "text", "date", "address"
       { input_type: nil }
     else

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -43,7 +43,7 @@ class PagesController < ApplicationController
 private
 
   def page_params
-    params.require(:page).permit(:question_text, :question_short_name, :hint_text, :answer_type, :is_optional, :answer_settings).merge(form_id: @form.id)
+    params.require(:page).permit(:question_text, :question_short_name, :hint_text, :answer_type, :is_optional).merge(form_id: @form.id)
   end
 
   def fetch_form

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,6 +24,7 @@ class PagesController < ApplicationController
   end
 
   def edit
+    reset_session_if_answer_settings_not_present
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     answer_type = session.dig(:page, "answer_type") || @page.answer_type
     answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
@@ -55,6 +56,16 @@ private
 
   def fetch_form
     @form = Form.find(params[:form_id])
+  end
+
+  def reset_session_if_answer_settings_not_present
+    answer_type = session.dig(:page, "answer_type")
+    answer_settings = session.dig(:page, "answer_settings")
+
+    if (%w[selection text date address].include? answer_type) && (answer_settings.blank? || answer_settings == {})
+      clear_questions_session_data
+      redirect_to edit_page_path(params[:form_id], params[:page_id])
+    end
   end
 
   def handle_submit_action

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,7 +13,8 @@ class PagesController < ApplicationController
   def create
     answer_type = session.dig(:page, "answer_type")
     answer_settings = session.dig(:page, "answer_settings")
-    @page = Page.new(page_params.merge(answer_settings:, answer_type:))
+    is_optional = session.dig(:page, "is_optional") == "true"
+    @page = Page.new(page_params.merge(answer_settings:, answer_type:, is_optional:))
 
     if @page.save
       clear_questions_session_data
@@ -25,18 +26,20 @@ class PagesController < ApplicationController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type")
-    answer_settings = session.dig(:page, "answer_settings")
+    answer_type = session.dig(:page, "answer_type") || @page.answer_type
+    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
+    is_optional = session.dig(:page, "is_optional") == "true" || @page.is_optional
 
-    @page.load(answer_settings:, answer_type:)
+    @page.load(answer_settings:, answer_type:, is_optional:)
   end
 
   def update
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type")
-    answer_settings = session.dig(:page, "answer_settings")
+    answer_type = session.dig(:page, "answer_type") || @page.answer_type
+    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
+    is_optional = session.dig(:page, "is_optional") == "true" || @page.is_optional
 
-    @page.load(page_params.merge(answer_settings:, answer_type:))
+    @page.load(page_params.merge(answer_settings:, answer_type:, is_optional:))
 
     if @page.save
       handle_submit_action

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,19 +25,12 @@ class PagesController < ApplicationController
   def edit
     reset_session_if_answer_settings_not_present
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type") || @page.answer_type
-    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
-    is_optional = session.dig(:page, "is_optional") || @page.is_optional
-
-    @page.load(answer_settings:, answer_type:, is_optional:)
+    @page.load_from_session(session, %w[answer_settings answer_type is_optional])
   end
 
   def update
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    answer_type = session.dig(:page, "answer_type") || @page.answer_type
-    answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
-
-    @page.load(page_params.merge(answer_settings:, answer_type:))
+    @page.load_from_session(session, %w[answer_type answer_settings]).load(page_params)
 
     if @page.save
       clear_questions_session_data

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,15 +4,16 @@ class PagesController < ApplicationController
   skip_before_action :clear_questions_session_data
 
   def new
-    answer_type = session[:page]["answer_type"]
-    answer_settings = session[:page]["answer_settings"]
-    is_optional = session[:page]["is_optional"] == "true"
+    answer_type = session.dig(:page, "answer_type")
+    answer_settings = session.dig(:page, "answer_settings")
+    is_optional = session.dig(:page, "is_optional") == "true"
     @page = Page.new(form_id: @form.id, answer_type:, answer_settings:, is_optional:)
   end
 
   def create
-    answer_settings = session[:page]["answer_settings"] if session[:page].present?
-    @page = Page.new(page_params.merge(answer_settings:))
+    answer_type = session.dig(:page, "answer_type")
+    answer_settings = session.dig(:page, "answer_settings")
+    @page = Page.new(page_params.merge(answer_settings:, answer_type:))
 
     if @page.save
       clear_questions_session_data
@@ -24,12 +25,18 @@ class PagesController < ApplicationController
 
   def edit
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    answer_type = session.dig(:page, "answer_type")
+    answer_settings = session.dig(:page, "answer_settings")
+
+    @page.load(answer_settings:, answer_type:)
   end
 
   def update
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
+    answer_type = session.dig(:page, "answer_type")
+    answer_settings = session.dig(:page, "answer_settings")
 
-    @page.load(page_params)
+    @page.load(page_params.merge(answer_settings:, answer_type:))
 
     if @page.save
       handle_submit_action

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,9 +11,8 @@ class PagesController < ApplicationController
   end
 
   def create
-    answer_type = session.dig(:page, "answer_type")
     answer_settings = session.dig(:page, "answer_settings")
-    @page = Page.new(page_params.merge({ answer_type:, answer_settings: }))
+    @page = Page.new(page_params.merge(answer_settings:))
 
     if @page.save
       clear_questions_session_data

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,8 +13,7 @@ class PagesController < ApplicationController
   def create
     answer_type = session.dig(:page, "answer_type")
     answer_settings = session.dig(:page, "answer_settings")
-    is_optional = session.dig(:page, "is_optional") == "true"
-    @page = Page.new(page_params.merge(answer_settings:, answer_type:, is_optional:))
+    @page = Page.new(page_params.merge({ answer_type:, answer_settings: }))
 
     if @page.save
       clear_questions_session_data
@@ -28,7 +27,7 @@ class PagesController < ApplicationController
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     answer_type = session.dig(:page, "answer_type") || @page.answer_type
     answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
-    is_optional = session.dig(:page, "is_optional") == "true" || @page.is_optional
+    is_optional = session.dig(:page, "is_optional") || @page.is_optional
 
     @page.load(answer_settings:, answer_type:, is_optional:)
   end
@@ -37,11 +36,11 @@ class PagesController < ApplicationController
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     answer_type = session.dig(:page, "answer_type") || @page.answer_type
     answer_settings = session.dig(:page, "answer_settings") || @page.answer_settings
-    is_optional = session.dig(:page, "is_optional") == "true" || @page.is_optional
 
-    @page.load(page_params.merge(answer_settings:, answer_type:, is_optional:))
+    @page.load(page_params.merge(answer_settings:, answer_type:))
 
     if @page.save
+      clear_questions_session_data
       handle_submit_action
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -61,7 +61,7 @@ private
     answer_type = session.dig(:page, "answer_type")
     answer_settings = session.dig(:page, "answer_settings")
 
-    if (%w[selection text date address].include? answer_type) && (answer_settings.blank? || answer_settings == {})
+    if (Page::COMPLEX_ANSWER_TYPES.include? answer_type) && (answer_settings.blank? || answer_settings == {})
       clear_questions_session_data
       redirect_to edit_page_path(params[:form_id], params[:page_id])
     end

--- a/app/forms/forms/address_settings_form.rb
+++ b/app/forms/forms/address_settings_form.rb
@@ -17,12 +17,6 @@ class Forms::AddressSettingsForm
     session[:page][:answer_settings] = { input_type: { uk_address:, international_address: } }
   end
 
-  def assign_values_to_page(page)
-    return false if invalid?
-
-    page.answer_settings = { input_type: { uk_address:, international_address: } }
-  end
-
   def at_least_one_selected?
     errors.add(:base, :blank) if uk_address == "false" && international_address == "false"
   end

--- a/app/forms/forms/date_settings_form.rb
+++ b/app/forms/forms/date_settings_form.rb
@@ -14,10 +14,4 @@ class Forms::DateSettingsForm
     session[:page] = {} if session[:page].blank?
     session[:page][:answer_settings] = { input_type: }
   end
-
-  def assign_values_to_page(page)
-    return false if invalid?
-
-    page.answer_settings = { input_type: }
-  end
 end

--- a/app/forms/forms/selections_settings_form.rb
+++ b/app/forms/forms/selections_settings_form.rb
@@ -9,6 +9,12 @@ class Forms::SelectionsSettingsForm
 
   validate :selection_options, :validate_selection_options
 
+  def convert_to_selection_option(hash)
+    Forms::SelectionOption.new(hash)
+  end
+
+  DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }].map { |hash| Forms::SelectionOption.new(hash) }, only_one_option: false, include_none_of_the_above: false }.freeze
+
   def add_another
     selection_options.append(Forms::SelectionOption.new({ name: "" }))
   end
@@ -45,13 +51,5 @@ class Forms::SelectionsSettingsForm
 
   def filter_out_blank_options
     self.selection_options = selection_options.filter { |option| option.name.present? }
-  end
-
-  def convert_to_selection_option(hash)
-    Forms::SelectionOption.new(hash)
-  end
-
-  def default_options
-    { selection_options: [{ name: "" }, { name: "" }].map(&method(:convert_to_selection_option)), only_one_option: false, include_none_of_the_above: false }
   end
 end

--- a/app/forms/forms/selections_settings_form.rb
+++ b/app/forms/forms/selections_settings_form.rb
@@ -36,13 +36,6 @@ class Forms::SelectionsSettingsForm
     session[:page][:is_optional] = include_none_of_the_above
   end
 
-  def assign_values_to_page(page)
-    return false if invalid?
-
-    page.answer_settings = answer_settings
-    page.is_optional = include_none_of_the_above
-  end
-
   def validate_selection_options
     return errors.add(:selection_options, :minimum) if selection_options.length < 2
     return errors.add(:selection_options, :maximum) if selection_options.length > 20

--- a/app/forms/forms/selections_settings_form.rb
+++ b/app/forms/forms/selections_settings_form.rb
@@ -46,4 +46,12 @@ class Forms::SelectionsSettingsForm
   def filter_out_blank_options
     self.selection_options = selection_options.filter { |option| option.name.present? }
   end
+
+  def convert_to_selection_option(hash)
+    Forms::SelectionOption.new(hash)
+  end
+
+  def default_options
+    { selection_options: [{ name: "" }, { name: "" }].map(&method(:convert_to_selection_option)), only_one_option: false, include_none_of_the_above: false }
+  end
 end

--- a/app/forms/forms/selections_settings_form.rb
+++ b/app/forms/forms/selections_settings_form.rb
@@ -3,17 +3,17 @@ class Forms::SelectionsSettingsForm
   include ActiveModel::Validations
   include ActiveModel::Validations::Callbacks
 
-  before_validation :filter_out_blank_options
+  DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }].map { |hash| Forms::SelectionOption.new(hash) }, only_one_option: false, include_none_of_the_above: false }.freeze
 
   attr_accessor :selection_options, :only_one_option, :include_none_of_the_above
+
+  before_validation :filter_out_blank_options
 
   validate :selection_options, :validate_selection_options
 
   def convert_to_selection_option(hash)
     Forms::SelectionOption.new(hash)
   end
-
-  DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }].map { |hash| Forms::SelectionOption.new(hash) }, only_one_option: false, include_none_of_the_above: false }.freeze
 
   def add_another
     selection_options.append(Forms::SelectionOption.new({ name: "" }))

--- a/app/forms/forms/text_settings_form.rb
+++ b/app/forms/forms/text_settings_form.rb
@@ -14,10 +14,4 @@ class Forms::TextSettingsForm
     session[:page] = {} if session[:page].blank?
     session[:page][:answer_settings] = { input_type: }
   end
-
-  def assign_values_to_page(page)
-    return false if invalid?
-
-    page.answer_settings = { input_type: }
-  end
 end

--- a/app/forms/forms/type_of_answer_form.rb
+++ b/app/forms/forms/type_of_answer_form.rb
@@ -9,6 +9,6 @@ class Forms::TypeOfAnswerForm
   def submit(session)
     return false if invalid?
 
-    session[:page] = { answer_type: }
+    session[:page] = { answer_type:, answer_settings: nil }
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -37,6 +37,10 @@ class Page < ActiveResource::Base
     save!
   end
 
+  def load_from_session(session, key)
+    self.load(key => session.dig(:page, key) || send(key.to_sym))
+  end
+
 private
 
   def is_optional_value

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -43,6 +43,7 @@ class Page < ActiveResource::Base
     keys.each do |key|
       self.load(key => session.dig(:page, key) || send(key.to_sym))
     end
+    self
   end
 
 private

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -39,8 +39,10 @@ class Page < ActiveResource::Base
     save!
   end
 
-  def load_from_session(session, key)
-    self.load(key => session.dig(:page, key) || send(key.to_sym))
+  def load_from_session(session, keys)
+    keys.each do |key|
+      self.load(key => session.dig(:page, key) || send(key.to_sym))
+    end
   end
 
 private

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -19,6 +19,10 @@ class Page < ActiveResource::Base
     self.is_optional = is_optional_value
   end
 
+  def is_optional?
+    is_optional_value || is_optional == true
+  end
+
   def move_page(direction)
     return false unless %i[up down].include? direction
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,6 +6,8 @@ class Page < ActiveResource::Base
 
   ANSWER_TYPES = %w[single_line number address date email national_insurance_number phone_number long_text selection organisation_name text].freeze
 
+  COMPLEX_ANSWER_TYPES = %w[selection text date address].freeze
+
   belongs_to :form
   validates :question_text, presence: true
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }

--- a/app/views/pages/address_settings.html.erb
+++ b/app/views/pages/address_settings.html.erb
@@ -9,7 +9,7 @@
         <%= f.govuk_check_box 'uk_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.uk_addresses") }%>
         <%= f.govuk_check_box 'international_address', "true", "false", multiple: false, small: true, label: { text: t("helpers.label.page.address_settings_options.names.international_addresses") }%>
       <% end %>
-      <%= f.govuk_submit t('save_and_continue') %>
+      <%= f.govuk_submit t('continue') %>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/date_settings.html.erb
+++ b/app/views/pages/date_settings.html.erb
@@ -13,7 +13,7 @@
             legend: { text: t('page_titles.date_settings'), size: 'l', tag: 'h1' },
             caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' },
           )  %>
-      <%= f.govuk_submit t('save_and_continue') %>
+      <%= f.govuk_submit t('continue') %>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/selections_settings.html.erb
+++ b/app/views/pages/selections_settings.html.erb
@@ -43,7 +43,7 @@
         <% end %>
       </div>
 
-      <%= f.govuk_submit t('save_and_continue') %>
+      <%= f.govuk_submit t('continue') %>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/text_settings.html.erb
+++ b/app/views/pages/text_settings.html.erb
@@ -13,7 +13,7 @@
             legend: { text: t('page_titles.text_settings'), size: 'l', tag: 'h1' },
             caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' },
           )  %>
-      <%= f.govuk_submit t('save_and_continue') %>
+      <%= f.govuk_submit t('continue') %>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/type-of-answer.html.erb
+++ b/app/views/pages/type-of-answer.html.erb
@@ -27,7 +27,7 @@
             )  %>
       <% end %>
 
-      <%= f.govuk_submit t('save_and_continue'), value: "true", name: :set_answer_type %>
+      <%= f.govuk_submit t('continue'), value: "true", name: :set_answer_type %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
       hint: Select at least one option
       title: How can people get help with filling in this form?
   contact_govuk_forms: Contact the GOV.UK Forms team
+  continue: Continue
   declaration_form:
     new:
       body_html: |

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -102,7 +102,7 @@ private
   def and_i_select_a_type_of_answer_option(answer_type)
     expect(page.find("h1")).to have_text "What kind of answer do you need to this question?"
     choose I18n.t("helpers.label.page.answer_type_options.names.#{answer_type}")
-    click_button "Save and continue"
+    click_button "Continue"
     fill_in_selection_settings if answer_type == "selection"
     fill_in_text_settings if answer_type == "text"
     fill_in_date_settings if answer_type == "date"
@@ -136,7 +136,7 @@ private
     fill_in "Option 2", with: "Checkbox option 2"
     click_button "Add another option"
     fill_in "Option 3", with: "Checkbox option 3"
-    click_button "Save and continue"
+    click_button "Continue"
     click_link "Change Options"
     expect(page.find("h1")).to have_text "Create a list of options"
     check "People can only select one option"
@@ -144,26 +144,26 @@ private
     click_button "Remove option 3"
     fill_in "Option 1", with: "Radio option 1"
     fill_in "Option 2", with: "Radio option 2"
-    click_button "Save and continue"
+    click_button "Continue"
   end
 
   def fill_in_text_settings
     expect(page.find("h1")).to have_text "How much text will people need to provide?"
     choose "Single line of text"
-    click_button "Save and continue"
+    click_button "Continue"
   end
 
   def fill_in_date_settings
     expect(page.find("h1")).to have_text "Are you asking for someone's date of birth?"
     choose "No"
-    click_button "Save and continue"
+    click_button "Continue"
   end
 
   def fill_in_address_settings
     expect(page.find("h1")).to have_text "What kind of addresses do you expect to receive?"
     check "UK addresses"
     check "International addresses"
-    click_button "Save and continue"
+    click_button "Continue"
     expect(page.find(".govuk-summary-list")).to have_text "UK and international addresses"
   end
 end

--- a/spec/forms/selections_settings_form_spec.rb
+++ b/spec/forms/selections_settings_form_spec.rb
@@ -93,24 +93,6 @@ RSpec.describe Forms::SelectionsSettingsForm, type: :model do
     end
   end
 
-  describe "assign_values_to_page" do
-    let(:page) { build :page, :with_hints, answer_type: "selection", id: 1, form_id: 1 }
-
-    it "returns false if the form is invalid" do
-      selections_settings_form.selection_options = []
-      expect(selections_settings_form.submit(page)).to be_falsey
-    end
-
-    it "assigns values to the page object" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| Forms::SelectionOption.new({ name: i.to_s }) }
-      selections_settings_form.only_one_option = true
-      selections_settings_form.include_none_of_the_above = true
-      selections_settings_form.assign_values_to_page(page)
-      expect(page.answer_settings.to_json).to eq({ only_one_option: true, selection_options: [Forms::SelectionOption.new(name: "1"), Forms::SelectionOption.new(name: "2")] }.to_json)
-      expect(page.is_optional).to eq(true)
-    end
-  end
-
   describe "filter_out_blank_options" do
     it "filters out blank inputs" do
       selections_settings_form.selection_options = [Forms::SelectionOption.new(name: "1"), Forms::SelectionOption.new(name: ""), Forms::SelectionOption.new(name: "2")]

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -73,7 +73,7 @@ describe Page do
 
     context "when the key is not present in the session" do
       it "returns the value from the page" do
-        page.load_from_session(session_mock, "answer_type")
+        page.load_from_session(session_mock, %w[answer_type])
         expect(page.answer_type).to eq("date")
       end
     end
@@ -82,7 +82,7 @@ describe Page do
       let(:session_mock) { { page: { answer_type: nil } } }
 
       it "returns the value from the page" do
-        page.load_from_session(session_mock, "answer_type")
+        page.load_from_session(session_mock, %w[answer_type])
         expect(page.answer_type).to eq("date")
       end
     end
@@ -91,7 +91,7 @@ describe Page do
       let(:session_mock) { { page: { "answer_type" => "address" } } }
 
       it "returns the value from the session" do
-        page.load_from_session(session_mock, "answer_type")
+        page.load_from_session(session_mock, %w[answer_type])
         expect(page.answer_type).to eq("address")
       end
     end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -50,4 +50,50 @@ describe Page do
       expect(page.move_page(:invalid_direction)).to eq(false)
     end
   end
+
+  describe "#is_optional?" do
+    [
+      { input: true, result: true },
+      { input: "true", result: true },
+      { input: false, result: false },
+      { input: "false", result: false },
+      { input: "0", result: false },
+      { input: nil, result: false },
+    ].each do |scenario|
+      it "returns #{scenario[:result]} when is_optional is #{scenario[:input]}" do
+        page = described_class.new(is_optional: scenario[:input])
+        expect(page.is_optional?).to eq scenario[:result]
+      end
+    end
+  end
+
+  describe "#load_from_session" do
+    let(:page) { described_class.new(answer_type: "date") }
+    let(:session_mock) { { page: {} } }
+
+    context "when the key is not present in the session" do
+      it "returns the value from the page" do
+        page.load_from_session(session_mock, "answer_type")
+        expect(page.answer_type).to eq("date")
+      end
+    end
+
+    context "when the key is nil in the session" do
+      let(:session_mock) { { page: { answer_type: nil } } }
+
+      it "returns the value from the page" do
+        page.load_from_session(session_mock, "answer_type")
+        expect(page.answer_type).to eq("date")
+      end
+    end
+
+    context "when the key is present in the session" do
+      let(:session_mock) { { page: { "answer_type" => "address" } } }
+
+      it "returns the value from the session" do
+        page.load_from_session(session_mock, "answer_type")
+        expect(page.answer_type).to eq("address")
+      end
+    end
+  end
 end

--- a/spec/requests/pages/address_settings_spec.rb
+++ b/spec/requests/pages/address_settings_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "AddressSettings controller", type: :request, feature_autocomplet
   describe "#update" do
     let(:page) do
       new_page = build :page, :with_address_settings, id: 2, form_id: form.id
-      new_page.answer_settings = OpenStruct.new(input_type: OpenStruct.new(uk_address: "false", international_address: "true"))
+      new_page.answer_settings = { input_type: { uk_address: "false", international_address: "true" } }
       new_page
     end
 
@@ -137,12 +137,11 @@ RSpec.describe "AddressSettings controller", type: :request, feature_autocomplet
         post address_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_address_settings_form: { uk_address: "true", international_address: "false" } }
       end
 
-      it "loads the updated input type from the page params" do
+      it "loads the updated input type into the session from the page params" do
         form_instance_variable = assigns(:address_settings_form)
         expect(form_instance_variable.uk_address).to eq "true"
         expect(form_instance_variable.international_address).to eq "false"
-        page_instance_variable = assigns(:page)
-        expect(page_instance_variable.answer_settings["input_type"]).to eq({ "international_address" => "false", "uk_address" => "true" })
+        expect(session[:page][:answer_settings]).to eq({ "input_type": { uk_address: "true", international_address: "false" } })
       end
 
       it "redirects the user to the edit question page" do

--- a/spec/requests/pages/date_settings_spec.rb
+++ b/spec/requests/pages/date_settings_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "DateSettings controller", type: :request, feature_autocomplete_a
   describe "#update" do
     let(:page) do
       new_page = build :page, :with_date_settings, id: 2, form_id: form.id
-      new_page.answer_settings = OpenStruct.new(input_type: OpenStruct.new(uk_date: "false", international_date: "true"))
+      new_page.answer_settings = { input_type: { uk_date: "false", international_date: "true" } }
       new_page
     end
 
@@ -137,8 +137,7 @@ RSpec.describe "DateSettings controller", type: :request, feature_autocomplete_a
       it "loads the updated input type from the page params" do
         form_instance_variable = assigns(:date_settings_form)
         expect(form_instance_variable.input_type).to eq "other_date"
-        page_instance_variable = assigns(:page)
-        expect(page_instance_variable.answer_settings["input_type"]).to eq "other_date"
+        expect(session[:page][:answer_settings]).to eq({ "input_type": "other_date" })
       end
 
       it "redirects the user to the edit question page" do

--- a/spec/requests/pages/text_settings_spec.rb
+++ b/spec/requests/pages/text_settings_spec.rb
@@ -133,8 +133,7 @@ RSpec.describe "TextSettings controller", type: :request, feature_autocomplete_a
       it "saves the updated input type to DB" do
         form_instance_variable = assigns(:text_settings_form)
         expect(form_instance_variable.input_type).to eq input_type
-        page_instance_variable = assigns(:page)
-        expect(page_instance_variable.answer_settings["input_type"]).to eq input_type
+        expect(session[:page][:answer_settings]).to eq({ input_type: })
       end
 
       it "redirects the user to the edit question page" do

--- a/spec/requests/pages/type_of_answer_spec.rb
+++ b/spec/requests/pages/type_of_answer_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "TypeOfAnswer controller", type: :request do
         let(:type_of_answer_form) { build :type_of_answer_form, :with_simple_answer_type, form: }
 
         it "saves the answer type to session" do
-          expect(session[:page]).to eq({ "answer_type": type_of_answer_form.answer_type })
+          expect(session[:page]).to eq({ answer_type: type_of_answer_form.answer_type, answer_settings: nil })
         end
 
         it "redirects the user to the question details page" do
@@ -77,7 +77,7 @@ RSpec.describe "TypeOfAnswer controller", type: :request do
         end
 
         it "saves the answer type to session" do
-          expect(session[:page]).to eq({ "answer_type": type_of_answer_form.answer_type })
+          expect(session[:page]).to eq({ answer_type: type_of_answer_form.answer_type, answer_settings: nil })
         end
 
         it "redirects the user to the question details page" do
@@ -93,7 +93,7 @@ RSpec.describe "TypeOfAnswer controller", type: :request do
         end
 
         it "saves the answer type to session" do
-          expect(session[:page]).to eq({ "answer_type": type_of_answer_form.answer_type })
+          expect(session[:page]).to eq({ answer_type: type_of_answer_form.answer_type, answer_settings: nil })
         end
 
         it "redirects the user to the question details page" do
@@ -109,7 +109,7 @@ RSpec.describe "TypeOfAnswer controller", type: :request do
         end
 
         it "saves the answer type to session" do
-          expect(session[:page]).to eq({ "answer_type": type_of_answer_form.answer_type })
+          expect(session[:page]).to eq({ answer_type: type_of_answer_form.answer_type, answer_settings: nil })
         end
 
         it "redirects the user to the question details page" do
@@ -125,7 +125,7 @@ RSpec.describe "TypeOfAnswer controller", type: :request do
         end
 
         it "saves the answer type to session" do
-          expect(session[:page]).to eq({ "answer_type": type_of_answer_form.answer_type })
+          expect(session[:page]).to eq({ answer_type: type_of_answer_form.answer_type, answer_settings: nil })
         end
 
         it "redirects the user to the question details page" do

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -8,18 +8,12 @@ RSpec.describe "Pages", type: :request do
     }
   end
 
+  let(:form_response) do
+    (build :form, id: 2)
+  end
+
   describe "Editing an existing page" do
     describe "Given a page" do
-      let(:form_response) do
-        {
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          id: 2,
-          org: "test-org",
-        }.to_json
-      end
-
       let(:form_pages_response) do
         [{
           id: 1,
@@ -54,7 +48,7 @@ RSpec.describe "Pages", type: :request do
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", req_headers, form_response, 200
+          mock.get "/api/v1/forms/2", req_headers, form_response.to_json, 200
           mock.get "/api/v1/forms/2/pages", req_headers, form_pages_response, 200
           mock.get "/api/v1/forms/2/pages/1", req_headers, page_response, 200
         end
@@ -77,16 +71,6 @@ RSpec.describe "Pages", type: :request do
 
   describe "Updating an existing page" do
     describe "Given a page" do
-      let(:form_response) do
-        {
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          id: 2,
-          org: "test-org",
-        }.to_json
-      end
-
       let(:form_pages_response) do
         [{
           id: 1,
@@ -141,7 +125,7 @@ RSpec.describe "Pages", type: :request do
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", req_headers, form_response, 200
+          mock.get "/api/v1/forms/2", req_headers, form_response.to_json, 200
           mock.get "/api/v1/forms/2/pages", req_headers, form_pages_response, 200
           mock.get "/api/v1/forms/2/pages/1", req_headers, page_response, 200
           mock.put "/api/v1/forms/2/pages/1", post_headers
@@ -182,16 +166,6 @@ RSpec.describe "Pages", type: :request do
   end
 
   describe "Creating a new page" do
-    let(:form_response) do
-      {
-        name: "Form name",
-        form_slug: "form-name",
-        submission_email: "submission@email.com",
-        id: 2,
-        org: "test-org",
-      }.to_json
-    end
-
     let(:req_headers) do
       {
         "X-API-Token" => ENV["API_KEY"],
@@ -220,7 +194,7 @@ RSpec.describe "Pages", type: :request do
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", req_headers, form_response, 200
+          mock.get "/api/v1/forms/2", req_headers, form_response.to_json, 200
           mock.get "/api/v1/forms/2/pages", req_headers, [].to_json, 200
           mock.post "/api/v1/forms/2/pages", post_headers
         end
@@ -253,17 +227,6 @@ RSpec.describe "Pages", type: :request do
 
   describe "Deleting an existing page" do
     describe "Given a valid page" do
-      let(:form) do
-        Form.new({
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          id: 2,
-          org: "test-org",
-          start_page: 1,
-        })
-      end
-
       let(:page) do
         Page.new({
           id: 1,
@@ -286,7 +249,7 @@ RSpec.describe "Pages", type: :request do
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+          mock.get "/api/v1/forms/2", req_headers, form_response.to_json, 200
           mock.get "/api/v1/forms/2/pages/1", req_headers, page.to_json, 200
         end
 
@@ -294,7 +257,7 @@ RSpec.describe "Pages", type: :request do
       end
 
       it "reads the form from the API" do
-        expect(form).to have_been_read
+        expect(form_response).to have_been_read
       end
 
       it "reads the page from the API" do
@@ -305,17 +268,6 @@ RSpec.describe "Pages", type: :request do
 
   describe "Destroying an existing page" do
     describe "Given a valid page" do
-      let(:form) do
-        {
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          id: 2,
-          org: "test-org",
-          start_page: 1,
-        }.to_json
-      end
-
       let(:page) do
         Page.new({
           id: 1,
@@ -348,7 +300,7 @@ RSpec.describe "Pages", type: :request do
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", req_headers, form, 200
+          mock.get "/api/v1/forms/2", req_headers, form_response.to_json, 200
           mock.get "/api/v1/forms/2/pages", req_headers, form_pages_response, 200
           mock.get "/api/v1/forms/2/pages/1", req_headers, page.to_json, 200
           mock.put "/api/v1/forms/2", post_headers

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "Pages", type: :request do
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
           answer_settings: nil,
+          is_optional: false,
         }.to_json
       end
 
@@ -94,6 +95,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Work address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          answer_settings: nil,
           is_optional: false,
         }].to_json
       end
@@ -106,6 +108,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Work address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          answer_settings: nil,
           is_optional: false,
         }.to_json
       end
@@ -116,6 +119,7 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Home address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          answer_settings: nil,
           is_optional: false,
         }
       end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -115,12 +115,13 @@ RSpec.describe "Pages", type: :request do
 
       let(:updated_page_data) do
         {
+          id: 1,
           question_text: "What is your home address?",
           question_short_name: "Home address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
           answer_settings: nil,
-          is_optional: false,
+          is_optional: nil,
         }
       end
 
@@ -165,7 +166,13 @@ RSpec.describe "Pages", type: :request do
 
       it "Updates the page on the API" do
         expected_request = ActiveResource::Request.new(:put, "/api/v1/forms/2/pages/1", updated_page_data.to_json, post_headers)
-        expect(ActiveResource::HttpMock.requests).to include(expected_request)
+        matched_request = ActiveResource::HttpMock.requests.find do |request|
+          request.method == expected_request.method &&
+            request.path == expected_request.path &&
+            request.body == expected_request.body
+        end
+
+        expect(matched_request).to eq expected_request
       end
 
       it "Redirects you to the new type of answer page" do
@@ -206,6 +213,8 @@ RSpec.describe "Pages", type: :request do
           question_short_name: "Home address",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          is_optional: nil,
+          answer_settings: nil,
         }
       end
 
@@ -231,7 +240,13 @@ RSpec.describe "Pages", type: :request do
 
       it "Creates the page on the API" do
         expected_request = ActiveResource::Request.new(:post, "/api/v1/forms/2/pages", new_page_data.to_json, post_headers)
-        expect(ActiveResource::HttpMock.requests).to include(expected_request)
+        matched_request = ActiveResource::HttpMock.requests.find do |request|
+          request.method == expected_request.method &&
+            request.path == expected_request.path &&
+            request.body == expected_request.body
+        end
+
+        expect(matched_request).to eq expected_request
       end
     end
   end

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -12,7 +12,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
     allow(form).to receive(:persisted?).and_return(true)
     allow(type_of_answer_form).to receive(:persisted?).and_return(true)
 
-    # mock the formg.page_number method
+    # mock the form.page_number method
     allow(form).to receive(:page_number).and_return(question_number)
 
     # mock the path helper
@@ -61,6 +61,6 @@ describe "pages/type_of_answer.html.erb", type: :view do
   end
 
   it "has a submit button with the correct text" do
-    expect(rendered).to have_button("Save and continue")
+    expect(rendered).to have_button("Continue")
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
Previously we were saving pages to the API when editing a page's answer_type or answer_settings. This meant that if a user's editing journey was interrupted the page could be left in a corrupt state on the API (e.g. pages with a `answer_type: selection` and `selection_settings: nil` would cause a 500 error in both the admin and the runner).

The app now saves answer_type and answer_settings into the session, and only saves them to the API when the page is saved on the Edit Question page. This is similar to the way that the new page journey works, but with added logic for retrieving the values from the API if there is nothing in the session.

Also includes:
- some cleanup of the `selections_settings` controller
- setting sensible defaults for `answer_settings` when switching answer type
- some test cleanup

Trello card: https://trello.com/c/N06qu8Ew/424-bug-question-pages-break-when-user-changes-an-existing-questions-answer-type-to-one-that-has-answersettings

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
