### PR TITLE
Allow user to select check your answers page as goto page

### DIFF
--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -33,7 +33,7 @@ module PageListComponent
       if condition.goto_page_id.present?
         I18n.t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
       elsif condition.skip_to_end
-        I18n.t("page_conditions.condition_goto_page_text", goto_page_text: "Check your answers")
+        I18n.t("page_conditions.condition_goto_page_text", goto_page_text: I18n.t("page_conditions.check_your_answers"))
       else
         I18n.t("page_conditions.condition_goto_page_text_with_errors")
       end

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -32,6 +32,8 @@ module PageListComponent
     def goto_page_text_for_condition(condition)
       if condition.goto_page_id.present?
         I18n.t("page_conditions.condition_goto_page_text", goto_page_text: question_text_for_page(condition.goto_page_id))
+      elsif condition.skip_to_end
+        I18n.t("page_conditions.condition_goto_page_text", goto_page_text: "Check your answers")
       else
         I18n.t("page_conditions.condition_goto_page_text_with_errors")
       end

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -38,7 +38,7 @@ class Pages::ConditionsController < PagesController
   def edit
     condition = Condition.find(params[:condition_id], params: { form_id: @form.id, page_id: page.id })
 
-    condition_form = Pages::ConditionsForm.new(form: @form, page:, record: condition, answer_value: condition.answer_value, goto_page_id: condition.goto_page_id)
+    condition_form = Pages::ConditionsForm.new(form: @form, page:, record: condition, answer_value: condition.answer_value, goto_page_id: condition.goto_page_id, skip_to_end: condition.skip_to_end).assign_condition_values
 
     condition_form.check_errors_from_api
 
@@ -52,7 +52,7 @@ class Pages::ConditionsController < PagesController
 
     condition_form = Pages::ConditionsForm.new(form_params)
 
-    if condition_form.update
+    if condition_form.update_condition
       redirect_to form_pages_path(@form), success: t("banner.success.route_updated", question_position: condition_form.page.position)
     else
       render template: "pages/conditions/edit", locals: { condition_form: }, status: :unprocessable_entity

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -2,26 +2,32 @@ class Pages::ConditionsForm
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :form, :page, :check_page_id, :routing_page_id, :answer_value, :goto_page_id, :record
+  attr_accessor :form, :page, :check_page_id, :routing_page_id, :answer_value, :goto_page_id, :record, :skip_to_end
 
   validates :answer_value, :goto_page_id, presence: true
 
   def submit
     return false if invalid?
 
+    assign_skip_to_end
+
     Condition.create!(form_id: form.id,
                       page_id: page.id,
                       check_page_id: page.id,
                       routing_page_id: page.id,
                       answer_value:,
-                      goto_page_id:)
+                      goto_page_id:,
+                      skip_to_end:)
   end
 
-  def update
+  def update_condition
     return false if invalid?
+
+    assign_skip_to_end
 
     record.answer_value = answer_value
     record.goto_page_id = goto_page_id
+    record.skip_to_end = skip_to_end
 
     record.save!
   end
@@ -35,12 +41,28 @@ class Pages::ConditionsForm
 
   def goto_page_options
     # TODO: add end of form/check your answers as an option
-    [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }].flatten
+    [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }, OpenStruct.new(id: "check_your_answers", question_text: "Check your answers")].flatten
   end
 
   def check_errors_from_api
     record.errors_with_fields.each do |error|
       errors.add(error[:field], error[:name].to_sym)
+    end
+  end
+
+  def assign_condition_values
+    if goto_page_id.nil? && skip_to_end
+      self.goto_page_id = "check_your_answers"
+    end
+    self
+  end
+
+  def assign_skip_to_end
+    if goto_page_id == "check_your_answers"
+      self.goto_page_id = nil
+      self.skip_to_end = true
+    else
+      self.skip_to_end = false
     end
   end
 end

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -40,8 +40,7 @@ class Pages::ConditionsForm
   end
 
   def goto_page_options
