### PR TITLE
Simplify routing error UI

### DIFF
--- a/app/components/page_list_component/_index.scss
+++ b/app/components/page_list_component/_index.scss
@@ -20,7 +20,8 @@
   }
 }
 
-.app-page_list__route-text--error:link,
-.app-page_list__route-text--error:visited {
+.app-page_list__route-text--error {
+  @include govuk-responsive-margin(2, "bottom");
   color: $govuk-error-colour;
+  font-weight: 700;
 }

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -40,28 +40,25 @@
                 </dt>
 
                 <dd class="govuk-summary-list__value">
-                  <p class="govuk-!-margin-2">
-                    <%= t("page_conditions.#{condition.validation_errors.length > 1 || condition.has_errors_for_field?(:answer_value) ? "condition_check_page_text_with_errors" : "condition_check_page_text"}", check_page_text: question_text_for_page(condition.check_page_id)) %>
+                  <ul class="govuk-list govuk-!-margin-0">
+                    <% condition.validation_errors.each do |error| %>
+                      <li class="app-page_list__route-text--error">
+                        <%= t("page_conditions.errors.page_list.#{error.name}", page_index: page.position) %>
+                      </li>
+                    <% end %>
+                  </ul>
+
+                  <p>
+                    <%= t("page_conditions.condition_check_page_text", check_page_text: question_text_for_page(condition.check_page_id)) %>
                   </p>
 
-                  <% if condition.has_multiple_errors? %>
-                    <ul class="govuk-list govuk-list--bullet">
-                      <% condition.errors_with_fields.each do |error| %>
-                      <li><%= error_link(error_key: error[:name], edit_link:edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page:, field: error[:field]) %></li>
-                      <% end %>
-                    </ul>
-                  <% else %>
-                    <%= content_tag(
-                      :p,
-                      answer_value_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page),
-                      class: "govuk-!-margin-2"
-                      ) %>
-                    <%= content_tag(
-                      :p,
-                      goto_page_text_for_condition(condition, edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id), page),
-                      class: "govuk-!-margin-2"
-                      ) %>
-                  <% end %>
+                  <p>
+                    <%= answer_value_text_for_condition(condition) %>
+                  </p>
+
+                  <p>
+                    <%= goto_page_text_for_condition(condition) %>
+                  </p>
                 </dd>
 
                 <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -21,32 +21,19 @@ module PageListComponent
       @pages.find { |page| page.id == id }.question_text
     end
 
-    def error_link(error_key:, edit_link:, page:, field:)
-      content_tag(
-        :a,
-        I18n.t("page_conditions.errors.page_list.#{error_key}", page_index: page.position),
-        class: "app-page_list__route-text--error",
-        href: "#{edit_link}##{Pages::ConditionsForm.new.id_for_field(field)}",
-      )
-    end
-
-    def answer_value_text_for_condition(condition, edit_link, page)
-      if condition.errors_include?("answer_value_doesnt_exist")
-        error_link(error_key: "answer_value_doesnt_exist", edit_link:, page:, field: :answer_value)
-      else
+    def answer_value_text_for_condition(condition)
+      if condition.answer_value.present?
         I18n.t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
+      else
+        I18n.t("page_conditions.condition_answer_value_text_with_errors")
       end
     end
 
-    def goto_page_text_for_condition(condition, edit_link, page)
-      if condition.errors_include?("goto_page_doesnt_exist")
-        error_link(error_key: "goto_page_doesnt_exist", edit_link:, page:, field: :goto_page_id)
-      elsif condition.errors_include?("cannot_have_goto_page_before_routing_page")
-        error_link(error_key: "cannot_have_goto_page_before_routing_page", edit_link:, page:, field: :goto_page_id)
-      elsif condition.errors_include?("cannot_route_to_next_page")
-        error_link(error_key: "cannot_route_to_next_page", edit_link:, page:, field: :goto_page_id)
-      else
+    def goto_page_text_for_condition(condition)
+      if condition.goto_page_id.present?
         I18n.t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
