### PR TITLE
Add content for show_live_form

### DIFF
--- a/app/components/form_status_tag_description_component/view.html.erb
+++ b/app/components/form_status_tag_description_component/view.html.erb
@@ -1,0 +1,4 @@
+<dl class="govuk-!-margin-bottom-7">
+  <dt class="govuk-visually-hidden"><%= t('status_tag_description_component.status') %></dt>
+  <dd class="govuk-!-margin-0"><%= render FormStatusTagComponent::View.new(status: @status) %></dd>
+</dl>

--- a/app/components/form_status_tag_description_component/view.rb
+++ b/app/components/form_status_tag_description_component/view.rb
@@ -1,0 +1,10 @@
+module FormStatusTagDescriptionComponent
+  class View < ViewComponent::Base
+    attr_accessor :status
+
+    def initialize(status: "DRAFT")
+      super
+      @status = status.upcase
+    end
+  end
+end

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -8,12 +8,8 @@
       <span class="govuk-caption-l"><%= @form.name %></span><span class="govuk-visually-hidden"> - </span>
       <%= @form.live? ? t("forms.form_overview.live_title") : t("forms.form_overview.title") %>
     </h1>
-    <dl class="govuk-!-margin-bottom-7">
-      <dt class="govuk-visually-hidden">Status</dt>
-      <dd class="govuk-!-margin-0"><%= render FormStatusTagComponent::View.new(status: @form.status) %></dd>
-    </dl>
 
-
+    <%= render FormStatusTagDescriptionComponent::View.new(status: @form.status) %>
 
     <% if flash[:message] %>
       <p class="govuk-body"><%= flash[:message] %></p>

--- a/app/views/forms/show_live.html.erb
+++ b/app/views/forms/show_live.html.erb
@@ -5,9 +5,50 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-      <span class="govuk-caption-l"><%= @form.name %></span><span class="govuk-visually-hidden"> - </span>
-      <%= @form.live? ? t("forms.form_overview.live_title") : t("forms.form_overview.title") %>
+      <%= @form.name %>
     </h1>
-    <p class="govuk-body">Live form placeholder</p>
+    <dl class="govuk-!-margin-bottom-7">
+      <dt class="govuk-visually-hidden">Status</dt>
+      <dd class="govuk-!-margin-0"><%= render FormStatusTagComponent::View.new(status: @form.status) %></dd>
+    </dl>
+
+    <p class="govuk-body">
+      <%= render PreviewLinkComponent::View.new(@form.pages, link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug)) %>
+    </p>
+
+    <h2 class="govuk-heading-m"><%= t('show_live_form.form_url') %></h2>
+    <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug, live: true ))%>
+
+    <h2 class="govuk-heading-m"><%= t('show_live_form.form_content') %></h2>
+    <ul class="govuk-list">
+      <li> <%= govuk_link_to t('show_live_form.questions', count: @form.pages.count), form_pages_path(@form.id) %> </li>
+      <li> <%= govuk_link_to t('show_live_form.declaration'), declaration_path(@form.id) %> </li>
+      <li> <%= govuk_link_to t('show_live_form.what_happens_next'), what_happens_next_path(@form.id) %> </li>
+    </ul>
+
+    <h2 class="govuk-heading-m"><%= t('show_live_form.submission_email') %></h2>
+    <p class="govuk-body"><%= @form.submission_email %></p>
+
+    <h2 class="govuk-heading-m"><%= t('show_live_form.privacy_policy_link') %></h2>
+    <p class="govuk-body"><%= govuk_link_to(@form.privacy_policy_url, @form.privacy_policy_url) %></p>
+
+    <h2 class="govuk-heading-m"><%= t('show_live_form.contact_details') %></h2>
+
+    <% if @form.support_email %>
+      <h3 class="govuk-heading-s"><%= t('show_live_form.support_email') %></h3>
+      <p class="govuk-body"><%= @form.support_email %></p>
+    <% end %>
+
+    <% if @form.support_phone %>
+      <h3 class="govuk-heading-s"><%= t('show_live_form.support_phone') %></h3>
+      <p class="govuk-body"><%= @form.support_phone %></p>
+    <% end %>
+
+    <% if @form.support_url %>
+      <h3 class="govuk-heading-s"><%= t('show_live_form.support_url') %></h3>
+      <p class="govuk-body"><%= govuk_link_to @form.support_url_text, @form.support_url %></p>
+    <% end %>
+
+    <%= govuk_button_link_to t('show_live_form.edit_link'), form_path(@form.id, edit: true) %>
   </div>
 </div>

