### PR TITLE
Add "Create a draft" call to action button

### DIFF
--- a/app/views/live/show_form.html.erb
+++ b/app/views/live/show_form.html.erb
@@ -51,5 +51,11 @@
       <h3 class="govuk-heading-s"><%= t('show_live_form.support_url') %></h3>
       <p class="govuk-body"><%= govuk_link_to form.support_url_text, form.support_url %></p>
     <% end %>
+
+    <% if FeatureService.enabled?(:draft_live_versioning) %>
+      <p class="govuk-body">
+        <%= govuk_button_link_to t('show_live_form.draft_create'), form_path(form.id) %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -397,6 +397,7 @@ en:
     contact_details: Your form’s contact details for support
     declaration: Declaration
     declaration_description: Your form’s declaration is shown to people when they have answered all the questions, just before they submit the form.
+    draft_create: Create a draft to edit
     privacy_policy_link: Privacy policy link
     questions: Questions
     questions_link:

--- a/spec/views/live/show_form.html.erb_spec.rb
+++ b/spec/views/live/show_form.html.erb_spec.rb
@@ -116,7 +116,13 @@ describe "live/show_form.html.erb" do
     end
   end
 
-  xit "contains a link to edit the form" do
-    expect(rendered).to have_link("Edit this form", href: form_path(form.id, edit: true))
+  it "does not contain a link to create a new draft" do
+    expect(rendered).not_to have_link(t("show_live_form.draft_create"), href: form_path(form.id))
+  end
+
+  context "when draft/live feature enabled", feature_draft_live_versioning: true do
+    it "contains a link to create a new draft" do
+      expect(rendered).to have_link(t("show_live_form.draft_create"), href: form_path(form.id))
+    end
   end
 end


### PR DESCRIPTION

#### What problem does the pull request solve?

This takes the used back to the form task list page.

Trello card: https://trello.com/c/jWdf1F56/514-add-create-a-draft-to-edit-button-if-form-doesnt-already-have-a-draft-or-edit-the-draft-of-this-formif-form-does-have-an-existin

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
