### PR TITLE
Add organisation table

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -6,10 +6,12 @@ class FormsController < ApplicationController
     render template: "errors/not_found", status: :not_found
   end
 
+  rescue_from FormPolicy::UserMissingOrganisationError do
+    render template: "errors/user_missing_organisation_error", status: :forbidden
+  end
+
   def index
     @forms = policy_scope(Form) || []
-  rescue FormPolicy::UserMissingOrganisationError
-    render template: "errors/user_missing_organisation_error", status: :forbidden
   end
 
   def show

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -9,7 +9,7 @@ class FormsController < ApplicationController
   def index
     @forms = policy_scope(Form) || []
   rescue FormPolicy::UserMissingOrganisationError
-    render template: "errors/user_missing_organisation_error", status: :ok
+    render template: "errors/user_missing_organisation_error", status: :forbidden
   end
 
   def show

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,2 @@
+class Organisation < ApplicationRecord
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,2 +1,3 @@
 class Organisation < ApplicationRecord
+  has_many :users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   include GDS::SSO::User
 
+  belongs_to :organisation, optional: true
+
   serialize :permissions, Array
 
   enum :role, {

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -7,19 +7,21 @@ class FormPolicy
     attr_reader :user, :form, :scope
 
     def initialize(user, scope)
+      raise UserMissingOrganisationError, "Missing required attribute organisation_slug" if user.organisation_slug.blank?
+
       @user = user
       @scope = scope
     end
 
     def resolve
-      raise UserMissingOrganisationError, "Missing required attribute organisation_slug" if user.organisation_slug.blank?
-
       scope
         .where(org: user.organisation_slug)
     end
   end
 
   def initialize(user, form)
+    raise UserMissingOrganisationError, "Missing required attribute organisation_slug" if user.organisation_slug.blank?
+
     @user = user
     @form = form
   end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -35,6 +35,7 @@ class FormPolicy
 private
 
   def users_organisation_owns_form
-    user.organisation_slug == form.org
+    organisation_slug = user.organisation&.slug || user.organisation_slug
+    organisation_slug == form.org
   end
 end

--- a/db/migrate/20230426150134_create_organisations.rb
+++ b/db/migrate/20230426150134_create_organisations.rb
@@ -1,0 +1,14 @@
+class CreateOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :organisations do |t|
+      t.string :content_id, null: false
+      t.string :slug, null: false
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :organisations, :content_id, unique: true
+    add_index :organisations, :slug, unique: true
+  end
+end

--- a/db/migrate/20230426150135_add_organisations_for_existing_users.rb
+++ b/db/migrate/20230426150135_add_organisations_for_existing_users.rb
@@ -1,0 +1,23 @@
+class AddOrganisationsForExistingUsers < ActiveRecord::Migration[7.0]
+  def up
+    Organisation.create!(content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9", slug: "government-digital-service", name: "Government Digital Service")
+
+    # For each user created by gds-sso create a record in organisation table,
+    # getting the data from the GOV.UK organisations API
+    User.where.not(organisation_content_id: nil).select(:organisation_content_id, :organisation_slug).distinct.each do |user|
+      next if Organisation.find_by(content_id: user.organisation_content_id)
+
+      organisation_json = JSON.parse(Net::HTTP.get(URI("https://www.gov.uk/api/organisations/#{user.organisation_slug}")))
+
+      Organisation.create!(
+        content_id: organisation_json["details"]["content_id"],
+        slug: organisation_json["details"]["slug"],
+        name: organisation_json["title"],
+      )
+    end
+  end
+
+  def down
+    Organisation.delete_all
+  end
+end

--- a/db/migrate/20230426150950_add_organisation_ref_to_users.rb
+++ b/db/migrate/20230426150950_add_organisation_ref_to_users.rb
@@ -1,0 +1,8 @@
+require "json"
+require "net/http"
+
+class AddOrganisationRefToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :users, :organisation, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20230426150951_update_organisation_ref_for_existing_users.rb
+++ b/db/migrate/20230426150951_update_organisation_ref_for_existing_users.rb
@@ -1,0 +1,12 @@
+require "json"
+require "net/http"
+
+class UpdateOrganisationRefForExistingUsers < ActiveRecord::Migration[7.0]
+  def up
+    # For each user created by gds-sso, link to a record in organisation table.
+    User.where.not(organisation_content_id: nil).find_each do |user|
+      organisation = Organisation.find_by(content_id: user.organisation_content_id)
+      user.update!(organisation_id: organisation.id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_04_075703) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_26_150135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_04_075703) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["form_id"], name: "index_form_submission_emails_on_form_id"
+  end
+
+  create_table "organisations", force: :cascade do |t|
+    t.string "content_id", null: false
+    t.string "slug", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_id"], name: "index_organisations_on_content_id", unique: true
+    t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_26_150135) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_26_150951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_26_150135) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "role", default: "editor"
+    t.bigint "organisation_id"
+    t.index ["organisation_id"], name: "index_users_on_organisation_id"
   end
 
