### PR TITLE
Add auth provider to User model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,10 @@ gem "pg", "~> 1.5"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 6.3.0"
 
+# Used for handling authentication
+gem "gds-sso"
+gem "omniauth"
+
 # Used for handling authorisation policies
 gem "pundit"
 
@@ -49,8 +53,6 @@ gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
-#
-gem "gds-sso"
 
 # Use govuk-components for displaying govuk themed forms
 gem "govuk-components", "~> 4.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,6 +476,7 @@ DEPENDENCIES
   i18n-tasks (~> 1.0.11)
   jbuilder
   lograge
+  omniauth
   pg (~> 1.5)
   puma (~> 6.3.0)
   pundit

--- a/app/lib/event_logger.rb
+++ b/app/lib/event_logger.rb
@@ -1,0 +1,5 @@
+class EventLogger
+  def self.log(tag, object)
+    Rails.logger.tagged(tag).info(object.to_json)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   end
 
   def self.find_for_auth(attributes)
-    user = where(uid: attributes[:uid]).first ||
+    user = where(provider: attributes[:provider], uid: attributes[:uid]).first ||
       where(email: attributes[:email]).first
 
     if user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
   def self.find_for_gds_oauth(auth_hash)
     auth_hash = auth_hash.to_hash
     find_for_auth(
+      provider: auth_hash["provider"],
       uid: auth_hash["uid"],
       email: auth_hash["info"]["email"],
       name: auth_hash["info"]["name"],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,29 @@ class User < ApplicationRecord
   validates :role, presence: true
   validates :organisation_id, presence: true, if: -> { organisation_id_was.present? }
   validates :has_access, inclusion: [true, false]
+
+  def self.find_for_gds_oauth(auth_hash)
+    auth_hash = auth_hash.to_hash
+    find_for_auth(
+      uid: auth_hash["uid"],
+      email: auth_hash["info"]["email"],
+      name: auth_hash["info"]["name"],
+      permissions: auth_hash["extra"]["user"]["permissions"],
+      organisation_slug: auth_hash["extra"]["user"]["organisation_slug"],
+      organisation_content_id: auth_hash["extra"]["user"]["organisation_content_id"],
+      disabled: auth_hash["extra"]["user"]["disabled"],
+    )
+  end
+
+  def self.find_for_auth(attributes)
+    user = where(uid: attributes[:uid]).first ||
+      where(email: attributes[:email]).first
+
+    if user
+      user.update!(attributes)
+      user
+    else # Create a new user.
+      create!(attributes)
+    end
+  end
 end

--- a/db/migrate/20230531104116_add_provider_to_user.rb
+++ b/db/migrate/20230531104116_add_provider_to_user.rb
@@ -1,0 +1,6 @@
+class AddProviderToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :provider, :string
+    add_index :users, %i[provider uid], unique: true
+  end
+end

--- a/db/migrate/20230531131201_update_provider_for_existing_users.rb
+++ b/db/migrate/20230531131201_update_provider_for_existing_users.rb
@@ -1,0 +1,11 @@
+class UpdateProviderForExistingUsers < ActiveRecord::Migration[7.0]
+  class User < ApplicationRecord; end
+
+  def up
+    User.where.not(uid: nil).update_all(provider: :gds) # currently we only have one provider
+  end
+
+  def down
+    User.update_all(provider: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_16_134034) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_31_131201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,7 +52,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_16_134034) do
     t.string "role", default: "editor"
     t.bigint "organisation_id"
     t.boolean "has_access", default: true
+    t.string "provider"
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 
   add_foreign_key "users", "organisations"

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     name { Faker::Name.name }
     email { Faker::Internet.email(name:, domain: "example.gov.uk") }
     uid { Faker::Internet.uuid }
+    provider { "factory_bot" }
     role { :editor }
     has_access { true }
 

--- a/spec/integration/gds_sso_spec.rb
+++ b/spec/integration/gds_sso_spec.rb
@@ -50,4 +50,32 @@ RSpec.describe "usage of gds-sso gem" do
       expect(request.env["warden"].authenticated?).to be true
     end
   end
