### PR TITLE
Inline form content into show_live page

### DIFF
--- a/app/views/forms/show_live.html.erb
+++ b/app/views/forms/show_live.html.erb
@@ -19,9 +19,11 @@
     <h2 class="govuk-heading-m"><%= t('show_live_form.questions') %></h2>
     <p class="govuk-body"><%= govuk_link_to t('show_live_form.questions_link', count: @form.pages.count), form_pages_path(@form.id) %></p>
 
-    <h2 class="govuk-heading-m"><%= t('show_live_form.declaration') %></h2>
-    <p class="govuk-body"><%= @form.declaration_text %></p>
-    <%= govuk_details(summary_text: t('show_live_form.what_is_declaration'), text: t('show_live_form.declaration_description')) %>
+    <% if @form.declaration_text.present? %>
+      <h2 class="govuk-heading-m"><%= t('show_live_form.declaration') %></h2>
+      <p class="govuk-body"><%= @form.declaration_text %></p>
+      <%= govuk_details(summary_text: t('show_live_form.what_is_declaration'), text: t('show_live_form.declaration_description')) %>
+    <% end %>
 
     <h2 class="govuk-heading-m"><%= t('show_live_form.what_happens_next') %></h2>
     <p class="govuk-body"><%= @form.what_happens_next_text %></p>

--- a/app/views/forms/show_live.html.erb
+++ b/app/views/forms/show_live.html.erb
@@ -16,12 +16,16 @@
 
     <%= render FormUrlComponent::View.new(link_to_runner(ENV["RUNNER_BASE"], @form.id, @form.form_slug, live: true ))%>
 
-    <h2 class="govuk-heading-m"><%= t('show_live_form.form_content') %></h2>
-    <ul class="govuk-list">
-      <li> <%= govuk_link_to t('show_live_form.questions', count: @form.pages.count), form_pages_path(@form.id) %> </li>
-      <li> <%= govuk_link_to t('show_live_form.declaration'), declaration_path(@form.id) %> </li>
-      <li> <%= govuk_link_to t('show_live_form.what_happens_next'), what_happens_next_path(@form.id) %> </li>
-    </ul>
+    <h2 class="govuk-heading-m"><%= t('show_live_form.questions') %></h2>
+    <p class="govuk-body"><%= govuk_link_to t('show_live_form.questions_link', count: @form.pages.count), form_pages_path(@form.id) %></p>
+
+    <h2 class="govuk-heading-m"><%= t('show_live_form.declaration') %></h2>
+    <p class="govuk-body"><%= @form.declaration_text %></p>
+    <%= govuk_details(summary_text: t('show_live_form.what_is_declaration'), text: t('show_live_form.declaration_description')) %>
+
+    <h2 class="govuk-heading-m"><%= t('show_live_form.what_happens_next') %></h2>
+    <p class="govuk-body"><%= @form.what_happens_next_text %></p>
+    <%= govuk_details(summary_text: t('show_live_form.what_is_what_happens_next'), text: t('show_live_form.what_happens_next_description')) %>
 
     <h2 class="govuk-heading-m"><%= t('show_live_form.submission_email') %></h2>
     <p class="govuk-body"><%= @form.submission_email %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,7 +363,7 @@ en:
     what_happens_next: What happens next information
     what_happens_next_description: Information about what happens next is shown to people when they have completed and submitted a form.
     what_is_declaration: What is a declaration?
-    what_is_what_happens_next: What is 'what happens next information'?
+    what_is_what_happens_next: What is ‘what happens next information’?
   skip_to_main_content: Skip to main content
   status_tag_description_component:
     status: Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -356,7 +356,6 @@ en:
     questions_link:
       one: View your form's 1 question
       other: View your form's %{count} questions
-      zero: no questions
     submission_email: Submission email
     support_email: Email
     support_phone: Phone

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -349,18 +349,22 @@ en:
   show_live_form:
     contact_details: Your form’s contact details
     declaration: Declaration
+    declaration_description: Your form's declaration is shown to people when they have answered all the questions, just before they submit the form.
     edit_link: Edit this form
-    form_content: Form content
     privacy_policy_link: Privacy policy link
-    questions:
-      one: 1 question
-      other: "%{count} questions"
-      zero: no quesions
+    questions: Questions
+    questions_link:
+      one: View your form's 1 question
+      other: View your form's %{count} questions
+      zero: no questions
     submission_email: Submission email
     support_email: Email
     support_phone: Phone
     support_url: Support contact online
-    what_happens_next: What happens next
+    what_happens_next: What happens next information
+    what_happens_next_description: Information about what happens next is shown to people when they have completed and submitted a form.
+    what_is_declaration: What is a declaration?
+    what_is_what_happens_next: What is 'what happens next information'?
   skip_to_main_content: Skip to main content
   status_tag_description_component:
     status: Status

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     end
 
     trait :live do
+      with_pages
       live_at { Time.zone.now }
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
       what_happens_next_text { "We usually respond to applications within 10 working days." }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -44,7 +44,7 @@ describe Form do
 
   describe "#ready_for_live?" do
     context "when a form is complete and ready to be made live" do
-      let(:completed_form) { build :form, :with_pages, :live }
+      let(:completed_form) { build :form, :live }
 
       it "returns true" do
         expect(completed_form.ready_for_live?).to eq true
@@ -104,7 +104,7 @@ describe Form do
   end
 
   describe "#page_number" do
-    let(:completed_form) { build :form, :with_pages, :live }
+    let(:completed_form) { build :form, :live }
 
     context "with an existing page" do
       let(:page)  { completed_form.pages.first }

