### PR TITLE
Fix status counter for live forms

### DIFF
--- a/app/components/task_list_component/view.html.erb
+++ b/app/components/task_list_component/view.html.erb
@@ -1,4 +1,4 @@
-<% if completed_task_count.present? && total_task_count.present? %>
+<% if (completed_task_count.present? && total_task_count.present?) && (completed_task_count != total_task_count ) %>
   <%= tag.p(class:"govuk-body app-task-list__summary") do %>
     You've completed <%= completed_task_count %> of <%= total_task_count %> tasks.
   <% end %>

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -75,11 +75,10 @@ class TaskStatusService
   end
 
   def make_live_status
-    if mandatory_tasks_completed?
-      :not_started
-    else
-      :cannot_start
-    end
+    return :completed if @form.live?
+    return :not_started if mandatory_tasks_completed?
+
+    :cannot_start
   end
 
   def mandatory_tasks_completed?

--- a/spec/components/task_list_component/task_list_component_preview.rb
+++ b/spec/components/task_list_component/task_list_component_preview.rb
@@ -64,8 +64,8 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
 
   def with_status_summary
     render(TaskListComponent::View.new(
-             completed_task_count: "10",
-             total_task_count: "20",
+             completed_task_count: "1",
+             total_task_count: "4",
              sections: [
                { title: "Make a form",
                  rows: [
@@ -73,6 +73,22 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
                    { task_name: "Edit the questions of your form", path: "#", status: :not_started, active: true },
                    { task_name: "Edit the email address", path: "#", status: :cannot_start },
                    { task_name: "Confirm the submission email address", path: "#", status: :cannot_start, active: false },
+                 ] },
+             ],
+           ))
+  end
+
+  def with_status_summary_all_tasks_completed
+    render(TaskListComponent::View.new(
+             completed_task_count: "4",
+             total_task_count: "4",
+             sections: [
+               { title: "Make a form",
+                 rows: [
+                   { task_name: "Edit the name of your form", path: "#", active: true, status: :completed, hint_text: "Describe your form clearly", confirm_path: "#confirm-path" },
+                   { task_name: "Edit the questions of your form", path: "#", status: :completed, active: true },
+                   { task_name: "Edit the email address", path: "#", status: :completed },
+                   { task_name: "Confirm the submission email address", path: "#", status: :completed, active: false },
                  ] },
              ],
            ))

--- a/spec/components/task_list_component/view_spec.rb
+++ b/spec/components/task_list_component/view_spec.rb
@@ -95,6 +95,25 @@ RSpec.describe TaskListComponent::View, type: :component do
       it "does render the summary text at the top of the task list" do
         expect(page).to have_selector(".app-task-list__summary", text: "You've completed 23 of 34 tasks.")
       end
+
+      context "when all tasks completed then hide the summary text (i.e form is live)" do
+        before do
+          render_inline(described_class.new(completed_task_count: "34", total_task_count: "34", sections: [
+            { title: "section a",
+              rows: [
+                { task_name: "task a", path: "#", status:, active: },
+              ] },
+            { title: "section 2",
+              rows: [
+                { task_name: "task d", path: "#", status:, active: },
+              ] },
+          ]))
+        end
+
+        it "does not render the summary text at the top of the task list" do
+          expect(page).not_to have_selector(".app-task-list__summary", text: "You've completed 34 of 34 tasks.")
+        end
+      end
     end
   end
 

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -7,7 +7,7 @@ describe TaskStatusService do
 
   describe "statuses" do
     describe "name status" do
-      let(:form) { build(:form, :new_form, id: 1) }
+      let(:form) { build(:form, :new_form) }
 
       it "returns the correct default value" do
         expect(task_status_service.name_status).to eq :completed
@@ -16,7 +16,7 @@ describe TaskStatusService do
 
     describe "pages status" do
       context "with a new form" do
-        let(:form) { build(:form, :new_form, id: 1) }
+        let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
           expect(task_status_service.pages_status).to eq :not_started
@@ -24,14 +24,14 @@ describe TaskStatusService do
       end
 
       context "with a form which has pages" do
-        let(:form) { build(:form, :new_form, :with_pages, id: 1, question_section_completed: false) }
+        let(:form) { build(:form, :new_form, :with_pages, question_section_completed: false) }
 
         it "returns the in progress status" do
           expect(task_status_service.pages_status).to eq :in_progress
         end
 
         context "and questions marked completed" do
-          let(:form) { build(:form, :new_form, :with_pages, id: 1, question_section_completed: true) }
+          let(:form) { build(:form, :new_form, :with_pages, question_section_completed: true) }
 
           it "returns the completed status" do
             expect(task_status_service.pages_status).to eq :completed
@@ -42,7 +42,7 @@ describe TaskStatusService do
 
     describe "declaration status" do
       context "with a new form" do
-        let(:form) { build(:form, :new_form, id: 1) }
+        let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
           expect(task_status_service.declaration_status).to eq :not_started
@@ -50,7 +50,7 @@ describe TaskStatusService do
       end
 
       context "with a form which has no declaration content and is marked incomplete" do
-        let(:form) { build(:form, id: 1, declaration_section_completed: false) }
+        let(:form) { build(:form, declaration_section_completed: false) }
 
         it "returns the not started status" do
           expect(task_status_service.declaration_status).to eq :not_started
