### PR TITLE
Add active resource logging for local dev

### DIFF
--- a/config/initializers/active_resource.rb
+++ b/config/initializers/active_resource.rb
@@ -1,0 +1,8 @@
+# Lets log all requests to the API in development only for now
+if Rails.env.development?
+  ActiveSupport::Notifications.subscribe("request.active_resource") do |_name, _time, _stamp, _id, payload|
+    method = payload[:method]
+    request = payload[:request_uri]
+    Rails.logger.info "FORMS_API: #{method} #{request}"
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?

This is an exact copy of how we log active resource requests in forms-runner. This PR ensure that both our apps log the same way for local development.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
