### PR TITLE
Make sure we use organisation.slug, not organisation_slug

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,7 @@ class ApplicationController < ActionController::Base
     if @current_user.present?
       payload[:user_id] = @current_user.id
       payload[:user_email] = @current_user.email
-      payload[:user_organisation_slug] = @current_user.organisation_slug
+      payload[:user_organisation_slug] = @current_user.organisation&.slug
     end
     payload[:request_id] = request.request_id
     payload[:user_ip] = user_ip(request.env.fetch("HTTP_X_FORWARDED_FOR", ""))

--- a/app/controllers/forms/change_name_controller.rb
+++ b/app/controllers/forms/change_name_controller.rb
@@ -9,7 +9,7 @@ module Forms
     def create
       form = Form.new({
         name: params[:name],
-        org: @current_user.organisation_slug,
+        org: @current_user.organisation.slug,
       })
 
       authorize form, :can_view_form?

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -29,7 +29,7 @@ describe ApplicationController, type: :controller do
 
   context "when authenticating a user" do
     it "invokes Signon authentication when basic auth is not enabled" do
-      signon_user = User.new(name: "tester", organisation_slug: "testing")
+      signon_user = build :user, name: "tester", organisation_slug: "testing"
 
       # Mock GDS SSO
       allow(request.env["warden"]).to receive(:authenticate!).and_return(true)

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -15,8 +15,9 @@ FactoryBot.define do
 
     after(:build) do |user|
       if user.organisation.present?
-        user.organisation_slug = user.organisation.slug
-        user.organisation_content_id = user.organisation.content_id
+        # set deprecated attributes to nil to make sure no code is accidentally relying on them
+        user.organisation_slug = nil
+        user.organisation_content_id = nil
       end
     end
 


### PR DESCRIPTION
While working on PR #450 I learnt we are still assigning the organisation slug from Signon to the form ownership information.

This is a bug, and could have caused users who had been assigned to an organisation different from their Signon org to be unable to view or edit forms they tried to create.

Fix this, and tweak our tests to surface this and any future issues.