### PR TITLE
Refactor draft/live attributes

### DIFF
--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -1,7 +1,7 @@
 module Forms
   class MakeLiveController < BaseController
     def new
-      if current_form.live? && !FeatureService.enabled?(:draft_live_versioning)
+      if current_form.has_live_version && !FeatureService.enabled?(:draft_live_versioning)
         render_confirmation(:form)
       else
         @make_live_form = MakeLiveForm.new(form: current_form)
@@ -11,7 +11,7 @@ module Forms
 
     def create
       @make_live_form = MakeLiveForm.new(**make_live_form_params)
-      already_live = @make_live_form.form.live?
+      already_live = @make_live_form.form.has_live_version
 
       if @make_live_form.submit
         if @make_live_form.made_live?
@@ -31,7 +31,7 @@ module Forms
     end
 
     def render_new
-      if current_form.live?
+      if current_form.has_live_version
         render "make_your_changes_live"
       else
         render "make_your_form_live"

--- a/app/forms/forms/change_email_form.rb
+++ b/app/forms/forms/change_email_form.rb
@@ -6,7 +6,7 @@ class Forms::ChangeEmailForm
 
   EMAIL_REGEX = /.*@.*/
   GOVUK_EMAIL_REGEX = /\.gov\.uk\z/i
-  validates :submission_email, presence: true, if: -> { form.live? }
+  validates :submission_email, presence: true, if: -> { form.has_live_version }
   validates :submission_email, format: { with: EMAIL_REGEX, message: :invalid_email }, if: -> { submission_email.present? }
   validates :submission_email, format: { with: GOVUK_EMAIL_REGEX, message: :non_govuk_email }, if: -> { submission_email.present? }
 

--- a/app/forms/forms/contact_details_form.rb
+++ b/app/forms/forms/contact_details_form.rb
@@ -80,6 +80,6 @@ private
   def validate_presence
     return false if FeatureService.enabled?(:draft_live_versioning)
 
-    form.live?
+    form.has_live_version
   end
 end

--- a/app/forms/forms/privacy_policy_form.rb
+++ b/app/forms/forms/privacy_policy_form.rb
@@ -26,6 +26,6 @@ private
   def validate_presence
     return false if FeatureService.enabled?(:draft_live_versioning)
 
-    form.live?
+    form.has_live_version
   end
 end

--- a/app/forms/forms/what_happens_next_form.rb
+++ b/app/forms/forms/what_happens_next_form.rb
@@ -24,6 +24,6 @@ private
   def validate_presence
     return false if FeatureService.enabled?(:draft_live_versioning)
 
-    form.live?
+    form.has_live_version
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -15,12 +15,8 @@ class Form < ActiveResource::Base
     pages.find { |p| !p.has_next_page? }
   end
 
-  def live?
-    live_at.present? && live_at < Time.zone.now
-  end
-
   def status
-    live? ? :live : :draft
+    has_live_version ? :live : :draft
   end
 
   def save_page(page)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -19,10 +19,6 @@ class Form < ActiveResource::Base
     live_at.present? && live_at < Time.zone.now
   end
 
-  def draft?
-    !live?
-  end
-
   def status
     live? ? :live : :draft
   end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -27,7 +27,7 @@ class FormTaskListService
 private
 
   def create_or_edit
-    @form.live? ? "edit" : "create"
+    @form.has_live_version ? "edit" : "create"
   end
 
   def section_1_tasks
@@ -58,7 +58,7 @@ private
   end
 
   def section_4_tasks
-    if !FeatureService.enabled?(:draft_live_versioning) && @form.live?
+    if !FeatureService.enabled?(:draft_live_versioning) && @form.has_live_version
       return []
     end
 

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -75,7 +75,7 @@ class TaskStatusService
   end
 
   def make_live_status
-    return nil if @form.live?
+    return nil if @form.has_live_version
     return :not_started if mandatory_tasks_completed?
 
     :cannot_start

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -24,7 +24,7 @@
       @forms.each do |form|
         body.row do |row|
           row.cell do
-            if form.live?
+            if form.has_live_version
               govuk_link_to(form.name, live_form_path(form.id))
             else
               govuk_link_to(form.name, form_path(form.id))

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,12 +1,12 @@
 <% set_page_title(@form.name) %>
 
