### PR TITLE
Add rake and task for test and linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ To run linting with fixes you can use
 make lint-fix
 ```
 
+### Running tasks before pushing
+
+Before pushing code changes, it's a good idea to run the tests, use rubocop to format your code, and normalize the locales. We have a rake task for running all of these commands in parallel:
+
+```bash
+bin/rake run_code_quality_checks
+```
+
 ## Configuration and deployment
 
 The forms-admin app is containerised (see [Dockerfile](https://github.com/alphagov/forms-admin/blob/main/Dockerfile)) and can be deployed however you would normally deploy a containerised app.

--- a/lib/tasks/code_quality_checks.rake
+++ b/lib/tasks/code_quality_checks.rake
@@ -1,0 +1,17 @@
+desc "Lint with rubocop"
+task lint_rubocop: :environment do
+  sh "bundle exec rubocop -A"
+end
+
+desc "Test with rspec"
+task test_rspec: :environment do
+  sh "bundle exec rspec"
+end
+
+desc "Normalize locales"
+task normalize_locales: :environment do
+  sh "i18n-tasks normalize"
+end
+
+desc "Run code quality checks"
+multitask run_code_quality_checks: %i[lint_rubocop test_rspec normalize_locales]


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds rake tasks for linting, runnning tests and normalising locales, and a `run code_quality_checks` task to do them all in parallel. This should make it easier to run them all before committing / pushing your code. There's probably a case for running this task in a git hook but that's a task for another PR.

Trello card: none

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
  - [x] README.md
  - [n/a] Elsewhere (please link)
