### PR TITLE
Add condition form class and create action

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -10,12 +10,27 @@ class Pages::ConditionsController < PagesController
   end
 
   def new
-    render template: "pages/conditions/new", locals: { form: @form, page: }
+    condition_form = Pages::ConditionsForm.new(form: @form, page:)
+    render template: "pages/conditions/new", locals: { condition_form: }
+  end
+
+  def create
+    condition_form = Pages::ConditionsForm.new(condition_form_params)
+
+    if condition_form.submit
+      redirect_to form_pages_path(@form)
+    else
+      render template: "pages/conditions/new", locals: { condition_form: }, status: :unprocessable_entity
+    end
   end
 
 private
 
   def can_add_page_routing
     authorize @form, :can_add_page_routing_conditions?
+  end
+
+  def condition_form_params
+    params.require(:pages_conditions_form).permit(:answer_value, :goto_page_id).merge(form: @form, page:)
   end
 end

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -1,0 +1,31 @@
+class Pages::ConditionsForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :form, :page, :check_page_id, :routing_page_id, :answer_value, :goto_page_id
+
+  validates :answer_value, :goto_page_id, presence: true
+
+  def submit
+    return false if invalid?
+
+    Condition.create!(form_id: form.id,
+                      page_id: page.id,
+                      check_page_id: page.id,
+                      routing_page_id: page.id,
+                      answer_value:,
+                      goto_page_id:)
+  end
+
+  def routing_answer_options
+    options = page.answer_settings.selection_options
+    options << OpenStruct.new(name: I18n.t("page_options_service.selection_type.none_of_the_above")) if page.is_optional
+
+    [OpenStruct.new(name: nil), options].flatten
+  end
+
+  def goto_page_options
+    # TODO: add end of form/check your answers as an option
+    [OpenStruct.new(id: nil, question_text: nil), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }].flatten
+  end
+end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,0 +1,8 @@
+class Condition < ActiveResource::Base
+  self.site = Settings.forms_api.base_url
+  self.prefix = "/api/v1/forms/:form_id/pages/:page_id/"
+  self.include_format_in_path = false
+  headers["X-API-Token"] = Settings.forms_api.auth_key
+
+  belongs_to :page
+end

--- a/app/views/pages/conditions/new.html.erb
+++ b/app/views/pages/conditions/new.html.erb
@@ -1,25 +1,28 @@
-<% set_page_title(t("page_titles.routing_page")) %>
-<% content_for :back_link, govuk_back_link_to(routing_page_path(form)) %>
+<% set_page_title(title_with_error_prefix(t('page_titles.routing_page'), condition_form.errors&.any?)) %>
+<% content_for :back_link, govuk_back_link_to(routing_page_path(condition_form.form.id)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: condition_form, url: create_condition_path(condition_form.form.id), method: 'POST') do |f| %>
+      <% if condition_form&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
 
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= form.name %></span>
-      <%= t("page_titles.routing_page") %>
-    </h1>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= condition_form.form.name %></span>
+        <%= t("page_titles.routing_page") %>
+      </h1>
 
-    <%= govuk_summary_list do |summary_list|
-      summary_list.with_row do |row|
-        row.with_key { t("new_condition.routing_page_text") }
-        row.with_value { page.question_text }
-        row.with_action(text: "Change", href: routing_page_path(form), visually_hidden_text: "routing question")
-      end;
-    end %>
+      <%= govuk_summary_list do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { t("new_condition.routing_page_text") }
+          row.with_value { condition_form.page.question_text }
+          row.with_action(text: "Change", href: routing_page_path(condition_form.form.id), visually_hidden_text: "routing question")
+        end;
+      end %>
 
-    <%= form_with(model: nil, url: "#", method: 'POST') do |f| %>
-      <%= f.govuk_collection_select :routing_answer, page.answer_settings.selection_options, :name, :name, label: { text: "is answered as" } %>
-      <%= f.govuk_collection_select :goto_page_id, form.pages, :id, :question_text, label: { text: "take the person to" } %>
+      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :name, :name %>
+      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text %>
       <%= f.govuk_submit t("save_and_continue") %>
     <% end %>
   </div>

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -1,0 +1,15 @@
+en:
+  helpers:
+    label:
+      pages_conditions_form:
+        answer_value: is answered as
+        goto_page_id: take the person to
+  activemodel:
+    errors:
+      models:
+        pages/conditions_form:
+          attributes:
+            answer_value:
+              blank: Select an answer value
+            goto_page_id:
+              blank: Select a page to take the person to

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
       scope "/:page_id" do
         scope "/conditions" do
           get "/new" => "pages/conditions#new", as: :new_condition
