### PR TITLE
Fix issue where legacy live form pages would not have any routing_conditions

### DIFF
--- a/app/service/page_options_service.rb
+++ b/app/service/page_options_service.rb
@@ -24,7 +24,7 @@ class PageOptionsService
     options.concat(date_options) if @page.answer_type == "date"
     options.concat(address_options) if @page.answer_type == "address"
     options.concat(name_options) if @page.answer_type == "name"
-    options.concat(route_options) if FeatureService.enabled?(:basic_routing) && @page.routing_conditions.present?
+    options.concat(route_options) if FeatureService.enabled?(:basic_routing) && @page.respond_to?(:routing_conditions) && @page.routing_conditions.present?
     options
   end
 

--- a/spec/service/page_options_service_spec.rb
+++ b/spec/service/page_options_service_spec.rb
@@ -169,14 +169,28 @@ describe PageOptionsService do
       let(:page) { build :page, id: 1, answer_type: "email", routing_conditions: }
       let(:condition_1) { build :condition, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
       let(:condition_2) { build :condition, routing_page_id: 1, check_page_id: 1, answer_value: "England", goto_page_id: 4 }
+      let(:routing_conditions) { nil }
+
+      context "with a legacy page that doesn't have routing conditions method" do
+        subject(:page_options_service) do
+          page_without_routing_conditions_method = page.dup.tap { |p| p.routing_conditions = nil }
+          described_class.new(page: page_without_routing_conditions_method, pages:)
+        end
+
+        it "returns the correct options" do
+          expect(page_options_service.all_options_for_answer_type).to include(
+            { key:  { text: "Answer type" }, value: { text: "Email address" } },
+          )
+        end
+      end
 
       context "with no condition" do
         let(:routing_conditions) { [] }
 
         it "returns the correct options" do
-          expect(page_options_service.all_options_for_answer_type).not_to include([
+          expect(page_options_service.all_options_for_answer_type).to include(
             { key:  { text: "Answer type" }, value: { text: "Email address" } },
-          ])
+          )
         end
       end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

We were seeing the following errors raised (https://govuk-forms.sentry.io/issues/4202070888)

undefined method `routing_conditions' for #<Page:0x00007fd74edf1650 @attributes={"id"=>230, "question_text"=>"What’s the name of the organisation?", "hint_text"=>"", "answer_type"=>"organisation_name", "next_page"=>nil, "is_optional"=>nil, "answer_settings"=>nil, "created_at"=>"2023-01-05T12:39:22.617Z", "updated_at"=>"2023-01-05T12:39:22.617Z", "position"=>1}, @prefix_options={:form_id=>143}, @persisted=true> (NoMethodError)


Trello card: https://trello.com/c/S8pCtxgd/824-form-creators-cannot-view-existing-live-form-questions

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
