### PR TITLE
Fixup redirect after user deletes a page

### DIFF
--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -76,7 +76,7 @@ module Forms
     end
 
     def delete_page(form, page)
-      success_url = form_path(form)
+      success_url = form_pages_path(form)
 
       authorize form, :can_view_form?
       if page.destroy

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -355,8 +355,8 @@ RSpec.describe "Pages", type: :request do
         delete destroy_page_path(form_id: 2, page_id: 1, forms_delete_confirmation_form: { confirm_deletion: "true" })
       end
 
-      it "Redirects you to the home screen" do
-        expect(response).to redirect_to(form_path(form_id: 2))
+      it "Redirects you to the page index screen" do
+        expect(response).to redirect_to(form_pages_path)
       end
 
       it "Deletes the form on the API" do


### PR DESCRIPTION
#### What problem does the pull request solve?
Instead of taking the user to the form show page (with the tasklist). They should really end up on the list of pages for the form they are viewing. This allows them to continue with add/edit/delete pages.

Trello card: https://trello.com/c/KmpDZmLe/680-deleting-a-question-returns-user-to-form-tasklist-page-not-add-and-edit-your-questions

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
