### PR TITLE
Improve confirmation code error messages

### DIFF
--- a/config/locales/forms/submission_email_form.yml
+++ b/config/locales/forms/submission_email_form.yml
@@ -10,9 +10,9 @@ en:
         forms/submission_email_form:
           attributes:
             temporary_submission_email:
-              blank: Enter an email address for the form
-              invalid_email: Enter an email address in the correct format, like name@example.com
+              blank: Enter an email address
+              invalid_email: Enter an email address in the correct format, like name@example.gov.uk
               non_govuk_email: Enter an email address ending in .gov.uk
             email_code:
-              invalid_email_code: The code should be 6 characters long
-              email_code_mismatch: This code is not correct - double check the code or send a new one
+              invalid_email_code: The code should be 6 numbers - double check the code or set the email address again to send a new one
+              email_code_mismatch: This code is not correct - double check the code or set the email address again to send a new one


### PR DESCRIPTION
#### What problem does the pull request solve?

Trello card: https://trello.com/c/mCBxdk5x/529-fix-email-confirmation-code-error-messages-in-production

When the email confirmation loop was implemented in production, the ‘resend confirmation code’ link was not included. So the error message if you enter nothing or a 6 numbers that aren't correct is not as helpful as it could be. 

Changed it to: 

> This code is not correct - double check the code or set the email address again to send a new one

---

Also updated the other confirmation code error message as it is not as helpful as it could be either. It’s shown when you enter anything that isn’t 6 numbers and says: "The code should be 6 characters long". This is shown even if you enter 6 letters.

Changed it to: 

> The code should be 6 numbers - double check the code or set the email address again to send a new one

---

Also removed some unnecessary words from one email address field error message and made the example email address that's used in another more relevant.

---

#### Checklist

- [ yup] I've used the pull request template
- [ nope ] I've linked this PR to the relevant issue (if mission work)
- [ nope ] I've written unit tests for these changes (if code change)
- [ yup ] I've updated the documentation in (If any documentation requires updating)
  - [nope ] README.md
  - [ yup ] [The validation and error messages document](https://docs.google.com/document/d/1hHVb_Yj2pBURBcA_HhdcNqKcinp9rjd16sDwpWf7MIk/edit?usp=sharing)
