### PR TITLE
Use govuk-frontend global styles

### DIFF
--- a/app/components/form_url_component/view.html.erb
+++ b/app/components/form_url_component/view.html.erb
@@ -3,7 +3,7 @@
     <%= t("form_url_component.form_url") %>
   </h2>
 
-  <p class="govuk-body" data-copy-target>
+  <p data-copy-target>
     <%= @runner_link %>
   </p>
 <% end %>

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -25,7 +25,7 @@ module PageListComponent
       content_tag(
         :a,
         I18n.t("page_conditions.errors.page_list.#{error_key}", page_index: page.position),
-        class: "govuk-link app-page_list__route-text--error",
+        class: "app-page_list__route-text--error",
         href: "#{edit_link}##{Pages::ConditionsForm.new.id_for_field(field)}",
       )
     end

--- a/app/components/task_list_component/view.html.erb
+++ b/app/components/task_list_component/view.html.erb
@@ -1,5 +1,5 @@
 <% if render_counter? %>
-  <%= tag.p(class:"govuk-body app-task-list__summary") do %>
+  <%= tag.p(class:"app-task-list__summary") do %>
     You’ve completed <%= completed_task_count %> of <%= total_task_count %> tasks.
   <% end %>
 <% end %>

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -1,5 +1,7 @@
 $govuk-images-path: "@govuk/assets/images/";
 $govuk-fonts-path: "@govuk/assets/fonts/";
+$govuk-new-link-styles: true;
+$govuk-global-styles: true;
 
 @import "govuk/all";
 @import "../styles/app_select_options";

--- a/app/views/errors/access_denied.html.erb
+++ b/app/views/errors/access_denied.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.access_denied') %></h1>
-    <%= simple_format(t('forbidden.body_html', link: contact_link(t('forbidden.link_text'))), class: 'govuk-body') %>
+    <%= simple_format(t('forbidden.body_html', link: contact_link(t('forbidden.link_text')))) %>
   </div>
 </div>
 

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('forbidden.title') %></h1>
-    <%= simple_format(t('forbidden.body_html', link: contact_link(t('forbidden.link_text'))), class: 'govuk-body') %>
+    <%= simple_format(t('forbidden.body_html', link: contact_link(t('forbidden.link_text')))) %>
   </div>
 </div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('internal_server_error.title') %></h1>
-    <%= simple_format(t('internal_server_error.body'), class: 'govuk-body') %>
+    <%= simple_format(t('internal_server_error.body')) %>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('not_found.title') %></h1>
-    <%= simple_format(t('not_found.body'), class: 'govuk-body') %>
+    <%= simple_format(t('not_found.body')) %>
   </div>
 </div>

--- a/app/views/errors/service_unavailable.html.erb
+++ b/app/views/errors/service_unavailable.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('service_unavailable.title') %></h1>
-    <%= simple_format(t('service_unavailable.body_html', link: contact_link), class: 'govuk-body') %>
+    <%= simple_format(t('service_unavailable.body_html', link: contact_link)) %>
   </div>
 </div>

--- a/app/views/errors/user_missing_organisation_error.html.erb
+++ b/app/views/errors/user_missing_organisation_error.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('user_missing_organisation.title') %></h1>
-    <%= simple_format(t('user_missing_organisation.body', contact_link: contact_link), class: 'govuk-body') %>
+    <%= simple_format(t('user_missing_organisation.body', contact_link: contact_link)) %>
   </div>
 </div>
 

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -2,7 +2,7 @@
 <h1 class="govuk-heading-l"><%= t("home.main_heading") %></h1>
 
 <% if flash[:message] %>
-  <p class="govuk-body">
+  <p>
     <%= flash[:message] %>
   </p>
 <% end %>

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -6,13 +6,13 @@
 
     <h2 class="govuk-heading-m"><%= t('make_live.confirmation.form_name') %></h2>
 
