### PR TITLE
Add configuration of authentication provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "puma", "~> 6.3.0"
 # Used for handling authentication
 gem "gds-sso"
 gem "omniauth"
+gem "warden"
 
 # Used for handling authorisation policies
 gem "pundit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -494,6 +494,7 @@ DEPENDENCIES
   tzinfo-data
   validate_url
   vite_rails
+  warden
   web-console
   webdrivers
   webmock

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 require "resolv"
 
 class ApplicationController < ActionController::Base
-  include GDS::SSO::ControllerMethods
   include Pundit::Authorization
   before_action :set_request_id
   before_action :check_service_unavailable
@@ -74,6 +73,18 @@ class ApplicationController < ActionController::Base
   def user_ip(forwarded_for = "")
     first_ip_string = forwarded_for.split(",").first
     Regexp.union([Resolv::IPv4::Regex, Resolv::IPv6::Regex]).match(first_ip_string) && first_ip_string
+  end
+
+  def warden
+    request.env["warden"]
+  end
+
+  def user_signed_in
+    warden && warden.authenticated? && !warden.user.remotely_signed_out?
+  end
+
+  def current_user
+    warden.user if user_signed_in
   end
 
   def authenticate_user!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,7 +108,7 @@ class ApplicationController < ActionController::Base
       basic_auth
     else
       # signon auth
-      super
+      warden.authenticate! Settings.auth_provider.to_sym
       @current_user = current_user
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,7 +77,7 @@ class ApplicationController < ActionController::Base
   end
 
   def authenticate_user!
-    warden.authenticate! Settings.basic_auth.enabled ? :basic_auth : Settings.auth_provider.to_sym
+    warden.authenticate! Settings.auth_provider.to_sym
 
     # set user instance variable for views
     @current_user = current_user

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,11 +65,20 @@ module ApplicationHelper
   end
 
   def header_component_options(user:, can_manage_users:)
+    auth_links = {
+      gds_sso: {
+        user_profile_link: GDS::SSO::Config.oauth_root_url,
+        signout_link: gds_sign_out_path,
+      },
+    }
+    auth_links.default = {}
+    links = auth_links[Settings.auth_provider.to_sym]
+
     { is_signed_in: user.present?,
       user_name: user&.name.presence,
-      user_profile_link: (user.blank? || Settings.basic_auth.enabled ? nil : GDS::SSO::Config.oauth_root_url),
+      user_profile_link: (user.blank? ? nil : links[:user_profile_link]),
       list_of_users_path: (can_manage_users ? users_path : nil),
-      signout_link: (user.blank? || Settings.basic_auth.enabled ? nil : gds_sign_out_path) }
+      signout_link: (user.blank? ? nil : links[:signout_link]) }
   end
 
   def user_role_options(roles = User.roles.keys)

--- a/config/initializers/warden/strategies/basic_auth.rb
+++ b/config/initializers/warden/strategies/basic_auth.rb
@@ -20,11 +20,11 @@ Warden::Strategies.add(:basic_auth) do
     )
 
     if status.nil?
