### PR TITLE
Change 'field' to 'box' for name question

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,20 +223,20 @@ en:
             first_and_last_name: ''
             first_middle_and_last_name: Middle name will not be mandatory
             full_name: ''
-            input_type: A single name field is easiest for people to complete - only ask for names separately if you need the individual parts of the name.
+            input_type: A single box for the full name is easiest for people to complete - only ask for names separately if you need the individual parts of the name.
             title: Only ask for a title if you really need it. People will be able to enter their preferred title.
           input_types:
-            first_and_last_name: First and last names in separate fields
-            first_middle_and_last_name: First, middle and last names in separate fields
-            full_name: Full name in a single field
+            first_and_last_name: First and last names in separate boxes
+            first_middle_and_last_name: First, middle and last names in separate boxes
+            full_name: Full name in a single box
           legends:
             input_type: How do you need to collect the name?
             title: Do you need the person’s title?
           names:
             'false': 'No'
-            first_and_last_name: First and last names in separate fields
-            first_middle_and_last_name: First, middle and last names in separate fields
-            full_name: Full name in a single field
+            first_and_last_name: First and last names in separate boxes
+            first_middle_and_last_name: First, middle and last names in separate boxes
+            full_name: Full name in a single box
             'true': 'Yes'
           title_needed:
             'false': 'No'

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -140,9 +140,9 @@ private
 
   def fill_in_name_settings
     expect(page.find("h1")).to have_text "Ask for a person’s name"
-    within_fieldset("How do you need to collect the name?") { choose("Full name in a single field") }
+    within_fieldset("How do you need to collect the name?") { choose("Full name in a single box") }
     within_fieldset("Do you need the person’s title?") { choose("No") }
     click_button "Continue"
-    expect(page.find(".govuk-summary-list")).to have_text "Full name in a single field"
+    expect(page.find(".govuk-summary-list")).to have_text "Full name in a single box"
   end
 end

--- a/spec/service/page_options_service_spec.rb
+++ b/spec/service/page_options_service_spec.rb
@@ -113,7 +113,7 @@ describe PageOptionsService do
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
-          { key: I18n.t("helpers.label.page.answer_type_options.title"), value: "<ul class=\"govuk-list\">\n<li>Person’s name</li>\n<li>Full name in a single field</li>\n<li>Title not needed</li>\n</ul>" },
+          { key: I18n.t("helpers.label.page.answer_type_options.title"), value: "<ul class=\"govuk-list\">\n<li>Person’s name</li>\n<li>Full name in a single box</li>\n<li>Title not needed</li>\n</ul>" },
         ])
       end
     end
@@ -123,7 +123,7 @@ describe PageOptionsService do
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
-          { key: I18n.t("helpers.label.page.answer_type_options.title"), value: "<ul class=\"govuk-list\">\n<li>Person’s name</li>\n<li>First and last names in separate fields</li>\n<li>Title needed</li>\n</ul>" },
+          { key: I18n.t("helpers.label.page.answer_type_options.title"), value: "<ul class=\"govuk-list\">\n<li>Person’s name</li>\n<li>First and last names in separate boxes</li>\n<li>Title needed</li>\n</ul>" },
         ])
       end
     end
@@ -133,7 +133,7 @@ describe PageOptionsService do
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
-          { key: I18n.t("helpers.label.page.answer_type_options.title"), value: "<ul class=\"govuk-list\">\n<li>Person’s name</li>\n<li>First, middle and last names in separate fields</li>\n<li>Title not needed</li>\n</ul>" },
+          { key: I18n.t("helpers.label.page.answer_type_options.title"), value: "<ul class=\"govuk-list\">\n<li>Person’s name</li>\n<li>First, middle and last names in separate boxes</li>\n<li>Title not needed</li>\n</ul>" },
         ])
       end
     end


### PR DESCRIPTION
#### What problem does the pull request solve?

In user research we saw that the use of the word ‘field’ can be jarring and confusing for some. 'Box' is a plainer language alternative.

This changes the use of 'field' in both the question and the playback of the question settings on the 'Edit question' page.

Trello card: https://trello.com/c/TKwIiHKH/678-change-references-to-field-in-name-pages-and-input-type-labels-to-something-less-jargonny

#### Checklist

- [x ] I've used the pull request template
- [ x] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
