### PR TITLE
Make the forbidden error message generic

### DIFF
--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('forbidden.title') %></h1>
-    <%= simple_format(t('forbidden.body_html', link: contact_link), class: 'govuk-body') %>
+    <%= simple_format(t('forbidden.body_html', link: contact_link(t('forbidden.link_text'))), class: 'govuk-body') %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,7 +70,11 @@ en:
     helpful_links: Helpful links
     privacy: Privacy
   forbidden:
-    body_html: You do not have permission to view this page as it does not belong to your organisation. %{link} if you think this is incorrect.
+    body_html: |
+      You do not have permission to view this page.
+
+      %{link} if you think this is incorrect.
+    link_text: Contact the GOV⁠.⁠UK Forms team
     title: You cannot view this page
   form_statuses:
     draft: DRAFT


### PR DESCRIPTION
The forbidden error message is shown whenever a pundit policy fails. For example, it's shown when a user tries to access a from from another organisation and when en Editor tries to access the /users page.

The current error message was written for the organisation case.

This commit updates the text so that the same page works for both.

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/11035856/234609555-368132de-9c82-44ab-a0de-c695f4a2cb4e.png">

#### What problem does the pull request solve?

Trello card: https://trello.com/c/zPSGHu5z/693-update-error-message-editor-user-would-see-if-they-tried-to-access-pages-that-relate-to-managing-users

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