+      else
+        I18n.t("page_conditions.condition_goto_page_text_with_errors")
       end
     end
 

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -38,10 +38,6 @@ class Pages::ConditionsForm
     [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }].flatten
   end
 
-  def id_for_field(field)
-    "pages-conditions-form-#{field.to_s.dasherize}-field-error"
-  end
-
   def check_errors_from_api
     record.errors_with_fields.each do |error|
       errors.add(error[:field], error[:name].to_sym)

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -18,19 +18,7 @@ class Condition < ActiveResource::Base
     end
   end
 
-  def has_errors_for_field?(field)
-    errors_with_fields.filter { |error| error[:field] == field }.any?
-  end
-
   def has_errors?
     validation_errors.any?
-  end
-
-  def has_multiple_errors?
-    validation_errors.length >= 2
-  end
-
-  def errors_include?(error_name)
-    has_errors? && validation_errors.map(&:name).include?(error_name)
   end
 end

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -20,8 +20,8 @@
         end;
       end %>
 
-      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label, id: condition_form.id_for_field(:answer_value), label: { for: condition_form.id_for_field(:answer_value) } %>
-      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text, id: condition_form.id_for_field(:goto_page_id), label: { for: condition_form.id_for_field(:goto_page_id) }  %>
+      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label %>
+      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text %>
       <%= f.govuk_submit t("save_and_continue") do
         govuk_button_link_to "Delete question route", delete_condition_path(condition_form.form.id, condition_form.page.id, condition_form.record.id), warning: true
       end %>

--- a/app/views/pages/conditions/new.html.erb
+++ b/app/views/pages/conditions/new.html.erb
@@ -21,8 +21,8 @@
         end;
       end %>
 
-      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label, id: condition_form.id_for_field(:answer_value) %>
-      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text, id: condition_form.id_for_field(:goto_page_id) %>
+      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label %>
+      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text %>
       <%= f.govuk_submit t("save_and_continue") %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,10 +341,11 @@ en:
     title: Page not found
   page_conditions:
     condition_answer_value_text: is answered as “%{answer_value}”
+    condition_answer_value_text_with_errors: is answered as [Answer not selected]
     condition_check_page_text: If the question “%{check_page_text}”
-    condition_check_page_text_with_errors: For the question “%{check_page_text}”
     condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to question %{goto_page_number}: “%{goto_page_text}”'
     condition_goto_page_text: take the person to “%{goto_page_text}”
+    condition_goto_page_text_with_errors: take the person to [Question not selected]
     condition_name: Question %{page_index}’s route
     errors:
       error_summary:
@@ -353,10 +354,10 @@ en:
         cannot_route_to_next_page: Question %{page_index}’s route is now next to the route’s end question - this makes the route unnecessary. Edit question %{page_index}’s route.
         goto_page_doesnt_exist: The question you’re taking the person to no longer exists - edit question %{page_index}’s route
       page_list:
-        answer_value_doesnt_exist: select the answer you want to base question %{page_index}’s route on
-        cannot_have_goto_page_before_routing_page: select another question or page you want to take the person to, or delete question %{page_index}’s route
-        cannot_route_to_next_page: select another question or page you want to take the person to, or delete question %{page_index}’s route
-        goto_page_doesnt_exist: select the question or page you want to take the person to, or delete question %{page_index}’s route
+        answer_value_doesnt_exist: The answer that question %{page_index}’s route is based on no longer exists - edit question %{page_index}’s route
+        cannot_have_goto_page_before_routing_page: The question you’re taking the person to is now above the route - edit question %{page_index}’s route
+        cannot_route_to_next_page: Question %{page_index}’s route is now next to the route’s end question - this makes the route unnecessary. Edit question %{page_index}’s route.
+        goto_page_doesnt_exist: The question you’re taking the person to no longer exists - edit question %{page_index}’s route
     route: Route
   page_options_service:
     answer_type: Answer type

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -72,7 +72,11 @@ RSpec.describe PageListComponent::View, type: :component do
         context "when the page has a single condition" do
           let(:routing_conditions) { [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3)] }
 
