### PR TITLE
Pundit errors in User research environment.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,4 +101,11 @@ class ApplicationController < ActionController::Base
     first_ip_string = forwarded_for.split(",").first
     Regexp.union([Resolv::IPv4::Regex, Resolv::IPv6::Regex]).match(first_ip_string) && first_ip_string
   end
+
+  # By default pundit uses `current_user` which worked when we are using signon
+  # but if we use basic auth `current_user` method isn't set and so we manually
+  # create @current_user and set that.
+  def pundit_user
+    @current_user
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

fixes https://govuk-forms.sentry.io/issues/4061297374/?project=6576190&referrer=issue-stream&stream_index=0

I tested this locally by enabling basic auth on my local build. I was able to replicate the error that was logged in sentry and could test the fix.

By default pundit uses `current_user` which worked perfectly for signon. But for basic auth `current_user` isn't available and so we created an instance var called `@current_user` which we setup for both authentication methods.

https://github.com/varvet/pundit#customize-pundit-user

Trello card: https://trello.com/c/MxEtFS0k/682-fixing-ur-environment

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
