### PR TITLE
Add errors to conditions in page list component

### DIFF
--- a/app/components/page_list_component/_index.scss
+++ b/app/components/page_list_component/_index.scss
@@ -9,5 +9,21 @@
 }
 
 .app-page-list__key {
-  width: 15%;
+  @include govuk-media-query($from: desktop) {
+    width: 20%;
+  }
+}
+
+.app-page-list__row--error {
+  border-left: 5px solid $govuk-error-colour;
+  padding-left: 10px;
+  @include govuk-media-query($from: tablet) {
+    padding-left: 0;
+  }
+}
+
+.app-page-list__row--error .app-page-list__key {
+  @include govuk-media-query($from: tablet) {
+    padding-left: 10px;
+  }
 }

--- a/app/components/page_list_component/_index.scss
+++ b/app/components/page_list_component/_index.scss
@@ -14,16 +14,13 @@
   }
 }
 
-.app-page-list__row--error {
-  border-left: 5px solid $govuk-error-colour;
-  padding-left: 10px;
+.govuk-form-group--error .app-page-list__key {
   @include govuk-media-query($from: tablet) {
-    padding-left: 0;
+    padding-left: govuk-spacing(3);
   }
 }
 
-.app-page-list__row--error .app-page-list__key {
-  @include govuk-media-query($from: tablet) {
-    padding-left: 10px;
-  }
+.app-page_list__route-text--error:link,
+.app-page_list__route-text--error:visited {
+  color: $govuk-error-colour;
 }

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -4,11 +4,10 @@
     <%= form_with url: move_page_url(@form_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <dl class="govuk-summary-list">
         <% @pages.each_with_index do |page, index| %>
-          <% page_index = index + 1 %>
           <div class="govuk-summary-list__row">
 
             <dt class="govuk-summary-list__key app-page-list__key">
-              <%= page_index %>
+              <%= page.position %>
             </dt>
 
             <dd class="govuk-summary-list__value">
@@ -19,15 +18,15 @@
 
               <div class="govuk-button-group form-action-group app-page-list__button-group">
                 <% if show_up_button(index) %>
-                  <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page_index), secondary: true, name: 'move_direction[up]', value: page.id %>
+                  <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page.position), secondary: true, name: 'move_direction[up]', value: page.id %>
                 <% end %>
                 <% if show_down_button(index)  %>
-                  <%= f.govuk_submit t("forms.form_overview.move_down_html", title: page_index), secondary: true, name: 'move_direction[down]', value: page.id %>
+                  <%= f.govuk_submit t("forms.form_overview.move_down_html", title: page.position), secondary: true, name: 'move_direction[down]', value: page.id %>
                 <% end %>
               </div>
 
               <%= govuk_link_to edit_page_path(@form_id, page.id) do %>
-                <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page_index %></span>
+                <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page.position %></span>
               <% end %>
 
             </dd>
@@ -37,7 +36,7 @@
             <% page.conditions.each do |condition| %>
               <div id="<%= error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "govuk-form-group--error": condition.has_errors?) %>">
                 <dt class="govuk-summary-list__key govuk-summary-list__key app-page-list__key">
-                  <%= t("page_conditions.condition_name", page_index:) %>
+                  <%= t("page_conditions.condition_name", page_index: page.position) %>
                 </dt>
 
                 <dd class="govuk-summary-list__value">
@@ -48,7 +47,7 @@
                     <%# List all errors, including for other fields %>
                     <ul class="govuk-list govuk-list--bullet">
                       <% condition.errors_with_fields.each do |error| %>
-                      <li><%= error_link(error_key: error[:name], edit_link:edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page_index:, field: error[:field]) %></li>
+                      <li><%= error_link(error_key: error[:name], edit_link:edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page:, field: error[:field]) %></li>
                       <% end %>
                     </ul>
                   <% else %>
@@ -63,14 +62,14 @@
                   <% end %>
                   <%= content_tag(
                     :p,
-                    goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page_index),
+                    goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page),
                     class: "govuk-!-margin-2"
                     ) unless condition.has_errors_for_field?(:answer_value) && condition.has_errors_for_field?(:goto_page_id) %>
                 </dd>
 
                 <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
                   <%= govuk_link_to edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id) do %>
-                    <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", page_index:)) %>
+                    <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", page_index: page.position)) %>
                   <% end %>
                 </dd>
               </div>

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -41,9 +41,31 @@
                 </dt>
 
                 <dd class="govuk-summary-list__value">
-                  <%= t("page_conditions.condition_check_page_text", check_page_text: question_text_for_page(condition.check_page_id)) %><br>
-                  <%= answer_value_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page_index) %><br>
-                  <%= goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page_index) %>
+                  <% if condition.has_errors_for_field?(:answer_value) %>
+                    <p class="govuk-!-margin-2">
+                      <%= t("page_conditions.condition_check_page_text_with_errors", check_page_text: question_text_for_page(condition.check_page_id)) %>
+                    </p>
+                    <%# List all errors, including for other fields %>
+                    <ul class="govuk-list govuk-list--bullet">
+                      <% condition.errors_with_fields.each do |error| %>
+                      <li><%= error_link(error_key: error[:name], edit_link:edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page_index:, field: error[:field]) %></li>
+                      <% end %>
+                    </ul>
+                  <% else %>
+                    <p class="govuk-!-margin-2">
+                      <%= t("page_conditions.condition_check_page_text", check_page_text: question_text_for_page(condition.check_page_id)) %>
+                    </p>
+                    <%= content_tag(
+                      :p,
+                      t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value),
+                      class: "govuk-!-margin-2"
+                      ) %>
+                  <% end %>
+                  <%= content_tag(
+                    :p,
+                    goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page_index),
+                    class: "govuk-!-margin-2"
+                    ) unless condition.has_errors_for_field?(:answer_value) && condition.has_errors_for_field?(:goto_page_id) %>
                 </dd>
 
                 <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -41,8 +41,8 @@
 
                 <dd class="govuk-summary-list__value">
                   <%= t("page_conditions.condition_check_page_text", check_page_text: question_text_for_page(condition.check_page_id)) %><br>
