### PR TITLE
Prevent marking complete if routing has errors

### DIFF
--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -34,7 +34,7 @@
 
           <% if render_routing? %>
             <% page.conditions.each do |condition| %>
-              <div id="<%= PageListComponent::ErrorSummary::View.error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "govuk-form-group--error": condition.has_errors?) %>">
+              <div id="<%= PageListComponent::ErrorSummary::View.error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "govuk-form-group--error": condition.has_routing_errors?) %>">
                 <dt class="govuk-summary-list__key govuk-summary-list__key app-page-list__key">
                   <%= t("page_conditions.condition_name", page_index: page.position) %>
                 </dt>

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -31,7 +31,6 @@ class FormsController < ApplicationController
     if @mark_complete_form.mark_section
       redirect_to form_path(@form)
     else
-      flash[:message] = "Save unsuccessful"
       render "pages/index", status: :unprocessable_entity
     end
   end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -31,6 +31,7 @@ class FormsController < ApplicationController
     if @mark_complete_form.mark_section
       redirect_to form_path(@form)
     else
+      @mark_complete_form.mark_complete = "false"
       render "pages/index", status: :unprocessable_entity
     end
   end

--- a/app/forms/forms/mark_complete_form.rb
+++ b/app/forms/forms/mark_complete_form.rb
@@ -5,6 +5,7 @@ class Forms::MarkCompleteForm
   attr_accessor :mark_complete, :form
 
   validates :mark_complete, presence: true
+  validate :has_routing_errors, if: :marked_complete?
 
   def mark_section
     return false if invalid?
@@ -20,5 +21,13 @@ class Forms::MarkCompleteForm
   def assign_form_values
     self.mark_complete = form.try(:question_section_completed)
     self
+  end
+
+  def marked_complete?
+    mark_complete == "true"
+  end
+
+  def has_routing_errors
+    errors.add :base, :has_routing_errors if form.has_routing_errors?
   end
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -17,8 +17,4 @@ class Condition < ActiveResource::Base
       { name: error.name, field: error_fields[error.name.to_sym] || :answer_value }
     end
   end
-
-  def has_errors?
-    validation_errors.any?
-  end
 end

--- a/config/locales/forms/mark_complete.yml
+++ b/config/locales/forms/mark_complete.yml
@@ -4,5 +4,7 @@ en:
       models:
         forms/mark_complete_form:
           attributes:
+            base:
+              has_routing_errors: This form has validation errors
             mark_complete:
               blank: You must choose an option

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -6,27 +6,33 @@ FactoryBot.define do
     goto_page_id { nil }
     skip_to_end { false }
     validation_errors { [] }
+    has_routing_errors { false }
 
     trait :with_answer_value_missing do
       answer_value { nil }
+      has_routing_errors { true }
       validation_errors { [OpenStruct.new(name: "answer_value_doesnt_exist")] }
     end
 
     trait :with_goto_page_missing do
       goto_page_id { nil }
+      has_routing_errors { true }
       validation_errors { [OpenStruct.new(name: "goto_page_doesnt_exist")] }
     end
 
     trait :with_goto_page_before_check_page do
