### PR TITLE
Add routes to page list view

### DIFF
--- a/app/components/page_list_component/_index.scss
+++ b/app/components/page_list_component/_index.scss
@@ -9,5 +9,5 @@
 }
 
 .app-page-list__key {
-  width: 10%;
+  width: 15%;
 }

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -31,6 +31,30 @@
 
             </dd>
           </div>
+
+          <% if FeatureService.enabled?(:basic_routing) %>
+            <% page.routing_conditions.each do |condition| %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-summary-list__key app-page-list__key">
+                  <%= t("page_conditions.condition_name", page_index: index + 1) %>
+                </dt>
+
+                <dd class="govuk-summary-list__value">
+                  <%= t('page_conditions.condition_html',
+                    check_page_text: question_text_for_page(condition.check_page_id),
+                    answer_value: condition.answer_value,
+                    goto_page_text: question_text_for_page(condition.goto_page_id)
+                  ) %>
+                </dd>
+
+                <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
+                  <%= govuk_link_to "#" do %>
+                    <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", page_index: index + 1)) %>
+                  <% end %>
+                </dd>
+              </div>
+            <% end %>
+          <% end %>
         <% end %>
       </dl>
     <% end %>

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -15,5 +15,9 @@ module PageListComponent
     def show_down_button(index)
       index != @pages.length - 1
     end
+
+    def question_text_for_page(id)
+      @pages.find { |page| page.id == id }.question_text
+    end
   end
 end

--- a/app/service/page_summary_card_data_service.rb
+++ b/app/service/page_summary_card_data_service.rb
@@ -5,14 +5,15 @@ class PageSummaryCardDataService
     end
   end
 
-  def initialize(page:)
+  def initialize(page:, pages:)
     @page = page
+    @pages = pages
   end
 
   def build_data
     {
       title: build_title,
-      rows: PageOptionsService.call(page: @page).all_options_for_answer_type,
+      rows: PageOptionsService.call(page: @page, pages: @pages).all_options_for_answer_type,
     }
   end
 

--- a/app/views/live/show_pages.html.erb
+++ b/app/views/live/show_pages.html.erb
@@ -12,7 +12,7 @@
     <%= render FormStatusTagDescriptionComponent::View.new(status: :live) %>
 
     <% form.pages.each_with_index do |page, index| %>
-      <%= render(SummaryCardComponent::View.new( **PageSummaryCardDataService.call(page:).build_data)) %>
+      <%= render(SummaryCardComponent::View.new( **PageSummaryCardDataService.call(page:, pages: form.pages).build_data)) %>
     <% end %>
 
     <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
     delete_form: Delete draft form
     form_overview:
       edit: Edit
+      edit_with_visually_hidden_text_html: Edit <span class="govuk-visually-hidden">%{visually_hidden_text}</span>
       move_down_html: Move down <span class="govuk-visually-hidden">%{title}</span>
       move_up_html: Move up <span class="govuk-visually-hidden">%{title}</span>
       title_create: Create a form
@@ -304,6 +305,14 @@ en:
 
       If you pasted the web address, check you copied the entire address.
     title: Page not found
+  page_conditions:
+    condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to question %{goto_page_number}: “%{goto_page_text}”'
+    condition_html: |
+      If the question “%{check_page_text}”<br>
+      is answered as “%{answer_value}”<br>
+      take the person to “%{goto_page_text}”
+    condition_name: Question %{page_index}'s route
+    route: Route
   page_options_service:
     answer_type: Answer type
     date: Date

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
   draft_live_versioning: false
+  basic_routing: false
 
 forms_api:
   # Authentication key to authenticate forms-runner to forms-api

--- a/spec/components/page_list_component/page_list_component_preview.rb
+++ b/spec/components/page_list_component/page_list_component_preview.rb
@@ -1,12 +1,30 @@
 class PageListComponent::PageListComponentPreview < ViewComponent::Preview
+  include FactoryBot::Syntax::Methods
+
   def default
     render(PageListComponent::View.new(pages: [], form_id: 0))
   end
 
