### PR TITLE
Remove task-list-status feature flag

### DIFF
--- a/app/components/mark_complete_component/view.rb
+++ b/app/components/mark_complete_component/view.rb
@@ -15,10 +15,6 @@ module MarkCompleteComponent
       @hint = hint
     end
 
-    def render?
-      FeatureService.enabled?(:task_list_statuses)
-    end
-
     def mark_complete_options
       [OpenStruct.new(value: "true", name: t("mark_complete.true")), OpenStruct.new(value: "false", name: t("mark_complete.false"))]
     end

--- a/app/components/task_list_component/view.html.erb
+++ b/app/components/task_list_component/view.html.erb
@@ -21,7 +21,7 @@
                 <% end %>
               </span>
 
-              <% if FeatureService.enabled?(:task_list_statuses) && row.status.present? %>
+              <% if row.status.present? %>
                 <%= render GovukComponent::TagComponent.new(
                   text: "<span class='govuk-visually-hidden'>Status </span>".html_safe + I18n.t("task_statuses.#{row.status}"),
                   classes: "app-task-list__tag",

--- a/app/forms/forms/declaration_form.rb
+++ b/app/forms/forms/declaration_form.rb
@@ -5,7 +5,7 @@ class Forms::DeclarationForm
   attr_accessor :form, :declaration_text, :mark_complete
 
   validates :declaration_text, length: { maximum: 2000 }
-  validates :mark_complete, presence: true, if: -> { FeatureService.enabled?(:task_list_statuses) }
+  validates :mark_complete, presence: true
 
   def submit
     return false if invalid?

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -45,20 +45,12 @@ class Form < ActiveResource::Base
   def ready_for_live?
     @missing_sections = []
 
-    if FeatureService.enabled?(:task_list_statuses)
-      task_list_statuses = TaskStatusService.new(form: self)
-      @missing_sections << :missing_pages unless task_list_statuses.pages_status == :completed
-      @missing_sections << :missing_submission_email unless task_list_statuses.submission_email_status == :completed
-      @missing_sections << :missing_privacy_policy_url unless task_list_statuses.privacy_policy_status == :completed
-      @missing_sections << :missing_contact_details unless task_list_statuses.support_contact_details_status == :completed
-      @missing_sections << :missing_what_happens_next unless task_list_statuses.what_happens_next_status == :completed
-    else
-      @missing_sections << :missing_pages unless pages.any?
-      @missing_sections << :missing_submission_email if submission_email.blank?
-      @missing_sections << :missing_privacy_policy_url if privacy_policy_url.blank?
-      @missing_sections << :missing_contact_details unless support_email.present? || support_phone.present? || (support_url.present? && support_url_text.present?)
-      @missing_sections << :missing_what_happens_next if what_happens_next_text.blank?
-    end
+    task_list_statuses = TaskStatusService.new(form: self)
+    @missing_sections << :missing_pages unless task_list_statuses.pages_status == :completed
+    @missing_sections << :missing_submission_email unless task_list_statuses.submission_email_status == :completed
+    @missing_sections << :missing_privacy_policy_url unless task_list_statuses.privacy_policy_status == :completed
+    @missing_sections << :missing_contact_details unless task_list_statuses.support_contact_details_status == :completed
+    @missing_sections << :missing_what_happens_next unless task_list_statuses.what_happens_next_status == :completed
 
     if @missing_sections.any?
       false

--- a/app/views/forms/declaration/new.html.erb
+++ b/app/views/forms/declaration/new.html.erb
@@ -17,9 +17,7 @@
 
       <%= f.govuk_text_area :declaration_text, max_chars: 2000, label: {size: 'm' } %>
 
-      <% if FeatureService.enabled?(:task_list_statuses) %>
-        <%= render MarkCompleteComponent::View.new(generate_form: false, form_builder: f, form_model: @declaration_form) %>
-      <% end %>
+      <%= render MarkCompleteComponent::View.new(generate_form: false, form_builder: f, form_model: @declaration_form) %>
 
       <%= f.govuk_submit "Save and continue" %>
     <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,5 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
-  task_list_statuses: true
   reorder_pages: true
   autocomplete_answer_types: false
   live_view: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,5 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
-  task_list_statuses: true
   reorder_pages: true
   autocomplete_answer_types: true
   live_view: true

--- a/spec/components/mark_complete_component/view_spec.rb
+++ b/spec/components/mark_complete_component/view_spec.rb
@@ -9,47 +9,37 @@ RSpec.describe MarkCompleteComponent::View, type: :component do
   let(:form) { build(:form, :with_pages, id: 2) }
   let(:mark_complete_form) { Forms::MarkCompleteForm.new(form:).assign_form_values }
 
-  context "when the task status feature is enabled", feature_task_list_statuses: true do
-    context "when using the generate_form option" do
-      it "renders the form" do
-        render_inline(described_class.new(form_model: mark_complete_form, path: "/"))
-
-        expect(page.text).to have_text(I18n.t("mark_complete.legend"))
-      end
-
-      it "the label and hint text can be overridden" do
-        render_inline(described_class.new(form_model: mark_complete_form, path: "/", legend: I18n.t("pages.index.mark_complete.legend"), hint: "You can come back to your questions later"))
-
-        expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
-        expect(page.text).to have_text(I18n.t("pages.index.mark_complete.legend"))
-        expect(page.text).to have_text("You can come back to your questions later")
-      end
-    end
-
-    context "when not using the generate_form option" do
-      let(:form_builder) { generate_form_builder(mark_complete_form) }
-
-      it "renders the form" do
-        render_inline(described_class.new(form_builder:, generate_form: false))
-
-        expect(page.text).to have_text(I18n.t("mark_complete.legend"))
-      end
-
-      it "the label and hint text can be overridden" do
-        render_inline(described_class.new(form_builder:, generate_form: false, legend: I18n.t("pages.index.mark_complete.legend"), hint: "You can come back to your questions later"))
-
-        expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
-        expect(page.text).to have_text(I18n.t("pages.index.mark_complete.legend"))
-        expect(page.text).to have_text("You can come back to your questions later")
-      end
-    end
-  end
-
-  context "when the task status feature is disabled", feature_task_list_statuses: false do
+  context "when using the generate_form option" do
     it "renders the form" do
       render_inline(described_class.new(form_model: mark_complete_form, path: "/"))
 
+      expect(page.text).to have_text(I18n.t("mark_complete.legend"))
+    end
+
+    it "the label and hint text can be overridden" do
+      render_inline(described_class.new(form_model: mark_complete_form, path: "/", legend: I18n.t("pages.index.mark_complete.legend"), hint: "You can come back to your questions later"))
+
       expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
+      expect(page.text).to have_text(I18n.t("pages.index.mark_complete.legend"))
+      expect(page.text).to have_text("You can come back to your questions later")
+    end
+  end
+
+  context "when not using the generate_form option" do
+    let(:form_builder) { generate_form_builder(mark_complete_form) }
+
+    it "renders the form" do
+      render_inline(described_class.new(form_builder:, generate_form: false))
+
+      expect(page.text).to have_text(I18n.t("mark_complete.legend"))
+    end
+
+    it "the label and hint text can be overridden" do
+      render_inline(described_class.new(form_builder:, generate_form: false, legend: I18n.t("pages.index.mark_complete.legend"), hint: "You can come back to your questions later"))
+
+      expect(page.text).not_to have_text(I18n.t("mark_complete.legend"))
+      expect(page.text).to have_text(I18n.t("pages.index.mark_complete.legend"))
+      expect(page.text).to have_text("You can come back to your questions later")
     end
   end
 end

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -21,8 +21,9 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    include_examples expected_value_test, :task_list_statuses, features, true
     include_examples expected_value_test, :live_view, features, false
+    include_examples expected_value_test, :reorder_pages, features, true
+    include_examples expected_value_test, :autocomplete_answer_types, features, false
   end
 
   describe "govuk_notify" do

--- a/spec/forms/declaration_form_spec.rb
+++ b/spec/forms/declaration_form_spec.rb
@@ -3,89 +3,43 @@ require "rails_helper"
 RSpec.describe Forms::DeclarationForm, type: :model do
   describe "validations" do
     describe "Character length" do
-      context "when the task status feature is not enabled", feature_task_list_statuses: false do
-        it "is valid if less than 2000 characters" do
-          declaration_form = described_class.new(declaration_text: "a")
-
-          expect(declaration_form).to be_valid
-        end
-
-        it "is valid if 2000 characters" do
-          declaration_form = described_class.new(declaration_text: "a" * 2000)
-
-          expect(declaration_form).to be_valid
-        end
-
-        it "is invalid if more than 2000 characters" do
-          declaration_form = described_class.new(declaration_text: "a" * 2001)
-          error_message = I18n.t("activemodel.errors.models.forms/declaration_form.attributes.declaration_text.too_long")
-
-          expect(declaration_form).not_to be_valid
-
-          declaration_form.validate(:declaration_text)
-
-          expect(declaration_form.errors.full_messages_for(:declaration_text)).to include(
-            "Declaration text #{error_message}",
-          )
-        end
-      end
-
-      context "when the task status feature is enabled", feature_task_list_statuses: true do
-        it "is valid if less than 2000 characters" do
-          declaration_form = described_class.new(declaration_text: "a", mark_complete: true)
-
-          expect(declaration_form).to be_valid
-        end
-
-        it "is valid if 2000 characters" do
-          declaration_form = described_class.new(declaration_text: "a" * 2000, mark_complete: true)
-
-          expect(declaration_form).to be_valid
-        end
-
-        it "is invalid if more than 2000 characters" do
-          declaration_form = described_class.new(declaration_text: "a" * 2001, mark_complete: true)
-          error_message = I18n.t("activemodel.errors.models.forms/declaration_form.attributes.declaration_text.too_long")
-
-          expect(declaration_form).not_to be_valid
-
-          declaration_form.validate(:declaration_text)
-
-          expect(declaration_form.errors.full_messages_for(:declaration_text)).to include(
-            "Declaration text #{error_message}",
-          )
-        end
-      end
-    end
-
-    context "when the task status feature is not enabled", feature_task_list_statuses: false do
-      it "is valid if declaration text is blank" do
-        declaration_form = described_class.new(declaration_text: "")
+      it "is valid if less than 2000 characters" do
+        declaration_form = described_class.new(declaration_text: "a", mark_complete: true)
 
         expect(declaration_form).to be_valid
       end
 
-      it "is valid if mark complete is blank" do
-        declaration_form = described_class.new(mark_complete: "")
-
-        expect(declaration_form).to be_valid
-        expect(declaration_form.errors.full_messages_for(:mark_complete)).not_to include "Mark complete #{I18n.t('activemodel.errors.models.forms/declaration_form.attributes.mark_complete.blank')}"
-      end
-    end
-
-    context "when the task status feature is enabled", feature_task_list_statuses: true do
-      it "is valid if declaration text is blank" do
-        declaration_form = described_class.new(declaration_text: "", mark_complete: true)
+      it "is valid if 2000 characters" do
+        declaration_form = described_class.new(declaration_text: "a" * 2000, mark_complete: true)
 
         expect(declaration_form).to be_valid
       end
 
-      it "is not valid if mark complete is blank" do
-        declaration_form = described_class.new(mark_complete: nil)
+      it "is invalid if more than 2000 characters" do
+        declaration_form = described_class.new(declaration_text: "a" * 2001, mark_complete: true)
+        error_message = I18n.t("activemodel.errors.models.forms/declaration_form.attributes.declaration_text.too_long")
 
         expect(declaration_form).not_to be_valid
-        expect(declaration_form.errors.full_messages_for(:mark_complete)).to include "Mark complete #{I18n.t('activemodel.errors.models.forms/declaration_form.attributes.mark_complete.blank')}"
+
+        declaration_form.validate(:declaration_text)
+
+        expect(declaration_form.errors.full_messages_for(:declaration_text)).to include(
+          "Declaration text #{error_message}",
+        )
       end
+    end
+
+    it "is valid if declaration text is blank" do
+      declaration_form = described_class.new(declaration_text: "", mark_complete: true)
+
+      expect(declaration_form).to be_valid
+    end
+
+    it "is not valid if mark complete is blank" do
+      declaration_form = described_class.new(mark_complete: nil)
+
+      expect(declaration_form).not_to be_valid
+      expect(declaration_form.errors.full_messages_for(:mark_complete)).to include "Mark complete #{I18n.t('activemodel.errors.models.forms/declaration_form.attributes.mark_complete.blank')}"
     end
   end
 
@@ -95,23 +49,12 @@ RSpec.describe Forms::DeclarationForm, type: :model do
       expect(form.submit).to eq false
     end
 
-    context "when the task status feature is not enabled", feature_task_list_statuses: false do
-      it "sets the form's attribute value" do
-        form = OpenStruct.new(declaration_text: "abc")
-        declaration_form = described_class.new(form:, declaration_text: "new declaration text")
-        declaration_form.submit
-        expect(declaration_form.form.declaration_text).to eq "new declaration text"
-      end
-    end
-
-    context "when the task status feature is enabled", feature_task_list_statuses: true do
-      it "sets the form's attribute values" do
-        form = OpenStruct.new(declaration_text: "abc", declaration_section_completed: "false")
-        declaration_form = described_class.new(form:, declaration_text: "new declaration text", mark_complete: "true")
-        declaration_form.submit
-        expect(declaration_form.form.declaration_text).to eq "new declaration text"
-        expect(declaration_form.form.declaration_section_completed).to eq "true"
-      end
+    it "sets the form's attribute values" do
+      form = OpenStruct.new(declaration_text: "abc", declaration_section_completed: "false")
+      declaration_form = described_class.new(form:, declaration_text: "new declaration text", mark_complete: "true")
+      declaration_form.submit
+      expect(declaration_form.form.declaration_text).to eq "new declaration text"
+      expect(declaration_form.form.declaration_section_completed).to eq "true"
     end
   end
 end

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -63,13 +63,11 @@ describe FormTaskListService do
         expect(section_rows[3][:path]).to eq "/forms/1/what-happens-next"
       end
 
-      context "when task list statuses are enabled", feature_task_list_statuses: true do
-        it "has the correct default statuses" do
-          expect(section_rows.first[:status]).to eq :completed
-          expect(section_rows[1][:status]).to eq :not_started
-          expect(section_rows[2][:status]).to eq :not_started
-          expect(section_rows[3][:status]).to eq :not_started
-        end
+      it "has the correct default statuses" do
+        expect(section_rows.first[:status]).to eq :completed
+        expect(section_rows[1][:status]).to eq :not_started
+        expect(section_rows[2][:status]).to eq :not_started
+        expect(section_rows[3][:status]).to eq :not_started
       end
     end
 
@@ -100,10 +98,8 @@ describe FormTaskListService do
           expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_lists.section_2.hint_text_html", submission_email: form.submission_email)
         end
 
-        context "when task list statuses are enabled", feature_task_list_statuses: true do
-          it "has the correct default status" do
-            expect(section_rows.first[:status]).to eq :completed
-          end
+        it "has the correct default status" do
+          expect(section_rows.first[:status]).to eq :completed
         end
       end
 
@@ -112,73 +108,69 @@ describe FormTaskListService do
           expect(section_rows.first[:hint_text]).to be_nil
         end
 
-        context "when task list statuses are enabled", feature_task_list_statuses: true do
-          it "has the correct default status" do
-            expect(section_rows.first[:status]).to eq :not_started
-          end
+        it "has the correct default status" do
+          expect(section_rows.first[:status]).to eq :not_started
         end
       end
 
-      context "when task list statuses are enabled", feature_task_list_statuses: true do
-        context "and submission_email is set and no code sent" do
-          before do
-            form.submission_email = "test@example.gov.uk"
-          end
-
-          it "enter email has status of completed" do
-            expect(section_rows.first[:status]).to eq :completed
-          end
-
-          it "enter code has status of completed" do
-            expect(section_rows[1][:status]).to eq :completed
-          end
+      context "and submission_email is set and no code sent" do
+        before do
+          form.submission_email = "test@example.gov.uk"
         end
 
-        context "and submission_email is not set and no code sent" do
-          it "enter email has status of not_started" do
-            expect(section_rows.first[:status]).to eq :not_started
-          end
-
-          it "enter code has status of cannot_start" do
-            expect(section_rows[1][:status]).to eq :cannot_start
-          end
-
-          it "enter code is not active" do
-            expect(section_rows[1][:active]).to be_falsy
-          end
+        it "enter email has status of completed" do
+          expect(section_rows.first[:status]).to eq :completed
         end
 
-        context "and submission_email is not set and code sent" do
-          before do
-            create :form_submission_email, form_id: form.id, confirmation_code: form.id
-          end
+        it "enter code has status of completed" do
+          expect(section_rows[1][:status]).to eq :completed
+        end
+      end
 
-          it "enter email has status of in_progress" do
-            expect(section_rows.first[:status]).to eq :in_progress
-          end
-
-          it "enter code has status of incomplete" do
-            expect(section_rows[1][:status]).to eq :not_started
-          end
-
-          it "enter code is active" do
-            expect(section_rows[1][:active]).to be_truthy
-          end
+      context "and submission_email is not set and no code sent" do
+        it "enter email has status of not_started" do
+          expect(section_rows.first[:status]).to eq :not_started
         end
 
-        context "and submission_email is set and code blank" do
-          before do
-            form.submission_email = "test@example.gov.uk"
-            create :form_submission_email, form_id: form.id, confirmation_code: nil
-          end
+        it "enter code has status of cannot_start" do
+          expect(section_rows[1][:status]).to eq :cannot_start
+        end
 
-          it "enter email has status of completed" do
-            expect(section_rows.first[:status]).to eq :completed
-          end
+        it "enter code is not active" do
+          expect(section_rows[1][:active]).to be_falsy
+        end
+      end
 
-          it "enter code has status of completed" do
-            expect(section_rows[1][:status]).to eq :completed
-          end
+      context "and submission_email is not set and code sent" do
+        before do
+          create :form_submission_email, form_id: form.id, confirmation_code: form.id
+        end
+
+        it "enter email has status of in_progress" do
+          expect(section_rows.first[:status]).to eq :in_progress
+        end
+
+        it "enter code has status of incomplete" do
+          expect(section_rows[1][:status]).to eq :not_started
+        end
+
+        it "enter code is active" do
+          expect(section_rows[1][:active]).to be_truthy
+        end
+      end
+
+      context "and submission_email is set and code blank" do
+        before do
+          form.submission_email = "test@example.gov.uk"
+          create :form_submission_email, form_id: form.id, confirmation_code: nil
+        end
+
+        it "enter email has status of completed" do
+          expect(section_rows.first[:status]).to eq :completed
+        end
+
+        it "enter code has status of completed" do
+          expect(section_rows[1][:status]).to eq :completed
         end
       end
     end
@@ -200,11 +192,9 @@ describe FormTaskListService do
         expect(section_rows[1][:path]).to eq "/forms/1/contact-details"
       end
 
-      context "when task list statuses are enabled", feature_task_list_statuses: true do
-        it "has the correct default statuses" do
-          expect(section_rows.first[:status]).to eq :not_started
-          expect(section_rows[1][:status]).to eq :not_started
-        end
+      it "has the correct default statuses" do
+        expect(section_rows.first[:status]).to eq :not_started
+        expect(section_rows[1][:status]).to eq :not_started
       end
     end
 
@@ -220,10 +210,8 @@ describe FormTaskListService do
         expect(section_rows.first[:path]).to be_empty
       end
 
-      context "when task list statuses are enabled", feature_task_list_statuses: true do
-        it "has the correct default status" do
-          expect(section_rows.first[:status]).to eq :cannot_start
-        end
+      it "has the correct default status" do
+        expect(section_rows.first[:status]).to eq :cannot_start
       end
 
       context "when form is ready to make live" do
@@ -239,10 +227,8 @@ describe FormTaskListService do
           expect(section_rows.first[:path]).to eq "/forms/1/make-live"
         end
 
-        context "when task list statuses are enabled", feature_task_list_statuses: true do
-          it "has the correct default status" do
-            expect(section_rows.first[:status]).to eq :not_started
-          end
+        it "has the correct default status" do
+          expect(section_rows.first[:status]).to eq :not_started
         end
       end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

Removes task list status feature flag. We know we want to display status against each task

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
