### PR TITLE
Make the email address of fake users match the name

### DIFF
--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user, class: "User" do
-    email { Faker::Internet.email(domain: "example.gov.uk") }
     name { Faker::Name.name }
+    email { Faker::Internet.email(name:, domain: "example.gov.uk") }
     uid { Faker::Internet.uuid }
     role { :editor }
 


### PR DESCRIPTION
It kind of annoys me that the fake users created in the database seed have email addresses that don't match their names.