### PR TITLE
Add organisation select to edit user form

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,9 +18,8 @@ class UsersController < ApplicationController
 
   def update
     authorize @current_user, :can_manage_user?
-    user.role = user_params[:role]
 
-    if user.save
+    if user.update(user_params)
       redirect_to users_path
     else
       render :edit, status: :unprocessable_entity
@@ -30,7 +29,7 @@ class UsersController < ApplicationController
 private
 
   def user_params
-    params.require(:user).permit(:role)
+    params.require(:user).permit(:role, :organisation_id)
   end
 
   def user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,5 @@ class User < ApplicationRecord
   }
 
   validates :role, presence: true
+  validates :organisation_id, presence: true, if: -> { organisation_id_was.present? }
 end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -7,7 +7,7 @@ class FormPolicy
     attr_reader :user, :form, :scope
 
     def initialize(user, scope)
-      raise UserMissingOrganisationError, "Missing required attribute organisation_slug" if user.organisation_slug.blank?
+      raise UserMissingOrganisationError, "Missing required attribute organisation_id" if user.organisation.blank?
 
       @user = user
       @scope = scope
@@ -15,12 +15,12 @@ class FormPolicy
 
     def resolve
       scope
-        .where(org: user.organisation_slug)
+        .where(org: user.organisation.slug)
     end
   end
 
   def initialize(user, form)
-    raise UserMissingOrganisationError, "Missing required attribute organisation_slug" if user.organisation_slug.blank?
+    raise UserMissingOrganisationError, "Missing required attribute organisation_id" if user.organisation.blank?
 
     @user = user
     @form = form
@@ -37,7 +37,6 @@ class FormPolicy
 private
 
   def users_organisation_owns_form
-    organisation_slug = user.organisation&.slug || user.organisation_slug
-    organisation_slug == form.org
+    user.organisation.slug == form.org
   end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -25,6 +25,11 @@
         end
 
         summary_list.with_row do |row|
+          row.with_key { t('users.index.table_headings.signon_organisation') }
+          row.with_value { @user.organisation_slug || t("users.index.organisation_blank") }
+        end
+
+        summary_list.with_row do |row|
           row.with_key { t('users.index.table_headings.organisation') }
           row.with_value { @user.organisation&.name || t("users.index.organisation_blank") }
         end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -40,7 +40,13 @@
         end
       end %>
 
