### PR TITLE
Fix missing org

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -8,6 +8,8 @@ class FormsController < ApplicationController
 
   def index
     @forms = policy_scope(Form) || []
+  rescue FormPolicy::UserMissingOrganisationError
+    render template: "errors/user_missing_organisation_error", status: :ok
   end
 
   def show

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -1,6 +1,8 @@
 class FormPolicy
   attr_reader :user, :form
 
+  class UserMissingOrganisationError < StandardError; end
+
   class Scope
     attr_reader :user, :form, :scope
 
@@ -10,6 +12,8 @@ class FormPolicy
     end
 
     def resolve
+      raise UserMissingOrganisationError, "Missing required attribute organisation_slug" if user.organisation_slug.blank?
+
       scope
         .where(org: user.organisation_slug)
     end

--- a/app/views/errors/user_missing_organisation_error.html.erb
+++ b/app/views/errors/user_missing_organisation_error.html.erb
@@ -1,0 +1,9 @@
+<% set_page_title(t("page_titles.user_missing_organisation")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('user_missing_organisation.title') %></h1>
+    <%= simple_format(t('user_missing_organisation.body'), class: 'govuk-body') %>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,6 +351,7 @@ en:
     set_email_form: Set the email address for completed forms
     text_settings: How much text will people need to provide?
     type_of_answer: What kind of answer do you need to this question?
+    user_missing_organisation: You have not been assigned an organisation
     what_happens_next_form: Form submitted page
     your_changes_are_live: Your changes are live
     your_form_is_live: Your form is live
@@ -471,6 +472,11 @@ en:
     completed: completed
     in_progress: in progress
     not_started: not started
+  user_missing_organisation:
+    body: 'You don’t have an organisation assigned to your account. Contact a GOV.UK Forms super admin to assign an organisation to your account. You will then be able to use GOV.UK Forms.
+
+      '
+    title: You have not been assigned an organisation
   users:
     cancel: Cancel
     edit:

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -63,5 +63,21 @@ describe FormPolicy do
         expect(ActiveResource::HttpMock.requests).to include forms_request
       end
     end
+
+    context "with a user with no organisation_slug" do
+      let(:user) { build :user, organisation_slug: nil }
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms?org=", headers, gds_forms.to_json, 200
+        end
+      end
+
+      it "throws an eception" do
+        expect { policy_scope.resolve }.to raise_error(FormPolicy::UserMissingOrganisationError)
+        forms_request = ActiveResource::Request.new(:get, "/api/v1/forms?org=", {}, headers)
+        expect(ActiveResource::HttpMock.requests).not_to include forms_request
+      end
+    end
   end
 end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -196,6 +196,10 @@ RSpec.describe "Forms", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
+      it "renders correct page" do
+        expect(response).to render_template("errors/user_missing_organisation_error")
+      end
+
       it "does not make a call to the API" do
         expect(ActiveResource::HttpMock.requests).to be_empty
       end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -167,16 +167,38 @@ RSpec.describe "Forms", type: :request do
        }]
     end
 
-    before do
+    it "Reads the forms from the API" do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms?org=test-org", headers, forms_response.to_json, 200
       end
       get root_path
-    end
 
-    it "Reads the forms from the API" do
       forms_request = ActiveResource::Request.new(:get, "/api/v1/forms?org=test-org", {}, headers)
       expect(ActiveResource::HttpMock.requests).to include forms_request
+    end
+
+    context "when the user does not hve a valid organisation set" do
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms?org=", headers, forms_response.to_json, 200
+        end
+
+        login_as build(:user, organisation_slug: nil)
+
+        get root_path
+      end
+
+      after do
+        GDS::SSO.test_user = nil
+      end
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not make a call to the API" do
+        expect(ActiveResource::HttpMock.requests).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
# Fix permissions for users without organisation set

When users who don't have an organisation_slug set in signon login, they are shown forms from across all organisations.

This happens because a get request is made to the API '/api/v1/forms?org='. The API [now returns all forms if org is not present](https://github.com/alphagov/forms-api/commit/766991cb)

The FormPolicy has been updated to check for users who are missing organisation_slug.

The following error is now shown:

<img width="992" alt="image" src="https://user-images.githubusercontent.com/11035856/233108297-4f17365f-dba2-4ea3-a83f-4eb0734be80b.png">

Trello card: https://trello.com/c/lhCMh9bG/717-bug-unhelpful-error-message-when-a-users-organisation-hasnt-been-set-in-govuk-signon

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