@@ -58,7 +58,7 @@ describe TaskStatusService do
       end
 
       context "with a form which has declaration content and is marked incomplete" do
-        let(:form) { build(:form, id: 1, declaration_text: "I understand the implications", declaration_section_completed: false) }
+        let(:form) { build(:form, declaration_text: "I understand the implications", declaration_section_completed: false) }
 
         it "returns the in progress status" do
           expect(task_status_service.declaration_status).to eq :in_progress
@@ -66,7 +66,7 @@ describe TaskStatusService do
       end
 
       context "with a form which has a declaration marked complete" do
-        let(:form) { build(:form, id: 1, declaration_section_completed: true) }
+        let(:form) { build(:form, declaration_section_completed: true) }
 
         it "returns the completed status" do
           expect(task_status_service.declaration_status).to eq :completed
@@ -76,7 +76,7 @@ describe TaskStatusService do
 
     describe "what happens next status" do
       context "with a new form" do
-        let(:form) { build(:form, :new_form, id: 1) }
+        let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
           expect(task_status_service.what_happens_next_status).to eq :not_started
@@ -84,7 +84,7 @@ describe TaskStatusService do
       end
 
       context "with a form which has a what happens next section" do
-        let(:form) { build(:form, :new_form, id: 1, what_happens_next_text: "We usually respond to applications within 10 working days.") }
+        let(:form) { build(:form, :new_form, what_happens_next_text: "We usually respond to applications within 10 working days.") }
 
         it "returns the in progress status" do
           expect(task_status_service.what_happens_next_status).to eq :completed
@@ -94,7 +94,7 @@ describe TaskStatusService do
 
     describe "submission email status" do
       context "with a new form" do
-        let(:form) { build(:form, :new_form, id: 1) }
+        let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
           expect(task_status_service.submission_email_status).to eq :not_started
@@ -102,7 +102,7 @@ describe TaskStatusService do
       end
 
       context "with a form which has an email set" do
-        let(:form) { build(:form, :new_form, id: 1, submission_email: Faker::Internet.email(domain: "example.gov.uk")) }
+        let(:form) { build(:form, :new_form, submission_email: Faker::Internet.email(domain: "example.gov.uk")) }
 
         it "returns the in progress status" do
           expect(task_status_service.submission_email_status).to eq :completed
@@ -112,7 +112,7 @@ describe TaskStatusService do
 
     describe "privacy policy status" do
       context "with a new form" do
-        let(:form) { build(:form, :new_form, id: 1) }
+        let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
           expect(task_status_service.privacy_policy_status).to eq :not_started
@@ -120,7 +120,7 @@ describe TaskStatusService do
       end
 
       context "with a form which has a privacy policy section" do
-        let(:form) { build(:form, :new_form, id: 1, privacy_policy_url: Faker::Internet.url(host: "gov.uk")) }
+        let(:form) { build(:form, :new_form, privacy_policy_url: Faker::Internet.url(host: "gov.uk")) }
 
         it "returns the in progress status" do
           expect(task_status_service.privacy_policy_status).to eq :completed
@@ -130,7 +130,7 @@ describe TaskStatusService do
 
     describe "support contact details status status" do
       context "with a new form" do
-        let(:form) { build(:form, :new_form, id: 1) }
+        let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
           expect(task_status_service.support_contact_details_status).to eq :not_started
@@ -138,7 +138,7 @@ describe TaskStatusService do
       end
 
       context "with a form which has contact details set" do
-        let(:form) { build(:form, :new_form, :with_support, id: 1) }
+        let(:form) { build(:form, :new_form, :with_support) }
 
         it "returns the in progress status" do
           expect(task_status_service.support_contact_details_status).to eq :completed
@@ -148,7 +148,7 @@ describe TaskStatusService do
 
     describe "make live status" do
       context "with a new form" do
-        let(:form) { build(:form, :new_form, id: 1) }
+        let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
           expect(task_status_service.make_live_status).to eq :cannot_start
@@ -156,10 +156,18 @@ describe TaskStatusService do
       end
 
       context "with a form which is ready to go live" do
-        let(:form) { build(:form, :ready_for_live, id: 1) }
+        let(:form) { build(:form, :ready_for_live) }
 
         it "returns the not started status" do
           expect(task_status_service.make_live_status).to eq :not_started
+        end
+      end
+
+      context "with a live form" do
+        let(:form) { build(:form, :live) }
+
+        it "returns the completed status" do
+          expect(task_status_service.make_live_status).to eq :completed
         end
       end
     end


### PR DESCRIPTION
#### What problem does the pull request solve?

BUG: We were counting all tasks needed to make form live, but we didn't mark the "make form live" task as completed once the form went live so it meant that live forms ended up reporting that the user completed 8 out of 9 tasks.
Designers agreed that we should just hide this text once a form is live and this is a temporary solution because eventually when a form is live, it will become read-only and the user will not longer see this task list.

- Mark "make form live task" completed when its made live.
- hide summary text when completed & total count match (i.e form is live)

#### Before
![image](https://user-images.githubusercontent.com/3441519/212680581-fd7b7ca5-8c08-43e6-8a85-4143f7de60ff.png)

#### After
![image](https://user-images.githubusercontent.com/3441519/212680620-39fff9b9-1252-46c5-8312-77a6076b4e55.png)

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