-    <p class="govuk-body"><%= @form.name %></p>
+    <p><%= @form.name %></p>
 
     <%= render FormUrlComponent::View.new(link_to_runner(Settings.forms_runner.url, @form.id, @form.form_slug, mode: :live )) %>
 
     <%= t("make_live.confirmation.body_html") %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t("make_live.confirmation.continue_link"), live_form_path(@form.id) %>
     </p>
   </div>

--- a/app/views/forms/make_live/make_your_changes_live.html.erb
+++ b/app/views/forms/make_live/make_your_changes_live.html.erb
@@ -14,11 +14,11 @@
         <%= t("page_titles.make_changes_live_form") %>
       </h1>
 
-      <p class="govuk-body">
+      <p>
         <%= t("make_changes_live.warning") %>
       </p>
 
-      <p class="govuk-body">
+      <p>
         <%= t("make_changes_live.url_will_remain_same") %>
       </p>
 

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -12,10 +12,10 @@
     <%= render FormStatusTagDescriptionComponent::View.new(status: :draft) %>
 
     <% if flash[:message] %>
-      <p class="govuk-body"><%= flash[:message] %></p>
+      <p><%= flash[:message] %></p>
     <% end %>
 
-    <p class="govuk-body govuk-!-margin-bottom-9">
+    <p class="govuk-!-margin-bottom-9">
       <%= render PreviewLinkComponent::View.new(@form.pages, link_to_runner(Settings.forms_runner.url, @form.id, @form.form_slug)) %>
     </p>
 

--- a/app/views/forms/submission_email/submission_email_code_sent.html.erb
+++ b/app/views/forms/submission_email/submission_email_code_sent.html.erb
@@ -4,5 +4,5 @@
 </h1>
 <%= t('email_code_sent.body_html', temp_email: @submission_email_form.temporary_submission_email) %>
 
-<p class="govuk-body"><%= govuk_link_to "Enter the email address confirmation code", submission_email_code_path( @submission_email_form.form) %></p>
-<p class="govuk-body"><%= govuk_link_to(t('email_code_sent.continue'), form_path) %></p>
+<p><%= govuk_link_to "Enter the email address confirmation code", submission_email_code_path( @submission_email_form.form) %></p>
+<p><%= govuk_link_to(t('email_code_sent.continue'), form_path) %></p>

--- a/app/views/forms/submission_email/submission_email_confirmed.html.erb
+++ b/app/views/forms/submission_email/submission_email_confirmed.html.erb
@@ -5,4 +5,4 @@
 
 <%= t('email_code_success.body_html', submission_email: @submission_email_form.form.submission_email) %>
 
-<p class="govuk-body"><%= govuk_link_to(t('email_code_success.continue'), form_path) %></p>
+<p><%= govuk_link_to(t('email_code_success.continue'), form_path) %></p>

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -14,9 +14,9 @@
         <%= t("page_titles.what_happens_next_form") %>
       </h1>
 
-      <p class="govuk-body">This page will be shown after someone has completed and submitted the form to let them know that the form has been submitted successfully.</p>
+      <p>This page will be shown after someone has completed and submitted the form to let them know that the form has been submitted successfully.</p>
 
-      <p class="govuk-body">Add some content to let people know what will happen next and when, so they know what to expect.</p>
+      <p>Add some content to let people know what will happen next and when, so they know what to expect.</p>
 
       <h2 class="govuk-heading-s">Example</h2>
 

--- a/app/views/live/show_form.html.erb
+++ b/app/views/live/show_form.html.erb
@@ -10,49 +10,49 @@
 
     <%= render FormStatusTagDescriptionComponent::View.new(status: :live) %>
 
-    <p class="govuk-body">
+    <p>
       <%= render PreviewLinkComponent::View.new(form.pages, link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: :preview_live)) %>
     </p>
 
     <%= render FormUrlComponent::View.new(link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: :live ))%>
 
     <h2 class="govuk-heading-m"><%= t('show_live_form.questions') %></h2>
