### PR TITLE
Fix table caption in case where user does not have an organisation

### DIFF
--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -11,7 +11,7 @@
 
 <% if @forms.any? %>
   <%= govuk_table do |table| %>
-    <%= table.with_caption(size: 'm', text: t("home.form_table_caption", organisation_name: @current_user.organisation.name)) %>
+    <%= table.with_caption(size: 'm', text: @current_user.organisation ? t("home.form_table_caption", organisation_name: @current_user.organisation.name) : t("home.your_forms")) %>
 
     <%= table.with_head do |head|
        head.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,6 +263,7 @@ en:
     form_table_caption: "%{organisation_name} forms"
     main_heading: GOV.UK Forms
     preview: Preview this form in a new tab
+    your_forms: Your forms
   internal_server_error:
     body: Please try again later.
     title: Sorry, there is a problem with the service

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -66,6 +66,14 @@ describe "forms/index.html.erb" do
       ]
     end
 
+    context "with a user has no organisation" do
+      let(:user) { build :user, :with_no_org }
+
+      it "has a table caption without an organisation name" do
+        expect(rendered).to have_css(".govuk-table__caption", text: "Your forms")
+      end
+    end
+
     context "when a form is live renders link to 'live' form readonly view" do
       let(:forms) { [OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", has_live_version: false), OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2", status: "live", has_live_version: true)] }
 


### PR DESCRIPTION
Fixes PR #425, [alert #11127](https://governmentdigitalservice.pagerduty.com/incidents/Q2PZ1FGZZXTVFB), trello card https://trello.com/c/KaIq9kJN

We forgot to handle the case where the user does not have an organisation, this PR restores the original 'Your forms' caption in that situation.