-      success! User.new(
+      success! User.find_or_initialize_by(
         name: Settings.basic_auth.username,
         email: "#{Settings.basic_auth.username}@example.com",
         role: :editor,
-        organisation: Organisation.new(
+        organisation: Organisation.find_or_initialize_by(
           name: Settings.basic_auth.organisation.name,
           slug: Settings.basic_auth.organisation.slug,
           content_id: Settings.basic_auth.organisation.content_id,

--- a/config/initializers/warden/strategies/basic_auth.rb
+++ b/config/initializers/warden/strategies/basic_auth.rb
@@ -1,0 +1,37 @@
+Warden::Strategies.add(:basic_auth) do
+  include ActionController::HttpAuthentication::Basic::ControllerMethods
+
+  attr_writer :status
+
+  def request
+    @request ||= ActionDispatch::Request.new(@env)
+  end
+
+  def response_body=(message)
+    @message = message
+  end
+
+  def authenticate!
+    logger.debug("Authenticating with basic_auth strategy")
+
+    http_basic_authenticate_or_request_with(
+      name: Settings.basic_auth.username,
+      password: Settings.basic_auth.password,
+    )
+
+    if status.nil?
+      success! User.new(
+        name: Settings.basic_auth.username,
+        email: "#{Settings.basic_auth.username}@example.com",
+        role: :editor,
+        organisation: Organisation.new(
+          name: Settings.basic_auth.organisation.name,
+          slug: Settings.basic_auth.organisation.slug,
+          content_id: Settings.basic_auth.organisation.content_id,
+        ),
+      )
+    else
+      custom! [@status, headers, [@message]]
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,7 +33,6 @@ sentry:
 auth_provider: # use default auth_provider from environment
 
 basic_auth:
-  enabled: false
   username: basic_auth_user
   password:
   organisation:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,6 +29,9 @@ sentry:
   dsn:
   environment: local
 
+# How we authenticate users
+auth_provider: # use default auth_provider from environment
+
 basic_auth:
   enabled: false
   username: basic_auth_user

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,3 +6,6 @@ forms_api:
   base_url: http://localhost:9292
   # Authentication key to authenticate forms-runner to forms-api
   auth_key: changeme
+
+# Use mock authentication
+auth_provider: mock_gds_sso

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,2 @@
+# Use real authentication
+auth_provider: gds_sso

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -11,3 +11,6 @@ service_unavailable: false
 forms_runner:
   # Base URL to point users to the app in the UI
   url: runner-host
+
+# Use mock authentication
+auth_provider: mock_gds_sso

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -40,11 +40,13 @@ describe ApplicationController, type: :controller do
         allow(warden_spy).to receive(:authenticate!).and_return(true)
         allow(controller).to receive(:current_user).and_return(user)
 
+        allow(Settings).to receive(:auth_provider).and_return("gds_sso")
+
         get :index
       end
 
       it "uses GOV.UK Signon" do
-        expect(warden_spy).to have_received(:authenticate!)
+        expect(warden_spy).to have_received(:authenticate!).with(:gds_sso)
       end
 
       it "sets @current_user" do

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -56,30 +56,21 @@ describe ApplicationController, type: :controller do
 
     context "when basic auth is enabled" do
       before do
-        # Mock warden manager and config
-        warden_config_double = instance_double(Warden::Config, intercept_401: false)
-        warden_manager_double = instance_double(Warden::Manager, config: warden_config_double)
-        allow(warden_spy).to receive(:manager).and_return(warden_manager_double)
-        expect(warden_config_double).to receive(:intercept_401=).with(false)
+        # Mock Warden
+        allow(warden_spy).to receive(:authenticate!).and_return(true)
+        allow(controller).to receive(:current_user).and_return(user)
 
         allow(Settings.basic_auth).to receive(:enabled).and_return(true)
-
-        allow(controller)
-          .to receive(:http_basic_authenticate_or_request_with)
-          .and_return(true)
 
         get :index
       end
 
       it "uses HTTP Basic Authentication" do
-        expect(controller)
-          .to have_received(:http_basic_authenticate_or_request_with)
+        expect(warden_spy).to have_received(:authenticate!).with(:basic_auth)
       end
 
       it "sets @current_user" do
-        expect(assigns[:current_user].name).to eq("basic_auth_user")
-        expect(assigns[:current_user].email).to eq("basic_auth_user@example.com")
-        expect(assigns[:current_user].organisation.slug).to eq("gds-user-research")
+        expect(assigns[:current_user]).to eq user
       end
     end
   end

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -60,7 +60,7 @@ describe ApplicationController, type: :controller do
         allow(warden_spy).to receive(:authenticate!).and_return(true)
         allow(controller).to receive(:current_user).and_return(user)
 
-        allow(Settings.basic_auth).to receive(:enabled).and_return(true)
+        allow(Settings).to receive(:auth_provider).and_return("basic_auth")
 
         get :index
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -154,7 +154,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
 
-    context "when a user is signed in" do
+    context "when a user is signed in with GOV.UK Signon" do
+      before do
+        allow(Settings).to receive(:auth_provider).and_return("gds_sso")
+      end
+
       it "returns the following options" do
         expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: true,
                                                                                   list_of_users_path: nil,
@@ -177,8 +181,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       context "when http basic auth is enabled" do
         it "returns the following options" do
-          basic_auth_double = object_double("basic_auth_double", enabled: true)
-          allow(Settings).to receive(:basic_auth).and_return(basic_auth_double)
+          allow(Settings).to receive(:auth_provider).and_return("basic_auth")
 
           expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: true,
                                                                                     list_of_users_path: nil,

--- a/spec/integration/basic_auth_spec.rb
+++ b/spec/integration/basic_auth_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "using basic auth" do
+  let(:username) { "tester" }
+  let(:password) { "password" }
+
+  let(:basic_auth_settings) do
+    Config::Options.new(
+      organisation: Config::Options.new(
+        slug: "test-org",
+        name: "Test Org",
+        content_id: "",
+      ),
+      enabled: true,
+      username:,
+      password:,
+    )
+  end
+
+  before do
+    api_headers = {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?org=test-org", api_headers, [].to_json, 200
+    end
+
+    allow(Settings).to receive(:basic_auth).and_return(basic_auth_settings)
+  end
+
+  it "app requests HTTP Basic Authentication when no user is logged in" do
+    logout
+
+    get root_path
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(response.headers["WWW-Authenticate"]).to eq 'Basic realm="Application"'
+  end
+
+  describe "authentication" do
+    before do
+      allow(Settings).to receive(:basic_auth).and_return(basic_auth_settings)
+
+      auth = ActionController::HttpAuthentication::Basic
+        .encode_credentials(username, password)
+
+      get root_path, headers: { "HTTP_AUTHORIZATION": auth }
+    end
+
+    it "signs in user as defined in settings" do
+      expect(assigns[:current_user].name).to eq username
+      expect(assigns[:current_user].email).to eq "#{username}@example.com"
+      expect(assigns[:current_user].organisation.slug).to eq "test-org"
+    end
+  end
+end

--- a/spec/integration/basic_auth_spec.rb
+++ b/spec/integration/basic_auth_spec.rb
@@ -4,12 +4,16 @@ RSpec.describe "using basic auth" do
   let(:username) { "tester" }
   let(:password) { "password" }
 
+  let!(:organisation) do
+    build :organisation, slug: "test-org"
+  end
+
   let(:basic_auth_settings) do
     Config::Options.new(
       organisation: Config::Options.new(
         slug: "test-org",
         name: "Test Org",
-        content_id: "",
+        content_id: organisation.content_id,
       ),
       enabled: true,
       username:,

--- a/spec/integration/basic_auth_spec.rb
+++ b/spec/integration/basic_auth_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "using basic auth" do
         name: "Test Org",
         content_id: organisation.content_id,
       ),
-      enabled: true,
       username:,
       password:,
     )
@@ -31,7 +30,7 @@ RSpec.describe "using basic auth" do
       mock.get "/api/v1/forms?org=test-org", api_headers, [].to_json, 200
     end
 
-    allow(Settings).to receive(:basic_auth).and_return(basic_auth_settings)
+    allow(Settings).to receive(:auth_provider).and_return("basic_auth")
   end
 
   it "app requests HTTP Basic Authentication when no user is logged in" do

--- a/spec/integration/basic_auth_spec.rb
+++ b/spec/integration/basic_auth_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe "using basic auth" do
       get root_path, headers: { "HTTP_AUTHORIZATION": auth }
     end
 
+    it "authenticates with Warden" do
+      expect(request.env["warden"].authenticated?).to be true
+    end
+
     it "signs in user as defined in settings" do
       expect(assigns[:current_user].name).to eq username
       expect(assigns[:current_user].email).to eq "#{username}@example.com"

--- a/spec/integration/gds_sso_spec.rb
+++ b/spec/integration/gds_sso_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "usage of gds-sso gem" do
+  before do
+    allow(Settings).to receive(:auth_provider).and_return("gds_sso")
+  end
+
   let(:omniauth_hash) do
     OmniAuth::AuthHash.new({
       provider: "gds",


### PR DESCRIPTION
We want to be able to use other authentication strategies in forms-admin. This PR refactors the application controller to allow configuration of the strategy using the settings files or environment variable.

We also deprecate the old way of selecting the basic authentication strategy, and move the basic authentication strategy out the application controller and into a Warden strategy.

Note that for the setting, we call it `auth_provider`, not `auth_strategy`. The term strategy is used consistently in Warden, but in OmniAuth provider and strategy are used somewhat interchangeably. I think arguably you could say the provider is the external identity provider and the strategy is the code you use to communicate with it, but in the context of a configuration setting there isn't too much difference in it. To be consistent with what we save in our database (see PR https://github.com/alphagov/forms-admin/pull/469) and to better express the intention of the configuration variable, I think we should stick with provider.