### PR TITLE
Restore "Require users to have organisation_id set to use GOV.UK Forms"

### DIFF
--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -7,7 +7,7 @@ class FormPolicy
     attr_reader :user, :form, :scope
 
     def initialize(user, scope)
-      raise UserMissingOrganisationError, "Missing required attribute organisation_slug" if user.organisation_slug.blank?
+      raise UserMissingOrganisationError, "Missing required attribute organisation_id" if user.organisation.blank?
 
       @user = user
       @scope = scope
@@ -15,12 +15,12 @@ class FormPolicy
 
     def resolve
       scope
-        .where(org: user.organisation&.slug || user.organisation_slug)
+        .where(org: user.organisation.slug)
     end
   end
 
   def initialize(user, form)
-    raise UserMissingOrganisationError, "Missing required attribute organisation_slug" if user.organisation_slug.blank?
+    raise UserMissingOrganisationError, "Missing required attribute organisation_id" if user.organisation.blank?
 
     @user = user
     @form = form
@@ -46,7 +46,6 @@ class FormPolicy
 private
 
   def users_organisation_owns_form
-    organisation_slug = user.organisation&.slug || user.organisation_slug
-    organisation_slug == form.org
+    user.organisation.slug == form.org
   end
 end

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -27,7 +27,9 @@ describe FormPolicy do
       context "with an organisation not in the organisation table" do
         let(:user) { build :user, :with_unknown_org, organisation_slug: "gds" }
 
-        it { is_expected.to permit_actions(%i[can_view_form]) }
+        it "raises an error" do
+          expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+        end
       end
     end
   end
@@ -91,6 +93,17 @@ describe FormPolicy do
     end
 
     let(:gds_forms) { build_list :form, 2, org: "gds" }
+
+    it "uses organisation slug to scope what forms a user can see" do
+      organisation_slug = instance_double(String)
+      scope = class_spy(Form)
+
+      allow(user).to receive_message_chain(:organisation, :slug) { organisation_slug } # rubocop:disable RSpec/MessageChain
+
+      described_class.new(user, scope).resolve
+
+      expect(scope).to have_received(:where).with(org: organisation_slug)
+    end
 
     context "with no organisation set" do
       let(:user) { build :user, :with_no_org }


### PR DESCRIPTION
Trello card: https://trello.com/c/6qASsHQl

Reverts alphagov/forms-admin#428, which reverted a commit from alphagov/forms-admin#414.

This restores the requirement for users to have been assigned an organisation ID in the database to be able to use GOV.UK Forms.

We had to revert it because a data migration hadn't taken place as expected, now that #434 has been merged we should be safe to restore the change.