-                  <%= answer_value_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id)) %><br>
-                  <%= goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id)) %>
+                  <%= answer_value_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), index + 1) %><br>
+                  <%= goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), index + 1) %>
                 </dd>
 
                 <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -4,10 +4,11 @@
     <%= form_with url: move_page_url(@form_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <dl class="govuk-summary-list">
         <% @pages.each_with_index do |page, index| %>
+          <% page_index = index + 1 %>
           <div class="govuk-summary-list__row">
 
             <dt class="govuk-summary-list__key app-page-list__key">
-              <%= index + 1 %>
+              <%= page_index %>
             </dt>
 
             <dd class="govuk-summary-list__value">
@@ -18,15 +19,15 @@
 
               <div class="govuk-button-group form-action-group app-page-list__button-group">
                 <% if show_up_button(index) %>
-                  <%= f.govuk_submit t("forms.form_overview.move_up_html", title: index + 1), secondary: true, name: 'move_direction[up]', value: page.id %>
+                  <%= f.govuk_submit t("forms.form_overview.move_up_html", title: page_index), secondary: true, name: 'move_direction[up]', value: page.id %>
                 <% end %>
                 <% if show_down_button(index)  %>
-                  <%= f.govuk_submit t("forms.form_overview.move_down_html", title: index + 1), secondary: true, name: 'move_direction[down]', value: page.id %>
+                  <%= f.govuk_submit t("forms.form_overview.move_down_html", title: page_index), secondary: true, name: 'move_direction[down]', value: page.id %>
                 <% end %>
               </div>
 
               <%= govuk_link_to edit_page_path(@form_id, page.id) do %>
-                <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= index + 1 %></span>
+                <%= t("forms.form_overview.edit") %> <span class="govuk-visually-hidden"><%= page_index %></span>
               <% end %>
 
             </dd>
@@ -36,18 +37,18 @@
             <% page.conditions.each do |condition| %>
               <div id="<%= error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "govuk-form-group--error": condition.has_errors?) %>">
                 <dt class="govuk-summary-list__key govuk-summary-list__key app-page-list__key">
-                  <%= t("page_conditions.condition_name", page_index: index + 1) %>
+                  <%= t("page_conditions.condition_name", page_index:) %>
                 </dt>
 
                 <dd class="govuk-summary-list__value">
                   <%= t("page_conditions.condition_check_page_text", check_page_text: question_text_for_page(condition.check_page_id)) %><br>
-                  <%= answer_value_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), index + 1) %><br>
-                  <%= goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), index + 1) %>
+                  <%= answer_value_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page_index) %><br>
+                  <%= goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page_index) %>
                 </dd>
 
                 <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
                   <%= govuk_link_to edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id) do %>
-                    <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", page_index: index + 1)) %>
+                    <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", page_index:)) %>
                   <% end %>
                 </dd>
               </div>

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -33,18 +33,16 @@
           </div>
 
           <% if FeatureService.enabled?(:basic_routing) %>
-            <% page.routing_conditions.each do |condition| %>
-              <div id="<%= PageListComponent::Errors.new.error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "app-page-list__row--error": PageListComponent::Errors.new.has_errors(page)) %>">
+            <% page.conditions.each do |condition| %>
+              <div id="<%= error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "govuk-form-group--error": condition.has_errors?) %>">
                 <dt class="govuk-summary-list__key govuk-summary-list__key app-page-list__key">
                   <%= t("page_conditions.condition_name", page_index: index + 1) %>
                 </dt>
 
                 <dd class="govuk-summary-list__value">
-                  <%= t('page_conditions.condition_html',
-                    check_page_text: question_text_for_page(condition.check_page_id),
-                    answer_value: condition.answer_value,
-                    goto_page_text: question_text_for_page(condition.goto_page_id)
-                  ) %>
+                  <%= t("page_conditions.condition_check_page_text", check_page_text: question_text_for_page(condition.check_page_id)) %><br>
+                  <%= answer_value_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id)) %><br>
+                  <%= goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id)) %>
                 </dd>
 
                 <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -34,7 +34,7 @@
 
           <% if FeatureService.enabled?(:basic_routing) %>
             <% page.routing_conditions.each do |condition| %>
-              <div class="govuk-summary-list__row">
+              <div id="<%= PageListComponent::Errors.new.error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "app-page-list__row--error": PageListComponent::Errors.new.has_errors(page)) %>">
                 <dt class="govuk-summary-list__key govuk-summary-list__key app-page-list__key">
                   <%= t("page_conditions.condition_name", page_index: index + 1) %>
                 </dt>

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -19,5 +19,35 @@ module PageListComponent
     def question_text_for_page(id)
       @pages.find { |page| page.id == id }.question_text
     end
+
+    def error_id(number)
+      "condition_#{number}"
+    end
+
+    def error_link(error_name, edit_link)
+      content_tag(
+        :a,
+        I18n.t("page_conditions.errors.#{error_name}"),
+        class: "govuk-link app-page_list__route-text--error",
+        href: edit_link,
+      )
+    end
+
+    def answer_value_text_for_condition(condition, edit_link)
+      if condition.errors_include("answer_value_doesnt_exist")
+        error_link("answer_value_doesnt_exist", edit_link)
+      else
+        t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
+      end
+    end
+
+    def goto_page_text_for_condition(condition, edit_link)
+      if condition.errors_include("goto_page_doesnt_exist")
+        error_key = condition.errors_include("answer_value_doesnt_exist") ? "goto_page_doesnt_exist_and_nor_does_answer_value" : "goto_page_doesnt_exist"
+        error_link(error_key, edit_link)
+      else
+        t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
+      end
+    end
   end
 end

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -24,27 +24,27 @@ module PageListComponent
       "condition_#{number}"
     end
 
-    def error_link(error_name, edit_link)
+    def error_link(error_name, edit_link, page_index)
       content_tag(
         :a,
-        I18n.t("page_conditions.errors.#{error_name}"),
+        I18n.t("page_conditions.errors.#{error_name}", page_index:),
         class: "govuk-link app-page_list__route-text--error",
         href: edit_link,
       )
     end
 
-    def answer_value_text_for_condition(condition, edit_link)
+    def answer_value_text_for_condition(condition, edit_link, page_index)
       if condition.errors_include?("answer_value_doesnt_exist")
-        error_link("answer_value_doesnt_exist", edit_link)
+        error_link("answer_value_doesnt_exist", edit_link, page_index)
       else
         t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
       end
     end
 
-    def goto_page_text_for_condition(condition, edit_link)
+    def goto_page_text_for_condition(condition, edit_link, page_index)
       if condition.errors_include?("goto_page_doesnt_exist")
         error_key = condition.errors_include?("answer_value_doesnt_exist") ? "goto_page_doesnt_exist_and_nor_does_answer_value" : "goto_page_doesnt_exist"
-        error_link(error_key, edit_link)
+        error_link(error_key, edit_link, page_index)
       else
         t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
       end

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -33,14 +33,6 @@ module PageListComponent
       )
     end
 
-    def answer_value_text_for_condition(condition, edit_link, page_index)
-      if condition.errors_include?("answer_value_doesnt_exist")
-        error_link(error_key: "answer_value_doesnt_exist", edit_link:, page_index:, field: :answer_value)
-      else
-        t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
-      end
-    end
-
     def goto_page_text_for_condition(condition, edit_link, page_index)
       if condition.errors_include?("goto_page_doesnt_exist")
         error_link(error_key: "goto_page_doesnt_exist", edit_link:, page_index:, field: :goto_page_id)

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -37,7 +37,7 @@ module PageListComponent
       if condition.errors_include?("goto_page_doesnt_exist")
         error_link(error_key: "goto_page_doesnt_exist", edit_link:, page_index:, field: :goto_page_id)
       else
-        t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
+        I18n.t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
       end
     end
   end

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -24,18 +24,18 @@ module PageListComponent
       "condition_#{number}"
     end
 
-    def error_link(error_name, edit_link, page_index)
+    def error_link(error_key:, edit_link:, page_index:, field:)
       content_tag(
         :a,
-        I18n.t("page_conditions.errors.#{error_name}", page_index:),
+        I18n.t("page_conditions.errors.#{error_key}", page_index:),
         class: "govuk-link app-page_list__route-text--error",
-        href: edit_link,
+        href: "#{edit_link}##{Pages::ConditionsForm.new.id_for_field(field)}",
       )
     end
 
     def answer_value_text_for_condition(condition, edit_link, page_index)
       if condition.errors_include?("answer_value_doesnt_exist")