-  def with_pages
-    pages = [OpenStruct.new(id: 1, question_text: "Enter your name"),
-             OpenStruct.new(id: 2, question_text: "What is your pet's phone number?"),
-             OpenStruct.new(id: 3, question_text: "How many pets do you own?")]
+  def with_pages_and_no_conditions
+    pages = [OpenStruct.new(id: 1, question_text: "Enter your name", routing_conditions: []),
+             OpenStruct.new(id: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
+             OpenStruct.new(id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    render(PageListComponent::View.new(pages:, form_id: 0))
+  end
+
+  def with_pages_and_one_condition
+    routing_conditions = [(build :condition, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3)]
+    pages = [OpenStruct.new(id: 1, question_text: "Enter your name", routing_conditions:),
+             OpenStruct.new(id: 2, question_text: "What is your pet's phone number?", routing_conditions:),
+             OpenStruct.new(id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    render(PageListComponent::View.new(pages:, form_id: 0))
+  end
+
+  def with_pages_and_multiple_conditions
+    routing_conditions = [(build :condition, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3), (build :condition, routing_page_id: 1, check_page_id: 1, answer_value: "England", goto_page_id: 2)]
+    pages = [OpenStruct.new(id: 1, question_text: "Enter your name", routing_conditions:),
+             OpenStruct.new(id: 2, question_text: "What is your pet's phone number?", routing_conditions:),
+             OpenStruct.new(id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
     render(PageListComponent::View.new(pages:, form_id: 0))
   end
 end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -2,52 +2,117 @@ require "rails_helper"
 
 RSpec.describe PageListComponent::View, type: :component do
   let(:pages) { [] }
+  let(:routing_conditions) { [] }
+  let(:page_list_component) { described_class.new(pages:, form_id: 0) }
 
-  before do
-    render_inline(described_class.new(pages:, form_id: 0))
-  end
+  describe "rendering component" do
+    before do
+      render_inline(page_list_component)
+    end
 
-  context "when there are no pages" do
-    it "is blank" do
-      expect(page).not_to have_selector("*")
+    context "when there are no pages" do
+      it "is blank" do
+        expect(page).not_to have_selector("*")
+      end
+    end
+
+    context "when the form has a single page" do
+      let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?")] }
+
+      it "renders the question number" do
+        expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
+      end
+
+      it "renders question title" do
+        expect(page).to have_content("Enter your name")
+      end
+
+      it "renders link" do
+        expect(page).to have_link("Edit")
+      end
+
+      it "does not have re-ordering buttons" do
+        expect(page).not_to have_button("Move up")
+        expect(page).not_to have_button("Move down")
+      end
+    end
+
+    context "when the form has multiple pages" do
+      let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?"), OpenStruct.new(id: 2, question_text: "What is you pet's name?")] }
+
+      it "renders the question numbers" do
+        expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
+        expect(page).to have_css("dt.govuk-summary-list__key", text: "2")
+      end
+
+      it "renders a move up link" do
+        expect(page).to have_button("Move up")
+      end
+
+      it "renders a move down link" do
+        expect(page).to have_button("Move down")
+      end
+
+      context "when conditions are enabled", feature_basic_routing: true do
+        let(:pages) do
+          [OpenStruct.new(id: 1, question_text: "What country do you live in?", routing_conditions:),
+           OpenStruct.new(id: 2, question_text: "What is your name?", routing_conditions:),
+           OpenStruct.new(id: 3, question_text: "What is your pet's name?", routing_conditions:)]
+        end
+
+        context "when there are no conditions" do
+          it "conditions section is not present" do
+            expect(page).to have_css(".govuk-summary-list__row", count: pages.length)
+          end
+        end
+
+        context "when the page has a single condition" do
+          let(:routing_conditions) { [(build :condition, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3)] }
+
+          it "renders the routing details" do
+            translation_text = I18n.t("page_conditions.condition_html", check_page_text: pages[0].question_text, answer_value: "Wales", goto_page_text: pages[2].question_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: ActionController::Base.helpers.strip_tags(translation_text))
+          end
+
+          it "renders link" do
+            expect(page).to have_link("Edit")
+          end
+        end
+      end
     end
   end
 
-  context "when the form has a single page" do
-    let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?")] }
-
-    it "renders the question number" do
-      expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
+  describe "class methods" do
+    let(:pages) do
+      [OpenStruct.new(id: 1, question_text: "What country do you live in?", routing_conditions:),
+       OpenStruct.new(id: 2, question_text: "What is your name?", routing_conditions:),
+       OpenStruct.new(id: 3, question_text: "What is your pet's name?", routing_conditions:)]
     end
 
-    it "renders question title" do
-      expect(page).to have_content("Enter your name")
+    describe "show_up_button" do
+      it "returns false when index is 0" do
+        expect(page_list_component.show_up_button(0)).to be false
+      end
+
+      it "returns true when index is not 0" do
+        expect(page_list_component.show_up_button(1)).to be true
+      end
     end
 
-    it "renders link" do
-      expect(page).to have_link("Edit")
+    describe "show_down_button" do
+      it "returns false for the last page in the list" do
+        expect(page_list_component.show_down_button(pages.length - 1)).to be false
+      end
+
+      it "returns true for other pages" do
+        expect(page_list_component.show_down_button(pages.length - 2)).to be true
+      end
     end
 
-    it "does not have re-ordering buttons" do
-      expect(page).not_to have_button("Move up")
-      expect(page).not_to have_button("Move down")
-    end
-  end
-
-  context "when the form has multiple pages" do
-    let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?"), OpenStruct.new(id: 2, question_text: "What is you pet's name?")] }
-
-    it "renders the question numbers" do
-      expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
-      expect(page).to have_css("dt.govuk-summary-list__key", text: "2")
-    end
-
-    it "renders a move up link" do
-      expect(page).to have_button("Move up")
-    end
-
-    it "renders a move down link" do
-      expect(page).to have_button("Move down")
+    describe "question_text_for_page" do
+      it "returns the corrrect question text for a page in the form" do
+        expect(page_list_component.question_text_for_page(1)).to eq pages[0].question_text
+      end
     end
   end
 end

--- a/spec/components/summary_card_component/view_preview.rb
+++ b/spec/components/summary_card_component/view_preview.rb
@@ -49,6 +49,34 @@ class SummaryCardComponent::ViewPreview < ViewComponent::Preview
     ]))
   end
 
+  def with_one_condition
+    options = ["England", "Wales", "Scotland", "Northern Ireland"]
+    condition_text = I18n.t("page_conditions.condition_compact_html", answer_value: "Wales", goto_page_number: 3, goto_page_text: "What is your name?").html_safe
+
+    render(SummaryCardComponent::View.new(title: "Which country do you live in?",
+                                          rows: [
+                                            { key: "Hint text", value: "Select all that apply" },
+                                            { key: "Answer type", value: "Selection from a list, one option only." },
+                                            { key: I18n.t("selections_settings.options_title"), value: ActionController::Base.helpers.sanitize("<ul class='govuk-list'><li>#{options.join('</li><li>')}</li></ul>") },
+                                            { key: "Route", value: condition_text },
+                                          ]))
+  end
+
+  def with_multiple_conditions
+    options = ["England", "Wales", "Scotland", "Northern Ireland"]
+    conditions = [I18n.t("page_conditions.condition_compact_html", answer_value: "Wales", goto_page_number: 3, goto_page_text: "What is your name?").html_safe,
+                  I18n.t("page_conditions.condition_compact_html", answer_value: "England", goto_page_number: 4, goto_page_text: "What is your address?").html_safe,
+                  I18n.t("page_conditions.condition_compact_html", answer_value: "Scotland", goto_page_number: 5, goto_page_text: "What is your date of birth?").html_safe]
+
+    render(SummaryCardComponent::View.new(title: "Which country do you live in?",
+                                          rows: [
+                                            { key: "Hint text", value: "Select all that apply" },
+                                            { key: "Answer type", value: "Selection from a list, one option only." },
+                                            { key: I18n.t("selections_settings.options_title"), value: ActionController::Base.helpers.sanitize("<ul class='govuk-list'><li>#{options.join('</li><li>')}</li></ul>") },
+                                            { key: "Route", value: ActionController::Base.helpers.sanitize("<ol class='govuk-list govuk-list--number'><li>#{conditions.join('</li><li>')}</li></ol>") },
+                                          ]))
+  end
+
   def answer_types_01_person_name_with_full_name_details_no_title
     options = [I18n.t("helpers.label.page.answer_type_options.names.name")]
     options << I18n.t("helpers.label.page.name_settings_options.input_types.first_middle_and_last_name")

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :condition, class: "OpenStruct" do
+    routing_page_id { nil }
+    check_page_id { nil }
+    answer_value { nil }
+    goto_page_id { nil }
+  end
+end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     is_optional { nil }
     answer_settings { nil }
     hint_text { nil }
+    routing_conditions { [] }
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda }

--- a/spec/service/page_summary_card_data_service_spec.rb
+++ b/spec/service/page_summary_card_data_service_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 describe PageSummaryCardDataService do
   let(:page) { build :page, is_optional: optional }
   let(:optional) { false }
-  let(:service) { described_class.call(page:) }
+  let(:pages) do
+    form = build :form, :with_pages
+    form.pages
+  end
+  let(:service) { described_class.call(page:, pages:) }
 
   describe "#build_data" do
     before do


### PR DESCRIPTION
#### What problem does the pull request solve?
As part of basic routing we want to play back the routes users have made.
- Adds a feature flag so we can merge this before the API work is finished
- Adds a new component for displaying routes on a draft
- Updates the existing PageOptionsService to show the routes on a live form

Limitations:
- for MVP we're only allowing a single condition per page (see the Trello card for conversation about this).
- The edit links don't go anywhere because we haven't built the add/edit flow yet.
- there's no way to create routes within the app yet, so if you want to test this locally you'll need to:
  - enable the `basic_routing` feature flag in forms-admin/config/settings/development.yml
  - Create conditions manually in the Rails console: 
    - in forms-api, run `bin/rails console` to open the console
    - `Condition.create(check_page: Page.find(15), routing_page: Page.find(15), goto_page: Page.find(17), answer_value: "Wales")` to create a condition

Trello card: https://trello.com/c/Wblu8EV6/539-display-routes-in-page-list

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
