### PR TITLE
Update header_component to support users nav link

### DIFF
--- a/app/components/header_component/view.html.erb
+++ b/app/components/header_component/view.html.erb
@@ -1,6 +1,7 @@
 <% if is_signed_in? %>
   <%= govuk_header navigation_classes: ["govuk-header__navigation--end"] do |header|
     header.product_name(name: t("header.product_name"))
+    header.navigation_item(text: t('header.users'), href: list_of_users_path, active: false) if list_of_users_path.present?
     header.navigation_item(text: user_name, href: user_profile_link, active: false) if user_name.present?
     header.navigation_item(text: t("header.sign_out"), href: signout_link, active: false)
   end %>

--- a/app/components/header_component/view.rb
+++ b/app/components/header_component/view.rb
@@ -2,14 +2,15 @@
 
 module HeaderComponent
   class View < ViewComponent::Base
-    attr_accessor :is_signed_in, :user_name, :user_profile_link, :signout_link
+    attr_accessor :is_signed_in, :user_name, :user_profile_link, :signout_link, :list_of_users_path
 
-    def initialize(is_signed_in:, user_name:, user_profile_link:, signout_link:)
+    def initialize(is_signed_in:, user_name:, user_profile_link:, signout_link:, list_of_users_path:)
       super
       @is_signed_in = is_signed_in
       @user_name = user_name
       @user_profile_link = user_profile_link
       @signout_link = signout_link
+      @list_of_users_path = list_of_users_path
     end
 
     def is_signed_in?

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -1,0 +1,6 @@
+class ComponentPreviewController < ApplicationController
+  include ViewComponent::PreviewActions
+  include Pundit::Authorization
+
+  layout "application"
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,10 +64,11 @@ module ApplicationHelper
     "/node_modules/govuk-frontend/govuk/assets"
   end
 
-  def header_component_options(user)
+  def header_component_options(user:, can_manage_users:)
     { is_signed_in: user.present?,
       user_name: user&.name.presence,
       user_profile_link: (user.blank? || Settings.basic_auth.enabled ? nil : GDS::SSO::Config.oauth_root_url),
+      list_of_users_path: (can_manage_users ? users_path : nil),
       signout_link: (user.blank? || Settings.basic_auth.enabled ? nil : gds_sign_out_path) }
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,8 @@
 
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link"><%= t("skip_to_main_content") %></a>
 
-    <%= render HeaderComponent::View.new(**header_component_options(@current_user))%>
+    <%= render HeaderComponent::View.new(**header_component_options(user:@current_user,
+                                                                    can_manage_users: policy(@current_user).can_manage_user? ))%>
 
     <div class="govuk-width-container ">
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module FormsAdmin
 
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/preview"
+    config.view_component.preview_controller = "ComponentPreviewController"
     # Replace with value which will be true in local dev and PAAS dev
     config.view_component.show_previews = HostingEnvironment.test_environment?
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,7 @@ en:
   header:
     product_name: Forms
     sign_out: Sign out
+    users: Users
   helpers:
     hint:
       page:

--- a/spec/components/header_component/header_component_preview.rb
+++ b/spec/components/header_component/header_component_preview.rb
@@ -1,6 +1,7 @@
 class HeaderComponent::HeaderComponentPreview < ViewComponent::Preview
   def default
     render(HeaderComponent::View.new(is_signed_in: false,
+                                     list_of_users_path: nil,
                                      user_name: nil,
                                      user_profile_link: nil,
                                      signout_link: nil))
@@ -8,15 +9,25 @@ class HeaderComponent::HeaderComponentPreview < ViewComponent::Preview
 
   def with_user
     render(HeaderComponent::View.new(is_signed_in: true,
+                                     list_of_users_path: nil,
                                      user_name: "Joe Smith",
                                      user_profile_link: "http://www.example.com/",
                                      signout_link: "http://www.example.com/"))
   end
 
-  def with_user_who_has_no_name
+  def with_user_logged_in_using_basic_http_auth
     render(HeaderComponent::View.new(is_signed_in: true,
-                                     user_name: nil,
-                                     user_profile_link: "http://www.example.com/",
-                                     signout_link: "http://www.example.com/"))
+                                     list_of_users_path: "/users",
+                                     user_name: "Joe Smith",
+                                     user_profile_link: nil,
+                                     signout_link: nil))
+  end
+
+  def with_user_who_can_manage_users
+    render(HeaderComponent::View.new(is_signed_in: true,
+                                     list_of_users_path: "/users",
+                                     user_name: "Joe Smith",
+                                     user_profile_link: nil,
+                                     signout_link: nil))
   end
 end

--- a/spec/components/header_component/view_spec.rb
+++ b/spec/components/header_component/view_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe HeaderComponent::View, type: :component do
   describe "default status" do
     before do
       render_inline(described_class.new(is_signed_in: false,
+                                        list_of_users_path: nil,
                                         user_name: nil,
                                         user_profile_link: nil,
                                         signout_link: nil))