-    <p class="govuk-body"><%= govuk_link_to t('show_live_form.questions_link', count: form.pages.count), live_form_pages_path(form.id) %></p>
+    <p><%= govuk_link_to t('show_live_form.questions_link', count: form.pages.count), live_form_pages_path(form.id) %></p>
 
     <% if form.declaration_text.present? %>
       <h2 class="govuk-heading-m"><%= t('show_live_form.declaration') %></h2>
-      <p class="govuk-body"><%= form.declaration_text %></p>
+      <p><%= form.declaration_text %></p>
       <%= govuk_details(summary_text: t('show_live_form.what_is_declaration'), text: t('show_live_form.declaration_description')) %>
     <% end %>
 
     <h2 class="govuk-heading-m"><%= t('show_live_form.what_happens_next') %></h2>
-    <p class="govuk-body"><%= form.what_happens_next_text %></p>
+    <p><%= form.what_happens_next_text %></p>
     <%= govuk_details(summary_text: t('show_live_form.what_is_what_happens_next'), text: t('show_live_form.what_happens_next_description')) %>
 
     <h2 class="govuk-heading-m"><%= t('show_live_form.submission_email') %></h2>
-    <p class="govuk-body"><%= form.submission_email %></p>
+    <p><%= form.submission_email %></p>
 
     <h2 class="govuk-heading-m"><%= t('show_live_form.privacy_policy_link') %></h2>
-    <p class="govuk-body"><%= govuk_link_to(form.privacy_policy_url, form.privacy_policy_url) %></p>
+    <p><%= govuk_link_to(form.privacy_policy_url, form.privacy_policy_url) %></p>
 
     <h2 class="govuk-heading-m"><%= t('show_live_form.contact_details') %></h2>
 
     <% if form.support_email %>
       <h3 class="govuk-heading-s"><%= t('show_live_form.support_email') %></h3>
-      <p class="govuk-body"><%= form.support_email %></p>
+      <p><%= form.support_email %></p>
     <% end %>
 
     <% if form.support_phone %>
       <h3 class="govuk-heading-s"><%= t('show_live_form.support_phone') %></h3>
-      <p class="govuk-body"><%= form.support_phone %></p>
+      <p><%= form.support_phone %></p>
     <% end %>
 
     <% if form.support_url %>
       <h3 class="govuk-heading-s"><%= t('show_live_form.support_url') %></h3>
-      <p class="govuk-body"><%= govuk_link_to form.support_url_text, form.support_url %></p>
+      <p><%= govuk_link_to form.support_url_text, form.support_url %></p>
     <% end %>
 
-    <p class="govuk-body">
+    <p>
       <%# i18n-tasks-use t('show_live_form.draft_create') %>
       <%# i18n-tasks-use t('show_live_form.draft_edit') %>
       <%= govuk_button_link_to t("show_live_form.draft_#{ form_metadata.has_draft_version ? 'edit': 'create'}"), form_path(form.id) %>

--- a/app/views/live/show_pages.html.erb
+++ b/app/views/live/show_pages.html.erb
@@ -15,7 +15,7 @@
       <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: form.pages).build_data)%>
     <% end %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t("back_link.form_view"), live_form_path(form) %>
     </p>
   </div>

--- a/app/views/pages/address_settings.html.erb
+++ b/app/views/pages/address_settings.html.erb
@@ -12,7 +12,7 @@
       <%= f.govuk_submit t('continue') %>
     <% end %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>
     </p>
   </div>

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -7,7 +7,7 @@
       <%= t("page_titles.routing_page") %>
     </h1>
 
-    <p class="govuk-body">
+    <p>
       <%= t("routing_page.body_text") %>
     </p>
 

--- a/app/views/pages/date_settings.html.erb
+++ b/app/views/pages/date_settings.html.erb
@@ -16,7 +16,7 @@
       <%= f.govuk_submit t('continue') %>
     <% end %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>
     </p>
   </div>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -21,7 +21,7 @@
                                              change_name_settings_path: name_settings_edit_path(@form)
     } %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>
     </p>
   </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -16,7 +16,7 @@
     </dl>
 
     <% if flash[:message] %>
-      <p class="govuk-body"><%= flash[:message] %></p>
+      <p><%= flash[:message] %></p>
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), type_of_answer_new_path(@form), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>