-        error_link("answer_value_doesnt_exist", edit_link, page_index)
+        error_link(error_key: "answer_value_doesnt_exist", edit_link:, page_index:, field: :answer_value)
       else
         t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
       end
@@ -44,7 +44,7 @@ module PageListComponent
     def goto_page_text_for_condition(condition, edit_link, page_index)
       if condition.errors_include?("goto_page_doesnt_exist")
         error_key = condition.errors_include?("answer_value_doesnt_exist") ? "goto_page_doesnt_exist_and_nor_does_answer_value" : "goto_page_doesnt_exist"
-        error_link(error_key, edit_link, page_index)
+        error_link(error_key:, edit_link:, page_index:, field: :goto_page_id)
       else
         t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
       end

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -24,18 +24,18 @@ module PageListComponent
       "condition_#{number}"
     end
 
-    def error_link(error_key:, edit_link:, page_index:, field:)
+    def error_link(error_key:, edit_link:, page:, field:)
       content_tag(
         :a,
-        I18n.t("page_conditions.errors.#{error_key}", page_index:),
+        I18n.t("page_conditions.errors.#{error_key}", page_index: page.position),
         class: "govuk-link app-page_list__route-text--error",
         href: "#{edit_link}##{Pages::ConditionsForm.new.id_for_field(field)}",
       )
     end
 
-    def goto_page_text_for_condition(condition, edit_link, page_index)
+    def goto_page_text_for_condition(condition, edit_link, page)
       if condition.errors_include?("goto_page_doesnt_exist")
-        error_link(error_key: "goto_page_doesnt_exist", edit_link:, page_index:, field: :goto_page_id)
+        error_link(error_key: "goto_page_doesnt_exist", edit_link:, page:, field: :goto_page_id)
       else
         I18n.t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
       end

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -43,8 +43,7 @@ module PageListComponent
 
     def goto_page_text_for_condition(condition, edit_link, page_index)
       if condition.errors_include?("goto_page_doesnt_exist")
-        error_key = condition.errors_include?("answer_value_doesnt_exist") ? "goto_page_doesnt_exist_and_nor_does_answer_value" : "goto_page_doesnt_exist"
-        error_link(error_key:, edit_link:, page_index:, field: :goto_page_id)
+        error_link(error_key: "goto_page_doesnt_exist", edit_link:, page_index:, field: :goto_page_id)
       else
         t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
       end

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -34,7 +34,7 @@ module PageListComponent
     end
 
     def answer_value_text_for_condition(condition, edit_link)
-      if condition.errors_include("answer_value_doesnt_exist")
+      if condition.errors_include?("answer_value_doesnt_exist")
         error_link("answer_value_doesnt_exist", edit_link)
       else
         t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
@@ -42,8 +42,8 @@ module PageListComponent
     end
 
     def goto_page_text_for_condition(condition, edit_link)
-      if condition.errors_include("goto_page_doesnt_exist")
-        error_key = condition.errors_include("answer_value_doesnt_exist") ? "goto_page_doesnt_exist_and_nor_does_answer_value" : "goto_page_doesnt_exist"
+      if condition.errors_include?("goto_page_doesnt_exist")
+        error_key = condition.errors_include?("answer_value_doesnt_exist") ? "goto_page_doesnt_exist_and_nor_does_answer_value" : "goto_page_doesnt_exist"
         error_link(error_key, edit_link)
       else
         t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -37,4 +37,8 @@ class Pages::ConditionsForm
     # TODO: add end of form/check your answers as an option
     [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }].flatten
   end
+
+  def id_for_field(field)
+    "condition_#{field}"
+  end
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -6,6 +6,15 @@ class Condition < ActiveResource::Base
 
   belongs_to :page
 
+  def errors_with_fields
+    error_fields = { "goto_page_doesnt_exist" => :goto_page_id, "answer_value_doesnt_exist" => :answer_value }
+    validation_errors.map { |error| { name: error.name, field: error_fields[error.name] } }
+  end
+
+  def has_errors_for_field?(field)
+    errors_with_fields.filter { |error| error[:field] == field }.any?
+  end
+
   def has_errors?
     validation_errors.any?
   end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -20,6 +20,6 @@ class Condition < ActiveResource::Base
   end
 
   def errors_include?(error_name)
-    has_errors? && validation_errors.map(&:name)&.include?(error_name)
+    has_errors? && validation_errors.map(&:name).include?(error_name)
   end
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -5,4 +5,13 @@ class Condition < ActiveResource::Base
   headers["X-API-Token"] = Settings.forms_api.auth_key
 
   belongs_to :page
+
+  def has_errors?
+    # TODO: remove defined check once custom errors are in API
+    defined?(validation_errors) && validation_errors.any?
+  end
+
+  def errors_include(error_name)
+    has_errors? && validation_errors.map(&:name)&.include?(error_name)
+  end
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -7,8 +7,7 @@ class Condition < ActiveResource::Base
   belongs_to :page
 
   def has_errors?
-    # TODO: remove defined check once custom errors are in API
-    defined?(validation_errors) && validation_errors.any?
+    validation_errors.any?
   end
 
   def errors_include(error_name)

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -10,7 +10,7 @@ class Condition < ActiveResource::Base
     validation_errors.any?
   end
 
-  def errors_include(error_name)
+  def errors_include?(error_name)
     has_errors? && validation_errors.map(&:name)&.include?(error_name)
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -46,6 +46,10 @@ class Page < ActiveResource::Base
     self
   end
 
