### PR TITLE
Fix failing migration `UpdateOrganisationRefForExistingUsers`

### DIFF
--- a/db/migrate/20230511102334_update_organisation_ref_for_existing_users2.rb
+++ b/db/migrate/20230511102334_update_organisation_ref_for_existing_users2.rb
@@ -1,0 +1,18 @@
+class UpdateOrganisationRefForExistingUsers2 < ActiveRecord::Migration[7.0]
+  def up
+    # NOTE: Postgres specific SQL
+    execute <<-SQL
+      UPDATE users
+        SET organisation_id = organisations.id
+      FROM organisations
+          WHERE organisations.content_id = users.organisation_content_id;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE users
+        SET organisation_id = NULL;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_26_150951) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_102334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Trello card: https://trello.com/c/6qASsHQl

 ### Summary 

This commit adds a new migration intended to have the same effect as migration [20230426150951_update_organisation_ref_for_existing_users.rb](db/migrate/20230426150951_update_organisation_ref_for_existing_users.rb), introduced in pull request #408. That previous migration did not work as expected, due to an unexpected interaction with Active Record and another migration in the same PR, [20230426150134_create_organisations.rb](db/migrate/20230426150134_create_organisations.rb). This commit works around the issue by writing the migration in SQL, rather than relying on Active Record.

 ### Description of issue

The two migrations were in separate commits in the PR, 5baacbd and dd2d69b, as part of a series of four migrations. When these migrations were tested separately they worked as expected. However, after merging the PR and deploying the code the migrations were run together in one batch process, and this was what caused the problem to arise. I was able to later reproduce the behaviour locally by running `bin/rails db:migrate:redo STEP=4`, with dd2d69b checked out.

 #### Expected behaviour

The expected behaviour after running the migration `UpdateOrganisationRefForExistingUsers` is that each record in the users table with a value for `organisation_content_id` also has a value for the `organisation_id`, linking to the primary key of the organisation with the corresponding `content_id`.

 #### Actual behaviour

The behaviour observed when running the migration as a batch with `CreateOrganisations` was that the users with `organisation_content_id` set appeared to have been updated (the timestamp in `updated_at` is updated to the time when the migration is run), but the `organisation_id` is not changed from `NULL`.

 #### Explanation

By inspecting the SQL queries sent to the Postgres SQL server we found that the `UPDATE` commands never included `organisation_id` when the migrations were batched. From this we were able to deduce that the errant behaviour is caused by a quirk in our Active Record `User` model; if the table for the `Organisation` model does not exist at the time when the `belongs_to :organisation` line is run, then association is silently ignored and the attribute `organisation_id` is not added to the model.

It can be seen that the attribute is not added to the model by `belongs_to` by adding the line `puts User.attribute_names` to the up method for `UpdateOrganisationRefForExistingUsers`. When the migration is run alone with `bin/rails db:migrate:redo STEP=1`, the `User` class will include `organisation_id` in the list of attributes; when the migrations are batched together, it will not. However, it appears that the behaviour of `belongs_to` is not entirely negated, as an instance of the `User` model will have `organisation_id` in its own attributes. Although `organisation_id` will not be shown with `inspect`, the `attributes` method returns a hash which has `organisation_id` in it, and the instance responds to the setter `organisation_id=`.

This half-on/half-off state of the `organisation_id` attribute causes the behaviour of the `update!` method in the migration to be unexpected. We expect `update!` to raise an exception if asked to set an unknown attribute. However, in this scenario the instance object does respond to `organisation_id`, and so the `assign_attributes` step works normally; however, when it comes to the `save!` step, it seems that because the `User` class does not have `organisation_id` in its list of known attributes, it does not try to save its value.

 #### Workarounds

There does not appear to be a way to get the model class to update its list of attributes. Calling `reload` on an instance (for example as `User.first.reload`) has no effect, and there is no class method equivalent to the `reload` instance method that I have been able to find.

Because the issue only occurs when the `UpdateOrganisationRefForExistingUsers` migration is run in batch with the previous migration to create the organisations table, and the two migrations are in two different commits, careful releasing of the PR in two stages should result in the expected outcome; however, this does not work with the continuous deployment model we employ in our AWS release pipeline. Restrictions with our AWS setup also prevent us from easily sending a command to redo the migration there, which would otherwise be another workaround.

As AWS has already deployed the current migrations, we could simply include a new migration that reruns `UpdateOrganisationRefForExistingUsers`, and that would work; however, any developers who in the future rollback beyond the migrations in PR #401 for whatever reason will then need to be careful if they then wish to migrate forwards again, or their database will end up in the state where no users are associated with organisations.

Using an SQL statement to make the change sidesteps the issues with the behaviour of Active Record, and because we can include SQL in our migrations no special process is needed either for releasing to production or for developers migrating their local database back and forth.

 #### Prevention

Obviously, in an ideal world, more thorough testing of PR #408 would have caught this issue earlier, however the behaviour exhibited is somewhat surprising and it took a lot of headscratching to figure out what was going on, so I think it is worth saying a few words about possible lessons learned here.

The behaviour of Active Record associations makes sense when considering migrations mean that an association will in most circumstances be defined in the model before the tables exist; however that `save!` will silently fail to save attributes that can be assigned to the record seems like a bug to me, or at least something that should be documented. I was surprised to find that it did not appear to be a well known issue; however this may be because of the following point...

When trying to google for hints on what was going on, I found several blogs talking about how the rails migrate tool should not be used for 'data migrations' [[1], [2], [3], and others]. Some talked about issues with models getting out of date as a concern (although I did not find any mention of our particular issue), and suggested SQL as a solution to this. Others pointed to concerns about the time needed to make big changes to data, and suggested using manually run temporary rails tasks instead (as mentioned above this is currently difficult on our AWS setup). A third concern is based around a desire to have clear separation of concerns, and the proposed solution is to keep the schema and data migrations separate, and use a separate gem to run the data migrations after or with the schema migrations (it is not clear to me whether this would help with the issue we saw). It may be in future we will prefer to use one of these options instead of changing data in schema migrations.

[1]: https://thoughtbot.com/blog/data-migrations-in-rails
[2]: https://jtway.co/data-migrations-with-rails-6fa3d66f128f
[3]: https://alexey-shepelev.medium.com/data-migrations-in-ruby-on-rails-8ddf22f9c800