--- a/app/views/pages/name_settings.html.erb
+++ b/app/views/pages/name_settings.html.erb
@@ -31,7 +31,7 @@
       <%= f.govuk_submit t('continue') %>
     <% end %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>
     </p>
   </div>

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -21,7 +21,7 @@
                                              change_name_settings_path: name_settings_new_path(@form)
         } %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>
     </p>
   </div>

--- a/app/views/pages/selections_settings.html.erb
+++ b/app/views/pages/selections_settings.html.erb
@@ -46,7 +46,7 @@
       <%= f.govuk_submit t('continue') %>
     <% end %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>
     </p>
   </div>

--- a/app/views/pages/text_settings.html.erb
+++ b/app/views/pages/text_settings.html.erb
@@ -16,7 +16,7 @@
       <%= f.govuk_submit t('continue') %>
     <% end %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>
     </p>
   </div>

--- a/app/views/pages/type-of-answer.html.erb
+++ b/app/views/pages/type-of-answer.html.erb
@@ -27,7 +27,7 @@
       <%= f.govuk_submit t('continue'), value: "true", name: :set_answer_type %>
     <% end %>
 
-    <p class="govuk-body">
+    <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>
     </p>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,11 +31,11 @@ en:
   contact_details:
     new:
       body_html: |
-        <p class="govuk-body">
+        <p>
           You need to provide at least one way for people to get help if they get stuck while filling in this form.
         </p>
 
-        <p class="govuk-body">
+        <p>
           The contact information will be displayed at the bottom of every page of the form.
         </p>
       hint: Select at least one option
@@ -45,18 +45,18 @@ en:
   declaration_form:
     new:
       body_html: |
-        <p class="govuk-body">
+        <p>
           When someone has answered all the questions in
           your form, they’ll be shown a page that lists all of their answers.
           The page will ask them to check their answers before they submit the
           form.
         </p>
-        <p class="govuk-body">
+        <p>
           You can add a declaration to this page. A declaration is a statement
           that people must confirm they understand and agree to before they
           submit the form.
         </p>
-        <p class="govuk-body">
+        <p>
           You might want to add a declaration if you need people to confirm they
           have provided accurate information, or that they understand the
           consequences of providing false information.
@@ -79,13 +79,11 @@ en:
     delete_condition_legend: Are you sure you want to delete this question route?
   email_code_sent:
     body_html: |
-      <p class="govuk-body">We've sent a confirmation code and your email address to %{temp_email}.</p>
-      <p class="govuk-body">The recipient will be asked to give you the code. You need to enter the code to confirm the email address.</p>
+      <p>We've sent a confirmation code and your email address to %{temp_email}.</p>
+      <p>The recipient will be asked to give you the code. You need to enter the code to confirm the email address.</p>
     continue: Continue creating a form
   email_code_success:
-    body_html: '<p class="govuk-body">Completed forms will be sent to %{submission_email}.</p>
-
-      '
+    body_html: "<p>Completed forms will be sent to %{submission_email}.</p>\n"
     continue: Continue creating a form
   error_summary:
     heading: There is a problem
@@ -310,7 +308,7 @@ en:
   make_live:
     confirmation:
       body_html: |
-        <p class="govuk-body">
+        <p>
           The form will not be indexed by search engines, so people will not be able to find it easily.
           Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
         </p>
@@ -318,14 +316,14 @@ en:
       form_name: Form name
     new:
       body_html: |
-        <p class="govuk-body">
+        <p>
           When you make your form live you’ll get a URL for the form. The form
           will not be indexed by search engines, so people will not be able to
           find it easily. Contact your GOV.UK publishing team to publish a link to
           your form on GOV.UK so people can find it.
         </p>
 
-        <p class="govuk-body">
+        <p>
           After you have made your form live, completed forms will be sent to %{submission_email}.
         </p>
   mark_complete:
@@ -426,11 +424,11 @@ en:
     link: feedback
   privacy_policy_form:
     body_html: |