-<% content_for :back_link, @form.live? ? govuk_back_link_to(live_form_path(@form.id), t("back_link.form_view")) : govuk_back_link_to(root_path, t("back_link.forms")) %>
+<% content_for :back_link, @form.has_live_version ? govuk_back_link_to(live_form_path(@form.id), t("back_link.form_view")) : govuk_back_link_to(root_path, t("back_link.forms")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       <span class="govuk-caption-l"><%= @form.name %></span><span class="govuk-visually-hidden"> - </span>
-      <%= @form.live? ? t("forms.form_overview.title_edit") : t("forms.form_overview.title_create") %>
+      <%= @form.has_live_version ? t("forms.form_overview.title_edit") : t("forms.form_overview.title_create") %>
     </h1>
 
     <%= render FormStatusTagDescriptionComponent::View.new(status: ( FeatureService.enabled?(:draft_live_versioning) ? :draft : @form.status )) %>
@@ -19,7 +19,7 @@
       <%= render PreviewLinkComponent::View.new(@form.pages, link_to_runner(Settings.forms_runner.url, @form.id, @form.form_slug)) %>
     </p>
 
-    <% if @form.live? %>
+    <% if @form.has_live_version %>
       <% if FeatureService.enabled? :draft_live_versioning %>
         <div class="govuk-inset-text">
           <p><%= t("make_changes_live.warning") %></p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <% if !FeatureService.enabled?(:draft_live_versioning) and @form.live? %>
+    <% if !FeatureService.enabled?(:draft_live_versioning) and @form.has_live_version %>
       <%= render LiveFormWarningComponent::View.new() %>
     <% end %>
 

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :form, class: "Form" do
     sequence(:name) { |n| "Form #{n}" }
     sequence(:form_slug) { |n| "form-#{n}" }
+    has_draft_version { true }
+    has_live_version { false }
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
     org { "test-org" }
@@ -33,6 +35,8 @@ FactoryBot.define do
     trait :live do
       ready_for_live
       live_at { Time.zone.now }
+      has_draft_version { false }
+      has_live_version { true }
     end
 
     trait :with_pages do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,42 +1,19 @@
 require "rails_helper"
 
 describe Form do
-  let(:form) { described_class.new(id: 1, name: "Form 1", org: "Test org", live_at: "", submission_email: "") }
-
-  describe "#live?" do
-    context "when form is draft" do
-      it "return false" do
-        form.live_at = ""
-        expect(form.live?).to eq false
-      end
-    end
-
-    context "when form is live" do
-      it "return true" do
-        form.live_at = "2021-01-01T00:00:00.000Z"
-        expect(form.live?).to eq true
-      end
-    end
-
-    context "when form is live in the future" do
-      it "return false" do
-        form.live_at = "2101-01-01T00:00:00.000Z"
-        expect(form.live?).to eq false
-      end
-    end
-  end
+  let(:form) { described_class.new(id: 1, name: "Form 1", org: "Test org", submission_email: "") }
 
   describe "#status" do
-    context "when form is draft (live_at not set)" do
+    context "when form has not been made live" do
       it "returns 'draft'" do
-        form.live_at = ""
+        form.has_live_version = false
         expect(form.status).to eq :draft
       end
     end
 
-    context "when form is live (live_at is set)" do
+    context "when form has been made live" do
       it "returns 'live'" do
-        form.live_at = Time.zone.now.to_s
+        form.has_live_version = true
         expect(form.status).to eq :live
       end
     end

--- a/spec/requests/forms/what_happens_next/what_happens_next_spec.rb
+++ b/spec/requests/forms/what_happens_next/what_happens_next_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "WhatHappensNext controller", type: :request do
       org: "test-org",
       what_happens_next_text: "Good things come to those who wait",
       live_at: nil,
+      has_live_version: false,
     }.to_json
   end
 
@@ -21,6 +22,7 @@ RSpec.describe "WhatHappensNext controller", type: :request do
       org: "test-org",
       what_happens_next_text: "",
       live_at: nil,
+      has_live_version: false,
     )
   end
 
@@ -32,6 +34,7 @@ RSpec.describe "WhatHappensNext controller", type: :request do
       org: "test-org",
       what_happens_next_text: "Wait until you get a reply",
       live_at: nil,
+      has_live_version: false,
     })
   end
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe "Forms", type: :request do
         form_slug: "form",
         submission_email: "submission@email.com",
         live_at: nil,
+        has_live_version: false,
         org: "test-org",
       },
        {
@@ -159,6 +160,7 @@ RSpec.describe "Forms", type: :request do
          form_slug: "another-form",
          submission_email: "submission@email.com",
          live_at: nil,
+         has_live_version: false,
          org: "test-org",
        }]
     end

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -234,7 +234,7 @@ describe FormTaskListService do
 
       context "when form is live" do
         let(:section) do
-          allow(form).to receive(:live?).and_return(true)
+          allow(form).to receive(:has_live_version).and_return(true)
           described_class.call(form:).all_tasks[3]
         end
 

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -37,7 +37,7 @@ describe "forms/index.html.erb" do
     end
 
     context "when a form is live renders link to 'live' form readonly view" do
-      let(:forms) { [OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", live?: false), OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2", status: "live", live?: true)] }
+      let(:forms) { [OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", has_live_version: false), OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2", status: "live", has_live_version: true)] }
 
       it "allows the user to create a new form" do
         expect(rendered).to have_link("Create a form", href: forms_new_path)

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -42,7 +42,7 @@ describe "forms/show.html.erb" do
   end
 
   context "when form states is a live" do
-    let(:form) { OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2", status: "live", live?: true, pages: []) }
+    let(:form) { OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2", status: "live", has_live_version: true, pages: []) }
 
     it "rendered live tag" do
       expect(rendered).to have_css(".govuk-tag.govuk-tag--blue", text: "LIVE")


### PR DESCRIPTION
This PR refactors the admin frontend to use the new `has_draft_version`/`has_live_version` properties in the API response (see PR alphagov/forms-api#235).

This work is part of ticket https://trello.com/c/845sNCtW, working on the status tags, I've just pulled these changes out into a separate PR.