-          # post "/new" => "pages/conditions#create", as: :create_condition
+          post "/new" => "pages/conditions#create", as: :create_condition
         end
 
         scope "/edit" do

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -21,7 +21,6 @@ FactoryBot.define do
     trait :new_form do
       submission_email { "" }
       privacy_policy_url { "" }
-      pages { [] }
     end
 
     trait :ready_for_live do

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -56,5 +56,15 @@ FactoryBot.define do
       support_url { Faker::Internet.url(host: "gov.uk") }
       support_url_text { Faker::Lorem.sentence(word_count: 1, random_words_to_add: 4) }
     end
+
+    trait :ready_for_routing do
+      transient do
+        pages_count { 5 }
+      end
+
+      pages do
+        Array.new(pages_count) { association(:page, :with_selections_settings) }
+      end
+    end
   end
 end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -10,6 +10,7 @@ end
 
 FactoryBot.define do
   factory :page, class: "Page" do
+    association :form
     question_text { Faker::Lorem.question }
     answer_type { Page::ANSWER_TYPES.reject { |item| Page::ANSWER_TYPES_WITH_SETTINGS.include? item }.sample }
     is_optional { nil }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -10,7 +10,7 @@ end
 
 FactoryBot.define do
   factory :page, class: "Page" do
-    association :form
+    id { Faker::Number.number(digits: 2) }
     question_text { Faker::Lorem.question }
     answer_type { Page::ANSWER_TYPES.reject { |item| Page::ANSWER_TYPES_WITH_SETTINGS.include? item }.sample }
     is_optional { nil }

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe Pages::ConditionsForm, type: :model do
+  let(:conditions_form) { described_class.new(form: page.form, page:) }
+  let(:form) { build :form, id: 1 }
+  let(:form_with_pages) { build :form, pages: }
+  let(:pages) { build_list :page, 5, :with_selections_settings, form: }
+  let(:page) { pages.second }
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  # before do
+  #   form
+  # end
+
+  describe "validations" do
+    it "is invalid if answer_value is nil" do
+      error_message = I18n.t("activemodel.errors.models.pages/conditions_form.attributes.answer_value.blank")
+      conditions_form.answer_value = nil
+      expect(conditions_form).to be_invalid
+      expect(conditions_form.errors.full_messages_for(:answer_value)).to include("Answer value #{error_message}")
+    end
+
+    it "is invalid if goto_page_id is nil" do
+      error_message = I18n.t("activemodel.errors.models.pages/conditions_form.attributes.goto_page_id.blank")
+      conditions_form.goto_page_id = nil
+      expect(conditions_form).to be_invalid
+      expect(conditions_form.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
+    end
+  end
+
+  describe "#submit" do
+    context "when validation pass" do
+      it "creates a condition" do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.post "/api/v1/forms/1/pages/2/conditions", post_headers, { id: 2 }.to_json, 200
+        end
+
+        page.id = 2
+        conditions_form.answer_value = "Rabbit"
+        conditions_form.goto_page_id = 4
+
+        expect(conditions_form.submit).to be_truthy
+      end
+    end
+
+    context "when validations fail" do
+      it "returns false" do
+        invalid_conditions_form = described_class.new
+        expect(invalid_conditions_form.submit).to be false
+      end
+    end
+  end
+
+  describe "#routing_answer_options" do
+    it "returns a list of answers for the given page" do
+      result = conditions_form.routing_answer_options.map(&:name)
+      expect(result).to eq([nil, "Option 1", "Option 2"])
+    end
+
+    context "when selection setting includes 'none of the above'" do
+      let(:page) { build :page, :with_selections_settings, is_optional: "true" }
+
+      it "adds extra 'None of above' options to the end" do
+        result = conditions_form.routing_answer_options.map(&:name)
+        expect(result).to eq([nil, "Option 1", "Option 2", I18n.t("page_options_service.selection_type.none_of_the_above")])
+      end
+    end
+  end
+
+  describe "#goto_page_options" do
+    it "returns a list of answers for the given page" do
+      result = described_class.new(form: form_with_pages, page: form_with_pages.pages.first).goto_page_options
+      expect(result).to eq([OpenStruct.new(id: nil, question_text: nil), form_with_pages.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }].flatten)
+    end
+  end
+end

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Pages::ConditionsForm, type: :model do
-  let(:conditions_form) { described_class.new(form: page.form, page:) }
-  let(:form) { build :form, id: 1 }
-  let(:form_with_pages) { build :form, pages: }
-  let(:pages) { build_list :page, 5, :with_selections_settings, form: }
+  let(:conditions_form) { described_class.new(form:, page:) }
+  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:pages) { form.pages }
   let(:page) { pages.second }
 
   let(:post_headers) do
