### PR TITLE
Add question number to page list

### DIFF
--- a/app/components/page_list_component/_index.scss
+++ b/app/components/page_list_component/_index.scss
@@ -7,3 +7,7 @@
 .app-page-list__button-group {
   justify-content: end;
 }
+
+.app-page-list__key {
+  width: 10%;
+}

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -2,34 +2,37 @@
   <%if @pages.present?  %>
     <div class="app-page-list">
       <%= form_with url: move_page_url(@form_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-        <% @pages.each_with_index do |page, index| %>
-          <dl class="govuk-summary-list">
+        <dl class="govuk-summary-list">
+          <% @pages.each_with_index do |page, index| %>
             <div class="govuk-summary-list__row">
 
-              <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-                <%= question_text_with_optional_suffix(page) %>
+              <dt class="govuk-summary-list__key app-page-list__key">
+                <%= index + 1 %>
               </dt>
+
+              <dd class="govuk-summary-list__value">
+                <%= question_text_with_optional_suffix(page) %>
+              </dd>
 
               <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
 
                 <div class="govuk-button-group form-action-group app-page-list__button-group">
                   <% if show_up_button(index) %>
-                    <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page.question_text), secondary: true, name: 'move_direction[up]', value: page.id %>
+                    <%= f.govuk_submit t("forms.form_overview.move_up_html", title: index + 1), secondary: true, name: 'move_direction[up]', value: page.id %>
                   <% end %>
                   <% if show_down_button(index)  %>
-                    <%= f.govuk_submit t("forms.form_overview.move_down_html", title: page.question_text), secondary: true, name: 'move_direction[down]', value: page.id %>
+                    <%= f.govuk_submit t("forms.form_overview.move_down_html", title: index + 1), secondary: true, name: 'move_direction[down]', value: page.id %>
                   <% end %>
                 </div>
 
                 <%= govuk_link_to edit_page_path(@form_id, page) do %>
-                  <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.question_text %></span>
+                  <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= index + 1 %></span>
                 <% end %>
 
               </dd>
-
             </div>
-          </dl>
-        <% end %>
+          <% end %>
+        </dl>
       <% end %>
     </div>
   <% end %>

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -3,9 +3,12 @@ require "rails_helper"
 RSpec.describe PageListComponent::View, type: :component do
   let(:pages) { [] }
 
+  before do
+    render_inline(described_class.new(pages:, form_id: 0))
+  end
+
   context "when there are no pages" do
     it "is blank" do
-      render_inline(described_class.new(pages: [], form_id: 0))
       expect(page).not_to have_selector("*")
     end
   end
@@ -13,19 +16,20 @@ RSpec.describe PageListComponent::View, type: :component do
   context "when the form has a single page" do
     let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?")] }
 
+    it "renders the question number" do
+      expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
+    end
+
     it "renders question title" do
-      render_inline(described_class.new(pages:, form_id: 0))
       expect(page).to have_content("Enter your name")
     end
 
     it "renders link" do
-      render_inline(described_class.new(pages:, form_id: 0))
       expect(page).to have_link("Edit")
     end
 
     context "when re-ordering pages feature is enabled", feature_reorder_pages: true do
       it "does not have re-ordering buttons" do
-        render_inline(described_class.new(pages:, form_id: 0))
         expect(page).not_to have_button("Move up")
         expect(page).not_to have_button("Move down")
       end
@@ -35,14 +39,17 @@ RSpec.describe PageListComponent::View, type: :component do
   context "when the form has multiple pages" do
     let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?"), OpenStruct.new(id: 2, question_text: "What is you pet's name?")] }
 
+    it "renders the question numbers" do
+      expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
+      expect(page).to have_css("dt.govuk-summary-list__key", text: "2")
+    end
+
     context "when re-ordering pages feature is enabled", feature_reorder_pages: true do
       it "renders a move up link" do
-        render_inline(described_class.new(pages:, form_id: 0))
         expect(page).to have_button("Move up")
       end
 
       it "renders a move down link" do
-        render_inline(described_class.new(pages:, form_id: 0))
         expect(page).to have_button("Move down")
       end
     end


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds a page number to the page summary list. 

Some things worth noting:
- the page number, rather than the question text, is now the `<dt>` (i.e. the key for the row). As a result, I've also changed the hidden text on the row action buttons.
- the page list was previously being rendered wrongly - we were generating a separate `<dl>` for each row, so semantically our page was made up of muiltiple, unrelated single-item lists, rather than one big list. This PR addresses that issue

Trello card: https://trello.com/c/DvmX0i19/531-show-question-numbers-on-the-questions-list-page

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