+  def conditions
+    routing_conditions.map { |routing_condition| Condition.new(routing_condition.attributes) }
+  end
+
 private
 
   def is_optional_value

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(title_with_error_prefix(t('page_titles.routing_page'), condition_form.errors&.any?)) %>
+<% set_page_title(title_with_error_prefix(t('page_titles.routing_page_edit'), condition_form.errors&.any?)) %>
 <% content_for :back_link, govuk_back_link_to(form_pages_path(condition_form.form.id)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -20,8 +20,8 @@
         end;
       end %>
 
-      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label %>
-      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text %>
+      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label, id: condition_form.id_for_field(:answer_value), label: { for: condition_form.id_for_field(:answer_value) } %>
+      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text, id: condition_form.id_for_field(:goto_page_id), label: { for: condition_form.id_for_field(:goto_page_id) }  %>
       <%= f.govuk_submit t("save_and_continue") %>
     <% end %>
   </div>

--- a/app/views/pages/conditions/new.html.erb
+++ b/app/views/pages/conditions/new.html.erb
@@ -21,8 +21,8 @@
         end;
       end %>
 
-      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label %>
-      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text %>
+      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label, id: condition_form.id_for_field(:answer_value) %>
+      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text, id: condition_form.id_for_field(:goto_page_id) %>
       <%= f.govuk_submit t("save_and_continue") %>
     <% end %>
   </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -4,6 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%# TODO: add error summary %>
 
     <% if !FeatureService.enabled?(:draft_live_versioning) and @form.has_live_version %>
       <%= render LiveFormWarningComponent::View.new() %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,12 +316,15 @@ en:
       If you pasted the web address, check you copied the entire address.
     title: Page not found
   page_conditions:
+    condition_answer_value_text: is answered as “%{answer_value}”
+    condition_check_page_text: If the question “%{check_page_text}”
     condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to question %{goto_page_number}: “%{goto_page_text}”'
-    condition_html: |
-      If the question “%{check_page_text}”<br>
-      is answered as “%{answer_value}”<br>
-      take the person to “%{goto_page_text}”
+    condition_goto_page_text: take the person to “%{goto_page_text}”
     condition_name: Question %{page_index}'s route
+    errors:
+      answer_value_doesnt_exist: select the answer you want to base your route on
+      goto_page_doesnt_exist: select the question or page you want to take the person to, or delete this route
+      goto_page_doesnt_exist_and_nor_does_answer_value: and select the question or page you want to take the person to, or delete this route
     route: Route
   page_options_service:
     answer_type: Answer type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,7 +324,6 @@ en:
     errors:
       answer_value_doesnt_exist: select the answer you want to base question %{page_index}’s route on
       goto_page_doesnt_exist: select the question or page you want to take the person to, or delete question %{page_index}’s route
-      goto_page_doesnt_exist_and_nor_does_answer_value: and select the question or page you want to take the person to, or delete this route
     route: Route
   page_options_service:
     answer_type: Answer type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,7 +357,7 @@ en:
     not_found: Page not found
     privacy_policy_form: Provide a link to privacy information for this form
     routing_page: Add a question route
-    routing_page_edit: Edit question %{question_position}’s routes
+    routing_page_edit: Edit question %{question_position}’s route
     service_unavailable: Sorry, the service is unavailable
     set_email_form: Set the email address for completed forms
     text_settings: How much text will people need to provide?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,6 +318,7 @@ en:
   page_conditions:
     condition_answer_value_text: is answered as “%{answer_value}”
     condition_check_page_text: If the question “%{check_page_text}”
+    condition_check_page_text_with_errors: For the question “%{check_page_text}”
     condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to question %{goto_page_number}: “%{goto_page_text}”'
     condition_goto_page_text: take the person to “%{goto_page_text}”
     condition_name: Question %{page_index}’s route

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,10 +320,10 @@ en:
     condition_check_page_text: If the question “%{check_page_text}”
     condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to question %{goto_page_number}: “%{goto_page_text}”'
     condition_goto_page_text: take the person to “%{goto_page_text}”
-    condition_name: Question %{page_index}'s route
+    condition_name: Question %{page_index}’s route
     errors:
-      answer_value_doesnt_exist: select the answer you want to base your route on
-      goto_page_doesnt_exist: select the question or page you want to take the person to, or delete this route
+      answer_value_doesnt_exist: select the answer you want to base question %{page_index}’s route on
+      goto_page_doesnt_exist: select the question or page you want to take the person to, or delete question %{page_index}’s route
       goto_page_doesnt_exist_and_nor_does_answer_value: and select the question or page you want to take the person to, or delete this route
     route: Route
   page_options_service:

--- a/spec/components/page_list_component/page_list_component_preview.rb
+++ b/spec/components/page_list_component/page_list_component_preview.rb
@@ -23,9 +23,9 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
   def with_pages_and_multiple_conditions
     routing_conditions = [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3),
                           (build :condition, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England", goto_page_id: 2)]
-    pages = [OpenStruct.new(id: 1, question_text: "Enter your name", routing_conditions:),
-             OpenStruct.new(id: 2, question_text: "What is your pet's phone number?", routing_conditions:),
-             OpenStruct.new(id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    pages = [(build :page, id: 1, question_text: "Enter your name", routing_conditions:),
+             (build :page, id: 2, question_text: "What is your pet's phone number?", routing_conditions:),
+             (build :page, id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
     render(PageListComponent::View.new(pages:, form_id: 0))
   end
 
@@ -33,9 +33,9 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     routing_conditions = [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3),
                           (build :condition, :with_goto_page_missing, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England"),
                           (build :condition, :with_answer_value_and_goto_page_missing, id: 3, routing_page_id: 1, check_page_id: 1)]
-    pages = [(build :page, id: 1, question_text: "Enter your name", routing_conditions:),
-             (build :page, id: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
-             (build :page, id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions:),
+             (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
+             (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
     render(PageListComponent::View.new(pages:, form_id: 0))
   end
 end

--- a/spec/components/page_list_component/page_list_component_preview.rb
+++ b/spec/components/page_list_component/page_list_component_preview.rb
@@ -29,12 +29,13 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     render(PageListComponent::View.new(pages:, form_id: 0))
   end
 
-  def with_pages_and_error_conditions
-    routing_conditions = [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: nil, goto_page_id: nil),
-                          (build :condition, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England", goto_page_id: 2)]
-    pages = [OpenStruct.new(id: 1, question_text: "Enter your name", routing_conditions:),
-             OpenStruct.new(id: 2, question_text: "What is your pet's phone number?", routing_conditions:),
-             OpenStruct.new(id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+  def with_pages_and_conditions_with_errors
+    routing_conditions = [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3),
+                          (build :condition, :with_goto_page_missing, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England"),
+                          (build :condition, :with_answer_value_and_goto_page_missing, id: 3, routing_page_id: 1, check_page_id: 1)]
+    pages = [(build :page, id: 1, question_text: "Enter your name", routing_conditions:),
+             (build :page, id: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
+             (build :page, id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
     render(PageListComponent::View.new(pages:, form_id: 0))
   end
 end

--- a/spec/components/page_list_component/page_list_component_preview.rb
+++ b/spec/components/page_list_component/page_list_component_preview.rb
@@ -28,4 +28,13 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
              OpenStruct.new(id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
     render(PageListComponent::View.new(pages:, form_id: 0))
   end
+
+  def with_pages_and_error_conditions
+    routing_conditions = [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: nil, goto_page_id: nil),
+                          (build :condition, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England", goto_page_id: 2)]
+    pages = [OpenStruct.new(id: 1, question_text: "Enter your name", routing_conditions:),
+             OpenStruct.new(id: 2, question_text: "What is your pet's phone number?", routing_conditions:),
+             OpenStruct.new(id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    render(PageListComponent::View.new(pages:, form_id: 0))
+  end
 end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe PageListComponent::View, type: :component do
             condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist", page_index: 1)
             condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_text: pages[2].question_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
-            expect(page).to have_link(condition_answer_value_error, href: edit_condition_path)
+            expect(page).to have_link(condition_answer_value_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}")
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_goto_page_text)
           end
 
@@ -110,7 +110,7 @@ RSpec.describe PageListComponent::View, type: :component do
             condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist", page_index: 1)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_answer_value_text)
-            expect(page).to have_link(condition_goto_page_error, href: edit_condition_path)
+            expect(page).to have_link(condition_goto_page_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:goto_page_id)}")
           end
 
           it "renders link" do
@@ -126,8 +126,8 @@ RSpec.describe PageListComponent::View, type: :component do
             condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist", page_index: 1)
             condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist_and_nor_does_answer_value", page_index: 1)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
-            expect(page).to have_link(condition_answer_value_error, href: edit_condition_path)
-            expect(page).to have_link(condition_goto_page_error, href: edit_condition_path)
+            expect(page).to have_link(condition_answer_value_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}")
+            expect(page).to have_link(condition_goto_page_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:goto_page_id)}")
           end
 
           it "renders link" do
@@ -181,10 +181,10 @@ RSpec.describe PageListComponent::View, type: :component do
       let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
       let(:error_name) { condition.validation_errors[0].name }
       let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:error_link) { page_list_component.error_link(error_name, condition_edit_path, 1) }
+      let(:error_link) { page_list_component.error_link(error_key: error_name, edit_link: condition_edit_path, page_index: 1, field: :answer_value) }
 
       it "returns the corrrect error html for a given condition" do
-        expect(error_link).to eq "<a class=\"govuk-link app-page_list__route-text--error\" href=\"#{condition_edit_path}\">#{I18n.t("page_conditions.errors.#{error_name}", page_index: 1)}</a>"
+        expect(error_link).to eq "<a class=\"govuk-link app-page_list__route-text--error\" href=\"#{condition_edit_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}\">#{I18n.t("page_conditions.errors.#{error_name}", page_index: 1)}</a>"
       end
     end
 
@@ -204,7 +204,7 @@ RSpec.describe PageListComponent::View, type: :component do
         let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
 
         it "returns the error link" do
-          expect(answer_value_text).to eq page_list_component.error_link("answer_value_doesnt_exist", condition_edit_path, 1)
+          expect(answer_value_text).to eq page_list_component.error_link(error_key: "answer_value_doesnt_exist", edit_link: condition_edit_path, page_index: 1, field: :answer_value)
         end
       end
     end
@@ -225,14 +225,14 @@ RSpec.describe PageListComponent::View, type: :component do
         let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales") }
 
         it "returns the goto page error link" do
-          expect(goto_page_text).to eq page_list_component.error_link("goto_page_doesnt_exist", condition_edit_path, 1)
+          expect(goto_page_text).to eq page_list_component.error_link(error_key: "goto_page_doesnt_exist", edit_link: condition_edit_path, page_index: 1, field: :goto_page_id)
         end
 
         context "and the answer value is not present" do
           let(:condition) { (build :condition, :with_answer_value_and_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1) }
 
           it "returns the combined answer value and goto page error link" do
-            expect(goto_page_text).to eq page_list_component.error_link("goto_page_doesnt_exist_and_nor_does_answer_value", condition_edit_path, 1)
+            expect(goto_page_text).to eq page_list_component.error_link(error_key: "goto_page_doesnt_exist_and_nor_does_answer_value", edit_link: condition_edit_path, page_index: 1, field: :goto_page_id)
           end
         end
       end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PageListComponent::View, type: :component do
     end
 
     context "when the form has a single page" do
-      let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?")] }
+      let(:pages) { [(build :page, id: 1, question_text: "Enter your name?")] }
 
       it "renders the question number" do
         expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
@@ -38,7 +38,7 @@ RSpec.describe PageListComponent::View, type: :component do
     end
 
     context "when the form has multiple pages" do
-      let(:pages) { [OpenStruct.new(id: 1, question_text: "Enter your name?"), OpenStruct.new(id: 2, question_text: "What is you pet's name?")] }
+      let(:pages) { [(build :page, id: 1, question_text: "Enter your name?"), (build :page, id: 2, question_text: "What is you pet's name?")] }
 
       it "renders the question numbers" do
         expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
@@ -55,9 +55,9 @@ RSpec.describe PageListComponent::View, type: :component do
 
       context "when conditions are enabled", feature_basic_routing: true do
         let(:pages) do
-          [OpenStruct.new(id: 1, question_text: "What country do you live in?", routing_conditions:),
-           OpenStruct.new(id: 2, question_text: "What is your name?", routing_conditions:),
-           OpenStruct.new(id: 3, question_text: "What is your pet's name?", routing_conditions:)]
+          [(build :page, id: 1, question_text: "What country do you live in?", routing_conditions:),
+           (build :page, id: 2, question_text: "What is your name?", routing_conditions:),
+           (build :page, id: 3, question_text: "What is your pet's name?", routing_conditions:)]
         end
 
         context "when there are no conditions" do
@@ -70,23 +70,29 @@ RSpec.describe PageListComponent::View, type: :component do
           let(:routing_conditions) { [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3)] }
 
           it "renders the routing details" do
-            translation_text = I18n.t("page_conditions.condition_html", check_page_text: pages[0].question_text, answer_value: "Wales", goto_page_text: pages[2].question_text)
-            expect(page).to have_css("dd.govuk-summary-list__value", text: ActionController::Base.helpers.strip_tags(translation_text))
+            condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
+            condition_answer_value_text = I18n.t("page_conditions.condition_answer_value_text", answer_value: "Wales")
+            condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_text: pages[2].question_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_answer_value_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_goto_page_text)
           end
 
           it "renders link" do
             expect(page).to have_link("Edit")
           end
         end
+
+        # TODO: add tests for error cases
       end
     end
   end
 
   describe "class methods" do
     let(:pages) do
-      [OpenStruct.new(id: 1, question_text: "What country do you live in?", routing_conditions:),
-       OpenStruct.new(id: 2, question_text: "What is your name?", routing_conditions:),
-       OpenStruct.new(id: 3, question_text: "What is your pet's name?", routing_conditions:)]
+      [(build :page, id: 1, question_text: "What country do you live in?", routing_conditions:),
+       (build :page, id: 2, question_text: "What is your name?", routing_conditions:),
+       (build :page, id: 3, question_text: "What is your pet's name?", routing_conditions:)]
     end
 
     describe "show_up_button" do

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -70,11 +70,24 @@ RSpec.describe PageListComponent::View, type: :component do
         context "when the page has a single condition" do
           let(:routing_conditions) { [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3)] }
 
-          it "renders the routing details" do
+          it "renders the non-error text for the chack page" do
             condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
+          end
+
+          it "renders the answer_value text in a separate paragraph" do
+            condition_answer_value_text = I18n.t("page_conditions.condition_answer_value_text", answer_value: "Wales")
+            expect(page).to have_css("dd.govuk-summary-list__value > p", text: condition_answer_value_text)
+          end
+
+          it "renders the goto_page text in a separate paragraph" do
+            condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_text: pages[2].question_text)
+            expect(page).to have_css("dd.govuk-summary-list__value > p", text: condition_goto_page_text)
+          end
+
+          it "renders the routing details" do
             condition_answer_value_text = I18n.t("page_conditions.condition_answer_value_text", answer_value: "Wales")
             condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_text: pages[2].question_text)
-            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_answer_value_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_goto_page_text)
           end
@@ -87,13 +100,20 @@ RSpec.describe PageListComponent::View, type: :component do
         context "when the page has a condition with no answer_value" do
           let(:routing_conditions) { [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3)] }
 
-          it "renders the routing details" do
-            condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
+          it "renders the error-specific text for the check page" do
+            condition_check_page_text_with_errors = I18n.t("page_conditions.condition_check_page_text_with_errors", check_page_text: pages[0].question_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text_with_errors)
+          end
+
+          it "renders the answer_value error in an unordered list" do
             condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist", page_index: 1)
-            condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_text: pages[2].question_text)
-            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
+            expect(page).to have_css("ul > li > a", text: condition_answer_value_error)
             expect(page).to have_link(condition_answer_value_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}")
-            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_goto_page_text)
+          end
+
+          it "renders the goto_page text in a separate paragraph" do
+            condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_text: pages[2].question_text)
+            expect(page).to have_css("dd.govuk-summary-list__value > p", text: condition_goto_page_text)
           end
 
           it "renders link" do
@@ -104,13 +124,25 @@ RSpec.describe PageListComponent::View, type: :component do
         context "when the page has a condition with no goto_page set" do
           let(:routing_conditions) { [(build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales")] }
 
-          it "renders the routing details" do
+          it "renders the non-error text for the check page" do
             condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
-            condition_answer_value_text = I18n.t("page_conditions.condition_answer_value_text", answer_value: "Wales")
-            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist", page_index: 1)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
-            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_answer_value_text)
+          end
+
+          it "does not render the unordered error list" do
+            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist", page_index: 1)
+            expect(page).not_to have_css("ul > li > a", text: condition_goto_page_error)
+          end
+
+          it "renders the goto_page error in a separate paragraph" do
+            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist", page_index: 1)
+            expect(page).to have_css("dd.govuk-summary-list__value > p > a", text: condition_goto_page_error)
             expect(page).to have_link(condition_goto_page_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:goto_page_id)}")
+          end
+
+          it "renders the answer_value text in a separate paragraph" do
+            condition_answer_value_text = I18n.t("page_conditions.condition_answer_value_text", answer_value: "Wales")
+            expect(page).to have_css("dd.govuk-summary-list__value > p", text: condition_answer_value_text)
           end
 
           it "renders link" do
@@ -121,11 +153,16 @@ RSpec.describe PageListComponent::View, type: :component do
         context "when the page has a condition with no answer value or goto_page set" do
           let(:routing_conditions) { [(build :condition, :with_answer_value_and_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1)] }
 
-          it "renders the routing details" do
-            condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
+          it "renders the error-specific text for the check page" do
+            condition_check_page_text_with_errors = I18n.t("page_conditions.condition_check_page_text_with_errors", check_page_text: pages[0].question_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text_with_errors)
+          end
+
+          it "renders the errors in an unordered list" do
             condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist", page_index: 1)
             condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist", page_index: 1)
-            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
+            expect(page).to have_css("ul > li > a", text: condition_answer_value_error)
+            expect(page).to have_css("ul > li > a", text: condition_goto_page_error)
             expect(page).to have_link(condition_answer_value_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}")
             expect(page).to have_link(condition_goto_page_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:goto_page_id)}")
           end
@@ -185,27 +222,6 @@ RSpec.describe PageListComponent::View, type: :component do
 
       it "returns the corrrect error html for a given condition" do
         expect(error_link).to eq "<a class=\"govuk-link app-page_list__route-text--error\" href=\"#{condition_edit_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}\">#{I18n.t("page_conditions.errors.#{error_name}", page_index: 1)}</a>"
-      end
-    end
-
-    describe "answer_value_text_for_condition" do
-      let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:answer_value_text) { page_list_component.answer_value_text_for_condition(condition, condition_edit_path, 1) }
-
-      context "when the answer value is present" do
-        let(:condition) { (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3) }
-
-        it "returns the answer text" do
-          expect(answer_value_text).to eq I18n.t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
-        end
-      end
-
-      context "when the answer value is not present" do
-        let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
-
-        it "returns the error link" do
-          expect(answer_value_text).to eq page_list_component.error_link(error_key: "answer_value_doesnt_exist", edit_link: condition_edit_path, page_index: 1, field: :answer_value)
-        end
       end
     end
 

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe PageListComponent::View, type: :component do
           it "renders the routing details" do
             condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
             condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist", page_index: 1)
-            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist_and_nor_does_answer_value", page_index: 1)
+            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist", page_index: 1)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
             expect(page).to have_link(condition_answer_value_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}")
             expect(page).to have_link(condition_goto_page_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:goto_page_id)}")
@@ -226,14 +226,6 @@ RSpec.describe PageListComponent::View, type: :component do
 
         it "returns the goto page error link" do
           expect(goto_page_text).to eq page_list_component.error_link(error_key: "goto_page_doesnt_exist", edit_link: condition_edit_path, page_index: 1, field: :goto_page_id)
-        end
-
-        context "and the answer value is not present" do
-          let(:condition) { (build :condition, :with_answer_value_and_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1) }
-
-          it "returns the combined answer value and goto page error link" do
-            expect(goto_page_text).to eq page_list_component.error_link(error_key: "goto_page_doesnt_exist_and_nor_does_answer_value", edit_link: condition_edit_path, page_index: 1, field: :goto_page_id)
-          end
         end
       end
     end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PageListComponent::View, type: :component do
     end
 
     context "when the form has a single page" do
-      let(:pages) { [(build :page, id: 1, question_text: "Enter your name?")] }
+      let(:pages) { [(build :page, id: 1, position: 1, question_text: "Enter your name?")] }
 
       it "renders the question number" do
         expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
@@ -38,7 +38,7 @@ RSpec.describe PageListComponent::View, type: :component do
     end
 
     context "when the form has multiple pages" do
-      let(:pages) { [(build :page, id: 1, question_text: "Enter your name?"), (build :page, id: 2, question_text: "What is you pet's name?")] }
+      let(:pages) { [(build :page, id: 1, position: 1, question_text: "Enter your name?"), (build :page, id: 2, position: 2, question_text: "What is you pet's name?")] }
 
       it "renders the question numbers" do
         expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
@@ -55,9 +55,9 @@ RSpec.describe PageListComponent::View, type: :component do
 
       context "when conditions are enabled", feature_basic_routing: true do
         let(:pages) do
-          [(build :page, id: 1, question_text: "What country do you live in?", routing_conditions:),
-           (build :page, id: 2, question_text: "What is your name?", routing_conditions:),
-           (build :page, id: 3, question_text: "What is your pet's name?", routing_conditions:)]
+          [(build :page, id: 1, position: 1, question_text: "What country do you live in?", routing_conditions:),
+           (build :page, id: 2, position: 2, question_text: "What is your name?", routing_conditions:),
+           (build :page, id: 3, position: 3, question_text: "What is your pet's name?", routing_conditions:)]
         end
         let(:edit_condition_path) { "/forms/0/pages/1/conditions/1/edit" }
 
@@ -177,9 +177,9 @@ RSpec.describe PageListComponent::View, type: :component do
 
   describe "class methods" do
     let(:pages) do
-      [(build :page, id: 1, question_text: "What country do you live in?", routing_conditions:),
-       (build :page, id: 2, question_text: "What is your name?", routing_conditions:),
-       (build :page, id: 3, question_text: "What is your pet's name?", routing_conditions:)]
+      [(build :page, id: 1, position: 1, question_text: "What country do you live in?", routing_conditions:),
+       (build :page, id: 2, position: 2, question_text: "What is your name?", routing_conditions:),
+       (build :page, id: 3, position: 3, question_text: "What is your pet's name?", routing_conditions:)]
     end
 
     describe "show_up_button" do
@@ -218,7 +218,7 @@ RSpec.describe PageListComponent::View, type: :component do
       let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
       let(:error_name) { condition.validation_errors[0].name }
       let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:error_link) { page_list_component.error_link(error_key: error_name, edit_link: condition_edit_path, page_index: 1, field: :answer_value) }
+      let(:error_link) { page_list_component.error_link(error_key: error_name, edit_link: condition_edit_path, page: pages[0], field: :answer_value) }
 
       it "returns the corrrect error html for a given condition" do
         expect(error_link).to eq "<a class=\"govuk-link app-page_list__route-text--error\" href=\"#{condition_edit_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}\">#{I18n.t("page_conditions.errors.#{error_name}", page_index: 1)}</a>"
@@ -227,7 +227,7 @@ RSpec.describe PageListComponent::View, type: :component do
 
     describe "goto_page_text_for_condition" do
       let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:goto_page_text) { page_list_component.goto_page_text_for_condition(condition, condition_edit_path, 1) }
+      let(:goto_page_text) { page_list_component.goto_page_text_for_condition(condition, condition_edit_path, pages[0]) }
 
       context "when the goto page is set" do
         let(:condition) { (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3) }
@@ -241,7 +241,7 @@ RSpec.describe PageListComponent::View, type: :component do
         let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales") }
 
         it "returns the goto page error link" do
-          expect(goto_page_text).to eq page_list_component.error_link(error_key: "goto_page_doesnt_exist", edit_link: condition_edit_path, page_index: 1, field: :goto_page_id)
+          expect(goto_page_text).to eq page_list_component.error_link(error_key: "goto_page_doesnt_exist", edit_link: condition_edit_path, page: pages[0], field: :goto_page_id)
         end
       end
     end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe PageListComponent::View, type: :component do
            (build :page, id: 2, question_text: "What is your name?", routing_conditions:),
            (build :page, id: 3, question_text: "What is your pet's name?", routing_conditions:)]
         end
+        let(:edit_condition_path) { "/forms/0/pages/1/conditions/1/edit" }
 
         context "when there are no conditions" do
           it "conditions section is not present" do
@@ -83,7 +84,56 @@ RSpec.describe PageListComponent::View, type: :component do
           end
         end
 
-        # TODO: add tests for error cases
+        context "when the page has a condition with no answer_value" do
+          let(:routing_conditions) { [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3)] }
+
+          it "renders the routing details" do
+            condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
+            condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist")
+            condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_text: pages[2].question_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
+            expect(page).to have_link(condition_answer_value_error, href: edit_condition_path)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_goto_page_text)
+          end
+
+          it "renders link" do
+            expect(page).to have_link("Edit")
+          end
+        end
+
+        context "when the page has a condition with no goto_page set" do
+          let(:routing_conditions) { [(build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales")] }
+
+          it "renders the routing details" do
+            condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
+            condition_answer_value_text = I18n.t("page_conditions.condition_answer_value_text", answer_value: "Wales")
+            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist")
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_answer_value_text)
+            expect(page).to have_link(condition_goto_page_error, href: edit_condition_path)
+          end
+
+          it "renders link" do
+            expect(page).to have_link("Edit")
+          end
+        end
+
+        context "when the page has a condition with no answer value or goto_page set" do
+          let(:routing_conditions) { [(build :condition, :with_answer_value_and_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1)] }
+
+          it "renders the routing details" do
+            condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
+            condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist")
+            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist_and_nor_does_answer_value")
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
+            expect(page).to have_link(condition_answer_value_error, href: edit_condition_path)
+            expect(page).to have_link(condition_goto_page_error, href: edit_condition_path)
+          end
+
+          it "renders link" do
+            expect(page).to have_link("Edit")
+          end
+        end
       end
     end
   end
@@ -118,6 +168,73 @@ RSpec.describe PageListComponent::View, type: :component do
     describe "question_text_for_page" do
       it "returns the corrrect question text for a page in the form" do
         expect(page_list_component.question_text_for_page(1)).to eq pages[0].question_text
+      end
+    end
+
+    describe "error_id" do
+      it "returns the corrrect id text for a given condition number" do
+        expect(page_list_component.error_id(1)).to eq "condition_1"
+      end
+    end
+
+    describe "error_link" do
+      let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
+      let(:error_name) { condition.validation_errors[0].name }
+      let(:condition_edit_path) { "https://example.gov.uk" }
+      let(:error_link) { page_list_component.error_link(error_name, condition_edit_path) }
+
+      it "returns the corrrect error html for a given condition" do
+        expect(error_link).to eq "<a class=\"govuk-link app-page_list__route-text--error\" href=\"#{condition_edit_path}\">#{I18n.t("page_conditions.errors.#{error_name}")}</a>"
+      end
+    end
+
+    describe "answer_value_text_for_condition" do
+      let(:condition_edit_path) { "https://example.gov.uk" }
+      let(:answer_value_text) { page_list_component.answer_value_text_for_condition(condition, condition_edit_path) }
+
+      context "when the answer value is present" do
+        let(:condition) { (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3) }
+
+        it "returns the answer text" do
+          expect(answer_value_text).to eq I18n.t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
+        end
+      end
+
+      context "when the answer value is not present" do
+        let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
+
+        it "returns the error link" do
+          expect(answer_value_text).to eq page_list_component.error_link("answer_value_doesnt_exist", condition_edit_path)
+        end
+      end
+    end
+
+    describe "goto_page_text_for_condition" do
+      let(:condition_edit_path) { "https://example.gov.uk" }
+      let(:goto_page_text) { page_list_component.goto_page_text_for_condition(condition, condition_edit_path) }
+
+      context "when the goto page is set" do
+        let(:condition) { (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3) }
+
+        it "returns the goto page text" do
+          expect(goto_page_text).to eq I18n.t("page_conditions.condition_goto_page_text", goto_page_text: page_list_component.question_text_for_page(condition.goto_page_id))
+        end
+      end
+
+      context "when the goto page is not set" do
+        let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales") }
+
+        it "returns the goto page error link" do
+          expect(goto_page_text).to eq page_list_component.error_link("goto_page_doesnt_exist", condition_edit_path)
+        end
+
+        context "and the answer value is not present" do
+          let(:condition) { (build :condition, :with_answer_value_and_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1) }
+
+          it "returns the combined answer value and goto page error link" do
+            expect(goto_page_text).to eq page_list_component.error_link("goto_page_doesnt_exist_and_nor_does_answer_value", condition_edit_path)
+          end
+        end
       end
     end
   end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe PageListComponent::View, type: :component do
 
           it "renders the routing details" do
             condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
-            condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist")
+            condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist", page_index: 1)
             condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_text: pages[2].question_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
             expect(page).to have_link(condition_answer_value_error, href: edit_condition_path)
@@ -107,7 +107,7 @@ RSpec.describe PageListComponent::View, type: :component do
           it "renders the routing details" do
             condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
             condition_answer_value_text = I18n.t("page_conditions.condition_answer_value_text", answer_value: "Wales")
-            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist")
+            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist", page_index: 1)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_answer_value_text)
             expect(page).to have_link(condition_goto_page_error, href: edit_condition_path)
@@ -123,8 +123,8 @@ RSpec.describe PageListComponent::View, type: :component do
 
           it "renders the routing details" do
             condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
-            condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist")
-            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist_and_nor_does_answer_value")
+            condition_answer_value_error = I18n.t("page_conditions.errors.answer_value_doesnt_exist", page_index: 1)
+            condition_goto_page_error = I18n.t("page_conditions.errors.goto_page_doesnt_exist_and_nor_does_answer_value", page_index: 1)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
             expect(page).to have_link(condition_answer_value_error, href: edit_condition_path)
             expect(page).to have_link(condition_goto_page_error, href: edit_condition_path)
@@ -181,16 +181,16 @@ RSpec.describe PageListComponent::View, type: :component do
       let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
       let(:error_name) { condition.validation_errors[0].name }
       let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:error_link) { page_list_component.error_link(error_name, condition_edit_path) }
+      let(:error_link) { page_list_component.error_link(error_name, condition_edit_path, 1) }
 
       it "returns the corrrect error html for a given condition" do
-        expect(error_link).to eq "<a class=\"govuk-link app-page_list__route-text--error\" href=\"#{condition_edit_path}\">#{I18n.t("page_conditions.errors.#{error_name}")}</a>"
+        expect(error_link).to eq "<a class=\"govuk-link app-page_list__route-text--error\" href=\"#{condition_edit_path}\">#{I18n.t("page_conditions.errors.#{error_name}", page_index: 1)}</a>"
       end
     end
 
     describe "answer_value_text_for_condition" do
       let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:answer_value_text) { page_list_component.answer_value_text_for_condition(condition, condition_edit_path) }