@@ -75,8 +74,8 @@ RSpec.describe Pages::ConditionsForm, type: :model do
 
   describe "#goto_page_options" do
     it "returns a list of answers for the given page" do
-      result = described_class.new(form: form_with_pages, page: form_with_pages.pages.first).goto_page_options
-      expect(result).to eq([OpenStruct.new(id: nil, question_text: nil), form_with_pages.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }].flatten)
+      result = described_class.new(form:, page: pages.first).goto_page_options
+      expect(result).to eq([OpenStruct.new(id: nil, question_text: nil), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }].flatten)
     end
   end
 end

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       expect(response).to redirect_to new_condition_path(form.id, selected_page.id)
     end
 
-    context "when user should not be allowed to  add routes to pages" do
+    context "when user should not be allowed to add routes to pages" do
       let(:expected_to_raise_error) { true }
 
       it "Renders the forbidden page" do
@@ -126,7 +126,67 @@ RSpec.describe Pages::ConditionsController, type: :request do
       expect(response).to render_template("pages/conditions/new")
     end
 
-    context "when user should not be allowed to  add routes to pages" do
+    context "when user should not be allowed to add routes to pages" do
+      let(:expected_to_raise_error) { true }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:selected_page) { pages.first }
+    let(:submit_result) { true }
+
+    before do
+      selected_page.id = 1
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/1", req_headers, selected_page.to_json, 200
+      end
+
+      if expected_to_raise_error
+        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
+      else
+        allow(Pundit).to receive(:authorize).and_return(true)
+      end
+
+      conditional_form = Pages::ConditionsForm.new(form:, page: selected_page, answer_value: "Yes", goto_page_id: 3)
+
+      allow(conditional_form).to receive(:submit).and_return(submit_result)
+
+      allow(Pages::ConditionsForm).to receive(:new).and_return(conditional_form)
+
+      post create_condition_path(form_id: form.id, page_id: selected_page.id, params: { pages_conditions_form: { routing_page_id: 1, check_page_id: 1, goto_page_id: 3, answer_value: "Wales" } })
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+
+    it "redirects to the page list" do
+      expect(response).to redirect_to form_pages_path(form.id)
+    end
+
+    context "when form submit fails" do
+      let(:submit_result) { false }
+
+      it "return 422 error code" do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders new page" do
+        expect(response).to render_template("pages/conditions/new")
+      end
+    end
+
+    context "when user should not be allowed to add routes to pages" do
       let(:expected_to_raise_error) { true }
 
       it "Renders the forbidden page" do

--- a/spec/views/pages/conditions/new.html.erb_spec.rb
+++ b/spec/views/pages/conditions/new.html.erb_spec.rb
@@ -3,14 +3,16 @@ require "rails_helper"
 describe "pages/conditions/new.html.erb" do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 3, :with_selections_settings, form_id: 1 }
+  let(:condition_form) { Pages::ConditionsForm.new(form:, page: pages.first) }
 
   before do
     allow(view).to receive(:form_pages_path).and_return("/forms/1/pages")
     allow(view).to receive(:routing_page_path).and_return("/forms/1/new-condition")
     allow(view).to receive(:set_routing_page_path).and_return("/forms/1/new-condition")
+    allow(view).to receive(:create_condition_path).and_return("/forms/1/pages/1/conditions/new")
     allow(form).to receive(:qualifying_route_pages).and_return(pages)
 
-    render template: "pages/conditions/new", locals: { form:, page: pages.first }
+    render template: "pages/conditions/new", locals: { condition_form: }
   end
 
   it "contains page heading and sub-heading" do


### PR DESCRIPTION
#### What problem does the pull request solve?

- Adds a new `Pages::ConditionsForm` class for validations and custom functionality needed on the new conditions page
- Add new `create` post endpoint to create the actual condition record
- basic form validations on the new conditions pages
- adds default nil options to the answer_value and goto_page_id select list
- adds a "None of the above" option to answer_value if the page is optional

Trello card: https://trello.com/c/gxgmZmXA/564-add-conditions-to-pages-in-admin

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
