### PR TITLE
Use select list if there are more than 10 routable pages

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -50,6 +50,10 @@ class Page < ActiveResource::Base
     routing_conditions.map { |routing_condition| Condition.new(routing_condition.attributes) }
   end
 
+  def question_with_number
+    "#{position}. #{question_text}"
+  end
+
 private
 
   def is_optional_value

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -12,15 +12,28 @@
     </p>
 
     <%= form_with(model: form, url: set_routing_page_path(form.id), method: 'POST') do |f| %>
-      <%= f.govuk_collection_radio_buttons :routing_page_id,
-                                           form.qualifying_route_pages,
-                                           :id, :question_text,
-                                           legend: {
-                                             text: t("routing_page.legend_text"),
-                                             size: 'm' },
-                                           hint:{
-                                             text: t("routing_page.legend_hint_text") }
-      %>
+      <% if form.qualifying_route_pages.length <= 10 %>
+        <%= f.govuk_collection_radio_buttons :routing_page_id,
+                                            form.qualifying_route_pages,
+                                            :id, :question_text,
+                                            legend: {
+                                              text: t("routing_page.legend_text"),
+                                              size: 'm' },
+                                            hint:{
+                                              text: t("routing_page.legend_hint_text") }
+        %>
+      <% else %>
+        <%= f.govuk_collection_select :routing_page_id,
+                                            form.qualifying_route_pages,
+                                            :id, :question_text,
+                                            label: {
+                                              text: t("routing_page.legend_text"),
+                                              size: 'm' },
+                                            hint:{
+                                              text: t("routing_page.legend_hint_text") }
+        %>
+      <% end %>
+
       <%= f.govuk_submit t("continue") %>
     <% end %>
   </div>

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -25,7 +25,7 @@
       <% else %>
         <%= f.govuk_collection_select :routing_page_id,
                                             form.qualifying_route_pages,
-                                            :id, :question_text,
+                                            :id, :question_with_number,
                                             label: {
                                               text: t("routing_page.legend_text"),
                                               size: 'm' },

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -96,4 +96,12 @@ describe Page do
       end
     end
   end
+
+  describe "#question_with_number" do
+    let(:page) { described_class.new(question_text: "What's your name?", position: 5) }
+
+    it "returns the page number and question text as a string" do
+      expect(page.question_with_number).to eq("#{page.position}. #{page.question_text}")
+    end
+  end
 end

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -57,6 +57,10 @@ describe "pages/conditions/routing_page.html.erb" do
     it "has a select option for each routing pages" do
       expect(rendered).to have_css("select > option", count: pages.length)
     end
+
+    it "includes the page number and question text" do
+      expect(rendered).to have_text(pages.first.question_with_number)
+    end
   end
 
   it "has a submit button" do

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -22,13 +22,41 @@ describe "pages/conditions/routing_page.html.erb" do
     expect(rendered).to have_css("p.govuk-body", text: t("routing_page.body_text"))
   end
 
-  it "contains a fieldset legend asking a user to select a question page" do
-    expect(rendered).to have_css(".govuk-fieldset__legend", text: t("routing_page.legend_text"))
-    expect(rendered).to have_css("div.govuk-hint", text: t("routing_page.legend_hint_text"))
+  context "with fewer than 10 options" do
+    it "contains a fieldset legend asking a user to select a question page" do
+      expect(rendered).to have_css(".govuk-fieldset__legend", text: t("routing_page.legend_text"))
+      expect(rendered).to have_css("div.govuk-hint", text: t("routing_page.legend_hint_text"))
+    end
+
+    it "has a radio option for each routing pages" do
+      expect(rendered).to have_css(".govuk-radios__item", count: pages.length)
+    end
   end
 
-  it "has a radio option for each routing pages" do
-    expect(rendered).to have_css(".govuk-radios__item", count: pages.length)
+  context "with 10 options" do
+    let(:pages) { build_list :page, 10, :with_selections_settings, form_id: 1 }
+
+    it "contains a fieldset legend asking a user to select a question page" do
+      expect(rendered).to have_css(".govuk-fieldset__legend", text: t("routing_page.legend_text"))
+      expect(rendered).to have_css("div.govuk-hint", text: t("routing_page.legend_hint_text"))
+    end
+
+    it "has a radio option for each routing pages" do
+      expect(rendered).to have_css(".govuk-radios__item", count: pages.length)
+    end
+  end
+
+  context "with more than 10 options" do
+    let(:pages) { build_list :page, 11, :with_selections_settings, form_id: 1 }
+
+    it "contains a fieldset legend asking a user to select a question page" do
+      expect(rendered).to have_css(".govuk-label", text: t("routing_page.legend_text"))
+      expect(rendered).to have_css("div.govuk-hint", text: t("routing_page.legend_hint_text"))
+    end
+
+    it "has a select option for each routing pages" do
+      expect(rendered).to have_css("select > option", count: pages.length)
+    end
   end
 
   it "has a submit button" do


### PR DESCRIPTION
#### What problem does the pull request solve?
Switches the routing page UI to use a select list instead of a radio button group if there are more than 10 options to choose from.

Trello card: https://trello.com/c/F4Hpw6tU/675-update-new-route-page-to-use-a-select-list-when-there-are-more-than-10-options

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
