### PR TITLE
Fix bug with condition display on live forms

### DIFF
--- a/app/service/page_options_service.rb
+++ b/app/service/page_options_service.rb
@@ -131,12 +131,17 @@ private
   end
 
   def print_route(condition)
-    goto_question = @pages.find { |page| page.id == condition.goto_page_id }
-    goto_page_text = ActionController::Base.helpers.sanitize(goto_question.question_text)
-    goto_page_number = @pages.find_index(goto_question) + 1
     answer_value = ActionController::Base.helpers.sanitize(condition.answer_value)
 
-    I18n.t("page_conditions.condition_compact_html", answer_value:, goto_page_number:, goto_page_text:).html_safe
+    if condition.skip_to_end
+      I18n.t("page_conditions.condition_compact_html_end_of_form", answer_value:).html_safe
+    else
+      goto_question = @pages.find { |page| page.id == condition.goto_page_id }
+      goto_page_text = ActionController::Base.helpers.sanitize(goto_question.question_text)
+      goto_page_number = @pages.find_index(goto_question) + 1
+
+      I18n.t("page_conditions.condition_compact_html", answer_value:, goto_page_number:, goto_page_text:).html_safe
+    end
   end
 
   def html_ordered_list(list_items)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -345,6 +345,7 @@ en:
     condition_answer_value_text_with_errors: is answered as [Answer not selected]
     condition_check_page_text: If the question “%{check_page_text}”
     condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to question %{goto_page_number}: “%{goto_page_text}”'
+    condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to “Check your answers”
     condition_goto_page_text: take the person to “%{goto_page_text}”
     condition_goto_page_text_with_errors: take the person to [Question not selected]
     condition_name: Question %{page_index}’s route

--- a/spec/service/page_options_service_spec.rb
+++ b/spec/service/page_options_service_spec.rb
@@ -219,6 +219,21 @@ describe PageOptionsService do
           )
         end
       end
+
+      context "with a condition that points to the end of the form" do
+        let(:routing_conditions) { [condition] }
+        let(:answer_value) { "Wales" }
+        let(:condition) { build :condition, answer_value:, goto_page_id: nil, skip_to_end: true }
+
+        it "returns the correct options" do
+          expect(page_options_service.all_options_for_answer_type).to include(
+            {
+              key: { text: I18n.t("page_conditions.route") },
+              value: { text: I18n.t("page_conditions.condition_compact_html_end_of_form", answer_value:) },
+            },
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

Fixes an issue with an issue I introduced in https://github.com/alphagov/forms-admin/pull/463, where a live form with a condition that points to the Check your answers page will throw an error when the user tries to view their form's pages.

Trello card: None

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a ] Elsewhere (please link)
