### PR TITLE
Iterate  routing goto question select list

### DIFF
--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -40,7 +40,8 @@ class Pages::ConditionsForm
   end
 
   def goto_page_options
-    [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten
+    page_options = pages_after_current_page(form.pages, page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
+    [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), page_options, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten
   end
 
   def check_errors_from_api
@@ -63,5 +64,11 @@ class Pages::ConditionsForm
     else
       self.skip_to_end = false
     end
+  end
+
+private
+
+  def pages_after_current_page(all_pages, current_page)
+    all_pages.filter { |page| page.position > current_page.position }
   end
 end

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -40,7 +40,7 @@ class Pages::ConditionsForm
   end
 
   def goto_page_options
-    [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten
+    [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten
   end
 
   def check_errors_from_api

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -17,7 +17,8 @@ FactoryBot.define do
     answer_settings { nil }
     hint_text { nil }
     routing_conditions { [] }
-    position { 1 }
+    sequence(:position) { |n| n }
+    question_with_text { "#{position}. #{question_text}" }
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda }

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -124,9 +124,27 @@ RSpec.describe Pages::ConditionsForm, type: :model do
   end
 
   describe "#goto_page_options" do
-    it "returns a list of answers for the given page" do
-      result = described_class.new(form:, page: pages.first).goto_page_options
-      expect(result).to eq([OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") }, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten)
+    context "when routing from the first form page" do
+      it "returns a list of all pages after the first page and includes 'Check your answers'" do
+        result = described_class.new(form:, page: pages.first).goto_page_options
+        expect(result).to eq([
+          OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")),
+          form.pages.drop(1).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+          OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
+        ].flatten)
+      end
+    end
+
+    context "when routing from the third form page" do
+      it "returns a list of answers that excludes any pages before the given page and the given page" do
+        routing_from_page_position = 3
+        result = described_class.new(form:, page: pages[routing_from_page_position - 1]).goto_page_options
+        expect(result).to eq([
+          OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")),
+          form.pages.drop(routing_from_page_position).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+          OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
+        ].flatten)
+      end
     end
   end
 

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Pages::ConditionsForm, type: :model do
   describe "#goto_page_options" do
     it "returns a list of answers for the given page" do
       result = described_class.new(form:, page: pages.first).goto_page_options
-      expect(result).to eq([OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: p.question_text) }, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten)
+      expect(result).to eq([OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), form.pages.map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") }, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten)
     end
   end
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     it "displays success message" do
       follow_redirect!
-      expect(response.body).to include(I18n.t("banner.success.route_created", question_position: 1))
+      expect(response.body).to include(I18n.t("banner.success.route_created", question_position: selected_page.position))
     end
 
     context "when form submit fails" do


### PR DESCRIPTION
#### What problem does the pull request solve?

- Add question number as a prefix to goto question select list options
- Shows only a list of pages after the page thats being routed from instead of all form pages


https://github.com/alphagov/forms-admin/assets/3441519/9215fc4e-5390-4449-8a68-159e38da539e



Trello card: https://trello.com/c/8RNvLYMn/812-iterate-routing-conditions-goto-page-select-list

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
