### PR TITLE
Tweak routing answer type change text

### DIFF
--- a/app/views/pages/type-of-answer.html.erb
+++ b/app/views/pages/type-of-answer.html.erb
@@ -6,7 +6,7 @@
     <% if @page.present? && @page.answer_type.to_sym == :selection && @page.conditions.any?  %>
       <%= govuk_notification_banner(title_text: t("type_of_answer.routing_warning_notification_title")) do |banner| %>
         <% banner.with_heading(text: t("type_of_answer.routing_warning_about_change_answer_type_heading")) %>
-        <%= t("type_of_answer.routing_warning_about_change_answer_type_html") %>
+        <%= t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(@form)) %>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -520,7 +520,13 @@ en:
     not_started: not started
   type_of_answer:
     routing_warning_about_change_answer_type_heading: Your existing question route may be deleted
-    routing_warning_about_change_answer_type_html: "<p>\n  Changing the answer type from \"Selection from a list of options\" to a different answer \n  type means your route will no longer work and will be deleted.\n</p>\n<p>\n  If you do not want to lose your question route you can cancel this change by using the back button \n  or clicking the \"Go to your questions\" link.\n</p>\n"
+    routing_warning_about_change_answer_type_html: |
+      <p>
+        Changing the answer type from “Selection from a list of options” to a different answer type means your route will no longer work and will be deleted.
+      </p>
+      <p>
+        If you do not want to lose your question route you can cancel this change by using the back button or <a href="%{pages_link_url}">go to your questions</a>.
+      </p>
     routing_warning_notification_title: Important
   user_missing_organisation:
     body: "%{contact_link} to assign an organisation to your account."

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -77,7 +77,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
 
     it "displays a warning about routes being deleted if answer type changes" do
       expect(Capybara.string(rendered).find(".govuk-notification-banner__content").text(normalize_ws: true))
-        .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_about_change_answer_type_html"))
+        .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(form)))
                         .text(normalize_ws: true))
     end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
Tweaks the answer type text to include a link to the page list.

Trello card: https://trello.com/c/I0qZazC6/789-update-answer-type-warning-message

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
