### PR TITLE
Add user edit page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,16 +13,14 @@ class UsersController < ApplicationController
 
   def edit
     authorize current_user, :can_manage_user?
-    @user = User.find(params[:id])
+    user
   end
 
   def update
     authorize current_user, :can_manage_user?
+    user.role = user_params[:role]
 
-    @user = User.find(params[:id])
-    @user.role = user_params[:role]
-
-    if @user.save
+    if user.save
       redirect_to users_path
     else
       render :edit
@@ -33,5 +31,9 @@ private
 
   def user_params
     params.require(:user).permit(:role)
+  end
+
+  def user
+    @user ||= User.find(params[:id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,8 +2,36 @@ class UsersController < ApplicationController
   after_action :verify_authorized
   after_action :verify_policy_scoped, only: :index
 
+  rescue_from ActiveRecord::RecordNotFound do
+    render template: "errors/not_found", status: :not_found
+  end
+
   def index
     authorize current_user, :can_manage_user?
     render template: "users/index", locals: { users: policy_scope(User) }
+  end
+
+  def edit
+    authorize current_user, :can_manage_user?
+    @user = User.find(params[:id])
+  end
+
+  def update
+    authorize current_user, :can_manage_user?
+
+    @user = User.find(params[:id])
+    @user.role = user_params[:role]
+
+    if @user.save
+      redirect_to users_path
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def user_params
+    params.require(:user).permit(:role)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,4 +70,10 @@ module ApplicationHelper
       user_profile_link: (user.blank? || Settings.basic_auth.enabled ? nil : GDS::SSO::Config.oauth_root_url),
       signout_link: (user.blank? || Settings.basic_auth.enabled ? nil : gds_sign_out_path) }
   end
+
+  def user_role_options(roles = User.roles.keys)
+    roles.map do |role|
+      OpenStruct.new(label: t("users.roles.#{role}.name"), value: role, description: t("users.roles.#{role}.description"))
+    end
+  end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,42 @@
+<% set_page_title(title_with_error_prefix(@user.name, @user.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(users_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t("users.edit.title") %>
+    </h1>
+
+    <h2 class="govuk-heading-m"><%= t("users.edit.caption") %></h2>
+    <%= govuk_summary_list(actions: false) do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { t('users.index.table_headings.name') }
+        row.with_value { @user.name }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('users.index.table_headings.email') }
+        row.with_value { @user.email }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('users.index.table_headings.organisation') }
+        row.with_value { @user.organisation_slug }
+      end
+    end %>
+
+    <%= form_with(model: @user) do |f| %>
+      <% if @user.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+      <span class="govuk-caption-l"><%= @item_name %></span>
+      <%= f.govuk_collection_radio_buttons :role, user_role_options, :value,:label, :description,
+      legend: { text: "Role", size: 'm', tag: 'h2' } %>
+
+    <%= f.govuk_submit t('users.save') do
+      govuk_link_to(t('users.cancel'), users_path, class: 'govuk-button govuk-button--secondary')
+    end %>
+  <% end %>
+
+  </div>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -34,7 +34,7 @@
       legend: { text: "Role", size: 'm', tag: 'h2' } %>
 
     <%= f.govuk_submit t('users.save') do
-      govuk_link_to(t('users.cancel'), users_path, class: 'govuk-button govuk-button--secondary')
+      govuk_button_link_to t('users.cancel'), users_path, secondary: true
     end %>
   <% end %>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,10 +17,12 @@
     <%= table.body do |body|
       users.each do |user|
         body.row do |row|
-          row.cell( text: user.name)
+          row.cell do
+            govuk_link_to(user.name, edit_user_path(user))
+          end
           row.cell( text: user.email)
           row.cell( text: user.organisation_slug)
-          row.cell( text: t("users.roles.#{user.role}"))
+          row.cell( text: t("users.roles.#{user.role}.name"))
         end
       end
     end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,29 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "491d5b53c0254f09b59ac8334571eea772e9b54c5ebb49202cd2b79392721999",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/users_controller.rb",
+      "line": 35,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:user).permit(:role)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "UsersController",
+        "method": "user_params"
+      },
+      "user_input": ":role",
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "note": ""
+    }
+  ],
+  "updated": "2023-04-11 12:44:26 +0100",
+  "brakeman_version": "5.4.1"
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -455,6 +455,10 @@ en:
     in_progress: in progress
     not_started: not started
   users:
+    cancel: Cancel
+    edit:
+      caption: User details
+      title: Edit user
     index:
       table_headings:
         email: Email address
@@ -464,5 +468,10 @@ en:
       title: Users
       users_caption: All users
     roles:
