### PR TITLE
Add error messaging for when a routing loop error

### DIFF
--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -41,6 +41,8 @@ module PageListComponent
     def goto_page_text_for_condition(condition, edit_link, page)
       if condition.errors_include?("goto_page_doesnt_exist")
         error_link(error_key: "goto_page_doesnt_exist", edit_link:, page:, field: :goto_page_id)
+      elsif condition.errors_include?("cannot_have_goto_page_before_routing_page")
+        error_link(error_key: "cannot_have_goto_page_before_routing_page", edit_link:, page:, field: :goto_page_id)
       else
         I18n.t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
       end

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -39,7 +39,7 @@ class Pages::ConditionsForm
   end
 
   def id_for_field(field)
-    "condition_#{field}"
+    "pages-conditions-form-#{field.to_s.dasherize}-field-error"
   end
 
   def check_errors_from_api

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -7,9 +7,13 @@ class Condition < ActiveResource::Base
   belongs_to :page
 
   def errors_with_fields
-    error_fields = { "goto_page_doesnt_exist" => :goto_page_id, "answer_value_doesnt_exist" => :answer_value }
+    error_fields = {
+      answer_value_doesnt_exist: :answer_value,
+      goto_page_doesnt_exist: :goto_page_id,
+      cannot_have_goto_page_before_routing_page: :goto_page_id,
+    }
     validation_errors.map do |error|
-      { name: error.name, field: error_fields[error.name] || :answer_value }
+      { name: error.name, field: error_fields[error.name.to_sym] || :answer_value }
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -345,9 +345,11 @@ en:
     errors:
       error_summary:
         answer_value_doesnt_exist: The answer that question %{page_index}’s route is based on no longer exists - edit question %{page_index}’s route
+        cannot_have_goto_page_before_routing_page: The question you’re taking the person to is now above the route - edit question %{page_index}’s route
         goto_page_doesnt_exist: The question you’re taking the person to no longer exists - edit question %{page_index}’s route
       page_list:
         answer_value_doesnt_exist: select the answer you want to base question %{page_index}’s route on
+        cannot_have_goto_page_before_routing_page: select another question or page you want to take the person to, or delete question %{page_index}’s route
         goto_page_doesnt_exist: select the question or page you want to take the person to, or delete question %{page_index}’s route
     route: Route
   page_options_service:

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -14,6 +14,7 @@ en:
               answer_value_doesnt_exist: Select the answer you want to base your route on, or delete this route
             goto_page_id:
               blank: Select the question or page you want to take the person to
+              cannot_have_goto_page_before_routing_page: Select the question or page you want to take the person to, or delete this route
               goto_page_doesnt_exist: Select the question or page you want to take the person to, or delete this route
         pages/delete_condition_form:
           attributes:

--- a/spec/components/page_list_component/page_list_component_preview.rb
+++ b/spec/components/page_list_component/page_list_component_preview.rb
@@ -2,14 +2,14 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
   include FactoryBot::Syntax::Methods
 
   def default