@@ -25,6 +26,7 @@ RSpec.describe HeaderComponent::View, type: :component do
   describe "logged in status" do
     before do
       render_inline(described_class.new(is_signed_in: true,
+                                        list_of_users_path: nil,
                                         user_name: "Joe Smith",
                                         user_profile_link: "http://signon.dev.gov.uk",
                                         signout_link: "/auth/gds/sign_out"))
@@ -46,6 +48,7 @@ RSpec.describe HeaderComponent::View, type: :component do
   context "when no profile link or signout in passed in" do
     before do
       render_inline(described_class.new(is_signed_in: true,
+                                        list_of_users_path: nil,
                                         user_name: "Joe Smith",
                                         user_profile_link: nil,
                                         signout_link: nil))
@@ -59,6 +62,32 @@ RSpec.describe HeaderComponent::View, type: :component do
     it "Signout appears without a link" do
       expect(page).not_to have_link(I18n.t("header.sign_out"))
       expect(page).to have_text(I18n.t("header.sign_out"))
+    end
+  end
+
+  context "when user has permission to view list of users" do
+    before do
+      render_inline(described_class.new(is_signed_in: true,
+                                        list_of_users_path: "https://forms.users",
+                                        user_name: "Joe Smith",
+                                        user_profile_link: "http://signon.dev.gov.uk",
+                                        signout_link: "/auth/gds/sign_out"))
+    end
+
+    it "contains the service name" do
+      expect(page).to have_text(I18n.t("header.product_name"))
+    end
+
+    it "contains the link to users pages" do
+      expect(page).to have_link(I18n.t("header.users"), href: "https://forms.users")
+    end
+
+    it "contains the profile link" do
+      expect(page).to have_link("Joe Smith", href: "http://signon.dev.gov.uk")
+    end
+
+    it "contains the sign out link" do
+      expect(page).to have_link(I18n.t("header.sign_out"), href: "/auth/gds/sign_out")
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -144,21 +144,35 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "#header_component_options" do
     let(:user) { build :user }
+    let(:can_manage_users) { false }
 
     context "when a user is not signed in" do
       let(:user) { nil }
 
       it "returns options" do
-        expect(helper.header_component_options(user)).to eq({ is_signed_in: false, signout_link: nil, user_name: nil, user_profile_link: nil })
+        expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: false, list_of_users_path: nil, signout_link: nil, user_name: nil, user_profile_link: nil })
       end
     end
 
     context "when a user is signed in" do
       it "returns the following options" do
-        expect(helper.header_component_options(user)).to eq({ is_signed_in: true,
-                                                              signout_link: "/auth/gds/sign_out",
-                                                              user_name: user.name,
-                                                              user_profile_link: "http://signon.dev.gov.uk" })
+        expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: true,
+                                                                                  list_of_users_path: nil,
+                                                                                  signout_link: "/auth/gds/sign_out",
+                                                                                  user_name: user.name,
+                                                                                  user_profile_link: "http://signon.dev.gov.uk" })
+      end
+
+      context "when can manager users" do
+        let(:can_manage_users) { true }
+
+        it "returns the following options" do
+          expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: true,
+                                                                                    list_of_users_path: users_path,
+                                                                                    signout_link: "/auth/gds/sign_out",
+                                                                                    user_name: user.name,
+                                                                                    user_profile_link: "http://signon.dev.gov.uk" })
+        end
       end
 
       context "when http basic auth is enabled" do
@@ -166,10 +180,11 @@ RSpec.describe ApplicationHelper, type: :helper do
           basic_auth_double = object_double("basic_auth_double", enabled: true)
           allow(Settings).to receive(:basic_auth).and_return(basic_auth_double)
 
-          expect(helper.header_component_options(user)).to eq({ is_signed_in: true,
-                                                                signout_link: nil,
-                                                                user_name: user.name,
-                                                                user_profile_link: nil })
+          expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: true,
+                                                                                    list_of_users_path: nil,
+                                                                                    signout_link: nil,
+                                                                                    user_name: user.name,
+                                                                                    user_profile_link: nil })
         end
       end
     end

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe "forms/show.html.erb" do
   before do
     assign(:form, form)
     assign(:task_status_counts, { completed: 12, total: 20 })
-    render template: "forms/show", layout: "layouts/application"
+    render template: "forms/show"
   end
 
   it "contains page heading and sub-heading" do
@@ -35,9 +35,7 @@ describe "forms/show.html.erb" do
     end
 
     it "has a back link to the forms page" do
-      expect(rendered).to have_link("Back to your forms", href: "/") { |link|
-        link.matches_css?(".govuk-back-link")
-      }
+      expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
     end
   end
 
@@ -49,9 +47,7 @@ describe "forms/show.html.erb" do
     end
 
     it "has a back link to the live form page" do