--- a/spec/views/forms/show_live.html.erb_spec.rb
+++ b/spec/views/forms/show_live.html.erb_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 describe "forms/show_live.html.erb" do
-  let(:form) { build(:form, :live, :with_pages, id: 2) }
+  let(:declaration) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
+  let(:what_happens_next) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
+  let(:form) { build(:form, :live, :with_pages, id: 2, declaration_text: declaration, what_happens_next_text: what_happens_next) }
 
   around do |example|
     ClimateControl.modify RUNNER_BASE: "runner-host" do
@@ -54,12 +56,12 @@ describe "forms/show_live.html.erb" do
     end
   end
 
-  it "contains a link to declaration" do
-    expect(rendered).to have_link("Declaration", href: "/declaration_path")
+  it "contains declaration" do
+    expect(rendered).to have_content(form.declaration_text)
   end
 
-  it "contains a link to what happens next" do
-    expect(rendered).to have_link("What happens next", href: "/what_happens_next_path")
+  it "contains what happens next text" do
+    expect(rendered).to have_content(form.what_happens_next_text)
   end
 
   it "contains the submission email" do

--- a/spec/views/forms/show_live.html.erb_spec.rb
+++ b/spec/views/forms/show_live.html.erb_spec.rb
@@ -62,7 +62,7 @@ describe "forms/show_live.html.erb" do
   end
 
   context "with no declaration set" do
-    let(:form) { build(:form, :live, :with_pages, id: 2) }
+    let(:declaration) { nil }
 
     it "does not include declaration" do
       expect(rendered).not_to have_css("h2", text: "Declaration")

--- a/spec/views/forms/show_live.html.erb_spec.rb
+++ b/spec/views/forms/show_live.html.erb_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "forms/show_live.html.erb" do
   let(:declaration) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:what_happens_next) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
-  let(:form) { build(:form, :live, :with_pages, id: 2, declaration_text: declaration, what_happens_next_text: what_happens_next) }
+  let(:form) { build(:form, :live, id: 2, declaration_text: declaration, what_happens_next_text: what_happens_next) }
 
   around do |example|
     ClimateControl.modify RUNNER_BASE: "runner-host" do
@@ -49,7 +49,7 @@ describe "forms/show_live.html.erb" do
   end
 
   context "with only a single question" do
-    let(:form) { build(:form, :live, :with_pages, id: 2, pages_count: 1) }
+    let(:form) { build(:form, :live, id: 2, pages_count: 1) }
 
     it "contains a link to edit questions with correct pluralization" do
       expect(rendered).to have_link("1 question", href: "/form-pages-path")
@@ -82,7 +82,7 @@ describe "forms/show_live.html.erb" do
   end
 
   context "with a support email address" do
-    let(:form) { build(:form, :live, :with_pages, id: 2, support_email: "support@example.gov.uk") }
+    let(:form) { build(:form, :live, id: 2, support_email: "support@example.gov.uk") }
 
     it "shows the support email address" do
       expect(rendered).to have_css("h3", text: "Email")
@@ -91,7 +91,7 @@ describe "forms/show_live.html.erb" do
   end
 
   context "with a support phone" do
-    let(:form) { build(:form, :live, :with_pages, id: 2, support_phone: "phone details") }
+    let(:form) { build(:form, :live, id: 2, support_phone: "phone details") }
 
     it "shows the support email address" do
       expect(rendered).to have_css("h3", text: "Phone")
@@ -100,7 +100,7 @@ describe "forms/show_live.html.erb" do
   end
 
   context "with a support online" do
-    let(:form) { build(:form, :live, :with_pages, id: 2, support_url_text: "website", support_url: "www.example.gov.uk") }
+    let(:form) { build(:form, :live, id: 2, support_url_text: "website", support_url: "www.example.gov.uk") }
 
     it "shows the support contact online" do
       expect(rendered).to have_css("h3", text: "Support contact online")
@@ -109,7 +109,7 @@ describe "forms/show_live.html.erb" do
   end
 
   context "with no support information set" do
-    let(:form) { build(:form, :live, :with_pages, id: 2, support_email: nil, support_phone: nil, support_url_text: nil, support_url: nil) }
+    let(:form) { build(:form, :live, id: 2, support_email: nil, support_phone: nil, support_url_text: nil, support_url: nil) }
 
     it "does not include support details if they are not set" do
       expect(rendered).not_to have_css("h3", text: "Email")

--- a/spec/views/forms/show_live.html.erb_spec.rb
+++ b/spec/views/forms/show_live.html.erb_spec.rb
@@ -57,7 +57,16 @@ describe "forms/show_live.html.erb" do
   end
 
   it "contains declaration" do
+    expect(rendered).to have_css("h2", text: "Declaration")
     expect(rendered).to have_content(form.declaration_text)
+  end
+
+  context "with no declaration set" do
+    let(:form) { build(:form, :live, :with_pages, id: 2) }
+
+    it "does not include declaration" do
+      expect(rendered).not_to have_css("h2", text: "Declaration")
+    end
   end
 
   it "contains what happens next text" do


### PR DESCRIPTION
# Live form declaration/what happens next

The current show_live page contains links to questions, declaration and what_happens_next sections. Because read only forms require extra implementation effort in these sections to display the information without allowing the user to edit them.

To make showing live forms easier, this commit replaces the current links to declaration and what happens next section directly into the show live page.

<img width="831" alt="image" src="https://user-images.githubusercontent.com/11035856/214034329-98064f29-029b-49b6-b853-5ca4c2e773b5.png">


The link to the question section is unchanged as may contain longer content.

#### What problem does the pull request solve?

Trello card: https://trello.com/c/1Io8YAMU/453-add-read-only-what-happens-next-content-to-the-live-form-overview-page

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
