### PR TITLE
Fix delete draft button displaying after form is live

### DIFF
--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -37,6 +37,6 @@
                                            sections: @task_list)
     %>
 
-    <%= govuk_button_link_to(t("forms.delete_form"), delete_form_path(@form.id), warning: true) unless @form.live?  %>
+    <%= govuk_button_link_to(t("forms.delete_form"), delete_form_path(@form.id), warning: true) unless @form.has_live_version  %>
   </div>
 </div>

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -60,7 +60,7 @@ describe "forms/show.html.erb" do
       end
 
       it "does not contain a link to delete the form" do
-        expect(rendered).not_to have_link("Delete draft form", href: delete_form_path(1))
+        expect(rendered).not_to have_link("Delete draft form", href: delete_form_path(2))
       end
     end
   end


### PR DESCRIPTION
#### What problem does the pull request solve?

The reason this bug was not caught in the first place is because the initial test was looking for a delete link with the wrong form id.

Trello card: https://trello.com/c/JqItg0Rg/654-fix-delete-draft-form-still-showing-after-a-form-as-gone-live

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
