### PR TITLE
Update answer type basic route warning to notification banner

### DIFF
--- a/app/views/pages/type-of-answer.html.erb
+++ b/app/views/pages/type-of-answer.html.erb
@@ -3,6 +3,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if @page.present? && @page.answer_type.to_sym == :selection && @page.conditions.any?  %>
+      <%= govuk_notification_banner(title_text: t("type_of_answer.routing_warning_notification_title")) do |banner| %>
+        <% banner.with_heading(text: t("type_of_answer.routing_warning_about_change_answer_type_heading")) %>
+        <%= t("type_of_answer.routing_warning_about_change_answer_type_html") %>
+      <% end %>
+    <% end %>
+
     <%= form_with model: [@form, @type_of_answer_form], url: @type_of_answer_path do |f| %>
       <%= f.govuk_error_summary %>
 
@@ -16,12 +23,6 @@
             caption: { text: "#{t("pages.question")} #{@form.page_number(@page)}" , size: 'l' },
             bold_labels: false,
           )  %>
-
-      <% if @page.present? && @page.answer_type.to_sym == :selection && @page.conditions.any?  %>
-        <%= govuk_inset_text do %>
-          <%= t("type_of_answer.routing_warning_about_change_answer_type_html") %>
-        <% end %>
-      <% end %>
 
       <%= f.govuk_submit t('continue'), value: "true", name: :set_answer_type %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,15 +521,9 @@ en:
     in_progress: in progress
     not_started: not started
   type_of_answer:
-    routing_warning_about_change_answer_type_html: |
-      <p class="govuk-body">
-        Changing the type of answer you need from “Selection from a list of options” to a different answer type means your
-        question route will no longer work and will be deleted.
-      </p>
-      <p class="govuk-body">
-        If you do not want to lose your question route you can cancel this change by using the back button or
-        clicking the “Go to your questions” link.
-      </p>
+    routing_warning_about_change_answer_type_heading: Your existing question route may be deleted
+    routing_warning_about_change_answer_type_html: "<p class=\"govuk-body\">\n  Changing the answer type from \"Selection from a list of options\" to a different answer \n  type means your route will no longer work and will be deleted.\n</p>\n<p class=\"govuk-body\">\n  If you do not want to lose your question route you can cancel this change by using the back button \n  or clicking the \"Go to your questions\" link.\n</p>\n"
+    routing_warning_notification_title: Important
   user_missing_organisation:
     body: "%{contact_link} to assign an organisation to your account."
     title: You do not have an organisation set for your account

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -67,7 +67,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
   end
 
   it "does not display a warning about routes being deleted if answer type changes" do
-    expect(rendered).not_to have_selector(".govuk-inset-text")
+    expect(rendered).not_to have_selector(".govuk-notification-banner__content")
   end
 
   context "when editing an existing" do
@@ -76,8 +76,8 @@ describe "pages/type_of_answer.html.erb", type: :view do
     let(:conditions) { [(build :condition)] }
 
     it "displays a warning about routes being deleted if answer type changes" do
-      expect(Capybara.string(rendered).find(".govuk-inset-text").text(normalize_ws: true))
-        .to eq(Capybara.string(I18n.t("type_of_answer.routing_warning_about_change_answer_type_html"))
+      expect(Capybara.string(rendered).find(".govuk-notification-banner__content").text(normalize_ws: true))
+        .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_about_change_answer_type_html"))
                         .text(normalize_ws: true))
     end
 
@@ -85,7 +85,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
       let(:answer_type) { "number" }
 
       it "does not display a warning about routes being deleted if answer type changes" do
-        expect(rendered).not_to have_selector(".govuk-inset-text")
+        expect(rendered).not_to have_selector(".govuk-notification-banner__content")
       end
     end
 
@@ -93,7 +93,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
       let(:conditions) { [] }
 
       it "does not display a warning about routes being deleted if answer type changes" do
-        expect(rendered).not_to have_selector(".govuk-inset-text")
+        expect(rendered).not_to have_selector(".govuk-notification-banner__content")
       end
     end
   end


### PR DESCRIPTION
#### What problem does the pull request solve?

originally, inset paragraph was difficult to implement at the top of the page. We placed it at the bottom which was a bit better.

However this made it look like it was a "broken" condition reveal radio button

https://design-system.service.gov.uk/components/radios/#conditionally-revealing-a-related-question

### Previous design
![image](https://github.com/alphagov/forms-admin/assets/3441519/043c266a-a3ed-4c74-8d33-2ea7f54f8459)


### New design
![image](https://github.com/alphagov/forms-admin/assets/3441519/bd568a86-7103-4ec1-9da9-525d3ebb3d04)


cc: @christophercameron-ixd @C-Harry 

Trello card: https://trello.com/c/I0qZazC6/789-update-answer-type-warning-message

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
