### PR TITLE
Remove warning about making changes to live form on questions page

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <% if @form.live? %>
+    <% if !FeatureService.enabled?(:draft_live_versioning) and @form.live? %>
       <%= render LiveFormWarningComponent::View.new() %>
     <% end %>
 


### PR DESCRIPTION
#### What problem does the pull request solve?

Removes warning about making changes to live form when draft/live versioning is enabled. This should have been included in #331, but was missed.

Trello card: https://trello.com/c/VTr26Wi1

<details>
<summary><h4>Screenshot</h4></summary>

![Screenshot of 'Add and edit your questions' for live form after changes in this PR](https://user-images.githubusercontent.com/503614/222791033-2865ee6e-2d70-4577-a34d-f38c3c3b1b4f.png)

</details>