### PR TITLE
Add ability to permit/deny access to GOV.UK Forms on a per user basis

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :set_request_id
   before_action :authenticate
   before_action :check_service_unavailable
+  before_action :check_access
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :clear_questions_session_data
@@ -52,6 +53,12 @@ class ApplicationController < ActionController::Base
   def check_service_unavailable
     if Settings.service_unavailable
       render "errors/service_unavailable", status: :service_unavailable, formats: :html
+    end
+  end
+
+  def check_access
+    unless @current_user.has_access?
+      render "errors/access_denied", status: :forbidden, formats: :html
     end
   end
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,7 +1,7 @@
 class ErrorsController < ApplicationController
   # We are safe to authenitcate forbidden errors as the user must be logged in
   # to get to this point
-  skip_before_action :authenticate, only: %i[not_found internal_server_error]
+  skip_before_action :authenticate, :check_access, only: %i[not_found internal_server_error]
 
   def not_found
     render status: :not_found

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,5 +1,5 @@
 class HeartbeatController < ApplicationController
-  skip_before_action :authenticate
+  skip_before_action :authenticate, :check_access
 
   def ping
     render(body: "PONG")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
 private
 
   def user_params
-    params.require(:user).permit(:role, :organisation_id)
+    params.require(:user).permit(:has_access, :role, :organisation_id)
   end
 
   def user

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -77,4 +77,10 @@ module ApplicationHelper
       OpenStruct.new(label: t("users.roles.#{role}.name"), value: role, description: t("users.roles.#{role}.description"))
     end
   end
+
+  def user_access_options(access_options = %w[true false])
+    access_options.map do |access|
+      OpenStruct.new(label: t("users.has_access.#{access}.name"), value: access, description: t("users.has_access.#{access}.description"))
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,5 @@ class User < ApplicationRecord
 
   validates :role, presence: true
   validates :organisation_id, presence: true, if: -> { organisation_id_was.present? }
+  validates :has_access, inclusion: [true, false]
 end

--- a/app/views/errors/access_denied.html.erb
+++ b/app/views/errors/access_denied.html.erb
@@ -1,0 +1,9 @@
+<% set_page_title(t("page_titles.access_denied")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('page_titles.access_denied') %></h1>
+    <%= simple_format(t('forbidden.body_html', link: contact_link(t('forbidden.link_text'))), class: 'govuk-body') %>
+  </div>
+</div>
+

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -38,6 +38,11 @@
           row.with_key { t('users.index.table_headings.role') }
           row.with_value { t("users.roles.#{@user.role}.name") }
         end
+
+        summary_list.with_row do |row|
+          row.with_key { t('users.edit.has_access') }
+          row.with_value { t("users.has_access.#{@user.has_access}.name") }
+        end
       end %>
 
       <%= f.govuk_collection_select :organisation_id, Organisation.order(:slug), :id, :name,
@@ -49,10 +54,13 @@
       <%= f.govuk_collection_radio_buttons :role, user_role_options, :value, :label, :description,
         legend: { text: t('users.edit.role'), size: 'm', tag: 'h2' } %>
 
+      <%= f.govuk_collection_radio_buttons :has_access, user_access_options, :value, :label, :description,
+        legend: { text: t('users.edit.access'), size: 'm', tag: 'h2' } %>
+
       <%= f.govuk_submit t('users.save') do
         govuk_button_link_to t('users.cancel'), users_path, secondary: true
       end %>
-  <% end %>
 
+    <% end %>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,6 +11,7 @@
         row.with_cell(header: true, text: t("users.index.table_headings.email"))
         row.with_cell(header: true, text: t("users.index.table_headings.organisation"))
         row.with_cell(header: true, text: t("users.index.table_headings.role"))
+        row.with_cell(header: true, text: t("users.index.table_headings.access"))
       end
     end %>
 
@@ -23,6 +24,7 @@
           row.with_cell( text: user.email)
           row.with_cell( text: user.organisation&.name || t("users.index.organisation_blank"))
           row.with_cell( text: t("users.roles.#{user.role}.name"))
+          row.with_cell( text: t("users.has_access.#{user.has_access}.name"))
         end
       end
     end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "59b9bd9b49e055eac513d2b6dbbe8cfd9f446bb5a97c1744837ece6f1e4f7ad2",
+      "fingerprint": "b95336ebd6bb9c957cacd45eb7ebb65f098195a8e7d0d202093c56ff0db17f97",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/users_controller.rb",
       "line": 32,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:user).permit(:role, :organisation_id)",
