### PR TITLE
Show user's organisation name in table caption on homepage

### DIFF
--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -11,7 +11,7 @@
 
 <% if @forms.any? %>
   <%= govuk_table do |table| %>
-    <%= table.with_caption(size: 'm', text: t("home.your_forms")) %>
+    <%= table.with_caption(size: 'm', text: t("home.form_table_caption", organisation_name: @current_user.organisation.name)) %>
 
     <%= table.with_head do |head|
        head.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,9 +260,9 @@ en:
     create_a_form: Create a form
     form_name_heading: Form name
     form_status_heading: Status
+    form_table_caption: "%{organisation_name} forms"
     main_heading: GOV.UK Forms
     preview: Preview this form in a new tab
-    your_forms: Your forms
   internal_server_error:
     body: Please try again later.
     title: Sorry, there is a problem with the service

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
 describe "forms/index.html.erb" do
+  let(:user) { build :user }
   let(:forms) { [] }
 
   before do
+    assign(:current_user, user)
     assign(:forms, forms)
     render template: "forms/index"
   end
@@ -14,7 +16,7 @@ describe "forms/index.html.erb" do
     end
 
     it "does not contain a a list of forms" do
-      expect(rendered).not_to have_text "Your forms"
+      expect(rendered).not_to have_table
     end
   end
 
@@ -32,8 +34,11 @@ describe "forms/index.html.erb" do
     end
 
     it "does contain a table listing the users forms and their status" do
-      expect(rendered).to have_css(".govuk-table__caption", text: "Your forms")
       expect(rendered).to have_css "tbody .govuk-table__row", count: 3
+    end
+
+    it "has a table caption with the name of the organisation that owns the forms" do
+      expect(rendered).to have_css(".govuk-table__caption", text: "#{user.organisation.name} forms")
     end
 
     it "displays links for each form" do
@@ -69,7 +74,6 @@ describe "forms/index.html.erb" do
       end
 
       it "does contain a table listing the users forms and their status" do
-        expect(rendered).to have_css(".govuk-table__caption", text: "Your forms")
         expect(rendered).to have_css "tbody .govuk-table__row", count: 2
       end
 

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -15,7 +15,6 @@ describe "forms/index.html.erb" do
 
     it "does not contain a a list of forms" do
       expect(rendered).not_to have_text "Your forms"
-      expect(rendered).not_to have_css ".govuk-summary-list"
     end
   end
 


### PR DESCRIPTION
Make it easier for users to see when their organisation has been changed by showing the name of the organisation in the table caption.

Trello card: https://trello.com/c/KaIq9kJN

### Screenshot

![Screenshot of forms-admin homepage](https://github.com/alphagov/forms-admin/assets/503614/39f59884-76fc-4f46-b137-8dc81b897103)