+
+  describe User do
+    describe ".find_for_gds_oauth" do
+      it "is called by the gds_sso Warden strategy" do
+        allow(described_class).to receive(:find_for_gds_oauth).and_call_original
+        allow(described_class).to receive(:find_for_auth).and_call_original
+
+        gds_sso = Warden::Strategies[:gds_sso].new({
+          "omniauth.auth" => omniauth_hash,
+        })
+        gds_sso.authenticate!
+
+        expect(described_class).to have_received(:find_for_gds_oauth)
+
+        expect(described_class).to have_received(:find_for_auth).with(
+          uid: "123456",
+          email: "test@example.com",
+          name: "Test User",
+          permissions: ["---"],
+          organisation_slug: "test-org",
+          organisation_content_id: "00000000-0000-0000-0000-000000000000",
+          disabled: false,
+        )
+
+        expect(gds_sso.successful?).to be true
+      end
+    end
+  end
 end

--- a/spec/integration/gds_sso_spec.rb
+++ b/spec/integration/gds_sso_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "usage of gds-sso gem" do
+  let(:omniauth_hash) do
+    OmniAuth::AuthHash.new({
+      provider: "gds",
+      uid: "123456",
+      info: {
+        email: "test@example.com",
+        name: "Test User",
+      },
+      extra: {
+        user: {
+          permissions: ["---"],
+          organisation_slug: "test-org",
+          organisation_content_id: "00000000-0000-0000-0000-000000000000",
+          disabled: false,
+        },
+      },
+    })
+  end
+
+  describe "authentication" do
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:gds] = nil
+    end
+
+    after do
+      OmniAuth.config.test_mode = false
+    end
+
+    it "redirects to OmniAuth when no user is logged in" do
+      logout
+
+      get root_path
+
+      expect(response).to redirect_to("/auth/gds")
+    end
+
+    it "authenticates with OmniAuth and Warden" do
+      OmniAuth.config.mock_auth[:gds] = omniauth_hash
+
+      get "/auth/gds"
+
+      expect(response).to redirect_to(gds_sign_in_path)
+
+      get gds_sign_in_path
+
+      expect(request.env["warden"].authenticated?).to be true
+    end
+  end
+end

