### PR TITLE
Ensure error summary is above page heading on all pages

### DIFF
--- a/app/views/pages/name_settings.html.erb
+++ b/app/views/pages/name_settings.html.erb
@@ -3,11 +3,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><span class="govuk-caption-l"><%= "#{t("pages.question")} #{@form.page_number(@page)}" %></span>
-      <%= t("page_titles.name_settings") %>
-    </h1>
     <%= form_with model: [@form, @name_settings_form], url: @name_settings_path do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l"><span class="govuk-caption-l"><%= "#{t("pages.question")} #{@form.page_number(@page)}" %></span>
+        <%= t("page_titles.name_settings") %>
+      </h1>
+
       <%= f.govuk_collection_radio_buttons(
             :input_type,
             Forms::NameSettingsForm::INPUT_TYPES,

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -3,37 +3,37 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      <%= t("users.edit.title") %>
-    </h1>
-
-    <h2 class="govuk-heading-m"><%= t("users.edit.caption") %></h2>
-    <%= govuk_summary_list(actions: false) do |summary_list|
-      summary_list.with_row do |row|
-        row.with_key { t('users.index.table_headings.name') }
-        row.with_value { @user.name }
-      end
-
-      summary_list.with_row do |row|
-        row.with_key { t('users.index.table_headings.email') }
-        row.with_value { @user.email }
-      end
-
-      summary_list.with_row do |row|
-        row.with_key { t('users.index.table_headings.organisation') }
-        row.with_value { @user.organisation&.name || t("users.index.organisation_blank") }
-      end
-
-      summary_list.with_row do |row|
-        row.with_key { t('users.index.table_headings.role') }
-        row.with_value { t("users.roles.#{@user.role}.name") }
-      end
-    end %>
-
     <%= form_with(model: @user) do |f| %>
       <% if @user.errors.any? %>
         <%= f.govuk_error_summary %>
       <% end %>
+
+      <h1 class="govuk-heading-l">
+        <%= t("users.edit.title") %>
+      </h1>
+
+      <h2 class="govuk-heading-m"><%= t("users.edit.caption") %></h2>
+      <%= govuk_summary_list(actions: false) do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { t('users.index.table_headings.name') }
+          row.with_value { @user.name }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { t('users.index.table_headings.email') }
+          row.with_value { @user.email }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { t('users.index.table_headings.organisation') }
+          row.with_value { @user.organisation&.name || t("users.index.organisation_blank") }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { t('users.index.table_headings.role') }
+          row.with_value { t("users.roles.#{@user.role}.name") }
+        end
+      end %>
 
       <%= f.govuk_collection_radio_buttons :role, user_role_options, :value,:label, :description,
         legend: { text: t('users.edit.role'), size: 'm', tag: 'h2' } %>


### PR DESCRIPTION
We want to make sure that the error summary component is at the top of the `main` container, below any breadcrumbs/back link, but before the `h1` [[1]]. This commit fixes pages where this is not the case, where necessary moving the page heading (and other content) inside the form.

[1]: https://design-system.service.gov.uk/components/error-summary/#where-to-put-the-error-summary