### PR TITLE
Add conditions to pages

### DIFF
--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -25,7 +25,7 @@
                 <% end %>
               </div>
 
-              <%= govuk_link_to edit_page_path(@form_id, page) do %>
+              <%= govuk_link_to edit_page_path(@form_id, page.id) do %>
                 <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= index + 1 %></span>
               <% end %>
 

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -1,0 +1,14 @@
+class Pages::ConditionsController < PagesController
+  def routing_page
+    render template: "pages/conditions/routing_page", locals: { form: @form }
+  end
+
+  def set_routing_page
+    routing_page = Page.find(params[:form][:routing_page_id], params: { form_id: @form.id })
+    redirect_to new_condition_path(@form, routing_page)
+  end
+
+  def new
+    render template: "pages/conditions/new", locals: { form: @form, page: }
+  end
+end

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -1,4 +1,5 @@
 class Pages::ConditionsController < PagesController
+  before_action :can_add_page_routing
   def routing_page
     render template: "pages/conditions/routing_page", locals: { form: @form }
   end
@@ -10,5 +11,11 @@ class Pages::ConditionsController < PagesController
 
   def new
     render template: "pages/conditions/new", locals: { form: @form, page: }
+  end
+
+private
+
+  def can_add_page_routing
+    authorize @form, :can_add_page_routing_conditions?
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -75,6 +75,10 @@ private
     @form = Form.find(params[:form_id])
   end
 
+  def page
+    @page ||= Page.find(params[:page_id], params: { form_id: @form.id })
+  end
+
   def move_params
     form_id = params.require(:form_id)
     p = params.require(:move_direction).permit(%i[up down])

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,13 +5,11 @@ class PagesController < ApplicationController
   after_action :verify_authorized
 
   def index
-    authorize @form, :can_view_form?
     @pages = @form.pages
     @mark_complete_form = Forms::MarkCompleteForm.new(form: @form).assign_form_values
   end
 
   def new
-    authorize @form, :can_view_form?
     answer_type = session.dig(:page, "answer_type")
     answer_settings = session.dig(:page, "answer_settings")
     is_optional = session.dig(:page, "is_optional") == "true"
@@ -19,8 +17,6 @@ class PagesController < ApplicationController
   end
 
   def create
-    authorize @form, :can_view_form?
-
     answer_settings = session.dig(:page, "answer_settings")
     @page = Page.new(page_params.merge(answer_settings:))
 
@@ -33,16 +29,12 @@ class PagesController < ApplicationController
   end
 
   def edit
-    authorize @form, :can_view_form?
-
     reset_session_if_answer_settings_not_present
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     @page.load_from_session(session, %w[answer_settings answer_type is_optional])
   end
 
   def update
-    authorize @form, :can_view_form?
-
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
     @page.load_from_session(session, %w[answer_type answer_settings]).load(page_params)
 
@@ -55,8 +47,6 @@ class PagesController < ApplicationController
   end
 
   def move_page
-    authorize @form, :can_view_form?
-
     Page.find(move_params[:page_id], params: { form_id: move_params[:form_id] }).move_page(move_params[:direction])
     redirect_to form_pages_path
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -15,6 +15,10 @@ class Form < ActiveResource::Base
     pages.find { |p| !p.has_next_page? }
   end
 
+  def qualifying_route_pages
+    pages.filter { |p| p.answer_type == "selection" && p.answer_settings.only_one_option == "true" }
+  end
+
   def status
     has_live_version ? :live : :draft
   end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -24,6 +24,10 @@ class FormPolicy
     users_organisation_owns_form
   end
 
+  def can_add_page_routing_conditions?
+    FeatureService.enabled?(:basic_routing) || user.super_admin?
+  end
+
 private
 
   def users_organisation_owns_form