-          it "renders the non-error text for the chack page" do
+          it "does not render any errors" do
+            expect(page).not_to have_css(".app-page_list__route-text--error")
+          end
+
+          it "renders the text for the check page" do
             condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
           end
@@ -102,20 +106,18 @@ RSpec.describe PageListComponent::View, type: :component do
         context "when the page has a condition with no answer_value" do
           let(:routing_conditions) { [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3)] }
 
-          it "renders the error-specific text for the check page" do
-            condition_check_page_text_with_errors = I18n.t("page_conditions.condition_check_page_text_with_errors", check_page_text: pages[0].question_text)
-            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text_with_errors)
-          end
-
-          it "does not render the unordered error list" do
-            condition_goto_page_error = I18n.t("page_conditions.errors.page_list.goto_page_doesnt_exist", page_index: 1)
-            expect(page).not_to have_css("ul > li > a", text: condition_goto_page_error)
-          end
-
-          it "renders the answer_value error in in a separate paragraph" do
+          it "renders the errors in an unordered list" do
             condition_answer_value_error = I18n.t("page_conditions.errors.page_list.answer_value_doesnt_exist", page_index: 1)
-            expect(page).to have_css("dd.govuk-summary-list__value > p", text: condition_answer_value_error)
-            expect(page).to have_link(condition_answer_value_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}")
+            expect(page).to have_css("ul > li", text: condition_answer_value_error)
+          end
+
+          it "renders the text for the check page" do
+            condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
+            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
+          end
+
+          it "renders the answer_value text with placeholder text" do
+            expect(page).to have_css("dd.govuk-summary-list__value > p", text: I18n.t("page_conditions.condition_answer_value_text_with_errors"))
           end
 
           it "renders the goto_page text in a separate paragraph" do
