### PR TITLE
Switch hint input field to textarea

### DIFF
--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -7,7 +7,7 @@
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
-  <%= f.govuk_text_field :hint_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("hint_text", page_object.answer_type, page_object.answer_settings) } %>
+  <%= f.govuk_text_area :hint_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("hint_text", page_object.answer_type, page_object.answer_settings) } %>
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -31,7 +31,7 @@ describe "pages/_form.html.erb", type: :view do
   end
 
   it "has a field with the hint text" do
-    expect(rendered).to have_field(type: "text", with: question.hint_text)
+    expect(rendered).to have_field(type: "textarea", with: question.hint_text)
   end
 
   it "has an unchecked optional checkbox" do


### PR DESCRIPTION
#### What problem does the pull request solve?
We should look at changing the question hint text input to a textarea. A few times in research it seems like creators have wanted to put in a bit more text, or copy paste long bits of hint text that it would be beneficial for them to see instead of having to scroll a single line input.

Trello card: https://trello.com/c/bIOlrGn5/509-hint-text-input-to-become-textarea

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