--- a/spec/integration/gds_sso_spec.rb
+++ b/spec/integration/gds_sso_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe "usage of gds-sso gem" do
         expect(described_class).to have_received(:find_for_gds_oauth)
 
         expect(described_class).to have_received(:find_for_auth).with(
+          provider: "gds",
           uid: "123456",
           email: "test@example.com",
           name: "Test User",

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+require_relative "../../app/lib/event_logger"
+
+RSpec.describe EventLogger do
+  before do
+    logger = LoggerMock.new
+    tagged_logging = ActiveSupport::TaggedLogging.new(logger)
+    allow(Rails).to receive(:logger).and_return(tagged_logging)
+  end
+
+  it "logs an event" do
+    described_class.log("event", { test: true })
+
+    expect(Rails.logger.logged(:info)).to eq [
+      '[event] {"test":true}',
+    ]
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,4 +46,43 @@ describe User do
       expect(user.valid?).to be false
     end
   end
+
+  describe ".find_for_auth" do
+    let!(:user) do
+      create :user, uid: "123456", name: "Test User", email: "test@example.com"
+    end
+
+    it "finds a user by uid" do
+      expect(described_class.find_for_auth(uid: "123456"))
+        .to eq user
+    end
+
+    it "finds a user by email address if no user with uid is found" do
+      expect(described_class.find_for_auth(uid: "111111", email: "test@example.com"))
+        .to eq user
+
+      expect(user.reload.uid).to eq "111111"
+    end
+
+    it "creates a user if one does not already exist" do
+      allow(described_class).to receive(:create!)
+
+      described_class.find_for_auth(
+        uid: "9999",
+        email: "fake@example.com",
+        name: "Fake Name",
+      )
+
+      expect(described_class).to have_received(:create!)
+    end
+
+    it "updates any user attributes that have changed" do
+      described_class.find_for_auth(
+        uid: "123456",
+        name: "New Name",
+      )
+
+      expect(user.reload.name).to eq "New Name"
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,5 +84,26 @@ describe User do
 
       expect(user.reload.name).to eq "New Name"
     end
+
+    it "logs attributes that will be updated" do
+      allow(EventLogger).to receive(:log)
+
+      described_class.find_for_auth(
+        uid: "111111",
+        name: "Test A. User",
+        email: "test@example.com",
+      )
+
+      expect(EventLogger).to have_received(:log).with(
+        "auth",
+        {
+          "user_id": user.id,
+          "user_changes": {
+            uid: %w[123456 111111],
+            name: ["Test User", "Test A. User"],
+          },
+        },
+      )
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -49,12 +49,17 @@ describe User do
 
   describe ".find_for_auth" do
     let!(:user) do
-      create :user, uid: "123456", name: "Test User", email: "test@example.com"
+      create :user, provider: "test", uid: "123456", name: "Test User", email: "test@example.com"
     end
 
     it "finds a user by uid" do
-      expect(described_class.find_for_auth(uid: "123456"))
+      expect(described_class.find_for_auth(provider: "test", uid: "123456"))
         .to eq user
+    end
+
+    it "avoids uid collisions" do
+      expect(described_class.find_for_auth(provider: "other", uid: "123456"))
+        .not_to eq user
     end
 
     it "finds a user by email address if no user with uid is found" do
@@ -68,6 +73,7 @@ describe User do
       allow(described_class).to receive(:create!)
 
       described_class.find_for_auth(
+        provider: "test",
         uid: "9999",
         email: "fake@example.com",
         name: "Fake Name",
@@ -78,6 +84,7 @@ describe User do
 
     it "updates any user attributes that have changed" do
       described_class.find_for_auth(
+        provider: "test",
         uid: "123456",
         name: "New Name",
       )
@@ -89,6 +96,7 @@ describe User do
       allow(EventLogger).to receive(:log)
 
       described_class.find_for_auth(
+        provider: "test",
         uid: "111111",
         name: "Test A. User",
         email: "test@example.com",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "capybara/rspec"
 
 require "pundit/matchers"
 require_relative "support/active_resource_mock"
+require_relative "support/logger_mock"
 require_relative "support/factorybot"
 require_relative "support/features"
 require_relative "support/authentication_feature_helpers"

--- a/spec/support/logger_mock.rb
+++ b/spec/support/logger_mock.rb
@@ -1,0 +1,20 @@
+# Based on ActiveSupport::LogSubscriber::TestHelper::MockLogger,
+# but with support for formatters/tagging.
+# https://github.com/rails/rails/blob/e88857bbb9d4e1dd64555c34541301870de4a45b/activesupport/lib/active_support/log_subscriber/test_helper.rb
+
+class LoggerMock
+  attr_reader :formatter
+
+  def initialize
+    @formatter = proc { |_severity, _time, _progname, msg| msg }
+    @logged = Hash.new { |h, k| h[k] = [] }
+  end
+
+  def logged(level)
+    @logged[level].compact.map { |l| l.to_s.strip }
+  end
+
+  def method_missing(level, msg = nil) # rubocop:disable Style/MissingRespondToMissing
+    @logged[level] << @formatter.call(level, Time.zone.now, "test", msg)
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?

Part of https://trello.com/c/KoHbF6Xc.

To make switching from one OAuth based identity provider to another a bit less risky, we add the name of provider to the users table so the `uid` can be disambiguated.

I'd suggest doing it this way (rather than just allowing the uids to be incosistent, or getting rid of uid altogether) because a) it's compatible with what Devise does [[1]] and b) because then we'll to be able to identify where users in our database have come from, which seems like it might be useful.

We can then, for audit purposes, log when a user signs in with a different provider, and record the changes that are made to the user record.

[1]: https://github.com/heartcombo/devise/wiki/OmniAuth:-Overview
