### PR TITLE
Make service unavailable page visible without signing in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,8 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods unless Settings.basic_auth.enabled
   include Pundit::Authorization
   before_action :set_request_id
-  before_action :authenticate
   before_action :check_service_unavailable
+  before_action :authenticate
   before_action :check_access
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,7 @@ class ApplicationController < ActionController::Base
   include Pundit::Authorization
   before_action :set_request_id
   before_action :check_service_unavailable
-  before_action :authenticate
-  before_action :check_access
+  before_action :authenticate_and_check_access
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :clear_questions_session_data
@@ -121,5 +120,12 @@ class ApplicationController < ActionController::Base
   # create @current_user and set that.
   def pundit_user
     @current_user
+  end
+
+private
+
+  def authenticate_and_check_access
+    authenticate
+    check_access
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,7 +1,7 @@
 class ErrorsController < ApplicationController
   # We are safe to authenitcate forbidden errors as the user must be logged in
   # to get to this point
-  skip_before_action :authenticate, :check_access, only: %i[not_found internal_server_error]
+  skip_before_action :authenticate_and_check_access, only: %i[not_found internal_server_error]
 
   def not_found
     render status: :not_found

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,5 +1,5 @@
 class HeartbeatController < ApplicationController
-  skip_before_action :authenticate, :check_access
+  skip_before_action :authenticate_and_check_access
 
   def ping
     render(body: "PONG")

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe ApplicationController, type: :request do
   context "when the service is unavailable" do
     before do
+      logout # service unavailable page should be visible even if user is not logged in
+
       allow(Settings).to receive(:service_unavailable).and_return(true)
       get "/"
     end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,6 +1,21 @@
 require "rails_helper"
 
 RSpec.describe ApplicationController, type: :request do
+  context "when the service is unavailable" do
+    before do
+      allow(Settings).to receive(:service_unavailable).and_return(true)
+      get "/"
+    end
+
+    it "returns http code 503" do
+      expect(response).to have_http_status(:service_unavailable)
+    end
+
+    it "renders the service unavailable page" do
+      expect(response).to render_template("errors/service_unavailable")
+    end
+  end
+
   context "when a user is logged in who does not have access" do
     let(:headers) do
       {

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -21,12 +21,4 @@ RSpec.describe ErrorsController, type: :request do
       expect(response).to have_http_status(:internal_server_error)
     end
   end
-
-  describe "Service unavailable page" do
-    it "returns http code 503" do
-      allow(Settings).to receive(:service_unavailable).and_return(true)
-      get "/"
-      expect(response).to have_http_status(:service_unavailable)
-    end
-  end
 end

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -1,9 +1,17 @@
 module AuthenticationFeatureHelpers
+  @cached_gds_sso_mock_invalid = ENV["GDS_SSO_MOCK_INVALID"]
+
   def login_as(user)
+    ENV["GDS_SSO_MOCK_INVALID"] = @cached_gds_sso_mock_invalid
+
     GDS::SSO.test_user = user
   end
 
   def logout
+    # If GDS_SSO_MOCK_INVALID is not present the gds-sso mock strategy will get
+    # the first user from the database when authenticate! is called
+    ENV["GDS_SSO_MOCK_INVALID"] = "true"
+
     GDS::SSO.test_user = nil
   end
 


### PR DESCRIPTION
Users shouldn't need to sign in to see that the service is unavailable.