### PR TITLE
Add error message when routing page is next to goto page

### DIFF
--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -43,6 +43,8 @@ module PageListComponent
         error_link(error_key: "goto_page_doesnt_exist", edit_link:, page:, field: :goto_page_id)
       elsif condition.errors_include?("cannot_have_goto_page_before_routing_page")
         error_link(error_key: "cannot_have_goto_page_before_routing_page", edit_link:, page:, field: :goto_page_id)
+      elsif condition.errors_include?("cannot_route_to_next_page")
+        error_link(error_key: "cannot_route_to_next_page", edit_link:, page:, field: :goto_page_id)
       else
         I18n.t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
       end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -11,6 +11,7 @@ class Condition < ActiveResource::Base
       answer_value_doesnt_exist: :answer_value,
       goto_page_doesnt_exist: :goto_page_id,
       cannot_have_goto_page_before_routing_page: :goto_page_id,
+      cannot_route_to_next_page: :goto_page_id,
     }
     validation_errors.map do |error|
       { name: error.name, field: error_fields[error.name.to_sym] || :answer_value }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -352,10 +352,12 @@ en:
       error_summary:
         answer_value_doesnt_exist: The answer that question %{page_index}’s route is based on no longer exists - edit question %{page_index}’s route
         cannot_have_goto_page_before_routing_page: The question you’re taking the person to is now above the route - edit question %{page_index}’s route
+        cannot_route_to_next_page: Question %{page_index}’s route is now next to the route’s end question - this makes the route unnecessary. Edit question %{page_index}’s route.
         goto_page_doesnt_exist: The question you’re taking the person to no longer exists - edit question %{page_index}’s route
       page_list:
         answer_value_doesnt_exist: select the answer you want to base question %{page_index}’s route on
         cannot_have_goto_page_before_routing_page: select another question or page you want to take the person to, or delete question %{page_index}’s route
+        cannot_route_to_next_page: select another question or page you want to take the person to, or delete question %{page_index}’s route
         goto_page_doesnt_exist: select the question or page you want to take the person to, or delete question %{page_index}’s route
     route: Route
   page_options_service:

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -15,6 +15,7 @@ en:
             goto_page_id:
               blank: Select the question or page you want to take the person to
               cannot_have_goto_page_before_routing_page: Select the question or page you want to take the person to, or delete this route
+              cannot_route_to_next_page: Select the question or page you want to take the person to, or delete this route
               goto_page_doesnt_exist: Select the question or page you want to take the person to, or delete this route
         pages/delete_condition_form:
           attributes:

--- a/spec/components/page_list_component/page_list_component_preview.rb
+++ b/spec/components/page_list_component/page_list_component_preview.rb
@@ -33,7 +33,8 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     routing_conditions = [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3),
                           (build :condition, :with_goto_page_missing, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England"),
                           (build :condition, :with_answer_value_and_goto_page_missing, id: 3, routing_page_id: 1, check_page_id: 1),
-                          (build :condition, :with_goto_page_before_check_page, id: 4, routing_page_id: 2, check_page_id: 2, answer_value: "England", goto_page_id: 1)]
+                          (build :condition, :with_goto_page_before_check_page, id: 4, routing_page_id: 2, check_page_id: 2, answer_value: "England", goto_page_id: 1),
+                          (build :condition, :with_goto_page_immediately_after_check_page, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 2)]
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions:),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -280,6 +280,14 @@ RSpec.describe PageListComponent::View, type: :component do
           expect(goto_page_text).to eq page_list_component.error_link(error_key: "cannot_have_goto_page_before_routing_page", edit_link: condition_edit_path, page: pages[0], field: :goto_page_id)
         end
       end
+
+      context "when the goto page is immediately after the check page" do
+        let(:condition) { (build :condition, :with_goto_page_immediately_after_check_page, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 2) }
+
+        it "returns the goto page error link" do
+          expect(goto_page_text).to eq page_list_component.error_link(error_key: "cannot_route_to_next_page", edit_link: condition_edit_path, page: pages[0], field: :goto_page_id)
+        end
+      end
     end
 
     describe "render_routing?" do

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -20,6 +20,10 @@ FactoryBot.define do
       validation_errors { [OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")] }
     end
 
+    trait :with_goto_page_immediately_after_check_page do
+      validation_errors { [OpenStruct.new(name: "cannot_route_to_next_page")] }
+    end
+
     trait :with_answer_value_and_goto_page_missing do
       goto_page_id { nil }
       validation_errors { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist")] }

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -70,10 +70,10 @@ describe Condition do
 
   describe "#errors_with_fields" do
     context "when the error is a known error" do
-      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist"), OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")] }
+      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist"), OpenStruct.new(name: "cannot_have_goto_page_before_routing_page"), OpenStruct.new(name: "cannot_route_to_next_page")] }
 
       it "returns the correct values for each error type" do
-        expect(condition.errors_with_fields).to eq [{ field: :answer_value, name: "answer_value_doesnt_exist" }, { field: :goto_page_id, name: "goto_page_doesnt_exist" }, { field: :goto_page_id, name: "cannot_have_goto_page_before_routing_page" }]
+        expect(condition.errors_with_fields).to eq [{ field: :answer_value, name: "answer_value_doesnt_exist" }, { field: :goto_page_id, name: "goto_page_doesnt_exist" }, { field: :goto_page_id, name: "cannot_have_goto_page_before_routing_page" }, { field: :goto_page_id, name: "cannot_route_to_next_page" }]
       end
     end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds an error message to the page list and the edit condition page for the scenario when the goto page is immediately after the routing page (making the route useless).

Trello card: https://trello.com/c/ke0EyHKD/773-display-routing-page-is-next-page-validation-error-in-forms-admin

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