+      has_routing_errors { true }
       validation_errors { [OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")] }
     end
 
     trait :with_goto_page_immediately_after_check_page do
+      has_routing_errors { true }
       validation_errors { [OpenStruct.new(name: "cannot_route_to_next_page")] }
     end
 
     trait :with_answer_value_and_goto_page_missing do
       goto_page_id { nil }
+      has_routing_errors { true }
       validation_errors { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist")] }
     end
   end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     declaration_text { nil }
     question_section_completed { false }
     declaration_section_completed { false }
+    has_routing_errors { false }
 
     trait :new_form do
       submission_email { "" }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
     routing_conditions { [] }
     sequence(:position) { |n| n }
     question_with_text { "#{position}. #{question_text}" }
+    has_routing_errors { false }
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda }

--- a/spec/forms/mark_complete_form_spec.rb
+++ b/spec/forms/mark_complete_form_spec.rb
@@ -1,30 +1,59 @@
 require "rails_helper"
 
 RSpec.describe Forms::MarkCompleteForm, type: :model do
+  let(:form) { build :form }
+  let(:mark_complete_form) { described_class.new(mark_complete:, form:) }
+  let(:mark_complete) { "true" }
+
   describe "validations" do
-    it "is not valid if blank" do
-      mark_complete_form = described_class.new(mark_complete: nil)
+    context "when mark_complete is blank" do
+      let(:mark_complete) { nil }
 
-      expect(mark_complete_form).not_to be_valid
+      it "is not valid" do
+        expect(mark_complete_form).not_to be_valid
+      end
     end
 
-    it "is valid if true" do
-      mark_complete_form = described_class.new(mark_complete: "true")
+    context "when mark_complete is true" do
+      let(:mark_complete) { "true" }
 
-      expect(mark_complete_form).to be_valid
+      it "is valid" do
+        expect(mark_complete_form).to be_valid
+      end
     end
 
-    it "is valid if false" do
-      mark_complete_form = described_class.new(mark_complete: "false")
+    context "when mark_complete is false" do
+      let(:mark_complete) { "false" }
 
-      expect(mark_complete_form).to be_valid
+      it "is valid" do
+        expect(mark_complete_form).to be_valid
+      end
+    end
+
+    context "when form has routing validation errors" do
+      let(:form) { build :form, :ready_for_routing, has_routing_errors: true }
+
+      context "when mark_complete is true" do
+        let(:mark_complete) { "true" }
+
+        it "is valid" do
+          error_message = I18n.t("activemodel.errors.models.forms/mark_complete_form.attributes.base.has_routing_errors")
+          expect(mark_complete_form).not_to be_valid
+          expect(mark_complete_form.errors.full_messages_for(:base)).to include(error_message)
+        end
+      end
+
+      context "when mark_complete is false" do
+        let(:mark_complete) { "false" }
+
+        it "is valid" do
+          expect(mark_complete_form).to be_valid
+        end
+      end
     end
   end
 
   describe "#save" do
-    let(:form) { build :form }
-    let(:mark_complete_form) { described_class.new(mark_complete: "true", form:) }
-
     context "when mark_complete_form is valid" do
       before do
         allow(mark_complete_form).to receive(:invalid?).and_return(false)
@@ -73,6 +102,32 @@ RSpec.describe Forms::MarkCompleteForm, type: :model do
 
       it "returns false if invalid" do
         expect(mark_complete_form.mark_section).to eq false
+      end
+    end
+  end
+
+  describe "marked_complete?" do
+    context "when mark_complete is nil" do
+      let(:mark_complete) { nil }
+
+      it "returns false" do
+        expect(mark_complete_form.marked_complete?).to eq false
+      end
+    end
+
+    context "when mark_complete is false" do
+      let(:mark_complete) { "false" }
+
+      it "returns false" do
+        expect(mark_complete_form.marked_complete?).to eq false
+      end
+    end
+
+    context "when mark_complete is true" do
+      let(:mark_complete) { "true" }
+
+      it "returns false" do
+        expect(mark_complete_form.marked_complete?).to eq true
       end
     end
   end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -4,22 +4,6 @@ describe Condition do
   let(:validation_errors) { [] }
   let(:condition) { described_class.new(id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3, validation_errors:) }
 
-  describe "#has_errors?" do
-    context "when condition has no errors" do
-      it "returns false" do
-        expect(condition.has_errors?).to be false
-      end
-    end
-
-    context "when condition has an error" do
-      let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist")] }
-
-      it "returns true" do
-        expect(condition.has_errors?).to be true
-      end
-    end
-  end
-
   describe "#errors_with_fields" do
     context "when the error is a known error" do
       let(:validation_errors) { [OpenStruct.new(name: "answer_value_doesnt_exist"), OpenStruct.new(name: "goto_page_doesnt_exist"), OpenStruct.new(name: "cannot_have_goto_page_before_routing_page"), OpenStruct.new(name: "cannot_route_to_next_page")] }

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -285,8 +285,12 @@ RSpec.describe FormsController, type: :request do
         expect(response).to render_template("pages/index")
       end
 
-      it "returns 300 error code" do
+      it "returns 422 error code" do
         expect(response.status).to eq(422)
+      end
+
+      it "sets mark_complete to false" do
+        expect(assigns[:mark_complete_form].mark_complete).to eq("false")
       end
     end
 

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -288,10 +288,6 @@ RSpec.describe FormsController, type: :request do
       it "returns 300 error code" do
         expect(response.status).to eq(422)
       end
-
-      it "sets a flash message" do
-        expect(flash[:message]).to eq "Save unsuccessful"
-      end
     end
 
     context "with a user with no organisation" do


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds a custom validation to the Mark Complete form to prevent a user marking the pages section complete if the form has any routing errors.

**Note**: needs to be merged and deployed _after_ the corresponding API PR (https://github.com/alphagov/forms-api/pull/282) - this relies on some methods that are introduced in that PR.

Trello card: https://trello.com/c/W5mLjhd3/804-prevent-users-marking-the-pages-section-as-complete-while-there-are-routing-errors

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
