### PR TITLE
Update delete form copy to match new designs

### DIFF
--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -57,6 +57,7 @@ module Forms
       else
         @url = destroy_form_path(@form)
         @confirm_deletion_legend = t("forms_delete_confirmation_form.confirm_deletion_form")
+        @confirm_deletion_live_form = t("forms_delete_confirmation_form.confirm_deletion_form_live_form") if @form.live?
         @item_name = @form.name
         @back_url = form_path(@form)
       end

--- a/app/views/forms/delete_confirmation/delete.html.erb
+++ b/app/views/forms/delete_confirmation/delete.html.erb
@@ -5,6 +5,9 @@
     <%= f.govuk_error_summary %>
   <% end %>
   <span class="govuk-caption-l"><%= @item_name %></span>
-  <%= f.govuk_collection_radio_buttons :confirm_deletion, @confirm_deletion_options, :value, legend: { text: @confirm_deletion_legend, size: 'l', tag: 'h1' } %>
+  <%= f.govuk_collection_radio_buttons :confirm_deletion, @confirm_deletion_options, :value,
+                                       legend: { text: @confirm_deletion_legend, size: 'l', tag: 'h1' },
+                                       hint: {text: @confirm_deletion_live_form} %>
+
   <%= f.govuk_submit %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
     copy_to_clipboard: Copy URL to clipboard
     form_url: Form URL
   forms:
-    delete_form: Delete form
+    delete_form: Delete draft form
     form_overview:
       edit: Edit
       move_down_html: Move down <span class="govuk-visually-hidden">%{title}</span>
@@ -126,7 +126,8 @@ en:
         make_live: Make your changes live
         title: Make your changes live
   forms_delete_confirmation_form:
-    confirm_deletion_form: Are you sure you want to delete this form?
+    confirm_deletion_form: Are you sure you want to delete this draft?
+    confirm_deletion_form_live_form: Deleting this draft will not remove the live form.
     confirm_deletion_page: Are you sure you want to delete this page?
   header:
     product_name: Forms

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -20,7 +20,7 @@ describe "forms/show.html.erb" do
   end
 
   it "contains a link to delete the form" do
-    expect(rendered).to have_link("Delete form", href: delete_form_path(1))
+    expect(rendered).to have_link("Delete draft form", href: delete_form_path(1))
   end
 
   it "contains a summary of completed tasks out of the total tasks" do
@@ -60,7 +60,7 @@ describe "forms/show.html.erb" do
       end
 
       it "does not contain a link to delete the form" do
-        expect(rendered).not_to have_link("Delete form", href: delete_form_path(1))
+        expect(rendered).not_to have_link("Delete draft form", href: delete_form_path(1))
       end
     end
   end


### PR DESCRIPTION
### What problem does the pull request solve?

Updates copy for delete form pages to refer to "deleting drafts" rather than deleting just the form.

##### Delete form button copy updated
![image](https://user-images.githubusercontent.com/3441519/227735012-222008f1-4d0a-4c9c-b072-a583d09fc619.png)

##### when form creator views deletion page for a draft form that has never been made live.
![image](https://user-images.githubusercontent.com/3441519/227735045-5a7f19af-f4f5-48b6-8bc6-888a2737cb1a.png)


##### when form creator views deletion page for a live form (They shouldn't be able to access this page in this state just yet but at least the copy is there if they stumble across it.

![image](https://user-images.githubusercontent.com/3441519/227734952-003fcaab-2b81-4f0c-b127-5ed06a6df883.png)


Trello card:

### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