--- a/app/views/forms/show_live.html.erb
+++ b/app/views/forms/show_live.html.erb
@@ -7,10 +7,8 @@
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       <%= @form.name %>
     </h1>
-    <dl class="govuk-!-margin-bottom-7">
-      <dt class="govuk-visually-hidden">Status</dt>
-      <dd class="govuk-!-margin-0"><%= render FormStatusTagComponent::View.new(status: @form.status) %></dd>
-    </dl>
+
+    <%= render FormStatusTagDescriptionComponent::View.new(status: @form.status) %>
 
     <p class="govuk-body">
       <%= render PreviewLinkComponent::View.new(@form.pages, link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,6 +363,8 @@ en:
     support_url: Support contact online
     what_happens_next: What happens next
   skip_to_main_content: Skip to main content
+  status_tag_description_component:
+    status: Status
   task_statuses:
     cannot_start: cannot start yet
     completed: completed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,6 +346,22 @@ en:
         <p class="govuk-body">
           The recipient will be asked to tell you the code. You will then need to enter the code to confirm the email address.
         </p>
+  show_live_form:
+    contact_details: Your form’s contact details
+    declaration: Declaration
+    edit_link: Edit this form
+    form_content: Form content
+    form_url: Form URL
+    privacy_policy_link: Privacy policy link
+    questions:
+      one: 1 question
+      other: "%{count} questions"
+      zero: no quesions
+    submission_email: Submission email
+    support_email: Email
+    support_phone: Phone
+    support_url: Support contact online
+    what_happens_next: What happens next
   skip_to_main_content: Skip to main content
   task_statuses:
     cannot_start: cannot start yet

--- a/spec/components/form_status_tag_description_component/form_status_tag_component_preview.rb
+++ b/spec/components/form_status_tag_description_component/form_status_tag_component_preview.rb
@@ -1,0 +1,9 @@
+class FormStatusTagDescriptionComponent::FormStatusTagComponentPreview < ViewComponent::Preview
+  def default
+    render(FormStatusTagDescriptionComponent::View.new)
+  end
+
+  def live_status
+    render(FormStatusTagDescriptionComponent::View.new(status: "live"))
+  end
+end

--- a/spec/components/form_status_tag_description_component/view_spec.rb
+++ b/spec/components/form_status_tag_description_component/view_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe FormStatusTagDescriptionComponent::View, type: :component do
+  describe "draft/default status" do
+    before do
+      render_inline(described_class.new)
+    end
+
+    it "renders the draft status by default" do
+      expect(page).to have_text("DRAFT")
+    end
+  end
+
+  describe "live status" do
+    before do
+      render_inline(described_class.new(status: "live"))
+    end
+
+    it "renders the status text" do
+      expect(page).to have_text("LIVE")
+    end
+  end
+end

--- a/spec/views/forms/show_live.html.erb_spec.rb
+++ b/spec/views/forms/show_live.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "forms/show_live.html.erb" do
-  let(:form) { build(:form, :live, id: 2) }
+  let(:form) { build(:form, :live, :with_pages, id: 2) }
 
   around do |example|
     ClimateControl.modify RUNNER_BASE: "runner-host" do
@@ -10,11 +10,104 @@ describe "forms/show_live.html.erb" do
   end
 
   before do
+    allow(view).to receive(:form_pages_path).and_return("/form-pages-path")
+    allow(view).to receive(:declaration_path).and_return("/declaration_path")
+    allow(view).to receive(:what_happens_next_path).and_return("/what_happens_next_path")
+
     assign(:form, form)
-    render template: "forms/show_live"
+    render(template: "forms/show_live", layout: "layouts/application")
   end
 
-  it "contains placeholder text" do
-    expect(rendered).to have_content("placeholder")
+  it "has the correct title" do
+    expect(rendered).to have_title "#{form.name} – GOV.UK Forms"
+  end
+
+  it "back link is set to root" do
+    expect(rendered).to have_link("Back to your forms", href: "/")
+  end
+
+  it "contains page heading" do
+    expect(rendered).to have_css("h1.govuk-heading-l", text: form.name)
+  end
+
+  it "rendered live tag" do
+    expect(rendered).to have_css(".govuk-tag.govuk-tag--blue", text: "LIVE")
+  end
+
+  it "contains a link to preview the form" do
+    expect(rendered).to have_link("Preview this form in a new tab", href: "runner-host/preview-form/2/#{form.form_slug}", visible: :all)
+  end
+
+  it "contains a link to the form in the runner" do
+    expect(rendered).to have_content("runner-host/form/2/#{form.form_slug}")
+  end
+
+  it "contains a link to edit questions" do
+    expect(rendered).to have_link("#{form.pages.count} questions", href: "/form-pages-path")
+  end
+
+  context "with only a single question" do
+    let(:form) { build(:form, :live, :with_pages, id: 2, pages_count: 1) }
+
+    it "contains a link to edit questions with correct pluralization" do
+      expect(rendered).to have_link("1 question", href: "/form-pages-path")
+    end
+  end
+
+  it "contains a link to declaration" do
+    expect(rendered).to have_link("Declaration", href: "/declaration_path")
+  end
+
+  it "contains a link to what happens next" do
+    expect(rendered).to have_link("What happens next", href: "/what_happens_next_path")
+  end
+
+  it "contains the submission email" do
+    expect(rendered).to have_content(form.submission_email)
+  end
+
+  it "contains link to privacy policy " do
+    expect(rendered).to have_link(form.privacy_policy_url, href: form.privacy_policy_url)
+  end
+
+  context "with a support email address" do
+    let(:form) { build(:form, :live, :with_pages, id: 2, support_email: "support@example.gov.uk") }
+
+    it "shows the support email address" do
+      expect(rendered).to have_css("h3", text: "Email")
+      expect(rendered).to have_content("support@example.gov.uk")
+    end
+  end
+
+  context "with a support phone" do
+    let(:form) { build(:form, :live, :with_pages, id: 2, support_phone: "phone details") }
+
+    it "shows the support email address" do
+      expect(rendered).to have_css("h3", text: "Phone")
+      expect(rendered).to have_content("phone details")
+    end
+  end
+
+  context "with a support online" do
+    let(:form) { build(:form, :live, :with_pages, id: 2, support_url_text: "website", support_url: "www.example.gov.uk") }
+
+    it "shows the support contact online" do
+      expect(rendered).to have_css("h3", text: "Support contact online")
+      expect(rendered).to have_link(form.support_url_text, href: form.support_url)
+    end
+  end
+
+  context "with no support information set" do
+    let(:form) { build(:form, :live, :with_pages, id: 2, support_email: nil, support_phone: nil, support_url_text: nil, support_url: nil) }
+
+    it "does not include support details if they are not set" do
+      expect(rendered).not_to have_css("h3", text: "Email")
+      expect(rendered).not_to have_css("h3", text: "Phone")
+      expect(rendered).not_to have_css("h3", text: "Support contact online")
+    end
+  end
+
+  it "contains a link to edit the form" do
+    expect(rendered).to have_link("Edit this form", href: form_path(form.id, edit: true))
   end
 end


### PR DESCRIPTION
# Add content for showing live forms

This feature is still behind a feature flag, so will only show in development for now.

This PR add's the basic content and tests for showing a live form in the admin.

For now, form creators can still edit live forms byt following the edit form link.

Trello card: https://trello.com/c/ApandpjI/425-add-view-live-form-page-admin

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