--- a/app/views/pages/conditions/new.html.erb
+++ b/app/views/pages/conditions/new.html.erb
@@ -1,0 +1,31 @@
+<% set_page_title(t("page_titles.routing_page")) %>
+<% content_for :back_link, govuk_back_link_to(routing_page_path(form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= form.name %></span>
+      <%= t("page_titles.routing_page") %>
+    </h1>
+
+    <!-- If the question "where were you born" Change -->
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t("new_condition.routing_page_text") %></dt>
+        <dd class="govuk-summary-list__value">“<%= page.question_text %>”</dd>
+        <dd class="govuk-summary-list__actions">
+          <%= govuk_link_to routing_page_path(form) do %>
+            <%= t("new_condition.routing_page_change_html") %>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+
+    <%= form_with(model: nil, url: "#", method: 'POST') do |f| %>
+      <%= f.govuk_collection_select :routing_answer, page.answer_settings.selection_options, :name, :name, label: { text: "is answered as" } %>
+      <%= f.govuk_collection_select :goto_page_id, form.pages, :id, :question_text, label: { text: "take the person to" } %>
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pages/conditions/new.html.erb
+++ b/app/views/pages/conditions/new.html.erb
@@ -9,18 +9,13 @@
       <%= t("page_titles.routing_page") %>
     </h1>
 
-    <!-- If the question "where were you born" Change -->
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t("new_condition.routing_page_text") %></dt>
-        <dd class="govuk-summary-list__value">“<%= page.question_text %>”</dd>
-        <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to routing_page_path(form) do %>
-            <%= t("new_condition.routing_page_change_html") %>
-          <% end %>
-        </dd>
-      </div>
-    </dl>
+    <%= govuk_summary_list do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { t("new_condition.routing_page_text") }
+        row.with_value { page.question_text }
+        row.with_action(text: "Change", href: routing_page_path(form), visually_hidden_text: "routing question")
+      end;
+    end %>
 
     <%= form_with(model: nil, url: "#", method: 'POST') do |f| %>
       <%= f.govuk_collection_select :routing_answer, page.answer_settings.selection_options, :name, :name, label: { text: "is answered as" } %>

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -1,5 +1,5 @@
 <% set_page_title(t("page_titles.routing_page")) %>
-<% content_for :back_link, govuk_back_link_to(form_pages_path(form)) %>
+<% content_for :back_link, govuk_back_link_to(form_pages_path(form.id)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
@@ -11,7 +11,7 @@
       <%= t("routing_page.body_text") %>
     </p>
 
-    <%= form_with(model: form, url: set_routing_page_path(form), method: 'POST') do |f| %>
+    <%= form_with(model: form, url: set_routing_page_path(form.id), method: 'POST') do |f| %>
       <%= f.govuk_collection_radio_buttons :routing_page_id,
                                            form.qualifying_route_pages,
                                            :id, :question_text,

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -1,0 +1,27 @@
+<% set_page_title(t("page_titles.routing_page")) %>
+<% content_for :back_link, govuk_back_link_to(form_pages_path(form)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= form.name %> </span>
+      <%= t("page_titles.routing_page") %>
+    </h1>
+
+    <p class="govuk-body">
+      <%= t("routing_page.body_text") %>
+    </p>
+
+    <%= form_with(model: form, url: set_routing_page_path(form), method: 'POST') do |f| %>
+      <%= f.govuk_collection_radio_buttons :routing_page_id,
+                                           form.qualifying_route_pages,
+                                           :id, :question_text,
+                                           legend: {
+                                             text: t("routing_page.legend_text"),
+                                             size: 'm' },
+                                           hint:{
+                                             text: t("routing_page.legend_hint_text") }
+      %>
+      <%= f.govuk_submit t("continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -23,6 +23,9 @@
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), type_of_answer_new_path(@form), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
+      <% if policy(@form).can_add_page_routing_conditions? %>
+        <%= govuk_button_link_to "Add a question route", routing_page_path(@form), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
+      <% end %>
       <%= render PreviewLinkComponent::View.new(@pages, link_to_runner(Settings.forms_runner.url, @form.id, @form.form_slug)) %>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,7 +301,6 @@ en:
     legend: Do you want to mark this task as complete?
     'true': 'Yes'
   new_condition:
-    routing_page_change_html: Change <span class="govuk-visually-hidden">routing question</span>
     routing_page_text: If the question
   not_found:
     body: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,6 +344,7 @@ en:
     new_page_form: Edit question
     not_found: Page not found
     privacy_policy_form: Provide a link to privacy information for this form
+    routing_page: Add a question route
     service_unavailable: Sorry, the service is unavailable
     set_email_form: Set the email address for completed forms
     text_settings: How much text will people need to provide?
@@ -405,6 +406,10 @@ en:
       </p>
     heading: Provide a link to privacy information for this form
     submit_button: Save and continue
+  routing_page:
+    body_text: "You can send people directly to the question or page you want, based on their previous answer. \nThis means they’ll only see questions that are relevant to them.\n"
+    legend_hint_text: A route can only start from a question where people select one item from a list
+    legend_text: Which question do you want your route to start from?
   save_and_continue: Save and continue
   selections_settings:
     add_another: Add another option

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,9 @@ en:
     hint: Selecting ‘Yes’ will mark this task as complete. You’ll still be able to make changes if you need to.
     legend: Do you want to mark this task as complete?
     'true': 'Yes'
+  new_condition:
+    routing_page_change_html: Change <span class="govuk-visually-hidden">routing question</span>
+    routing_page_text: If the question
   not_found:
     body: |
       If you typed the web address, check it is correct.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,15 @@ Rails.application.routes.draw do
         post "/" => "pages#create", as: :create_page
       end
 
+      get "/new-condition" => "pages/conditions#routing_page", as: :routing_page
+      post "/new-condition" => "pages/conditions#set_routing_page", as: :set_routing_page
+
       scope "/:page_id" do
+        scope "/conditions" do
+          get "/new" => "pages/conditions#new", as: :new_condition
+          # post "/new" => "pages/conditions#create", as: :create_condition
+        end
+
         scope "/edit" do
           get "/type-of-answer" => "pages/type_of_answer#edit", as: :type_of_answer_edit
           post "/type-of-answer" => "pages/type_of_answer#update", as: :type_of_answer_update

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -105,4 +105,14 @@ describe Form do
       end
     end
   end
+
+  describe "#qualifying_route_pages" do
+    let(:non_select_from_list_pages) { build_list(:page, 2) }
+    let(:select_from_list_pages) { build_list(:page, 4, :with_selections_settings) }
+    let(:form) { build :form, name: "Form 1", org: "Test org", submission_email: "", pages: non_select_from_list_pages + select_from_list_pages }
+
+    it "returns a list of pages that can be used as routing pages" do
+      expect(form.qualifying_route_pages).to eq(select_from_list_pages)
+    end
+  end
 end

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -6,13 +6,35 @@ describe FormPolicy do
   let(:form) { build :form, org: "gds" }
   let(:user) { build :user, organisation_slug: "gds" }
 
-  context "with a form editor" do
-    it { is_expected.to permit_actions(%i[can_view_form]) }
+  describe "#can_view_form?" do
+    context "with a form editor" do
+      it { is_expected.to permit_actions(%i[can_view_form]) }
 
-    context "but from another organisation" do
-      let(:user) { build :user, organisation_slug: "non-gds" }
+      context "but from another organisation" do
+        let(:user) { build :user, organisation_slug: "non-gds" }
 
-      it { is_expected.to forbid_actions(%i[can_view_form]) }
+        it { is_expected.to forbid_actions(%i[can_view_form]) }
+      end
+    end
+  end
+
+  describe "#can_add_page_routing_conditions?" do
+    describe "with a form editor" do
+      it { is_expected.to forbid_actions(%i[can_add_page_routing_conditions]) }
+
+      context "when feature flag is enabled", feature_basic_routing: true do
+        it { is_expected.to permit_actions(%i[can_add_page_routing_conditions]) }
+      end
+    end
+
+    describe "with a super admin user" do
+      let(:user) { build :user, :with_super_admin, organisation_slug: "gds" }
+
+      it { is_expected.to permit_actions(%i[can_add_page_routing_conditions]) }
+
+      context "when feature flag is enabled", feature_basic_routing: true do
+        it { is_expected.to permit_actions(%i[can_add_page_routing_conditions]) }
+      end
     end
   end
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe Pages::ConditionsController, type: :request do
+  let(:form) { build :form, id: 1 }
+  let(:pages) { build_list :page, 5, :with_selections_settings, form_id: form.id }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  describe "#routing_page" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+
+      get routing_page_path(form_id: form.id)
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+
+    it "renders the routing page template" do
+      expect(response).to render_template("pages/conditions/routing_page")
+    end
+  end
+
+  describe "#set_routing_page" do
+    let(:selected_page) { pages.first }
+
+    before do
+      selected_page.id = 1
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/1", req_headers, selected_page.to_json, 200
+      end
+
+      post routing_page_path(form_id: 1, params: { form: { routing_page_id: 1 } })
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+
+    it "redirects the user to the new conditions page" do
+      expect(response).to redirect_to new_condition_path(form.id, selected_page.id)
+    end
+  end
+
+  describe "#new" do
+    let(:selected_page) { pages.first }
+
+    before do
+      selected_page.id = 1
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/1", req_headers, selected_page.to_json, 200
+      end
+
+      get new_condition_path(form_id: 1, page_id: 1)
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+
+    it "renders the new condition page template" do
+      expect(response).to render_template("pages/conditions/new")
+    end
+  end
+end

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -18,11 +18,19 @@ RSpec.describe Pages::ConditionsController, type: :request do
     }
   end
 
+  let(:expected_to_raise_error) { false }
+
   describe "#routing_page" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+
+      if expected_to_raise_error
+        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
+      else
+        allow(Pundit).to receive(:authorize).and_return(true)
       end
 
       get routing_page_path(form_id: form.id)
@@ -34,6 +42,18 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     it "renders the routing page template" do
       expect(response).to render_template("pages/conditions/routing_page")
+    end
+
+    context "when user should not be allowed to  add routes to pages" do
+      let(:expected_to_raise_error) { true }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
     end
   end
 
@@ -48,6 +68,12 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages/1", req_headers, selected_page.to_json, 200
       end
 
+      if expected_to_raise_error
+        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
+      else
+        allow(Pundit).to receive(:authorize).and_return(true)
+      end
+
       post routing_page_path(form_id: 1, params: { form: { routing_page_id: 1 } })
     end
 
@@ -57,6 +83,18 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     it "redirects the user to the new conditions page" do
       expect(response).to redirect_to new_condition_path(form.id, selected_page.id)
+    end
+
+    context "when user should not be allowed to  add routes to pages" do
+      let(:expected_to_raise_error) { true }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
     end
   end
 
@@ -71,6 +109,12 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages/1", req_headers, selected_page.to_json, 200
       end
 
+      if expected_to_raise_error
+        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
+      else
+        allow(Pundit).to receive(:authorize).and_return(true)
+      end
+
       get new_condition_path(form_id: 1, page_id: 1)
     end
 
@@ -80,6 +124,18 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     it "renders the new condition page template" do
       expect(response).to render_template("pages/conditions/new")
+    end
+
+    context "when user should not be allowed to  add routes to pages" do
+      let(:expected_to_raise_error) { true }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
     end
   end
 end

--- a/spec/views/pages/conditions/new.html.erb_spec.rb
+++ b/spec/views/pages/conditions/new.html.erb_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe "pages/conditions/new.html.erb" do
+  let(:form) { build :form, id: 1 }
+  let(:pages) { build_list :page, 3, :with_selections_settings, form_id: 1 }
+
+  before do
+    allow(view).to receive(:form_pages_path).and_return("/forms/1/pages")
+    allow(view).to receive(:routing_page_path).and_return("/forms/1/new-condition")
+    allow(view).to receive(:set_routing_page_path).and_return("/forms/1/new-condition")
+    allow(form).to receive(:qualifying_route_pages).and_return(pages)
+
+    render template: "pages/conditions/new", locals: { form:, page: pages.first }
+  end
+
+  it "contains page heading and sub-heading" do
+    expect(rendered).to have_css("h1 .govuk-caption-l", text: form.name)
+    expect(rendered).to have_css("h1.govuk-heading-l", text: t("page_titles.routing_page"))
+  end
+
+  it "has a submit button" do
+    expect(rendered).to have_css("button[type='submit'].govuk-button", text: I18n.t("save_and_continue"))
+  end
+end

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe "pages/conditions/routing_page.html.erb" do
+  let(:form) { build :form, id: 1 }
+  let(:pages) { build_list :page, 3, :with_selections_settings, form_id: 1 }
+
+  before do
+    allow(view).to receive(:form_pages_path).and_return("/forms/1/pages")
+    allow(view).to receive(:routing_page_path).and_return("/forms/1/new-condition")
+    allow(view).to receive(:set_routing_page_path).and_return("/forms/1/new-condition")
+    allow(form).to receive(:qualifying_route_pages).and_return(pages)
+
+    render template: "pages/conditions/routing_page", locals: { form: }
+  end
+
+  it "contains page heading and sub-heading" do
+    expect(rendered).to have_css("h1 .govuk-caption-l", text: form.name)
+    expect(rendered).to have_css("h1.govuk-heading-l", text: t("page_titles.routing_page"))
+  end
+
+  it "contains body text" do
+    expect(rendered).to have_css("p.govuk-body", text: t("routing_page.body_text"))
+  end
+
+  it "contains a fieldset legend asking a user to select a question page" do
+    expect(rendered).to have_css(".govuk-fieldset__legend", text: t("routing_page.legend_text"))
+    expect(rendered).to have_css("div.govuk-hint", text: t("routing_page.legend_hint_text"))
+  end
+
+  it "has a radio option for each routing pages" do
+    expect(rendered).to have_css(".govuk-radios__item", count: pages.length)
+  end
+
+  it "has a submit button" do
+    expect(rendered).to have_css("button[type='submit'].govuk-button", text: "Continue")
+  end
+end

--- a/spec/views/pages/index.html.erb_spec.rb
+++ b/spec/views/pages/index.html.erb_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe "pages/index.html.erb" do
+  let(:form) { build :form, id: 1, pages: }
+  let(:pages) { [] }
+  let(:add_routing) { false }
+
+  before do
+    # mock the path helper
+    without_partial_double_verification do
+      allow(view).to receive(:policy).and_return(OpenStruct.new(can_add_page_routing_conditions?: add_routing))
+    end
+
+    allow(view).to receive(:form_path).and_return("/forms/1")
+    allow(view).to receive(:type_of_answer_new_path).and_return("/forms/1/pages/new/type-of-answer")
+    allow(view).to receive(:edit_page_path).and_return("/forms/1/pages/2/edit")
+    allow(view).to receive(:form_pages_path).and_return("/forms/1/pages")
+    allow(view).to receive(:routing_page_path).and_return("/forms/1/new-condition")
+
+    assign(:form, form)
+    assign(:pages, pages)
+    render template: "pages/index"
+  end
+
+  describe "when there are no pages to display" do
+    it "allows the user to add a page" do
+      expect(rendered).to have_link(I18n.t("pages.index.add_question"), href: type_of_answer_create_path(form.id))
+    end
+
+    it "does not contain a link to add page routing" do
+      expect(rendered).not_to have_link("Add a question route", href: routing_page_path(form.id))
+    end
+
+    it "does not contain a list of pages" do
+      expect(rendered).not_to have_text I18n.t("forms.form_overview.your_questions")
+      expect(rendered).not_to have_css ".govuk-summary-list"
+    end
+  end
+
+  describe "when there are one or more page to display" do
+    let(:pages) { [(build :page, id: 1, form_id: 1), (build :page, id: 2, form_id: 1), (build :page, id: 3, form_id: 1)] }
+
+    it "allows the user to add a page" do
+      expect(rendered).to have_link(I18n.t("pages.index.add_question"), href: type_of_answer_create_path(form.id))
+    end
+
+    it "does contain a summary list entry each page" do
+      expect(rendered).to have_text I18n.t("forms.form_overview.your_questions")
+      expect(rendered).to have_css ".govuk-summary-list__row", count: 3
+    end
+  end
+
+  describe "when the user can add page routing condition" do
+    let(:add_routing) { true }
+
+    it "does not contain a link to add page routing" do
+      expect(rendered).not_to have_link("Add a question route", href: routing_page_path(form.id))
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?

- Adds two new views
  - `forms/{form id}/new-condition` - a user sees a list of questions that are select one from a list
  - `forms/forms id}/pages/{page id}/conditions/new` - a user can pick an answer and page to redirect to if the form filler selects that answer
- adds a new secondary button to the pages index page so users can add conditions
- adds a new form policy called `can_add_page_routing_conditions?` which is used to controll access to the pages and ui

Trello card: https://trello.com/c/gxgmZmXA/564-add-conditions-to-pages-in-admin

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
