### PR TITLE
Question specific hint text bug

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,7 +47,7 @@ module ApplicationHelper
     case answer_type
     when "selection"
       answer_settings.only_one_option == "true" ? "radio" : "checkbox"
-    when "text"
+    when "text", "date"
       answer_settings.input_type
     else
       answer_type
@@ -56,6 +56,6 @@ module ApplicationHelper
 
   def hint_for_edit_page_field(field, answer_type, answer_settings)
     key = translation_key_for_answer_type(answer_type, answer_settings)
-    t("helpers.hint.page.#{field}.#{key}", default: t("helpers.hint.page.question_text.default"))
+    t("helpers.hint.page.#{field}.#{key}", default: t("helpers.hint.page.#{field}.default"))
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,12 +116,15 @@ en:
           address: You could use hint text to tell people how you will use their address. For example, ‘We’ll send your licence to this address.’
           checkbox: Use hint text to help people answer the question. For a question where people can select more than one answer you might want to use ‘Select all that apply’.
           date: Use hint text to help people answer the question. For a date question you could use ‘For example, 27 3 2007’.
+          date_of_birth: Use hint text to help people answer the question. For a date of birth question you could use ‘For example, 27 3 1998’.
           default: Use hint text to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for.
           email: You could use hint text to tell people how you will use their email address. For example, ‘We’ll only use your email address to contact you about your application.’
           long_text: Use hint text to help people answer the question. For example, you could give a bit more detail about the information you need.
+          name: Use hint text to help people answer the question. For example, you might need to ask people to enter their name as it’s written on an official document such as a passport or driving licence.
           national_insurance_number: Use hint text to help people answer the question. For example, ‘It’s on your National Insurance card, benefit letter, payslip or P60. For example, QQ 12 34 56 C.’
           number: Use hint text to help people answer the question. For example, ‘Do not include bank holidays’.
           organisation_name: Use hint text to help people answer the question. For example, you might need to ask people to enter the registered name of their company.
+          other_date: Use hint text to help people answer the question. For a date question you could use ‘For example, 27 3 2007’.
           phone_number: Use hint text to help people answer the question. For example, ‘You can provide either a home or mobile phone number.’
           radio: Use hint text to help people answer the question. For a question where people can only select one answer you might want to use ‘Select one option’.
           single_line: Use hint text to help people answer the question. For example, you could say what format the answer should be in or where to find it.
@@ -130,12 +133,15 @@ en:
           address: Ask the question the way you would in person. For example, ‘What’s your address?’
           checkbox: Ask the question the way you would in person. For example, ‘Which of these countries have you lived in?’
           date: Ask the question the way you would in person. For example, ‘What date was your passport issued?’
+          date_of_birth: Ask the question the way you would in person. For example, ‘What’s your date of birth?’
           default: Ask a question the way you would in person. For example ‘What is your address?’
           email: Ask the question the way you would in person. For example, ‘What’s your email address?’
           long_text: Ask the question the way you would in person. For example, ‘Why do you want to apply for this role?’
+          name: Ask the question the way you would in person. For example, ‘What’s your name?’
           national_insurance_number: Ask the question the way you would in person. For example, ‘What’s your National Insurance number?’
           number: Ask the question the way you would in person. For example, ‘How many holiday days do you get a year?’
           organisation_name: Ask the question the way you would in person. For example, ‘What’s the name of the organisation?’
+          other_date: Ask the question the way you would in person. For example, ‘What date was your passport issued?’
           phone_number: Ask the question the way you would in person. For example, ‘What’s your phone number?’
           radio: Ask the question the way you would in person. For example, ‘What country do you live in?’
           single_line: Ask the question the way you would in person. For example, ‘What’s your reference number?’

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -95,6 +95,19 @@ RSpec.describe ApplicationHelper, type: :helper do
         end
       end
     end
+
+    context "with date answer type" do
+      let(:answer_type) { "date" }
+      let(:answer_settings) { OpenStruct.new(input_type:) }
+
+      context "and 'input_type' set to a valid value" do
+        let(:input_type) { Forms::DateSettingsForm::INPUT_TYPES.sample }
+
+        it "returns the answer subtype" do
+          expect(helper.translation_key_for_answer_type(answer_type, answer_settings)).to eq input_type
+        end
+      end
+    end
   end
 
   describe "hint_for_edit_page_field" do
@@ -112,7 +125,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:answer_settings) { {} }
 
       it "returns the default hint text" do
-        expect(helper.hint_for_edit_page_field("question_text", answer_type, answer_settings)).to eq(I18n.t("helpers.hint.page.question_text.default"))
+        expect(helper.hint_for_edit_page_field("hint_text", answer_type, answer_settings)).to eq(I18n.t("helpers.hint.page.hint_text.default"))
       end
     end
   end


### PR DESCRIPTION
#### What problem does the pull request solve?
- Fixes question-specific hint text for date of birth and person's name answer types
- Adds a small fix for an issue we discovered where the same hint text was being returned for the question_text and hint_text fields

Trello card: https://trello.com/c/HJzjvH7I/521-forms-admin-dob-and-name-specific-hint-text-not-showing

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
