### PR TITLE
Refactor edit user pages

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
     if user.save
       redirect_to users_path
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,6 @@ class User < ApplicationRecord
     super_admin: "super_admin",
     editor: "editor",
   }
+
+  validates :role, presence: true
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -21,7 +21,7 @@
 
       summary_list.with_row do |row|
         row.with_key { t('users.index.table_headings.organisation') }
-        row.with_value { @user.organisation_slug }
+        row.with_value { @user.organisation&.name || t("users.index.organisation_blank") }
       end
 
       summary_list.with_row do |row|

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -34,13 +34,13 @@
       <% if @user.errors.any? %>
         <%= f.govuk_error_summary %>
       <% end %>
-      <span class="govuk-caption-l"><%= @item_name %></span>
-      <%= f.govuk_collection_radio_buttons :role, user_role_options, :value,:label, :description,
-      legend: { text: "Role", size: 'm', tag: 'h2' } %>
 
-    <%= f.govuk_submit t('users.save') do
-      govuk_button_link_to t('users.cancel'), users_path, secondary: true
-    end %>
+      <%= f.govuk_collection_radio_buttons :role, user_role_options, :value,:label, :description,
+        legend: { text: t('users.edit.role'), size: 'm', tag: 'h2' } %>
+
+      <%= f.govuk_submit t('users.save') do
+        govuk_button_link_to t('users.cancel'), users_path, secondary: true
+      end %>
   <% end %>
 
   </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -21,7 +21,7 @@
             govuk_link_to(user.name, edit_user_path(user))
           end
           row.with_cell( text: user.email)
-          row.with_cell( text: user.organisation_slug)
+          row.with_cell( text: user.organisation&.name || t("users.index.organisation_blank"))
           row.with_cell( text: t("users.roles.#{user.role}.name"))
         end
       end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -126,6 +126,7 @@ ignore_unused:
 # - 'simple_form.{placeholders,hints,labels}.*'
 # - 'simple_form.{error_notification,required}.:'
 - 'activemodel.errors.*'
+- 'activerecord.errors.*'
 - 'helpers.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -488,6 +488,7 @@ en:
     cancel: Cancel
     edit:
       caption: User details
+      role: Role
       title: Edit user
     index:
       organisation_blank: No organisation set

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,6 +490,7 @@ en:
       caption: User details
       title: Edit user
     index:
+      organisation_blank: No organisation set
       table_headings:
         email: Email address
         name: Name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,11 +2,17 @@
 en:
   activemodel:
     errors:
+      page:
+        attributes:
+          question_text:
+            blank: Question text cannot be blank
+  activerecord:
+    errors:
       models:
-        page:
+        user:
           attributes:
-            question_text:
-              blank: Question text cannot be blank
+            role:
+              blank: Select a role for the user
   address_settings:
     hint: Select all that apply
   back_link:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,12 @@ require "gds-sso/lint/user_spec"
 require "rails_helper"
 
 describe User do
+  subject(:user) { described_class.new }
+
+  it "validates" do
+    expect(user.valid?).to be true
+  end
+
   describe "role enum" do
     it "returns a list of roles" do
       expect(described_class.roles.keys).to eq(%w[super_admin editor])
@@ -10,4 +16,12 @@ describe User do
   end
 
   it_behaves_like "a gds-sso user class"
+
+  describe "role" do
+    it "is invalid if blank" do
+      user.role = nil
+
+      expect(user.valid?).to be false
+    end
+  end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe UsersController, type: :request do
         put user_path(-1), params: { user: { role: } }
         expect(response).to have_http_status(:not_found)
       end
+
+      it "does not update user if role is invalid" do
+        put user_path(user), params: { user: { role: nil } }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include "Select a role for the user"
+        expect(user.reload.role).not_to eq(nil)
+      end
     end
 
     context "when user is not a super_admin" do

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -27,8 +27,8 @@ describe "users/edit.html.erb" do
       expect(summary_list).to have_text(user.email)
     end
 
-    it "contains org" do
-      expect(summary_list).to have_text(user.organisation_slug)
+    it "contains organisation name" do
+      expect(rendered).to have_text(user.organisation.name)
     end
 
     it "contains role" do
@@ -39,5 +39,21 @@ describe "users/edit.html.erb" do
   it "has form fields" do
     expect(rendered).to have_checked_field("Editor")
     expect(rendered).to have_unchecked_field("Super admin")
+  end
+
+  context "with a user with an unknown organisation" do
+    let(:user) { build(:user, :with_unknown_org, id: 1) }
+
+    it "shows no organisation set" do
+      expect(rendered).to have_text("No organisation set")
+    end
+  end
+
+  context "with a user with no organisation set" do
+    let(:user) { build(:user, :with_no_org, id: 1) }
+
+    it "shows no organisation set" do
+      expect(rendered).to have_text("No organisation set")
+    end
   end
 end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -23,11 +23,27 @@ describe "users/index.html.erb" do
     expect(rendered).to have_text(users.first.email)
   end
 
-  it "contains org" do
-    expect(rendered).to have_text(users.first.organisation_slug)
+  it "contains organisation name" do
+    expect(rendered).to have_text(users.first.organisation.name)
   end
 
   it "contains role" do
     expect(rendered).to have_text("Editor")
+  end
+
+  context "with a user with an unknown organisation" do
+    let(:users) { [build(:user, :with_unknown_org, id: 1)] }
+
+    it "shows no organisation set" do
+      expect(rendered).to have_text("No organisation set")
+    end
+  end
+
+  context "with a user with no organisation set" do
+    let(:users) { [build(:user, :with_no_org, id: 1)] }
+
+    it "shows no organisation set" do
+      expect(rendered).to have_text("No organisation set")
+    end
   end
 end


### PR DESCRIPTION
Part of https://trello.com/c/6qASsHQl

Adds validation of user role, cleans up a few things, and uses organisation name instead of slug for display.

<details>
<summary><h3>Screenshots</h3></summary>

#### List of users
![Screenshot of `/users`](https://github.com/alphagov/forms-admin/assets/503614/d2844ec3-68fa-4654-91e6-ba26323f8e83)

#### Edit user page
![Screenshot of `/user/:id/edit`](https://github.com/alphagov/forms-admin/assets/503614/a7a9d81c-26db-47aa-877e-97f473d7a6d7)

#### Error when user role is not set 
![Screenshot of `/user/:id/edit` with 'Select a role for the user' error](https://github.com/alphagov/forms-admin/assets/503614/e8358aed-3b78-4b19-9d82-068ac840548b)


</details>