### PR TITLE
Update can_add_page_routing_conditions policy

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -16,7 +16,7 @@ class Form < ActiveResource::Base
   end
 
   def qualifying_route_pages
-    pages.filter { |p| p.answer_type == "selection" && p.answer_settings.only_one_option == "true" }
+    pages.filter { |p| p.answer_type == "selection" && p.answer_settings.only_one_option == "true" && p.position != pages.length && p.conditions.empty? }
   end
 
   def status

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -31,7 +31,10 @@ class FormPolicy
   end
 
   def can_add_page_routing_conditions?
-    FeatureService.enabled?(:basic_routing) || user.super_admin?
+    form_has_two_or_more_pages = form.pages.length >= 2
+    form_has_qualifying_pages = form.qualifying_route_pages.any?
+
+    FeatureService.enabled?(:basic_routing) && form_has_two_or_more_pages && form_has_qualifying_pages
   end
 
   def can_edit_page_routing_conditions?

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -25,7 +25,7 @@
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), type_of_answer_new_path(@form), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
       <% if policy(@form).can_add_page_routing_conditions? %>
-        <%= govuk_button_link_to "Add a question route", routing_page_path(@form), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
+        <%= govuk_button_link_to t("pages.index.add_a_question_route"), routing_page_path(@form), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
       <% end %>
       <%= render PreviewLinkComponent::View.new(@pages, link_to_runner(Settings.forms_runner.url, @form.id, @form.form_slug)) %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -397,6 +397,7 @@ en:
     go_to_your_questions: Go to your questions
     heading: Edit question
     index:
+      add_a_question_route: Add a question route
       add_question: Add a question
       mark_complete:
         legend: Have you finished editing your questions?

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -107,12 +107,26 @@ describe Form do
   end
 
   describe "#qualifying_route_pages" do
-    let(:non_select_from_list_pages) { build_list(:page, 2) }
-    let(:select_from_list_pages) { build_list(:page, 4, :with_selections_settings) }
-    let(:form) { build :form, name: "Form 1", org: "Test org", submission_email: "", pages: non_select_from_list_pages + select_from_list_pages }
+    let(:non_select_from_list_pages) do
+      (1..3).map do |index|
+        build :page, id: index, position: index
+      end
+    end
+    let(:selection_pages_with_routes) do
+      (4..5).map do |index|
+        build :page, :with_selections_settings, id: index, position: index, routing_conditions: [(build :condition, id: index, check_page_id: index, goto_page_id: index + 2)]
+      end
+    end
+    let(:selection_pages_without_routes) do
+      (6..9).map do |index|
+        build :page, :with_selections_settings, id: index, position: index, routing_conditions: []
+      end
+    end
+    let(:form) { build :form, name: "Form 1", org: "Test org", submission_email: "", pages: non_select_from_list_pages + selection_pages_with_routes + selection_pages_without_routes }
 
     it "returns a list of pages that can be used as routing pages" do
-      expect(form.qualifying_route_pages).to eq(select_from_list_pages)
+      selection_pages_with_routes_excluding_last_page = selection_pages_without_routes.take(selection_pages_without_routes.length - 1)
+      expect(form.qualifying_route_pages).to eq(selection_pages_with_routes_excluding_last_page)
     end
   end
 end

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -33,21 +33,49 @@ describe FormPolicy do
   end
 
   describe "#can_add_page_routing_conditions?" do
-    describe "with a form editor" do
-      it { is_expected.to forbid_actions(%i[can_add_page_routing_conditions]) }
+    let(:form) { build :form, pages:, org: "gds" }
+    let(:pages) { [] }
 
-      context "when feature flag is enabled", feature_basic_routing: true do
-        it { is_expected.to permit_actions(%i[can_add_page_routing_conditions]) }
-      end
+    describe "when basic_routing feature flag is not enabled", feature_basic_routing: false do
+      it { is_expected.to forbid_actions(%i[can_add_page_routing_conditions]) }
     end
 
-    describe "with a super admin user" do
-      let(:user) { build :user, :with_super_admin, organisation_slug: "gds" }
+    context "when basic_routing feature flag is enabled", feature_basic_routing: true do
+      context "and the form has one page" do
+        let(:pages) { [(build :page, position: 1, id: 1)] }
 
-      it { is_expected.to permit_actions(%i[can_add_page_routing_conditions]) }
+        it { is_expected.to forbid_actions(%i[can_add_page_routing_conditions]) }
+      end
 
-      context "when feature flag is enabled", feature_basic_routing: true do
-        it { is_expected.to permit_actions(%i[can_add_page_routing_conditions]) }
+      context "and the form has two or more pages" do
+        let(:pages) { [(build :page, position: 1, id: 1), (build :page, position: 2, id: 2)] }
+
+        context "and the form does not have a selection question" do
+          it { is_expected.to forbid_actions(%i[can_add_page_routing_conditions]) }
+        end
+
+        context "and the form only has a selection question with an existing route" do
+          let(:routing_conditions) { [(build :condition, id: 1, check_page_id: 1, answer_value: "Wales", goto_pageid: 2)] }
+          let(:pages) { [(build :page, :with_selections_settings, position: 1, id: 1, routing_conditions:), (build :page, position: 2, id: 2)] }
+
+          it { is_expected.to forbid_actions(%i[can_add_page_routing_conditions]) }
+        end
+
+        context "and the form has a selection question without an existing route" do
+          context "and the available selection question is the last page in the form" do
+            let(:routing_conditions) { [(build :condition, id: 1, check_page_id: 1, answer_value: "Wales", goto_pageid: 2)] }
+            let(:pages) { [(build :page, :with_selections_settings, position: 1, id: 1, routing_conditions:), (build :page, position: 2, id: 2), (build :page, :with_selections_settings, position: 3, id: 3)] }
+
+            it { is_expected.to forbid_actions(%i[can_add_page_routing_conditions]) }
+          end
+
+          context "and the available selection question is not the last page in the form" do
+            let(:routing_conditions) { [(build :condition, id: 1, check_page_id: 1, answer_value: "Wales", goto_pageid: 2)] }
+            let(:pages) { [(build :page, :with_selections_settings, position: 1, id: 1, routing_conditions:), (build :page, :with_selections_settings, position: 2, id: 2), (build :page, position: 3, id: 3)] }
+
+            it { is_expected.to permit_actions(%i[can_add_page_routing_conditions]) }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### What problem does the pull request solve?
Updates the qualifying_route_pages form method so that a form will only allow new routes to be added to pages which meet all of these conditions:
- are 'select from a list' questions with only one answer allowed (i.e. radio questions)
- aren't the last page in the form
- don't already have routes attached to them.

We also update the `can_add_page_routing_conditions?` form policy so that it:
- no longer includes the super admin check (so routing will only be visible on environments with the feature flag enabled)
- checks that there are qualifying route pages available.

Note: should probably wait for #435 to be merged and rebase before merging this one. 

Trello card: https://trello.com/c/Ga9bXJ8S/765-modify-the-logic-for-when-the-add-a-route-button-is-displayed

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