@@ -131,20 +133,18 @@ RSpec.describe PageListComponent::View, type: :component do
         context "when the page has a condition with no goto_page set" do
           let(:routing_conditions) { [(build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales")] }
 
-          it "renders the non-error text for the check page" do
+          it "renders the errors in an unordered list" do
+            condition_goto_page_error = I18n.t("page_conditions.errors.page_list.goto_page_doesnt_exist", page_index: 1)
+            expect(page).to have_css("ul > li", text: condition_goto_page_error)
+          end
+
+          it "renders the text for the check page" do
             condition_check_page_text = I18n.t("page_conditions.condition_check_page_text", check_page_text: pages[0].question_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text)
           end
 
-          it "does not render the unordered error list" do
-            condition_goto_page_error = I18n.t("page_conditions.errors.page_list.goto_page_doesnt_exist", page_index: 1)
-            expect(page).not_to have_css("ul > li > a", text: condition_goto_page_error)
-          end
-
-          it "renders the goto_page error in a separate paragraph" do
-            condition_goto_page_error = I18n.t("page_conditions.errors.page_list.goto_page_doesnt_exist", page_index: 1)
-            expect(page).to have_css("dd.govuk-summary-list__value > p > a", text: condition_goto_page_error)
-            expect(page).to have_link(condition_goto_page_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:goto_page_id)}")
+          it "renders the goto_page text with placeholder text" do
+            expect(page).to have_css("dd.govuk-summary-list__value > p", text: I18n.t("page_conditions.condition_goto_page_text_with_errors"))
           end
 
           it "renders the answer_value text in a separate paragraph" do
@@ -157,21 +157,14 @@ RSpec.describe PageListComponent::View, type: :component do
           end
         end
 
-        context "when the page has a condition with no answer value or goto_page set" do
+        context "when the page has a condition with multiple errors" do
           let(:routing_conditions) { [(build :condition, :with_answer_value_and_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1)] }
-
-          it "renders the error-specific text for the check page" do
-            condition_check_page_text_with_errors = I18n.t("page_conditions.condition_check_page_text_with_errors", check_page_text: pages[0].question_text)
-            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_check_page_text_with_errors)
-          end
 
           it "renders the errors in an unordered list" do
             condition_answer_value_error = I18n.t("page_conditions.errors.page_list.answer_value_doesnt_exist", page_index: 1)
             condition_goto_page_error = I18n.t("page_conditions.errors.page_list.goto_page_doesnt_exist", page_index: 1)
-            expect(page).to have_css("ul > li > a", text: condition_answer_value_error)
-            expect(page).to have_css("ul > li > a", text: condition_goto_page_error)
-            expect(page).to have_link(condition_answer_value_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}")
-            expect(page).to have_link(condition_goto_page_error, href: "#{edit_condition_path}##{Pages::ConditionsForm.new.id_for_field(:goto_page_id)}")
+            expect(page).to have_css("ul > li", text: condition_answer_value_error)
+            expect(page).to have_css("ul > li", text: condition_goto_page_error)
           end
 
           it "renders link" do
@@ -221,20 +214,9 @@ RSpec.describe PageListComponent::View, type: :component do
       end
     end
 
-    describe "error_link" do
-      let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
-      let(:error_name) { condition.validation_errors[0].name }
-      let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:error_link) { page_list_component.error_link(error_key: error_name, edit_link: condition_edit_path, page: pages[0], field: :answer_value) }
-
-      it "returns the corrrect error html for a given condition" do
-        expect(error_link).to eq "<a class=\"app-page_list__route-text--error\" href=\"#{condition_edit_path}##{Pages::ConditionsForm.new.id_for_field(:answer_value)}\">#{I18n.t("page_conditions.errors.page_list.#{error_name}", page_index: 1)}</a>"
-      end
-    end
-
     describe "answer_value_text_for_condition" do
       let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:answer_value_text) { page_list_component.answer_value_text_for_condition(condition, condition_edit_path, pages[0]) }
+      let(:answer_value_text) { page_list_component.answer_value_text_for_condition(condition) }
 
       context "when the answer value is set" do
         let(:condition) { (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3) }
@@ -247,15 +229,15 @@ RSpec.describe PageListComponent::View, type: :component do
       context "when the answer value is not set" do
         let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
 
-        it "returns the answer value error link" do
-          expect(answer_value_text).to eq page_list_component.error_link(error_key: "answer_value_doesnt_exist", edit_link: condition_edit_path, page: pages[0], field: :answer_value)
+        it "returns the answer value error text" do
+          expect(answer_value_text).to eq I18n.t("page_conditions.condition_answer_value_text_with_errors")
         end
       end
     end
 
     describe "goto_page_text_for_condition" do
       let(:condition_edit_path) { "https://example.gov.uk" }
-      let(:goto_page_text) { page_list_component.goto_page_text_for_condition(condition, condition_edit_path, pages[0]) }
+      let(:goto_page_text) { page_list_component.goto_page_text_for_condition(condition) }
 
       context "when the goto page is set" do
         let(:condition) { (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3) }
@@ -268,24 +250,8 @@ RSpec.describe PageListComponent::View, type: :component do
       context "when the goto page is not set" do
         let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales") }
 
