### PR TITLE
Add role to summary list on edit user page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,6 +23,11 @@
         row.with_key { t('users.index.table_headings.organisation') }
         row.with_value { @user.organisation_slug }
       end
+
+      summary_list.with_row do |row|
+        row.with_key { t('users.index.table_headings.role') }
+        row.with_value { t("users.roles.#{@user.role}.name") }
+      end
     end %>
 
     <%= form_with(model: @user) do |f| %>

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -30,6 +30,10 @@ describe "users/edit.html.erb" do
     it "contains org" do
       expect(summary_list).to have_text(user.organisation_slug)
     end
+
+    it "contains role" do
+      expect(summary_list).to have_text("Editor")
+    end
   end
 
   it "has form fields" do

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -14,16 +14,22 @@ describe "users/edit.html.erb" do
     expect(rendered).to have_css("h1.govuk-heading-l", text: /Edit user/)
   end
 
-  it "contains name" do
-    expect(rendered).to have_text(user.name)
-  end
+  describe "summary list" do
+    let(:summary_list) do
+      Capybara.string(rendered).find(".govuk-summary-list")
+    end
 
-  it "contains email" do
-    expect(rendered).to have_text(user.email)
-  end
+    it "contains name" do
+      expect(summary_list).to have_text(user.name)
+    end
 
-  it "contains org" do
-    expect(rendered).to have_text(user.organisation_slug)
+    it "contains email" do
+      expect(summary_list).to have_text(user.email)
+    end
+
+    it "contains org" do
+      expect(summary_list).to have_text(user.organisation_slug)
+    end
   end
 
   it "has form fields" do


### PR DESCRIPTION
Part of https://trello.com/c/6qASsHQl

To make the summary table consistent we're adding the role to the summary table, and keeping the organisation in the table when there is a form input for changing the user organisation.

See designs on Mural: https://app.mural.co/t/gaap0347/m/gaap0347/1680614423424/1147a31af301a59c17158cb623d11391a95cff62?wid=0-1683116546338

### Screenshot
![Screenshot of `/users/<id>/edit` with changes in this PR ](https://user-images.githubusercontent.com/503614/235966158-8031113f-00a3-492e-b9b1-31c05f8a448a.png)
