### PR TITLE
Refactor authentication feature helpers for specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ In order to use this:
 - uncomment out the exception triggers in [this file](config/initializers/sentry.rb)
 - Build the project and watch the errors come through on Sentry
 
+## Updating versions
+
+Use the [update_app_versions.sh script in forms-deploy](https://github.com/alphagov/forms-deploy/blob/main/support/update_app_versions.sh)
+
 ## Support
 
 Raise a Github issue if you need support.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,13 +67,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-  config.before(:example, type: :request) do |_example|
-    User.create!(email: "email@example.com", organisation_slug: "test-org")
-  end
-
-  config.before(:example, type: :feature) do |_example|
-    User.create!(email: "email@example.com", organisation_slug: "test-org")
-  end
 
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -188,10 +188,6 @@ RSpec.describe FormsController, type: :request do
         get root_path
       end
 
-      after do
-        GDS::SSO.test_user = nil
-      end
-
       it "returns 200" do
         expect(response).to have_http_status(:ok)
       end

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -3,6 +3,10 @@ module AuthenticationFeatureHelpers
     GDS::SSO.test_user = user
   end
 
+  def logout
+    GDS::SSO.test_user = nil
+  end
+
   def editor_user
     @editor_user ||= FactoryBot.build(:user)
   end
@@ -21,10 +25,12 @@ module AuthenticationFeatureHelpers
 end
 
 RSpec.configure do |config|
+  config.include AuthenticationFeatureHelpers, type: :feature
   config.include AuthenticationFeatureHelpers, type: :request
-  # TODO: This might be useful when we check for permissions in app, not in
-  # signon
-  #   config.before(:each, type: :request) do
-  #     login_as_editor_user
-  #   end
+  config.before(:example, type: :feature) do
+    login_as_editor_user
+  end
+  config.before(:example, type: :request) do
+    login_as_editor_user
+  end
 end


### PR DESCRIPTION
While working on https://trello.com/c/6qASsHQl I found some strange behaviour in a test I had written. It took me a while to figure out what was going on, partly because the code defining how users work in tests was located in several different places. This PR brings it all together, to hopefully make people's lives easier in future, and also to make it easier to stop relying on the gds-ssomock authentication strategy in future.