+  add_foreign_key "users", "organisations"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,12 +9,13 @@
 require "factory_bot"
 
 if HostingEnvironment.local_development? && User.none?
-  Organisation.create!(content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9", slug: "government-digital-service", name: "Government Digital Service")
+  gds = Organisation.create!(content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9", slug: "government-digital-service", name: "Government Digital Service")
 
   # Create default super-admin
   User.create!({ email: "example@example.com",
                  organisation_slug: "government-digital-service",
                  organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+                 organisation: gds,
                  name: "A User",
                  role: :super_admin,
                  uid: "123456" })
@@ -29,4 +30,13 @@ if HostingEnvironment.local_development? && User.none?
 
   # create extra super admins
   FactoryBot.create_list :user, 3, :with_super_admin
+
+  # while we're using Signon it is possible to have users who aren't linked to
+  # the same organisation as in Signon, or who have an organisation that isn't
+  # in the organisation table
+  FactoryBot.create :user, :with_unknown_org, organisation_slug: test_org.slug, organisation_content_id: test_org.content_id
+  FactoryBot.create :user, :with_unknown_org
+
+  # create a user who hasn't been assigned to an organisation yet
+  FactoryBot.create :user, :with_no_org
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,12 +9,20 @@
 require "factory_bot"
 
 if HostingEnvironment.local_development? && User.none?
+  Organisation.create!(content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9", slug: "government-digital-service", name: "Government Digital Service")
+
   # Create default super-admin
   User.create!({ email: "example@example.com",
                  organisation_slug: "government-digital-service",
+                 organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
                  name: "A User",
                  role: :super_admin,
                  uid: "123456" })
+
+  # create extra organisations
+  test_org = FactoryBot.create :organisation, slug: "test-org"
+  FactoryBot.create :organisation, slug: "ministry-of-tests"
+  FactoryBot.create :organisation, slug: "department-for-testing"
 
   # create extra editors
   FactoryBot.create_list :user, 3, role: :editor

--- a/spec/factories/models/organisations.rb
+++ b/spec/factories/models/organisations.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :organisation do
+    content_id { Faker::Internet.uuid }
+    slug { "test-org" }
+    name { ActiveSupport::Inflector.titleize slug }
+
+    initialize_with do
+      Organisation.create_with(content_id:, name:).find_or_create_by(slug:)
+    end
+  end
+end

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -3,11 +3,32 @@ FactoryBot.define do
     email { Faker::Internet.email(domain: "example.gov.uk") }
     name { Faker::Name.name }
     uid { Faker::Internet.uuid }
-    organisation_slug { "test-org" }
     role { :editor }
 
     trait :with_super_admin do
       role { :super_admin }
+    end
+
+    organisation_slug { "test-org" }
+    organisation { association :organisation, slug: organisation_slug }
+
+    after(:build) do |user|
+      if user.organisation.present?
+        user.organisation_slug = user.organisation.slug
+        user.organisation_content_id = user.organisation.content_id
+      end
+    end
+
+    trait :with_unknown_org do
+      organisation { nil }
+      organisation_slug { "unknown-org" }
+      organisation_content_id { Faker::Internet.uuid }
+    end
+
+    trait :with_no_org do
+      organisation { nil }
+      organisation_slug { nil }
+      organisation_content_id { nil }
     end
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Organisation, type: :model do
+  it "is an error to create an organisation with an existing slug" do
+    organisation = create(:organisation, slug: "duplicate-org")
+
+    expect {
+      described_class.create!(content_id: Faker::Internet.uuid, slug: organisation.slug, name: organisation.name)
+    }.to raise_error ActiveRecord::RecordNotUnique
+  end
+
+  describe "factory" do
+    it "does not create organisation if already exists" do
+      existing_organisation = create(:organisation, slug: "duplicate-org")
+      new_organisation = nil
+
+      expect {
+        new_organisation = create(:organisation, slug: "duplicate-org")
+      }.not_to raise_error
+
+      expect(new_organisation).to eq(existing_organisation)
+    end
+  end
+end

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -15,6 +15,12 @@ describe FormPolicy do
 
         it { is_expected.to forbid_actions(%i[can_view_form]) }
       end
+
+      context "with an organisation not in the organisation table" do
+        let(:user) { build :user, :with_unknown_org, organisation_slug: "gds" }
+
+        it { is_expected.to permit_actions(%i[can_view_form]) }
+      end
     end
   end
 
@@ -64,8 +70,8 @@ describe FormPolicy do
       end
     end
 
-    context "with a user with no organisation_slug" do
-      let(:user) { build :user, organisation_slug: nil }
+    context "with a user with no organisation" do
+      let(:user) { build :user, :with_no_org }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -6,6 +6,14 @@ describe FormPolicy do
   let(:form) { build :form, org: "gds" }
   let(:user) { build :user, organisation_slug: "gds" }
 
+  context "with no organisation set" do
+    let(:user) { build :user, :with_no_org }
+
+    it "raises an error" do
+      expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+    end
+  end
+
   describe "#can_view_form?" do
     context "with a form editor" do
       it { is_expected.to permit_actions(%i[can_view_form]) }
@@ -56,6 +64,14 @@ describe FormPolicy do
 
     let(:gds_forms) { build_list :form, 2, org: "gds" }
 
+    context "with no organisation set" do
+      let(:user) { build :user, :with_no_org }
+
+      it "raises an error" do
+        expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+      end
+    end
+
     context "with a form editor" do
       before do
         ActiveResource::HttpMock.respond_to do |mock|
@@ -79,7 +95,7 @@ describe FormPolicy do
         end
       end
 
-      it "throws an eception" do
+      it "raises an error" do
         expect { policy_scope.resolve }.to raise_error(FormPolicy::UserMissingOrganisationError)
         forms_request = ActiveResource::Request.new(:get, "/api/v1/forms?org=", {}, headers)
         expect(ActiveResource::HttpMock.requests).not_to include forms_request

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe FormsController, type: :request do
           mock.get "/api/v1/forms?org=", headers, forms_response.to_json, 200
         end
 
-        login_as build(:user, organisation_slug: nil)
+        login_as build(:user, :with_no_org)
 
         get root_path
       end

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -188,8 +188,8 @@ RSpec.describe FormsController, type: :request do
         get root_path
       end
 
-      it "returns 200" do
-        expect(response).to have_http_status(:ok)
+      it "returns 403 Forbidden" do
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "renders correct page" do


### PR DESCRIPTION
#### What problem does the pull request solve?

To be able to update a user's organisation within our service we need a separate organisation table, because `gds-sso` gem will revert any changes to organisation whenever a user logs in [[1]].

This PR creates the `Organisation` model, which has many users, and populates it with organisations of current users.

We assume that we are going to be using the same list of organisations (managed by GOV.UK [[2]]) that Signon uses, so the organisation table has the `content_id` as well as `slug`, as the content ID is a stable UUID while the slug can occasionally change. We also keep the organisation name in the table, to make it nicer for superadmins when they are changing the organisation of a user (feature to come in a subsequent PR).

Note that in general this PR handles the minimum needed to handle our current users and organisations; we don't have a way of adding new organisations to the table. We also don't do anything about organisations in form objects, as I think some changes to the API will be needed for that first. Tickets to fill in some of the gaps are already in the backlog however, so this state of affairs shouldn't persist for too long.

Also note that after merging this PR, new users will not be able to use the service as they will get the "Your organisation is not set" error. Until #414 is merged we will not have a way to assign users to an organisation.

Trello card: https://trello.com/c/6qASsHQl

[1]: https://github.com/alphagov/gds-sso/blob/a9c2a018dbebd07c35682b1523a2ad27a41d1185/lib/gds-sso/user.rb#L22
[2]: https://www.api.gov.uk/gds/gov-uk-organisations/#gov-uk-organisations