+      let(:answer_value_text) { page_list_component.answer_value_text_for_condition(condition, condition_edit_path, 1) }
 
       context "when the answer value is present" do
         let(:condition) { (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3) }
@@ -204,14 +204,14 @@ RSpec.describe PageListComponent::View, type: :component do
         let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
 
         it "returns the error link" do
-          expect(answer_value_text).to eq page_list_component.error_link("answer_value_doesnt_exist", condition_edit_path)
+          expect(answer_value_text).to eq page_list_component.error_link("answer_value_doesnt_exist", condition_edit_path, 1)
         end
       end
     end
 
     describe "goto_page_text_for_condition" do
       let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:goto_page_text) { page_list_component.goto_page_text_for_condition(condition, condition_edit_path) }
+      let(:goto_page_text) { page_list_component.goto_page_text_for_condition(condition, condition_edit_path, 1) }
 
       context "when the goto page is set" do
         let(:condition) { (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3) }
@@ -225,14 +225,14 @@ RSpec.describe PageListComponent::View, type: :component do
         let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales") }
 
         it "returns the goto page error link" do
-          expect(goto_page_text).to eq page_list_component.error_link("goto_page_doesnt_exist", condition_edit_path)
+          expect(goto_page_text).to eq page_list_component.error_link("goto_page_doesnt_exist", condition_edit_path, 1)
         end
 
         context "and the answer value is not present" do
           let(:condition) { (build :condition, :with_answer_value_and_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1) }
 
           it "returns the combined answer value and goto page error link" do
