### PR TITLE
Switch live show pages to use new live endpoint

### DIFF
--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -1,9 +1,15 @@
 class Forms::LiveController < Forms::BaseController
   def show_form
-    render template: "live/show_form", locals: { form: current_form }
+    render template: "live/show_form", locals: { form: current_live_form }
   end
 
   def show_pages
-    render template: "live/show_pages", locals: { form: current_form, pages: current_form.pages }
+    render template: "live/show_pages", locals: { form: current_live_form }
+  end
+
+private
+
+  def current_live_form
+    Form.find_live(params[:form_id])
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -9,6 +9,10 @@ class Form < ActiveResource::Base
 
   attr_accessor :missing_sections
 
+  def self.find_live(id)
+    find(:one, from: "#{prefix}forms/#{id}/live")
+  end
+
   def last_page
     pages.find { |p| !p.has_next_page? }
   end

--- a/app/views/live/show_pages.html.erb
+++ b/app/views/live/show_pages.html.erb
@@ -11,7 +11,7 @@
 
     <%= render FormStatusTagDescriptionComponent::View.new(status: form.status) %>
 
-    <% pages.each_with_index do |page, index| %>
+    <% form.pages.each_with_index do |page, index| %>
       <%= render(SummaryCardComponent::View.new( **PageSummaryCardDataService.call(page:).build_data)) %>
     <% end %>
 

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -31,12 +31,8 @@ FactoryBot.define do
     end
 
     trait :live do
-      with_pages
+      ready_for_live
       live_at { Time.zone.now }
-      support_email { Faker::Internet.email(domain: "example.gov.uk") }
-      what_happens_next_text { "We usually respond to applications within 10 working days." }
-      question_section_completed { true }
-      declaration_section_completed { true }
     end
 
     trait :with_pages do

--- a/spec/requests/forms/live_controller_spec.rb
+++ b/spec/requests/forms/live_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Forms::LiveController, type: :request do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/2", headers, form.to_json, 200
-        mock.get "/api/v1/forms/2/pages", headers, form.pages.to_json, 200
+        mock.get "/api/v1/forms/2/live", headers, form.to_json, 200
       end
 
       get live_form_path(2)
@@ -39,6 +39,7 @@ RSpec.describe Forms::LiveController, type: :request do
       before do
         ActiveResource::HttpMock.respond_to do |mock|
           mock.get "/api/v1/forms/2", headers, form.to_json, 200
+          mock.get "/api/v1/forms/2/live", headers, form.to_json, 200
         end
 
         get live_form_pages_path(2)

--- a/spec/views/live/show_pages.html.erb_spec.rb
+++ b/spec/views/live/show_pages.html.erb_spec.rb
@@ -2,12 +2,11 @@ require "rails_helper"
 
 describe "live/show_pages.html.erb" do
   let(:form) { build :form, :live, id: 1 }
-  let(:pages) { form.pages }
 
   before do
     allow(view).to receive(:live_form_path).and_return("/live-form-path")
 
-    render(template: "live/show_pages", layout: "layouts/application", locals: { form:, pages: })
+    render(template: "live/show_pages", layout: "layouts/application", locals: { form: })
   end
 
   it "form name is in the page title" do


### PR DESCRIPTION
#### What problem does the pull request solve?

The new endpoint is already being used by forms-runner and this is making sure that we are consistent by using the same end point for what will eventually be live forms.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
