### PR TITLE
Refactor form status tag components

### DIFF
--- a/app/components/form_status_tag_component/view.html.erb
+++ b/app/components/form_status_tag_component/view.html.erb
@@ -1,1 +1,1 @@
-<%= govuk_tag(text: status, colour: status_colour) %>
+<%= govuk_tag(text: status_text, colour: status_colour) %>

--- a/app/components/form_status_tag_component/view.rb
+++ b/app/components/form_status_tag_component/view.rb
@@ -1,17 +1,21 @@
 module FormStatusTagComponent
   class View < ViewComponent::Base
-    attr_accessor :status
-
-    def initialize(status: "DRAFT")
+    def initialize(status: :draft)
       super
-      @status = status.upcase
+      @status = status.to_sym
     end
 
     def status_colour
       {
         draft: "purple",
         live: "blue",
-      }[status.downcase.to_sym]
+      }[@status]
+    end
+
+    def status_text
+      # i18n-tasks-use t('form_statuses.draft')
+      # i18n-tasks-use t('form_statuses.live')
+      I18n.t("form_statuses.#{@status}")
     end
   end
 end

--- a/app/components/form_status_tag_description_component/view.html.erb
+++ b/app/components/form_status_tag_description_component/view.html.erb
@@ -1,4 +1,4 @@
 <dl class="govuk-!-margin-bottom-7">
   <dt class="govuk-visually-hidden"><%= t('status_tag_description_component.status') %></dt>
-  <dd class="govuk-!-margin-0"><%= render FormStatusTagComponent::View.new(status: @status) %></dd>
+  <dd class="govuk-!-margin-0"><%= render FormStatusTagComponent::View.new(status: status) %></dd>
 </dl>

--- a/app/components/form_status_tag_description_component/view.rb
+++ b/app/components/form_status_tag_description_component/view.rb
@@ -2,9 +2,9 @@ module FormStatusTagDescriptionComponent
   class View < ViewComponent::Base
     attr_accessor :status
 
-    def initialize(status: "DRAFT")
+    def initialize(status: :draft)
       super
-      @status = status.upcase
+      @status = status
     end
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -3,8 +3,6 @@ class Form < ActiveResource::Base
   self.include_format_in_path = false
   headers["X-API-Token"] = Settings.forms_api.auth_key
 
-  STATUSES = { draft: "draft", live: "live" }.freeze
-
   has_many :pages
 
   attr_accessor :missing_sections
@@ -26,9 +24,7 @@ class Form < ActiveResource::Base
   end
 
   def status
-    return STATUSES[:live] if live?
-
-    STATUSES[:draft]
+    live? ? :live : :draft
   end
 
   def save_page(page)

--- a/app/views/live/show_form.html.erb
+++ b/app/views/live/show_form.html.erb
@@ -8,7 +8,7 @@
       <%= form.name %>
     </h1>
 
-    <%= render FormStatusTagDescriptionComponent::View.new(status: form.status) %>
+    <%= render FormStatusTagDescriptionComponent::View.new(status: :live) %>
 
     <p class="govuk-body">
       <%= render PreviewLinkComponent::View.new(form.pages, link_to_runner(Settings.forms_runner.url, form.id, form.form_slug)) %>

--- a/app/views/live/show_pages.html.erb
+++ b/app/views/live/show_pages.html.erb
@@ -9,7 +9,7 @@
       <%= t("forms.form_overview.your_questions") %>
     </h1>
 
-    <%= render FormStatusTagDescriptionComponent::View.new(status: form.status) %>
+    <%= render FormStatusTagDescriptionComponent::View.new(status: :live) %>
 
     <% form.pages.each_with_index do |page, index| %>
       <%= render(SummaryCardComponent::View.new( **PageSummaryCardDataService.call(page:).build_data)) %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -15,7 +15,7 @@
     </h1>
     <dl class="govuk-!-margin-bottom-7">
       <dt class="govuk-visually-hidden">Status</dt>
-      <dd class="govuk-!-margin-0"><%= render FormStatusTagComponent::View.new(status: @form.status) %></dd>
+      <dd class="govuk-!-margin-0"><%= render FormStatusTagComponent::View.new(status: ( FeatureService.enabled?(:draft_live_versioning) ? :draft : @form.status )) %></dd>
     </dl>
 
     <% if flash[:message] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,9 @@ en:
   forbidden:
     body_html: You do not have permission to view this page as it does not belong to your organisation. %{link} if you think this is incorrect.
     title: You cannot view this page
+  form_statuses:
+    draft: DRAFT
+    live: LIVE
   form_url_component:
     copy_to_clipboard: Copy URL to clipboard
     form_url: Form URL

--- a/spec/components/form_status_tag_component/view_spec.rb
+++ b/spec/components/form_status_tag_component/view_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FormStatusTagComponent::View, type: :component do
 
   describe "live status" do
     before do
-      render_inline(described_class.new(status: "live"))
+      render_inline(described_class.new(status: :live))
     end
 
     it "renders the status text" do
@@ -29,7 +29,10 @@ RSpec.describe FormStatusTagComponent::View, type: :component do
     end
   end
 
-  # it "renders the link" do
-  #   expect(page).to have_text("https://example.com")
-  # end
+  describe "string status" do
+    it "accepts status as a string" do
+      expect(described_class.new(status: "draft").status_colour).to eq "purple"
+      expect(described_class.new(status: "live").status_colour).to eq "blue"
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -30,14 +30,14 @@ describe Form do
     context "when form is draft (live_at not set)" do
       it "returns 'draft'" do
         form.live_at = ""
-        expect(form.status).to eq "draft"
+        expect(form.status).to eq :draft
       end
     end
 
     context "when form is live (live_at is set)" do
       it "returns 'live'" do
         form.live_at = Time.zone.now.to_s
-        expect(form.status).to eq "live"
+        expect(form.status).to eq :live
       end
     end
   end


### PR DESCRIPTION
Rewrites the status tag components to get the tag text from the translation file. This lets us simplify the model a little.

I found I needed to do this as part of working towards the ticket [Add draft/live status to the forms list page](https://trello.com/c/845sNCtW), but I decided to split it out to keep the coming PR neater.