-        it "returns the goto page error link" do
-          expect(goto_page_text).to eq page_list_component.error_link(error_key: "goto_page_doesnt_exist", edit_link: condition_edit_path, page: pages[0], field: :goto_page_id)
-        end
-      end
-
-      context "when the goto page is before the check page" do
-        let(:condition) { (build :condition, :with_goto_page_before_check_page, id: 1, routing_page_id: 2, check_page_id: 2, answer_value: "Wales", goto_page_id: 1) }
-
-        it "returns the goto page error link" do
-          expect(goto_page_text).to eq page_list_component.error_link(error_key: "cannot_have_goto_page_before_routing_page", edit_link: condition_edit_path, page: pages[0], field: :goto_page_id)
-        end
-      end
-
-      context "when the goto page is immediately after the check page" do
-        let(:condition) { (build :condition, :with_goto_page_immediately_after_check_page, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 2) }
-
-        it "returns the goto page error link" do
-          expect(goto_page_text).to eq page_list_component.error_link(error_key: "cannot_route_to_next_page", edit_link: condition_edit_path, page: pages[0], field: :goto_page_id)
+        it "returns the goto page error text" do
+          expect(goto_page_text).to eq I18n.t("page_conditions.condition_goto_page_text_with_errors")
         end
       end
     end

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -111,13 +111,6 @@ RSpec.describe Pages::ConditionsForm, type: :model do
     end
   end
 
-  describe "#id_for_field" do
-    it "returns the correct id for a field" do
-      result = described_class.new(form:, page: pages.first).id_for_field(:answer_value)
-      expect(result).to eq("pages-conditions-form-answer-value-field-error")
-    end
-  end
-
   describe "#check_errors_from_api" do
     let(:condition) { build :condition, :with_answer_value_missing, id: 3, page_id: 2, routing_page_id: 1, answer_value: "England", check_page_id: 1, goto_page_id: 3 }
 

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -20,54 +20,6 @@ describe Condition do
     end
   end
 
-  describe "#has_multiple_errors?" do
-    context "when condition has no errors" do
-      it "returns false" do
-        expect(condition.has_multiple_errors?).to be false
-      end
-    end
-
-    context "when condition has one error" do
-      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist")] }
-
-      it "returns false" do
-        expect(condition.has_multiple_errors?).to be false
-      end
-    end
-
-    context "when condition has an error" do
-      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist")] }
-
-      it "returns true" do
-        expect(condition.has_multiple_errors?).to be true
-      end
-    end
-  end
-
-  describe "#errors_include?" do
-    context "when condition has no errors" do
-      it "returns false" do
-        expect(condition.errors_include?("answer_value_doesnt_exist")).to be false
-      end
-    end
-
-    context "when condition contains a different error" do
-      let(:validation_errors) { [OpenStruct.new(name: "goto_page_doesnt_exist")] }
-
-      it "returns false" do
-        expect(condition.errors_include?("answer_value_doesnt_exist")).to be false
-      end
-    end
-
-    context "when condition contains the relevant error" do
-      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist")] }
-
-      it "returns true" do
-        expect(condition.errors_include?("answer_value_doesnt_exist")).to be true
-      end
-    end
-  end
-
   describe "#errors_with_fields" do
     context "when the error is a known error" do
       let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist"), OpenStruct.new(name: "cannot_have_goto_page_before_routing_page"), OpenStruct.new(name: "cannot_route_to_next_page")] }
@@ -83,18 +35,6 @@ describe Condition do
       it "returns answer_value as a default" do
         expect(condition.errors_with_fields).to eq [{ field: :answer_value, name: "some_unknown_error" }]
       end
-    end
-  end
-
-  describe "#has_errors_for_field?" do
-    let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist")] }
-
-    it "returns true when the field has an error" do
-      expect(condition.has_errors_for_field?(:answer_value)).to be true
-    end
-
-    it "returns false when the field has no errors" do
-      expect(condition.has_errors_for_field?(:goto_page_id)).to be false
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
Updates the UI for routing errors:
- the errors in the page list are no longer links
- the errors in the page list now have the same text as those in the error summary
- the errors now appear above the route details, instead of replacing bits of it
- the answer value and goto page text will now show a placeholder if the relevant information doesn't exist

Trello card: https://trello.com/c/1KqRjuJT/794-change-routing-error-message-presentation

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a ] Elsewhere (please link)
