### PR TITLE
Add confirmation panel to 'your form is live' confirmation page

### DIFF
--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -2,8 +2,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"><%= @form.name %></span>
-    <h1 class="govuk-heading-l"><%= t('page_titles.your_form_is_live') %></h1>
+    <%= govuk_panel(title_text: t('page_titles.your_form_is_live')) %>
+
+    <h2 class="govuk-heading-m"><%= t('make_live.confirmation.form_name') %></h2>
+
+    <p class="govuk-body"><%= @form.name %></p>
+
+    <h2 class="govuk-heading-m"><%= t('make_live.confirmation.form_url') %></h2>
 
     <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug, live: true )) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,6 +213,8 @@ en:
           Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
         </p>
       continue_link: Continue to form details
+      form_name: Form name
+      form_url: Form URL
     new:
       body_html: |
         <p class="govuk-body">

--- a/spec/views/forms/make_live/confirmation.html.erb_spec.rb
+++ b/spec/views/forms/make_live/confirmation.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "forms/make_live/confirmation.html.erb" do
+  around do |example|
+    ClimateControl.modify RUNNER_BASE: "runner-host" do
+      example.run
+    end
+  end
+
+  before do
+    assign(:form, OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1"))
+    render template: "forms/make_live/confirmation"
+  end
+
+  it "contains page heading and sub-heading" do
+    expect(rendered).to have_css(".govuk-caption-l:has(+ h1)", text: "Form 1")
+    expect(rendered).to have_css("h1.govuk-heading-l", text: /Your form is live/)
+  end
+
+  it "contains the URL of the live form" do
+    expect(rendered).to have_text("runner-host/form/1/form-1")
+  end
+
+  it "contains a link to the form details" do
+    expect(rendered).to have_link("Continue to form details", href: form_path(1))
+  end
+end

--- a/spec/views/forms/make_live/confirmation.html.erb_spec.rb
+++ b/spec/views/forms/make_live/confirmation.html.erb_spec.rb
@@ -12,9 +12,8 @@ describe "forms/make_live/confirmation.html.erb" do
     render template: "forms/make_live/confirmation"
   end
 
-  it "contains page heading and sub-heading" do
-    expect(rendered).to have_css(".govuk-caption-l:has(+ h1)", text: "Form 1")
-    expect(rendered).to have_css("h1.govuk-heading-l", text: /Your form is live/)
+  it "contains a confirmation panel with a title" do
+    expect(rendered).to have_css(".govuk-panel--confirmation h1", text: /Your form is live/)
   end
 
   it "contains the URL of the live form" do


### PR DESCRIPTION
Make the 'your form is live' confirmation page match the GOV.UK Design System [confirmation pages](https://design-system.service.gov.uk/patterns/confirmation-pages/) pattern.

We also add some specs for this view.

Trello card: https://trello.com/c/lZBRotsv/364-add-green-panel-to-form-live-confirmation-page

Note that this PR doesn't change the form URL component, we'll do this in a separate PR.

##### Screenshot

![Screenshot of 'your form is live' page](https://user-images.githubusercontent.com/503614/213136456-e55cacf9-4ca5-4257-94bb-b2253285d2cd.png)

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)