+      "code": "params.require(:user).permit(:has_access, :role, :organisation_id)",
       "render_path": null,
       "location": {
         "type": "method",
@@ -24,6 +24,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-05-10 10:36:19 +0100",
+  "updated": "2023-05-17 13:14:15 +0100",
   "brakeman_version": "5.4.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -533,15 +533,25 @@ en:
   users:
     cancel: Cancel
     edit:
+      access: Permission to access GOV.UK Forms
       caption: User details
+      has_access: Access to GOV.UK Forms
       organisation: Organisation
       organisation_hint: The user will only be able to see their organisation’s forms
       organisation_prompt: Select an organisation
       role: Role
       title: Edit user
+    has_access:
+      'false':
+        description: Will not be able to use GOV.UK Forms
+        name: Denied
+      'true':
+        description: Will be able to use GOV.UK Forms
+        name: Permitted
     index:
       organisation_blank: No organisation set
       table_headings:
+        access: Access
         email: Email address
         name: Name
         organisation: Organisation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,6 +370,7 @@ en:
       none_of_the_above: None of the above
       only_one_option: Selection from a list, one option only.
   page_titles:
+    access_denied: You do not have permission to access GOV.UK Forms
     address_settings: What kind of addresses do you expect to receive?
     change_name_form: Name your form
     confirm_email_form: Enter the confirmation code

--- a/db/migrate/20230516134034_add_has_access_to_users.rb
+++ b/db/migrate/20230516134034_add_has_access_to_users.rb
@@ -1,0 +1,5 @@
+class AddHasAccessToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :has_access, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_102334) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_16_134034) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_102334) do
     t.datetime "updated_at", null: false
     t.string "role", default: "editor"
     t.bigint "organisation_id"
+    t.boolean "has_access", default: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
   end
 

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     email { Faker::Internet.email(name:, domain: "example.gov.uk") }
     uid { Faker::Internet.uuid }
     role { :editor }
+    has_access { true }
 
     trait :with_super_admin do
       role { :super_admin }

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe ApplicationController, type: :request do
+  context "when a user is logged in who does not have access" do
+    let(:headers) do
+      {
+        "X-API-Token" => Settings.forms_api.auth_key,
+        "Accept" => "application/json",
+      }
+    end
+
+    let(:user) { build :user, :super_admin, has_access: false }
+    let(:form) { build :form, id: 1 }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms?org=test-org", headers, [form].to_json, 200
+        mock.get "/api/v1/forms/1", headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", headers, form.pages.to_json, 200
+      end
+
+      login_as user
+    end
+
+    [
+      "/",
+      "/users",
+      "/forms/1",
+    ].each do |path|
+      context "when accessing #{path}" do
+        before do
+          get path
+        end
+
+        it "returns http code 403 for #{path}" do
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it "renders the access denied page" do
+          expect(response).to render_template("errors/access_denied")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -69,6 +69,11 @@ RSpec.describe UsersController, type: :request do
         expect(user.reload.super_admin?).to be true
       end
 
+      it "can update whether user has access" do
+        patch user_path(user), params: { user: { has_access: false } }
+        expect(user.reload.has_access).to be false
+      end
+
       it "when given a user which doesn't exist returns 404" do
         put user_path(-1), params: { user: { role: } }
         expect(response).to have_http_status(:not_found)

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -42,6 +42,10 @@ describe "users/edit.html.erb" do
     it "contains role" do
       expect(summary_list).to have_text("Editor")
     end
+
+    it "contains access" do
+      expect(summary_list).to have_text("Permitted")
+    end
   end
 
   describe "form" do
@@ -54,6 +58,11 @@ describe "users/edit.html.erb" do
       expect(rendered).to have_select(
         "Organisation", selected: "Test Org", with_options: ["Department For Tests", "Ministry Of Testing", "Test Org"]
       )
+    end
+
+    it "has access fields" do
+      expect(rendered).to have_checked_field("Permitted")
+      expect(rendered).to have_unchecked_field("Denied")
     end
   end
 

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -31,6 +31,10 @@ describe "users/index.html.erb" do
     expect(rendered).to have_text("Editor")
   end
 
+  it "contains access" do
+    expect(rendered).to have_text("Permitted")
+  end
+
   context "with a user with an unknown organisation" do
     let(:users) { [build(:user, :with_unknown_org, id: 1)] }
 


### PR DESCRIPTION
#### What problem does the pull request solve?

Currently Signon is used to manage whether a user has access to GOV.UK Forms. If we wanted to remove a users access, we would do that via Signon. To be able to migrate away from Signon, we need a way to restrict access to a user from within our service. (Note this is not about deleting a user). Only super admins will be able to remove or restore access.

We've done this by adding a `has_access` attribute on the User model to avoid any double negative confusion that may result from reusing the `disabled` attribute from Signon. A `before_action` is then used to show denied users a dropout page.

Trello card: https://trello.com/c/p8b7WDYn
