### PR TITLE
Remove presence validations from form tasks 

### DIFF
--- a/app/controllers/page_list_controller.rb
+++ b/app/controllers/page_list_controller.rb
@@ -5,13 +5,8 @@ class PageListController < ApplicationController
   def edit
     @form = Form.find(params[:form_id])
     @pages = @form.pages
-
-    if show_live?
-      render template: "page_list/edit_live"
-    else
-      @mark_complete_form = Forms::MarkCompleteForm.new(form: @form).assign_form_values
-      @mark_complete_options = mark_complete_options
-    end
+    @mark_complete_form = Forms::MarkCompleteForm.new(form: @form).assign_form_values
+    @mark_complete_options = mark_complete_options
   end
 
   def update
@@ -56,9 +51,5 @@ private
 
   def mark_complete_form_params
     params.require(:forms_mark_complete_form).permit(:mark_complete)
-  end
-
-  def show_live?
-    FeatureService.enabled?(:live_view) && @form.live? && params[:edit].blank?
   end
 end

--- a/app/forms/forms/contact_details_form.rb
+++ b/app/forms/forms/contact_details_form.rb
@@ -13,7 +13,7 @@ class Forms::ContactDetailsForm
   validates :link_href, presence: true, url: true, length: { maximum: 120 }, if: -> { supplied :supply_link }
   validates :link_text, presence: true, length: { maximum: 120 }, if: -> { supplied :supply_link }
 
-  validate :must_be_supply_contact_details, if: -> { form.live? }
+  validate :must_be_supply_contact_details, if: -> { validate_presence }
 
   def must_be_supply_contact_details
     errors.add(:contact_details_supplied, :must_be_supply_contact_details) if contact_details_supplied.reject(&:blank?).empty?
@@ -75,5 +75,11 @@ private
 
   def supplied(field)
     contact_details_supplied.map(&:to_sym).include? field
+  end
+
+  def validate_presence
+    return false if FeatureService.enabled?(:draft_live_versioning)
+
+    form.live?
   end
 end

--- a/app/forms/forms/privacy_policy_form.rb
+++ b/app/forms/forms/privacy_policy_form.rb
@@ -6,7 +6,7 @@ class Forms::PrivacyPolicyForm
 
   attr_accessor :form, :privacy_policy_url
 
-  validates :privacy_policy_url, presence: true, if: -> { form.live? }
+  validates :privacy_policy_url, presence: true, if: -> { validate_presence }
   validates :privacy_policy_url, url: true, if: -> { privacy_policy_url.present? }
 
   def submit
@@ -19,5 +19,13 @@ class Forms::PrivacyPolicyForm
   def assign_form_values
     self.privacy_policy_url = form.privacy_policy_url
     self
+  end
+
+private
+
+  def validate_presence
+    return false if FeatureService.enabled?(:draft_live_versioning)
+
+    form.live?
   end
 end

--- a/app/forms/forms/what_happens_next_form.rb
+++ b/app/forms/forms/what_happens_next_form.rb
@@ -4,7 +4,7 @@ class Forms::WhatHappensNextForm
 
   attr_accessor :form, :what_happens_next_text
 
-  validates :what_happens_next_text, presence: true, if: -> { form.live? }
+  validates :what_happens_next_text, presence: true, if: -> { validate_presence }
   validates :what_happens_next_text, length: { maximum: 2000 }
 
   def submit
@@ -17,5 +17,13 @@ class Forms::WhatHappensNextForm
   def assign_form_values
     self.what_happens_next_text = form.what_happens_next_text
     self
+  end
+
+private
+
+  def validate_presence
+    return false if FeatureService.enabled?(:draft_live_versioning)
+
+    form.live?
   end
 end

--- a/spec/forms/contact_details_form_spec.rb
+++ b/spec/forms/contact_details_form_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Forms::ContactDetailsForm, type: :model do
 
     context "when nothing is ticked" do
       it "is valid if form is in draft" do
-        contact_details_form = build :contact_details_form
+        contact_details_form = build :contact_details_form, contact_details_supplied: []
         expect(contact_details_form).to be_valid
       end
 

--- a/spec/forms/contact_details_form_spec.rb
+++ b/spec/forms/contact_details_form_spec.rb
@@ -155,6 +155,13 @@ RSpec.describe Forms::ContactDetailsForm, type: :model do
         expect(contact_details_form).to be_invalid
         expect(contact_details_form.errors.full_messages_for(:contact_details_supplied)).to include "Contact details supplied #{error_message}"
       end
+
+      context "when draft/live version feature enabled", feature_draft_live_versioning: true do
+        it "is valid if form is in draft" do
+          contact_details_form = build :contact_details_form, contact_details_supplied: []
+          expect(contact_details_form).to be_valid
+        end
+      end
     end
   end
 

--- a/spec/forms/privacy_policy_form_spec.rb
+++ b/spec/forms/privacy_policy_form_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe Forms::PrivacyPolicyForm, type: :model do
           "Privacy policy url #{error_message}",
         )
       end
+
+      context "when draft/live version feature enabled", feature_draft_live_versioning: true do
+        it "is valid if blank" do
+          privacy_policy_form = described_class.new(form:, privacy_policy_url: "")
+
+          expect(privacy_policy_form).to be_valid
+        end
+      end
     end
 
     context "when form is not live" do

--- a/spec/forms/what_happens_next_form_spec.rb
+++ b/spec/forms/what_happens_next_form_spec.rb
@@ -39,7 +39,14 @@ RSpec.describe Forms::WhatHappensNextForm, type: :model do
 
         expect(what_happens_next_form).not_to be_valid
       end
-      # More tests are required here -  e.g. that a valid submission updates the Form object
+
+      context "when draft/live version feature enabled", feature_draft_live_versioning: true do
+        it "is valid if blank" do
+          what_happens_next_form = described_class.new(form:, what_happens_next_text: "")
+
+          expect(what_happens_next_form).to be_valid
+        end
+      end
     end
 
     describe "#submit" do
@@ -96,7 +103,6 @@ RSpec.describe Forms::WhatHappensNextForm, type: :model do
 
         expect(what_happens_next_form).to be_valid
       end
-      # More tests are required here -  e.g. that a valid submission updates the Form object
     end
 
     describe "#submit" do


### PR DESCRIPTION
#### What problem does the pull request solve?

Disables presence validations on "What happens next", "Support contact details" and "Privacy Policy url" tasks to allow form creators to remove the attribute values and therefore marking them as incomplete.  
Form creators can already mark "Questions" as "In progress"/"Not started" by removing all questions or setting the "have you finished" to no.
Form creators can manually mark "Declaration" section as finished or not.

This does not "Clear" submission email or confirmation code. This will be done separately.

Trello card: https://trello.com/c/z2wxV8Ky/516-allow-tasks-to-be-marked-incomplete-for-draft-versions-of-forms

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