-      expect(rendered).to have_link("Back", href: "/forms/2/live") { |link|
-        link.matches_css?(".govuk-back-link")
-      }
+      expect(view.content_for(:back_link)).to have_link("Back", href: "/forms/2/live")
     end
 
     context "when feature flag is enabled", feature_draft_live_versioning: true do

--- a/spec/views/live/show_form.html.erb_spec.rb
+++ b/spec/views/live/show_form.html.erb_spec.rb
@@ -8,17 +8,15 @@ describe "live/show_form.html.erb" do
 
   before do
     allow(view).to receive(:live_form_pages_path).and_return("/live-form-pages-path")
-
-    # assign(:form, form)
-    render(template: "live/show_form", layout: "layouts/application", locals: { form_metadata:, form: })
+    render(template: "live/show_form", locals: { form_metadata:, form: })
   end
 
   it "has the correct title" do
-    expect(rendered).to have_title "#{form.name} – GOV.UK Forms"
+    expect(view.content_for(:title)).to have_content(form.name.to_s)
   end
 
   it "back link is set to root" do
-    expect(rendered).to have_link("Back to your forms", href: "/")
+    expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
   end
 
   it "contains page heading" do

--- a/spec/views/live/show_pages.html.erb_spec.rb
+++ b/spec/views/live/show_pages.html.erb_spec.rb
@@ -5,12 +5,11 @@ describe "live/show_pages.html.erb" do
 
   before do
     allow(view).to receive(:live_form_path).and_return("/live-form-path")
-
-    render(template: "live/show_pages", layout: "layouts/application", locals: { form: })
+    render(template: "live/show_pages", locals: { form: })
   end
 
   it "form name is in the page title" do
-    expect(rendered).to have_title(form.name.to_s)
+    expect(view.content_for(:title)).to have_content(form.name)
   end
 
   it "back link is set to form_path" do

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -29,17 +29,14 @@ describe "pages/edit.html.erb" do
     # that in this test
     ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
 
-    # Render the template with layout to include page title, we could check
-    # expect(view.content_for(:title)).to have_content("Question'<> 1 – GOV.UK Forms")
-    # instead, but this checks behaviour better
-    render(template: "pages/edit", layout: "layouts/application")
+    render template: "pages/edit"
   end
 
   context "when given a title with characters which need escaping" do
     let(:question_text) { "Question'<> 1" }
 
     it "has the correct title" do
-      expect(rendered).to have_title("Question'<> 1 – GOV.UK Forms")
+      expect(view.content_for(:title)).to have_content("Question'<> 1")
     end
   end
 end

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -25,15 +25,15 @@ describe "pages/type_of_answer.html.erb", type: :view do
     assign(:type_of_answer_form, type_of_answer_form)
     assign(:answer_types, answer_types)
 
-    render(template: "pages/type-of-answer", layout: "layouts/application")
+    render(template: "pages/type-of-answer")
   end
 
   it "has the correct title" do
-    expect(rendered).to have_title "Edit question – GOV.UK Forms"
+    expect(view.content_for(:title)).to have_content("Edit question")
   end
 
-  it "back link is set to form pages path" do
-    expect(rendered).to have_link("Back", href: "/forms/1/pages")
+  it "has a back link to the live form page" do
+    expect(view.content_for(:back_link)).to have_link("Back", href: "/forms/1/pages")
   end
 
   it "contains the question number" do

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe "users/edit.html.erb" do
 
   before do
     assign(:user, user)
-    render template: "users/edit", layout: "layouts/application"
+    render template: "users/edit"
   end
 
   it "contains page heading" do

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe "users/index.html.erb" do
   end
 
   before do
-    render template: "users/index", layout: "layouts/application", locals: { users: }
+    render template: "users/index", locals: { users: }
   end
 
   it "contains page heading" do


### PR DESCRIPTION
# Add link to users page for super_admin, refactor header_component

Header should display a link to users index page. The component
is not responsibly for working that out, it is down to the application_helper
to identify whether a user is responsible for managing users or not.

## Updates to view tests

The view tests were failing after introducing the policy check in
application_layout.

This is fixed by not rendering the view tests within the
application_layout.

The view tests originally used the application_layout to test the whole
page. This allowed the title and back_links to be checked directly
against the whole page, rather than checking the content passed from the
view to the application_layout.

This change makes the view tests more isolated and focussed. To test titles and
back_links, use:

```
expect(view.content_for(:title)).to have_content("title without the - GOV.UK Forms")
```

and

```
expect(view.content_for(:back_link)).to have_link("Back", href: "/forms/1/pages")
```

If you are testing a view which uses a pundit policy, you will need to
mock the policy method which is available in views.

You can do that on a per view basis by putting something like the below
in a before block:

```
without_partial_double_verification do
    allow(view).to receive_message_chain(:policy, :can_manage_user?).and_return(false)
  end
end
```

You can also use techniques like those in this thread:
https://github.com/varvet/pundit/issues/339

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