-            expect(goto_page_text).to eq page_list_component.error_link("goto_page_doesnt_exist_and_nor_does_answer_value", condition_edit_path)
+            expect(goto_page_text).to eq page_list_component.error_link("goto_page_doesnt_exist_and_nor_does_answer_value", condition_edit_path, 1)
           end
         end
       end

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -1,8 +1,24 @@
 FactoryBot.define do
-  factory :condition, class: "OpenStruct" do
+  factory :condition, class: "Condition" do
     routing_page_id { nil }
     check_page_id { nil }
     answer_value { nil }
     goto_page_id { nil }
+    validation_errors { [] }
+
+    trait :with_answer_value_missing do
+      answer_value { nil }
+      validation_errors { [OpenStruct.new(name: "answer_value_doesnt_exist")] }
+    end
+
+    trait :with_goto_page_missing do
+      goto_page_id { nil }
+      validation_errors { [OpenStruct.new(name: "goto_page_doesnt_exist")] }
+    end
+
+    trait :with_answer_value_and_goto_page_missing do
+      goto_page_id { nil }
+      validation_errors { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist")] }
+    end
   end
 end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     answer_settings { nil }
     hint_text { nil }
     routing_conditions { [] }
+    position { 1 }
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda }

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -110,4 +110,11 @@ RSpec.describe Pages::ConditionsForm, type: :model do
       expect(result).to eq([OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }].flatten)
     end
   end