-      <%= f.govuk_collection_radio_buttons :role, user_role_options, :value,:label, :description,
+      <%= f.govuk_collection_select :organisation_id, Organisation.order(:slug), :id, :name,
+        class: ['govuk-!-width-three-quarters'],
+        options: { prompt: t('users.edit.organisation_prompt') },
+        label: { text: t('users.edit.organisation'), size: 'm', tag: 'h2' },
+        hint: { text: t('users.edit.organisation_hint') } %>
+
+      <%= f.govuk_collection_radio_buttons :role, user_role_options, :value, :label, :description,
         legend: { text: t('users.edit.role'), size: 'm', tag: 'h2' } %>
 
       <%= f.govuk_submit t('users.save') do

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "491d5b53c0254f09b59ac8334571eea772e9b54c5ebb49202cd2b79392721999",
+      "fingerprint": "59b9bd9b49e055eac513d2b6dbbe8cfd9f446bb5a97c1744837ece6f1e4f7ad2",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/users_controller.rb",
-      "line": 35,
+      "line": 32,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:user).permit(:role)",
+      "code": "params.require(:user).permit(:role, :organisation_id)",
       "render_path": null,
       "location": {
         "type": "method",
@@ -24,6 +24,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-04-11 12:44:26 +0100",
+  "updated": "2023-05-10 10:36:19 +0100",
   "brakeman_version": "5.4.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,8 @@ en:
       models:
         user:
           attributes:
+            organisation_id:
+              blank: Select the user’s organisation
             role:
               blank: Select a role for the user
   address_settings:
@@ -494,6 +496,9 @@ en:
     cancel: Cancel
     edit:
       caption: User details
+      organisation: Organisation
+      organisation_hint: The user will only be able to see their organisation’s forms
+      organisation_prompt: Select an organisation
       role: Role
       title: Edit user
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -503,6 +503,7 @@ en:
         name: Name
         organisation: Organisation
         role: Role
+        signon_organisation: Signon organisation slug
       title: Users
       users_caption: All users
     roles:

--- a/spec/features/users/set_organisation_spec.rb
+++ b/spec/features/users/set_organisation_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+feature "Set or change a user's organisation", type: :feature do
+  let(:gds_forms) do
+    [build(:form, id: 1, org: "government-digital-service", name: "Test GDS Form")]
+  end
+
+  let(:test_org_forms) do
+    [build(:form, id: 2, org: "test-org", name: "Test Org Form")]
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  before do
+    Rails.application.load_seed
+
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?org=government-digital-service", req_headers, gds_forms.to_json, 200
+      mock.get "/api/v1/forms?org=test-org", req_headers, test_org_forms.to_json, 200
+    end
+
+    login_as_super_admin_user
+  end
+
+  scenario "Super admin can change a user's organisation" do
+    given_i_am_viewing_the_users_page
+    and_i_choose_a_user_to_edit
+    when_i_change_the_users_organisation
+    then_the_users_organisation_name_is_updated
+  end
+
+  scenario "Super admin can change their own organisation" do
+    given_i_am_a_super_admin_in_the_government_digital_service_organisation
+    when_i_change_my_organisation_to_test_org
+    then_i_cannot_see_the_government_digital_service_forms
+    but_i_can_see_the_test_org_forms
+  end
+
+private
+
+  def given_i_am_viewing_the_users_page
+    visit users_path
+  end
+
+  def and_i_choose_a_user_to_edit
+    edit_user_path_re = %r{/users/(?<id>\d+)/edit}
+    edit_user_link = page.find_all(:link, href: edit_user_path_re).sample
+    @user = User.find(edit_user_path_re.match(edit_user_link[:href])[:id])
+
+    edit_user_link.click
+    expect(page).to have_css "h1.govuk-heading-l", text: "Edit user"
+    expect(page).to have_text @user.name
+  end
+
+  def when_i_change_the_users_organisation
+    @old_organisation_name = @user.organisation&.name || I18n.t("users.index.organisation_blank")
+    @new_organisation_name = Organisation.pluck(:name).reject { |name| name == @old_organisation_name }.sample
+    select @new_organisation_name, from: "Organisation"
+    click_button "Save"
+  end
+
+  def then_the_users_organisation_name_is_updated
+    user_table_row = page.find(".govuk-table tr", text: @user.name)
+    expect(user_table_row).to have_text @new_organisation_name
+    expect(user_table_row).not_to have_text @old_organisation_name
+  end
+
+  def given_i_am_a_super_admin_in_the_government_digital_service_organisation
+    gds = Organisation.find_by(slug: "government-digital-service")
+    @user = User.find_by!(role: "super_admin", organisation: gds)
+    login_as @user
+
+    visit edit_user_path(@user.id)
+    expect(page).to have_text "Government Digital Service"
+
+    visit root_path
+    expect(page).to have_text "Test GDS Form"
+  end
+
+  def when_i_change_my_organisation_to_test_org
+    visit edit_user_path(@user.id)
+    select "Test Org", from: "Organisation"
+    click_button "Save"
+  end
+
+  def then_i_cannot_see_the_government_digital_service_forms
+    visit root_path
+    expect(page).not_to have_text "Test GDS Form"
+  end
+
+  def but_i_can_see_the_test_org_forms
+    visit root_path
+    expect(page).to have_text "Test Org Form"
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,4 +24,26 @@ describe User do
       expect(user.valid?).to be false
     end
   end
+
+  describe "organisation_id" do
+    it "is allowed to be nil" do
+      user.organisation_id = nil
+
+      expect(user.valid?).to be true
+    end
+  end
+
+  context "when updating organisation" do
+    it "is valid to leave organisation unset" do
+      user = create :user, :with_no_org
+      user.organisation_id = nil
+      expect(user.valid?).to be true
+    end
+
+    it "is not valid to unset organisation if it is already set" do
+      user = create :user, organisation_slug: "test-org"
+      user.organisation_id = nil
+      expect(user.valid?).to be false
+    end
+  end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe UsersController, type: :request do
   describe "#index" do
-    context "when user is a super_admin" do
+    context "when logged in as a super admin" do
       before do
         login_as_super_admin_user
         get users_path
@@ -18,7 +18,7 @@ RSpec.describe UsersController, type: :request do
       end
     end
 
-    context "when user is not a super_admin" do
+    context "when logged in without super admin role" do
       it "is forbidden" do
         login_as_editor_user
         get users_path
@@ -30,7 +30,7 @@ RSpec.describe UsersController, type: :request do
   describe "#edit" do
     let(:user) { create(:user) }
 
-    context "when user is a super_admin" do
+    context "when logged in as a super admin" do
       before do
         login_as_super_admin_user
         get edit_user_path(user)
@@ -45,7 +45,7 @@ RSpec.describe UsersController, type: :request do
       end
     end
 
-    context "when user is not a super_admin" do
+    context "when logged in without super admin role" do
       it "is forbidden" do
         login_as_editor_user
         get edit_user_path(user)
@@ -58,7 +58,7 @@ RSpec.describe UsersController, type: :request do
     let(:user) { create(:user) }
     let(:role) { :super_admin }
 
-    context "when user is a super_admin" do
+    context "when logged in as a super admin" do
       before do
         login_as_super_admin_user
       end
@@ -81,9 +81,33 @@ RSpec.describe UsersController, type: :request do
         expect(response.body).to include "Select a role for the user"
         expect(user.reload.role).not_to eq(nil)
       end
+
+      context "when user belongs to an organistion" do
+        it "does not update user if organisation is not chosen" do
+          put user_path(user), params: { user: { organisation_id: nil } }
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.body).to include "Select the user’s organisation"
+          expect(user.reload.organisation).not_to eq(nil)
+        end
+      end
+
+      [
+        ["with an unknown organisation", :with_unknown_org],
+        ["with no organisation set", :with_no_org],
+      ].each do |(title, trait)|
+        context "with a user #{title}" do
+          let(:user) { create(:user, trait) }
+
+          it "does not return error if organisation is not chosen" do
+            put user_path(user), params: { user: { organisation_id: nil } }
+            expect(response).to redirect_to(users_path)
+            expect(user.reload.organisation).to eq(nil)
+          end
+        end
+      end
     end
 
