### PR TITLE
Fix path to live form show page

### DIFF
--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -13,7 +13,11 @@
     <%= t("make_live.confirmation.body_html") %>
 
     <p class="govuk-body">
-      <%= govuk_link_to t("make_live.confirmation.continue_link"), form_path(@form.id) %>
+      <% if FeatureService.enabled?(:live_view) %>
+        <%= govuk_link_to t("make_live.confirmation.continue_link"), live_form_path(@form.id) %>
+      <% else %>
+        <%= govuk_link_to t("make_live.confirmation.continue_link"), form_path(@form.id) %>
+      <% end %>
     </p>
   </div>
 </div>

--- a/spec/views/forms/make_live/confirmation.html.erb_spec.rb
+++ b/spec/views/forms/make_live/confirmation.html.erb_spec.rb
@@ -23,4 +23,10 @@ describe "forms/make_live/confirmation.html.erb" do
   it "contains a link to the form details" do
     expect(rendered).to have_link("Continue to form details", href: form_path(1))
   end
+
+  context "when live form feature enabled", feature_live_view: true do
+    it "contains a link to the live form details" do
+      expect(rendered).to have_link("Continue to form details", href: live_form_path(1))
+    end
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

After making a form live users should be taken back to the live form show page

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