-    render(PageListComponent::View.new(pages: [], form_id: 0))
+    render(PageListComponent::View.new(pages: [], can_edit_page_routing: true, form_id: 0))
   end
 
   def with_pages_and_no_conditions
     pages = [OpenStruct.new(id: 1, question_text: "Enter your name", routing_conditions: []),
              OpenStruct.new(id: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
              OpenStruct.new(id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    render(PageListComponent::View.new(pages:, form_id: 0))
+    render(PageListComponent::View.new(pages:, can_edit_page_routing: true, form_id: 0))
   end
 
   def with_pages_and_one_condition
@@ -17,7 +17,7 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     pages = [OpenStruct.new(id: 1, question_text: "Enter your name", routing_conditions:),
              OpenStruct.new(id: 2, question_text: "What is your pet's phone number?", routing_conditions:),
              OpenStruct.new(id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    render(PageListComponent::View.new(pages:, form_id: 0))
+    render(PageListComponent::View.new(pages:, can_edit_page_routing: true, form_id: 0))
   end
 
   def with_pages_and_multiple_conditions
@@ -26,16 +26,17 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     pages = [(build :page, id: 1, question_text: "Enter your name", routing_conditions:),
              (build :page, id: 2, question_text: "What is your pet's phone number?", routing_conditions:),
              (build :page, id: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    render(PageListComponent::View.new(pages:, form_id: 0))
+    render(PageListComponent::View.new(pages:, can_edit_page_routing: true, form_id: 0))
   end
 
   def with_pages_and_conditions_with_errors
     routing_conditions = [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3),
                           (build :condition, :with_goto_page_missing, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England"),
-                          (build :condition, :with_answer_value_and_goto_page_missing, id: 3, routing_page_id: 1, check_page_id: 1)]
+                          (build :condition, :with_answer_value_and_goto_page_missing, id: 3, routing_page_id: 1, check_page_id: 1),
+                          (build :condition, :with_goto_page_before_check_page, id: 4, routing_page_id: 2, check_page_id: 2, answer_value: "England", goto_page_id: 1)]
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions:),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    render(PageListComponent::View.new(pages:, form_id: 0))
+    render(PageListComponent::View.new(pages:, can_edit_page_routing: true, form_id: 0))
   end
 end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -272,6 +272,14 @@ RSpec.describe PageListComponent::View, type: :component do
           expect(goto_page_text).to eq page_list_component.error_link(error_key: "goto_page_doesnt_exist", edit_link: condition_edit_path, page: pages[0], field: :goto_page_id)
         end
       end
+
+      context "when the goto page is before the check page" do
+        let(:condition) { (build :condition, :with_goto_page_before_check_page, id: 1, routing_page_id: 2, check_page_id: 2, answer_value: "Wales", goto_page_id: 1) }
+
+        it "returns the goto page error link" do
+          expect(goto_page_text).to eq page_list_component.error_link(error_key: "cannot_have_goto_page_before_routing_page", edit_link: condition_edit_path, page: pages[0], field: :goto_page_id)
+        end
+      end
     end
 
     describe "render_routing?" do

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
       validation_errors { [OpenStruct.new(name: "goto_page_doesnt_exist")] }
     end
 
+    trait :with_goto_page_before_check_page do
+      validation_errors { [OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")] }
+    end
+
     trait :with_answer_value_and_goto_page_missing do
       goto_page_id { nil }
       validation_errors { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist")] }

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Pages::ConditionsForm, type: :model do
   describe "#id_for_field" do
     it "returns the correct id for a field" do
       result = described_class.new(form:, page: pages.first).id_for_field(:answer_value)
-      expect(result).to eq("condition_answer_value")
+      expect(result).to eq("pages-conditions-form-answer-value-field-error")
     end
   end
 

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -70,10 +70,10 @@ describe Condition do
 
   describe "#errors_with_fields" do
     context "when the error is a known error" do
-      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist")] }
+      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist"), OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")] }
 
       it "returns the correct values for each error type" do
-        expect(condition.errors_with_fields).to eq [{ field: :answer_value, name: "answer_value_doesnt_exist" }, { field: :goto_page_id, name: "goto_page_doesnt_exist" }]
+        expect(condition.errors_with_fields).to eq [{ field: :answer_value, name: "answer_value_doesnt_exist" }, { field: :goto_page_id, name: "goto_page_doesnt_exist" }, { field: :goto_page_id, name: "cannot_have_goto_page_before_routing_page" }]
       end
     end
 

--- a/spec/views/pages/conditions/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/edit.html.erb_spec.rb
@@ -13,6 +13,7 @@ describe "pages/conditions/edit.html.erb" do
     allow(view).to receive(:create_condition_path).and_return("/forms/1/pages/1/conditions/new")
     allow(view).to receive(:delete_condition_path).and_return("/forms/1/pages/1/conditions/2/delete")
     allow(form).to receive(:qualifying_route_pages).and_return(pages)
+    condition_form.check_errors_from_api
 
     render template: "pages/conditions/edit", locals: { condition_form: }
   end
@@ -32,5 +33,17 @@ describe "pages/conditions/edit.html.erb" do
 
   it "has a delete route link" do
     expect(rendered).to have_link(text: "Delete question route", href: "/forms/1/pages/1/conditions/2/delete")
+  end
+
+  context "with a validation error" do
+    let(:condition) { build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3 }
+
+    it "has an error link that matches the field with errors" do
+      field_id = "pages-conditions-form-answer-value-field-error"
+
+      expect(rendered).to have_css(".govuk-error-summary")
+      expect(rendered).to have_link(I18n.t("activemodel.errors.models.pages/conditions_form.attributes.answer_value.answer_value_doesnt_exist", href: "##{field_id}"))
+      expect(rendered).to have_css("##{field_id}")
+    end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

Adds the error messaging for when a route's goto_page is before its check_page, causing the form to loop back on itself.

Also includes an update to the `id_for_field` method to make it match the way Rails generates ids.

Trello card: https://trello.com/c/7Lii1lvg/774-display-the-go-to-page-is-before-the-routing-page-validation-error-in-forms-admin

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