-      editor: Editor
-      super_adimn: Superadmin
+      editor:
+        description: Can create forms
+        name: Editor
+      super_admin:
+        description: Can create forms and manage users
+        name: Super admin
+    save: Save

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users, only: %i[index]
+  resources :users, only: %i[index edit update]
 
   # Page routes
   match "/403", to: "errors#forbidden", as: :error_403, via: :all

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -174,4 +174,21 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#user_role_options" do
+    before do
+      allow(I18n).to receive(:translate).with("users.roles.role1.name", any_args).and_return("name1")
+      allow(I18n).to receive(:translate).with("users.roles.role1.description", any_args).and_return("description1")
+
+      allow(I18n).to receive(:translate).with("users.roles.role2.name", any_args).and_return("name2")
+      allow(I18n).to receive(:translate).with("users.roles.role2.description", any_args).and_return("description2")
+    end
+
+    it "returns the correct options" do
+      expect(helper.user_role_options(%i[role1 role2])).to eq(
+        [OpenStruct.new(label: "name1", value: :role1, description: "description1"),
+         OpenStruct.new(label: "name2", value: :role2, description: "description2")],
+      )
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -5,23 +5,81 @@ RSpec.describe "Users", type: :request do
     context "when user is a super_admin" do
       before do
         login_as_super_admin_user
-        get "/users"
+        get users_path
       end
 
       it "returns http code 200" do
         expect(response).to have_http_status(:ok)
       end
 
-      it "renders the corect page" do
+      it "renders the correct page" do
         expect(response.body).to include("Users")
         expect(response).to render_template("users/index")
       end
     end
 
     context "when user is not a super_admin" do
-      it "does not allow access regular users" do
+      it "is forbidden" do
         login_as_editor_user
-        get "/users"
+        get users_path
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "#edit" do
+    let(:user) { create(:user) }
+
+    context "when user is a super_admin" do
+      before do
+        login_as_super_admin_user
+        get edit_user_path(user)
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the correct page" do
+        expect(response).to render_template("users/edit")
+      end
+    end
+
+    context "when user is not a super_admin" do
+      it "is forbidden" do
+        login_as_editor_user
+        get edit_user_path(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:user) { create(:user) }
+    let(:role) { :super_admin }
+
+    context "when user is a super_admin" do
+      before do
+        login_as_super_admin_user
+      end
+
+      it "redirects to /users page and updates user" do
+        put user_path(user), params: { user: { role: } }
+        expect(response).to redirect_to(users_path)
+        # TODO: This can change to .super_admin? after phase 2
+        expect(user.reload.role).to eq("super_admin")
+      end
+
+      it "when given a user which doesn't exist returns 404" do
+        put user_path(-1), params: { user: { role: } }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when user is not a super_admin" do
+      it "is forbidden" do
+        login_as_editor_user
+        put user_path(user), params: { user: { role: "super_admin" } }
         expect(response).to have_http_status(:forbidden)
       end
     end

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe "users/edit.html.erb" do
+  let(:user) do
+    build :user, id: 1
+  end
+
+  before do
+    assign(:user, user)
+    render template: "users/edit", layout: "layouts/application"
+  end
+
+  it "contains page heading" do
+    expect(rendered).to have_css("h1.govuk-heading-l", text: /Edit user/)
+  end
+
+  it "contains name" do
+    expect(rendered).to have_text(user.name)
+  end
+
+  it "contains email" do
+    expect(rendered).to have_text(user.email)
+  end
+
+  it "contains org" do
+    expect(rendered).to have_text(user.organisation_slug)
+  end
+
+  it "has form fields" do
+    expect(rendered).to have_checked_field("Editor")
+    expect(rendered).to have_unchecked_field("Super admin")
+  end
+end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -15,8 +15,8 @@ describe "users/index.html.erb" do
     expect(rendered).to have_css("h1.govuk-heading-l", text: /Users/)
   end
 
-  it "contains name" do
-    expect(rendered).to have_text(users.first.name)
+  it "contains a link to edit with name" do
+    expect(rendered).to have_link(users.first.name, href: edit_user_path(users.first))
   end
 
   it "contains email" do


### PR DESCRIPTION
# Add a way for super admins to edit users role

This adds the edit screen and routes to allow super admins to change the role of other users.

Trello card: https://trello.com/c/e0HKO8s2/685-create-new-pages-to-show-list-of-users-and-be-able-to-edit-users-role

It works but these are still todo: 
- Finish the update route to handle missing records, invalid params
- add view tests for the edit page
- extract the roles from the view 
- tidy up the new locale entries a bit

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
