### PR TITLE
Add live view feature

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -7,14 +7,26 @@ class FormsController < ApplicationController
 
   def show
     @form = Form.find(params[:form_id])
-    task_service = FormTaskListService.call(form: @form)
-    @task_list = task_service.all_tasks
-    @task_status_counts = task_service.task_counts
+    if show_live?
+      render template: "forms/show_live"
+    else
+      configure_tasklist
+    end
   end
 
 private
 
   def form_params
     params.require(:form).permit(:name, :submission_email)
+  end
+
+  def configure_tasklist
+    task_service = FormTaskListService.call(form: @form)
+    @task_list = task_service.all_tasks
+    @task_status_counts = task_service.task_counts
+  end
+
+  def show_live?
+    FeatureService.enabled?(:live_view) && @form.live? && params[:edit].blank?
   end
 end

--- a/app/views/forms/show_live.html.erb
+++ b/app/views/forms/show_live.html.erb
@@ -1,0 +1,13 @@
+<% set_page_title(@form.name) %>
+
+<% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+      <span class="govuk-caption-l"><%= @form.name %></span><span class="govuk-visually-hidden"> - </span>
+      <%= @form.live? ? t("forms.form_overview.live_title") : t("forms.form_overview.title") %>
+    </h1>
+    <p class="govuk-body">Live form placeholder</p>
+  </div>
+</div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,7 @@ features:
   task_list_statuses: true
   reorder_pages: true
   autocomplete_answer_types: false
+  live_view: false
 
 # Settings for GOV.UK Notify api & email templates
 govuk_notify:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,3 +3,4 @@ features:
   task_list_statuses: true
   reorder_pages: true
   autocomplete_answer_types: true
+  live_view: true

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,6 +22,7 @@ describe "Settings" do
     features = settings[:features]
 
     include_examples expected_value_test, :task_list_statuses, features, true
+    include_examples expected_value_test, :live_view, features, false
   end
 
   describe "govuk_notify" do

--- a/spec/views/forms/show_live.html.erb_spec.rb
+++ b/spec/views/forms/show_live.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe "forms/show_live.html.erb" do
+  let(:form) { build(:form, :live, id: 2) }
+
+  around do |example|
+    ClimateControl.modify RUNNER_BASE: "runner-host" do
+      example.run
+    end
+  end
+
+  before do
+    assign(:form, form)
+    render template: "forms/show_live"
+  end
+
+  it "contains placeholder text" do
+    expect(rendered).to have_content("placeholder")
+  end
+end


### PR DESCRIPTION
# Add new show view for live forms

The new feature flag will be used to gate the changes to the Form#show route which shows the tasklist.

Forms which are live have should be displayed to form creators differently than forms which have not been made live.

This commit adds a new view for live forms which is only enabled when the feature flag is true.

When the flag is enabled, live forms will be shown differently - this commit uses placeholder content for this case. The tasklist view can still be shown to the user by settings the `edit` query param. Following PR's will add the content and links for the new live_view.

The decision to show the live_view is made in the Forms controller and a new template, live_view is rendered. This allows setting up the tasklist, which only needs to happen in one case and concentrates the logic for showing the live view in one place. This could be moved to always using a single template and using partials. That seems to spread out the logic though and requires setting up the tasklist in both cases, which isn't needed.

Trello card: https://trello.com/c/ApandpjI/425-add-view-live-form-page-admin

#### Checklist

- [X] I've used the pull request template
- [X] I've linked this PR to the relevant issue (if mission work)
- [X] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
