### PR TITLE
Add errors to edit route page

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -29,6 +29,8 @@ class Pages::ConditionsController < PagesController
 
     condition_form = Pages::ConditionsForm.new(form: @form, page:, record: condition, answer_value: condition.answer_value, goto_page_id: condition.goto_page_id)
 
+    condition_form.check_errors_from_api
+
     render template: "pages/conditions/edit", locals: { condition_form: }
   end
 

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -41,4 +41,10 @@ class Pages::ConditionsForm
   def id_for_field(field)
     "condition_#{field}"
   end
+
+  def check_errors_from_api
+    record.errors_with_fields.each do |error|
+      errors.add(error[:field], error[:name].to_sym)
+    end
+  end
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -8,7 +8,9 @@ class Condition < ActiveResource::Base
 
   def errors_with_fields
     error_fields = { "goto_page_doesnt_exist" => :goto_page_id, "answer_value_doesnt_exist" => :answer_value }
-    validation_errors.map { |error| { name: error.name, field: error_fields[error.name] } }
+    validation_errors.map do |error|
+      { name: error.name, field: error_fields[error.name] || :answer_value }
+    end
   end
 
   def has_errors_for_field?(field)

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -11,8 +11,10 @@ en:
           attributes:
             answer_value:
               blank: Select the answer you want to base your route on
+              answer_value_doesnt_exist: Select the answer you want to base your route on, or delete this route
             goto_page_id:
               blank: Select the question or page you want to take the person to
+              goto_page_doesnt_exist: Select the question or page you want to take the person to, or delete this route
         pages/delete_condition_form:
           attributes:
             confirm_deletion:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
         scope "/conditions" do
           get "/new" => "pages/conditions#new", as: :new_condition
           post "/new" => "pages/conditions#create", as: :create_condition
-          get "/:condition_id/edit" => "pages/conditions#edit", as: :edit_condition
+          get "/:condition_id" => "pages/conditions#edit", as: :edit_condition
           put "/:condition_id" => "pages/conditions#update", as: :update_condition
           get "/:condition_id/delete" => "pages/conditions#delete", as: :delete_condition
           delete "/:condition_id/delete" => "pages/conditions#destroy", as: :destroy_condition

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe PageListComponent::View, type: :component do
            (build :page, id: 2, position: 2, question_text: "What is your name?", routing_conditions:),
            (build :page, id: 3, position: 3, question_text: "What is your pet's name?", routing_conditions:)]
         end
-        let(:edit_condition_path) { "/forms/0/pages/1/conditions/1/edit" }
+        let(:edit_condition_path) { "/forms/0/pages/1/conditions/1" }
 
         context "when there are no conditions" do
           it "conditions section is not present" do

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -117,4 +117,14 @@ RSpec.describe Pages::ConditionsForm, type: :model do
       expect(result).to eq("condition_answer_value")
     end
   end
+
+  describe "#check_errors_from_api" do
+    let(:condition) { build :condition, :with_answer_value_missing, id: 3, page_id: 2, routing_page_id: 1, answer_value: "England", check_page_id: 1, goto_page_id: 3 }
+
+    it "is invalid if there are API validation errors" do
+      error_message = I18n.t("activemodel.errors.models.pages/conditions_form.attributes.answer_value.answer_value_doesnt_exist")
+      conditions_form.check_errors_from_api
+      expect(conditions_form.errors.full_messages_for(:answer_value)).to include("Answer value #{error_message}")
+    end
+  end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -45,10 +45,20 @@ describe Condition do
   end
 
   describe "#errors_with_fields" do
-    let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist")] }
+    context "when the error is a known error" do
+      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist")] }
 
-    it "returns the correct values for each error type" do
-      expect(condition.errors_with_fields).to eq [{ field: :answer_value, name: "answer_value_doesnt_exist" }, { field: :goto_page_id, name: "goto_page_doesnt_exist" }]
+      it "returns the correct values for each error type" do
+        expect(condition.errors_with_fields).to eq [{ field: :answer_value, name: "answer_value_doesnt_exist" }, { field: :goto_page_id, name: "goto_page_doesnt_exist" }]
+      end
+    end
+
+    context "when the error is an unknown error" do
+      let(:validation_errors) { [OpenStruct.new(name: "some_unknown_error")] }
+
+      it "returns answer_value as a default" do
+        expect(condition.errors_with_fields).to eq [{ field: :answer_value, name: "some_unknown_error" }]
+      end
     end
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
- Fixes an issue where our edit and update pages had different routes
- adds a check to the edit route to pick up the errors from the API response
  - note that this only runs in the edit route - this is because if we put it in the update route it'll use old validation errors. The rest of our UI and validations _should_ prevent routes from being made invalid via update, so I don't think we need this check to run anywhere else.
  - Makes `errors_with_fields` return a default value, to stop the page breaking if the API returns an unknown error

Trello card: https://trello.com/c/aiXXPe86/674-error-display-in-admin-for-basic-routing

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