-    # TODO: add end of form/check your answers as an option
-    [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }, OpenStruct.new(id: "check_your_answers", question_text: "Check your answers")].flatten
+    [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten
   end
 
   def check_errors_from_api

--- a/app/forms/pages/delete_condition_form.rb
+++ b/app/forms/pages/delete_condition_form.rb
@@ -19,6 +19,8 @@ class Pages::DeleteConditionForm
   end
 
   def goto_page_question_text
+    return I18n.t("page_conditions.check_your_answers") if goto_page_id.nil? && record.skip_to_end
+
     form.pages.filter { |p| p.id == goto_page_id }.first&.question_text
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,6 +340,7 @@ en:
       If you pasted the web address, check you copied the entire address.
     title: Page not found
   page_conditions:
+    check_your_answers: Check your answers
     condition_answer_value_text: is answered as “%{answer_value}”
     condition_answer_value_text_with_errors: is answered as [Answer not selected]
     condition_check_page_text: If the question “%{check_page_text}”

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe PageListComponent::View, type: :component do
           let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", skip_to_end: true) }
 
           it "returns the goto page error text" do
-            expect(goto_page_text).to eq I18n.t("page_conditions.condition_goto_page_text", goto_page_text: "Check your answers")
+            expect(goto_page_text).to eq I18n.t("page_conditions.condition_goto_page_text", goto_page_text: I18n.t("page_conditions.check_your_answers"))
           end
         end
 

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -248,10 +248,20 @@ RSpec.describe PageListComponent::View, type: :component do
       end
 
       context "when the goto page is not set" do
-        let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales") }
+        context "and skip_to_end is true" do
+          let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", skip_to_end: true) }
 
-        it "returns the goto page error text" do
-          expect(goto_page_text).to eq I18n.t("page_conditions.condition_goto_page_text_with_errors")
+          it "returns the goto page error text" do
+            expect(goto_page_text).to eq I18n.t("page_conditions.condition_goto_page_text", goto_page_text: "Check your answers")
+          end
+        end
+
+        context "and skip_to_end is false" do
+          let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", skip_to_end: false) }
+
+          it "returns the goto page error text" do
+            expect(goto_page_text).to eq I18n.t("page_conditions.condition_goto_page_text_with_errors")
+          end
         end
       end
     end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -248,8 +248,11 @@ RSpec.describe PageListComponent::View, type: :component do
       end
 
       context "when the goto page is not set" do
+        let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", skip_to_end:) }
+        let(:skip_to_end) { false }
+
         context "and skip_to_end is true" do
-          let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", skip_to_end: true) }
+          let(:skip_to_end) { true }
 
           it "returns the goto page error text" do
             expect(goto_page_text).to eq I18n.t("page_conditions.condition_goto_page_text", goto_page_text: I18n.t("page_conditions.check_your_answers"))
@@ -257,8 +260,6 @@ RSpec.describe PageListComponent::View, type: :component do
         end
 
         context "and skip_to_end is false" do
-          let(:condition) { (build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", skip_to_end: false) }
-
           it "returns the goto page error text" do
             expect(goto_page_text).to eq I18n.t("page_conditions.condition_goto_page_text_with_errors")
           end

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     check_page_id { nil }
     answer_value { nil }
     goto_page_id { nil }
+    skip_to_end { false }
     validation_errors { [] }
 
     trait :with_answer_value_missing do

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Pages::ConditionsForm, type: :model do
   describe "#goto_page_options" do
     it "returns a list of answers for the given page" do
       result = described_class.new(form:, page: pages.first).goto_page_options
-      expect(result).to eq([OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }, OpenStruct.new(id: "check_your_answers", question_text: "Check your answers")].flatten)
+      expect(result).to eq([OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten)
     end
   end
 

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -142,9 +142,13 @@ RSpec.describe Pages::ConditionsForm, type: :model do
 
   describe "#assign_condition_values" do
     let(:conditions_form) { described_class.new(form:, page:, record: condition, answer_value: condition.answer_value, goto_page_id: condition.goto_page_id, skip_to_end: condition.skip_to_end) }
-    let(:condition) { build :condition, id: 3, page_id: 2, routing_page_id: 1, answer_value: "England", check_page_id: 1, goto_page_id: nil, skip_to_end: true }
+    let(:condition) { build :condition, id: 3, page_id: 2, routing_page_id: 1, answer_value: "England", check_page_id: 1, goto_page_id:, skip_to_end: }
+    let(:goto_page_id) { nil }
+    let(:skip_to_end) { false }
 
     context "when goto_page is nil and skip_to_end is set to true" do
+      let(:skip_to_end) { true }
+
       it "sets goto_page_id to 'check_your_answers'" do
         conditions_form.assign_condition_values
         expect(conditions_form.goto_page_id).to eq "check_your_answers"
@@ -152,8 +156,6 @@ RSpec.describe Pages::ConditionsForm, type: :model do
     end
 
     context "when goto_page is nil and skip_to_end is set to false" do
-      let(:condition) { build :condition, id: 3, page_id: 2, routing_page_id: 1, answer_value: "England", check_page_id: 1, goto_page_id: nil, skip_to_end: false }
-
       it "sets goto_page_id to 'check_your_answers'" do
         conditions_form.assign_condition_values
         expect(conditions_form.goto_page_id).to eq nil
@@ -161,7 +163,8 @@ RSpec.describe Pages::ConditionsForm, type: :model do
     end
 
     context "when goto_page is not nil" do
-      let(:condition) { build :condition, id: 3, page_id: 2, routing_page_id: 1, answer_value: "England", check_page_id: 1, goto_page_id: 3, skip_to_end: true }
+      let(:goto_page_id) { 3 }
+      let(:skip_to_end) { true }
 
       it "sets goto_page_id to 'check_your_answers'" do
         conditions_form.assign_condition_values
@@ -171,8 +174,12 @@ RSpec.describe Pages::ConditionsForm, type: :model do
   end
 
   describe "#assign_skip_to_end" do
+    let(:conditions_form) { described_class.new(form:, page:, goto_page_id:, skip_to_end:) }
+    let(:goto_page_id) { 3 }
+    let(:skip_to_end) { false }
+
     context "when goto_page is 'check_your_answers" do
-      let(:conditions_form) { described_class.new(form:, page:, goto_page_id: "check_your_answers", skip_to_end: false) }
+      let(:goto_page_id) { "check_your_answers" }
 
       it "sets goto_page_id to nil and skip_to_end to true" do
         conditions_form.assign_skip_to_end
@@ -182,7 +189,8 @@ RSpec.describe Pages::ConditionsForm, type: :model do
     end
 
     context "when goto_page is not 'check_your_answers" do
-      let(:conditions_form) { described_class.new(form:, page:, goto_page_id: 3, skip_to_end: nil) }
+      let(:goto_page_id) { 3 }
+      let(:skip_to_end) { true }
 
       it "does not change goto_page_id and sets skip_to_end to false" do
         conditions_form.assign_skip_to_end

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
       allow(Pages::ConditionsForm).to receive(:new).and_return(conditions_form)
       allow(conditions_form).to receive(:check_errors_from_api)
+      allow(conditions_form).to receive(:assign_condition_values).and_return(conditions_form)
 
       get edit_condition_path(form_id: 1, page_id: selected_page.id, condition_id: condition.id)
     end
@@ -247,6 +248,10 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     it "Checks the errors from the API response" do
       expect(conditions_form).to have_received(:check_errors_from_api).exactly(1).times
+    end
+
+    it "Calls assign_condition_values" do
+      expect(conditions_form).to have_received(:assign_condition_values).exactly(1).times
     end
 
     it "renders the new condition page template" do
@@ -287,7 +292,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
       conditional_form = Pages::ConditionsForm.new(form:, page: selected_page, record: condition, answer_value: "Yes", goto_page_id: 3)
 
-      allow(conditional_form).to receive(:update).and_return(submit_result)
+      allow(conditional_form).to receive(:update_condition).and_return(submit_result)
 
       allow(Pages::ConditionsForm).to receive(:new).and_return(conditional_form)
 

--- a/spec/views/pages/conditions/delete.html.erb_spec.rb
+++ b/spec/views/pages/conditions/delete.html.erb_spec.rb
@@ -17,6 +17,12 @@ describe "pages/conditions/delete.html.erb" do
     expect(rendered).to have_css("h1.govuk-heading-l", text: t("page_titles.routing_page_delete", question_position: page.position))
   end
 
+  it "contains the condition details" do
+    expect(rendered).to have_css(".govuk-summary-list__value", text: delete_condition_form.page.question_text)
+    expect(rendered).to have_css(".govuk-summary-list__value", text: delete_condition_form.answer_value)
+    expect(rendered).to have_css(".govuk-summary-list__value", text: delete_condition_form.goto_page_question_text)
+  end
+
   it "has a submit button" do
     expect(rendered).to have_css("button[type='submit'].govuk-button", text: I18n.t("save_and_continue"))
   end


### PR DESCRIPTION
#### What problem does the pull request solve?
Makes changes to allow users to route to the check your answers page.

- Adds 'Check your answers' as an option in the dropdown list
- Adds some logic to the condition form object to convert the id from the dropdown into the format the API expects
- Adds a translation for 'Check your answers' and displays this in the various places that currently show the goto_page question text

Trello card: https://trello.com/c/27Y35zlE/676-add-the-option-for-a-route-to-go-to-the-check-your-answers-page

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