-    context "when user is not a super_admin" do
+    context "when logged in without super admin role" do
       it "is forbidden" do
         login_as_editor_user
         put user_path(user), params: { user: { role: "super_admin" } }

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -6,6 +6,10 @@ describe "users/edit.html.erb" do
   end
 
   before do
+    build :organisation, slug: "test-org"
+    build :organisation, slug: "ministry-of-testing"
+    build :organisation, slug: "department-for-tests"
+
     assign(:user, user)
     render template: "users/edit"
   end
@@ -40,9 +44,17 @@ describe "users/edit.html.erb" do
     end
   end
 
-  it "has form fields" do
-    expect(rendered).to have_checked_field("Editor")
-    expect(rendered).to have_unchecked_field("Super admin")
+  describe "form" do
+    it "has role fields" do
+      expect(rendered).to have_checked_field("Editor")
+      expect(rendered).to have_unchecked_field("Super admin")
+    end
+
+    it "has organisation fields" do
+      expect(rendered).to have_select(
+        "Organisation", selected: "Test Org", with_options: ["Department For Tests", "Ministry Of Testing", "Test Org"]
+      )
+    end
   end
 
   context "with a user with an unknown organisation" do
@@ -55,6 +67,10 @@ describe "users/edit.html.erb" do
     it "shows no organisation set" do
       expect(rendered).to have_text("No organisation set")
     end
+
+    it "prompts super admin to choose organisation" do
+      expect(rendered).to have_select("Organisation", with_options: ["Select an organisation"])
+    end
   end
 
   context "with a user with no organisation set" do
@@ -62,6 +78,10 @@ describe "users/edit.html.erb" do
 
     it "shows no organisation set" do
       expect(rendered).to have_text("No organisation set")
+    end
+
+    it "prompts super admin to choose organisation" do
+      expect(rendered).to have_select("Organisation", with_options: ["Select an organisation"])
     end
   end
 end

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -27,6 +27,10 @@ describe "users/edit.html.erb" do
       expect(summary_list).to have_text(user.email)
     end
 
+    it "contains organisation slug from GOV.UK Signon" do
+      expect(summary_list).to have_text(user.organisation_slug)
+    end
+
     it "contains organisation name" do
       expect(rendered).to have_text(user.organisation.name)
     end
@@ -43,6 +47,10 @@ describe "users/edit.html.erb" do
 
   context "with a user with an unknown organisation" do
     let(:user) { build(:user, :with_unknown_org, id: 1) }
+
+    it "shows the organisation slug" do
+      expect(rendered).to have_text("unknown-org")
+    end
 
     it "shows no organisation set" do
       expect(rendered).to have_text("No organisation set")


### PR DESCRIPTION
#### What problem does the pull request solve?

We want superadmins to be able to assign users to organisations. Change the `/users` page in forms-admin to add a [select](https://govuk-form-builder.netlify.app/form-elements/select/) dropdown to choose organisation for user.

Trello card: https://trello.com/c/6qASsHQl

#### Screenshots

![Screenshot of /users/:id/edit with the changes from this PR](https://user-images.githubusercontent.com/503614/236266402-665d03d8-6eac-42ab-9179-dc3a4291e41c.png)