+
+  describe "#id_for_field" do
+    it "returns the correct id for a field" do
+      result = described_class.new(form:, page: pages.first).id_for_field(:answer_value)
+      expect(result).to eq("condition_answer_value")
+    end
+  end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -43,4 +43,24 @@ describe Condition do
       end
     end
   end
+
+  describe "#errors_with_fields" do
+    let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist")] }
+
+    it "returns the correct values for each error type" do
+      expect(condition.errors_with_fields).to eq [{ field: :answer_value, name: "answer_value_doesnt_exist" }, { field: :goto_page_id, name: "goto_page_doesnt_exist" }]
+    end
+  end
+
+  describe "#has_errors_for_field?" do
+    let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist")] }
+
+    it "returns true when the field has an error" do
+      expect(condition.has_errors_for_field?(:answer_value)).to be true
+    end
+
+    it "returns false when the field has no errors" do
+      expect(condition.has_errors_for_field?(:goto_page_id)).to be false
+    end
+  end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe Condition do
+  let(:validation_errors) { [] }
+  let(:condition) { described_class.new(id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3, validation_errors:) }
+
+  describe "#has_errors?" do
+    context "when condition has no errors" do
+      it "returns false" do
+        expect(condition.has_errors?).to be false
+      end
+    end
+
+    context "when condition has an error" do
+      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist")] }
+
+      it "returns true" do
+        expect(condition.has_errors?).to be true
+      end
+    end
+  end
+
+  describe "#errors_include?" do
+    context "when condition has no errors" do
+      it "returns false" do
+        expect(condition.errors_include?("answer_value_doesnt_exist")).to be false
+      end
+    end
+
+    context "when condition contains a different error" do
+      let(:validation_errors) { [OpenStruct.new(name: "goto_page_doesnt_exist")] }
+
+      it "returns false" do
+        expect(condition.errors_include?("answer_value_doesnt_exist")).to be false
+      end
+    end
+
+    context "when condition contains the relevant error" do
+      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist")] }
+
+      it "returns true" do
+        expect(condition.errors_include?("answer_value_doesnt_exist")).to be true
+      end
+    end
+  end
+end

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe FormsController, type: :request do
 
   describe "#mark_pages_section_completed" do
     let(:pages) do
