### PR TITLE
Fix seed attempting to create gds org again

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,8 @@
 require "factory_bot"
 
 if HostingEnvironment.local_development? && User.none?
-  gds = Organisation.create!(content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9", slug: "government-digital-service", name: "Government Digital Service")
+
+  gds = Organisation.find_or_create_by!(content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9", slug: "government-digital-service", name: "Government Digital Service")
 
   # Create default super-admin
   User.create!({ email: "example@example.com",


### PR DESCRIPTION
#### What problem does the pull request solve?
Error:
`ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_organisations_on_content_id" DETAIL:  Key (content_id)=(af07d5a5-df63-4ddc-9383-6a666845ebe9) already exists.`

How to replicate:
Drop, create, migrate your database and then run seed.

This migration https://github.com/alphagov/forms-admin/blob/main/db/migrate/20230426150135_add_organisations_for_existing_users.rb#L3 creates the organisation so when we try to seed the database it fails because it already exists.

Factorybot.create doesn't raise the same error for the other testing org creations because instead of just creating it sort of does as find_or_Create behind the scenes so it doesn't create unnecessary duplicate data.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
