### PR TITLE
Add routing success notices

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,8 @@ class ApplicationController < ActionController::Base
 
   before_action :clear_questions_session_data
 
+  add_flash_types :success
+
   rescue_from Pundit::NotAuthorizedError do |_exception|
     # Useful when we start adding more policies that require custom errors
     # policy_name = exception.policy.class.to_s.underscore

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -45,7 +45,7 @@ class Pages::ConditionsController < PagesController
     condition_form = Pages::ConditionsForm.new(form_params)
 
     if condition_form.update
-      redirect_to form_pages_path(@form)
+      redirect_to form_pages_path(@form), success: t("banner.success.route_updated", question_position: condition_form.page.position )
     else
       render template: "pages/conditions/edit", locals: { condition_form: }, status: :unprocessable_entity
     end

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -45,7 +45,7 @@ class Pages::ConditionsController < PagesController
     condition_form = Pages::ConditionsForm.new(form_params)
 
     if condition_form.update
-      redirect_to form_pages_path(@form), success: t("banner.success.route_updated", question_position: condition_form.page.position )
+      redirect_to form_pages_path(@form), success: t("banner.success.route_updated", question_position: condition_form.page.position)
     else
       render template: "pages/conditions/edit", locals: { condition_form: }, status: :unprocessable_entity
     end
@@ -69,7 +69,7 @@ class Pages::ConditionsController < PagesController
     if delete_condition_form.delete
       case delete_condition_form.confirm_deletion
       when "true"
-        redirect_to form_pages_path(@form.id, page.id)
+        redirect_to form_pages_path(@form.id, page.id), success: t("banner.success.route_deleted", question_position: delete_condition_form.page.position)
       when "false"
         redirect_to edit_condition_path(@form.id, page.id, condition.id)
       end

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -21,7 +21,7 @@ class Pages::ConditionsController < PagesController
     condition_form = Pages::ConditionsForm.new(condition_form_params)
 
     if condition_form.submit
-      redirect_to form_pages_path(@form)
+      redirect_to form_pages_path(@form), success: t("banner.success.route_created", question_position: condition_form.page.position)
     else
       render template: "pages/conditions/new", locals: { condition_form: }, status: :unprocessable_entity
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,16 @@
       <%= yield :back_link %>
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <% if success %>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <%= govuk_notification_banner(title_text: t("banner.success.title"), success: true) do |nb| %>
+                <% nb.with_heading(text: success) %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+
         <%= yield %>
       </main>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
   banner:
     success:
       route_created: Question %{question_position}’s route has been created
+      route_deleted: Question %{question_position}’s route has been deleted
       route_updated: Question %{question_position}’s route has been updated
       title: Success
   contact_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,10 @@ en:
     form_edit: Back to edit your form
     form_view: Back to your form
     forms: Back to your forms
+  banner:
+    success:
+      route_created: Question %{question_position}’s route has been created
+      title: Success
   contact_details:
     new:
       body_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
   banner:
     success:
       route_created: Question %{question_position}’s route has been created
+      route_updated: Question %{question_position}’s route has been updated
       title: Success
   contact_details:
     new:

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -171,6 +171,11 @@ RSpec.describe Pages::ConditionsController, type: :request do
       expect(response).to redirect_to form_pages_path(form.id)
     end
 
+    it "displays success message" do
+      follow_redirect!
+      expect(response.body).to include(I18n.t("banner.success.route_created", question_position: 1))
+    end
+
     context "when form submit fails" do
       let(:submit_result) { false }
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -291,6 +291,11 @@ RSpec.describe Pages::ConditionsController, type: :request do
       expect(response).to redirect_to form_pages_path(form.id)
     end
 
+    it "displays success message" do
+      follow_redirect!
+      expect(response.body).to include(I18n.t("banner.success.route_updated", question_position: 1))
+    end
+
     context "when form submit fails" do
       let(:submit_result) { false }
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -414,6 +414,11 @@ RSpec.describe Pages::ConditionsController, type: :request do
       expect(response).to redirect_to form_pages_path(form.id, selected_page.id)
     end
 
+    it "displays success message" do
+      follow_redirect!
+      expect(response.body).to include(I18n.t("banner.success.route_deleted", question_position: 1))
+    end
+
     context "when confirm deletion is false" do
       let(:confirm_deletion) { "false" }
 


### PR DESCRIPTION
#### What problem does the pull request solve?
- Adds notification banner to forms-admin to display success flash messages
- Adds 3 flash messages when a route is created, updated or deleted.

![image](https://github.com/alphagov/forms-admin/assets/3441519/6ca8ca70-4b43-4ba9-a44e-765034478049)
![image](https://github.com/alphagov/forms-admin/assets/3441519/3f0bcdb6-3d51-48e2-bbea-a7d67b536a92)

![image](https://github.com/alphagov/forms-admin/assets/3441519/28c1163c-976b-4da7-bcc5-abedcc391769)



Trello card: https://trello.com/c/3MdQwzIr/776-add-simple-routing-success-banner-notifications-to-forms-admin

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