-      <p class="govuk-body">
+      <p>
         To comply with the UK General Data Protection Regulation (UK GDPR), you must provide privacy information for the people who will enter their data into your form.
       </p>
 
-      <p class="govuk-body">
+      <p>
         The privacy information must include details such as:
         <ul class="govuk-list govuk-list--bullet">
           <li>
@@ -448,11 +446,11 @@ en:
         </ul>
       </p>
 
-      <p class="govuk-body">
+      <p>
         You may already publish this information, for example in a privacy notice or personal information charter. Existing privacy information may need to be updated to cover the data you are collecting in this form, or you may need a new privacy notice.
       </p>
 
-      <p class="govuk-body">
+      <p>
         To get help, contact your department’s data protection officer or data protection manager.
       </p>
     heading: Provide a link to privacy information for this form
@@ -482,15 +480,15 @@ en:
   set_email_form:
     new:
       body_html: |
-        <p class="govuk-body">
+        <p>
           You need to provide an email address for completed forms to be sent to for processing. It should be a shared government email inbox.
         </p>
 
-        <p class="govuk-body">
+        <p>
           To make sure the email address you provide is correct, we’ll send an email to it with a confirmation code and your email address.
         </p>
 
-        <p class="govuk-body">
+        <p>
           The recipient will be asked to tell you the code. You will then need to enter the code to confirm the email address.
         </p>
   show_live_form:
@@ -522,7 +520,7 @@ en:
     not_started: not started
   type_of_answer:
     routing_warning_about_change_answer_type_heading: Your existing question route may be deleted
-    routing_warning_about_change_answer_type_html: "<p class=\"govuk-body\">\n  Changing the answer type from \"Selection from a list of options\" to a different answer \n  type means your route will no longer work and will be deleted.\n</p>\n<p class=\"govuk-body\">\n  If you do not want to lose your question route you can cancel this change by using the back button \n  or clicking the \"Go to your questions\" link.\n</p>\n"
+    routing_warning_about_change_answer_type_html: "<p>\n  Changing the answer type from \"Selection from a list of options\" to a different answer \n  type means your route will no longer work and will be deleted.\n</p>\n<p>\n  If you do not want to lose your question route you can cancel this change by using the back button \n  or clicking the \"Go to your questions\" link.\n</p>\n"
     routing_warning_notification_title: Important
   user_missing_organisation:
     body: "%{contact_link} to assign an organisation to your account."

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe PageListComponent::View, type: :component do
       let(:error_link) { page_list_component.error_link(error_key: error_name, edit_link: condition_edit_path, page: pages[0], field: :answer_value) }
 
       it "returns the corrrect error html for a given condition" do
-        expect(error_link).to eq "<a class=\"govuk-link app-page_list__route-text--error\" href=\"#{condition_edit_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}\">#{I18n.t("page_conditions.errors.page_list.#{error_name}", page_index: 1)}</a>"
+        expect(error_link).to eq "<a class=\"app-page_list__route-text--error\" href=\"#{condition_edit_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}\">#{I18n.t("page_conditions.errors.page_list.#{error_name}", page_index: 1)}</a>"
       end
     end
 

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -19,7 +19,7 @@ describe "pages/conditions/routing_page.html.erb" do
   end
 
   it "contains body text" do
-    expect(rendered).to have_css("p.govuk-body", text: t("routing_page.body_text"))
+    expect(rendered).to have_css("p", text: t("routing_page.body_text"))
   end
 
   context "with fewer than 10 options" do


### PR DESCRIPTION
#### What problem does the pull request solve?

- Enables `$govuk-global-styles` in our CSS - this means that we won't have to add "govuk-body" and "govuk-link" classes any more
- Removes existing uses of govuk-body and govuk-link
- Also enables `$govuk-new-link-styles` - this gives us [improved, more accessible link styles](https://designnotes.blog.gov.uk/2021/07/07/making-links-easier-to-see-and-read-on-gov-uk/)

We already had both of these things enabled in forms-runner and forms-product-pages, but we missed forms-admin.

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