-      build(:page, page_id: 99)
+      [build(:page, page_id: 99)]
     end
 
     let(:form) do

--- a/spec/views/pages/index.html.erb_spec.rb
+++ b/spec/views/pages/index.html.erb_spec.rb
@@ -38,7 +38,7 @@ describe "pages/index.html.erb" do
   end
 
   describe "when there are one or more page to display" do
-    let(:pages) { [(build :page, id: 1, form_id: 1), (build :page, id: 2, form_id: 1), (build :page, id: 3, form_id: 1)] }
+    let(:pages) { [(build :page, id: 1, position: 1, form_id: 1), (build :page, id: 2, position: 2, form_id: 1), (build :page, id: 3, position: 3, form_id: 1)] }
 
     it "allows the user to add a page" do
       expect(rendered).to have_link(I18n.t("pages.index.add_question"), href: type_of_answer_create_path(form.id))


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds error messages to the page list component, so that users can see which routes have errors at a glance.

Doesn't include the error summary or the errors on individual route pages.

Trello card: https://trello.com/c/aiXXPe86/674-error-display-in-admin-for-basic-routing

TODO:

- [x] link errors to specific fields
- [x] switch between 'For the question...' and 'If the question...' if answer value is in error
- [x] display errors in a UL if answer value is in error
- [x] remove logic for adding 'and' text

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
