### PR TITLE
Preview link no longer need to open up in a new tab

### DIFF
--- a/app/components/preview_link_component/view.html.erb
+++ b/app/components/preview_link_component/view.html.erb
@@ -1,1 +1,1 @@
-<%= govuk_link_to t("home.preview"), @link, { target:"_blank", rel:"noopener noreferrer"} %>
+<%= govuk_link_to t("home.preview"), @link %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,7 +281,7 @@ en:
     form_status_heading: Status
     form_table_caption: "%{organisation_name} forms"
     main_heading: GOV.UK Forms
-    preview: Preview this form in a new tab
+    preview: Preview this form
     your_forms: Your forms
   internal_server_error:
     body: Please try again later.

--- a/spec/views/live/show_form.html.erb_spec.rb
+++ b/spec/views/live/show_form.html.erb_spec.rb
@@ -28,7 +28,7 @@ describe "live/show_form.html.erb" do
   end
 
   it "contains a link to preview the form" do
-    expect(rendered).to have_link("Preview this form in a new tab", href: "runner-host/preview-live/2/#{form.form_slug}", visible: :all)
+    expect(rendered).to have_link(t("home.preview"), href: "runner-host/preview-live/2/#{form.form_slug}", visible: :all)
   end
 
   it "contains a link to the form in the runner" do


### PR DESCRIPTION
#### What problem does the pull request solve?
User research has found that users get confused when opening up previews in new tab and how they get back to form admin

There is another ticket for forms-runner to add a link in forms-runner banner to bring the user back to forms-admin. The idea is that this will be merged at the same time as the changes to forms-runner so it will be easier for users to "toggle" between forms-runner and forms-admin.

Trello card: https://trello.com/c/Scetz4bk/772-change-preview-link-to-open-in-current-tab-window



#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
