### PR TITLE
Remove redirect on making_live_controller#new

### DIFF
--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -1,7 +1,7 @@
 module Forms
   class MakeLiveController < BaseController
     def new
-      redirect_to live_confirmation_url if current_form.live?
+      redirect_to live_confirmation_url if current_form.live? && !FeatureService.enabled?(:draft_live_versioning)
       @make_live_form = MakeLiveForm.new(form: current_form)
     end
 

--- a/spec/requests/make_form_live_spec.rb
+++ b/spec/requests/make_form_live_spec.rb
@@ -50,21 +50,19 @@ RSpec.describe "MakeLive controller", type: :request do
       get make_live_path(form_id: 2)
     end
 
-    context "when the form is not live" do
-      it "Reads the form from the API" do
-        expect(form).to have_been_read
-      end
-
-      it "returns 200" do
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "renders new" do
-        expect(response).to render_template(:new)
-      end
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
     end
 
-    context "when the form is already live" do
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders new" do
+      expect(response).to render_template(:new)
+    end
+
+    context "when the form is already live", feature_draft_live_versioning: false do
       let(:form) do
         build(:form,
               :live,


### PR DESCRIPTION
#### What problem does the pull request solve?

At first we were concerned about users trying to access the make_live page again but when we have draft/live implementation we will want users to be able to make their changes live.


Trello card: https://trello.com/c/VTr26Wi1/518-make-changes-live-in-forms-admin-and-update-task-list-content

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
