### PR TITLE
Add support for Auth0 identity provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "puma", "~> 6.3.0"
 # Used for handling authentication
 gem "gds-sso"
 gem "omniauth"
+gem "omniauth-auth0"
 gem "warden"
 
 # Used for handling authorisation policies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,9 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
+    omniauth-auth0 (3.1.0)
+      omniauth (~> 2)
+      omniauth-oauth2 (~> 1)
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
@@ -477,6 +480,7 @@ DEPENDENCIES
   jbuilder
   lograge
   omniauth
+  omniauth-auth0
   pg (~> 1.5)
   puma (~> 6.3.0)
   pundit

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,0 +1,46 @@
+class AuthenticationController < ApplicationController
+  skip_before_action :authenticate_and_check_access
+
+  layout false
+
+  def self.call(env)
+    action(:redirect_to_omniauth).call(env)
+  end
+
+  def redirect_to_omniauth
+    provider = if Settings.auth_provider == "gds_sso"
+                 "gds"
+               else
+                 Settings.auth_provider
+               end
+
+    store_location(attempted_path) if request.get?
+    redirect_to "/auth/#{provider}"
+  end
+
+  def callback_from_omniauth
+    authenticate_user!
+    redirect_to stored_location || "/"
+  end
+
+  def sign_out
+    warden.logout
+    redirect_to send(:"#{params[:provider]}_sign_out_url"), allow_other_host: true
+  end
+
+private
+
+  def attempted_path
+    request.env["warden.options"][:attempted_path]
+  end
+
+  def store_location(path)
+    # NOTE: If we ever start using Warden scopes, the key of this session
+    # variable should change depending on the scope in warden.options
+    session["user_return_to"] = path
+  end
+
+  def stored_location
+    session["user_return_to"]
+  end
+end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -43,4 +43,13 @@ private
   def stored_location
     session["user_return_to"]
   end
+
+  def auth0_sign_out_url
+    request_params = {
+      returnTo: root_url,
+      client_id: Settings.auth0.client_id,
+    }
+
+    URI::HTTPS.build(host: Settings.auth0.domain, path: "/v2/logout", query: request_params.to_query).to_s
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,6 +66,10 @@ module ApplicationHelper
 
   def header_component_options(user:, can_manage_users:)
     auth_links = {
+      auth0: {
+        user_profile_link: nil,
+        signout_link: sign_out_path(:auth0),
+      },
       gds_sso: {
         user_profile_link: GDS::SSO::Config.oauth_root_url,
         signout_link: gds_sign_out_path,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,13 +17,12 @@ class User < ApplicationRecord
   validates :has_access, inclusion: [true, false]
 
   def self.find_for_gds_oauth(auth_hash)
-    auth_hash = auth_hash.to_hash
     find_for_auth(
       provider: auth_hash["provider"],
       uid: auth_hash["uid"],
       email: auth_hash["info"]["email"],
       name: auth_hash["info"]["name"],
-      permissions: auth_hash["extra"]["user"]["permissions"],
+      permissions: auth_hash["extra"]["user"]["permissions"].to_a,
       organisation_slug: auth_hash["extra"]["user"]["organisation_slug"],
       organisation_content_id: auth_hash["extra"]["user"]["organisation_content_id"],
       disabled: auth_hash["extra"]["user"]["disabled"],

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -1,4 +1,17 @@
 Rails.application.config.before_initialize do
+  # Configure OmniAuth authentication middleware
+  # add Auth0 provider
+  Rails.application.config.app_middleware.use(
+    OmniAuth::Strategies::Auth0,
+    Settings.auth0.client_id,
+    Settings.auth0.client_secret,
+    Settings.auth0.domain,
+    callback_path: "/auth/auth0/callback",
+    authorize_params: {
+      scope: "openid email profile",
+    },
+  )
+
   # Configure Warden session management middleware
   # swap out the Warden::Manager installed by `gds-sso` gem
   Rails.application.config.app_middleware.swap Warden::Manager, Warden::Manager do |warden|

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -8,7 +8,7 @@ Rails.application.config.before_initialize do
     Settings.auth0.domain,
     callback_path: "/auth/auth0/callback",
     authorize_params: {
-      scope: "openid email profile",
+      scope: "openid email",
     },
   )
 

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -1,0 +1,7 @@
+Rails.application.config.before_initialize do
+  # Configure Warden session management middleware
+  # swap out the Warden::Manager installed by `gds-sso` gem
+  Rails.application.config.app_middleware.swap Warden::Manager, Warden::Manager do |warden|
+    warden.failure_app = AuthenticationController
+  end
+end

--- a/config/initializers/warden/strategies/auth0.rb
+++ b/config/initializers/warden/strategies/auth0.rb
@@ -18,7 +18,6 @@ private
       provider: auth_hash[:provider],
       uid: auth_hash[:uid],
       email: auth_hash[:info][:email],
-      name: auth_hash[:info][:name],
     )
   end
 end

--- a/config/initializers/warden/strategies/auth0.rb
+++ b/config/initializers/warden/strategies/auth0.rb
@@ -1,0 +1,24 @@
+Warden::Strategies.add(:auth0) do
+  def valid?
+    env["omniauth.auth"].present?
+  end
+
+  def authenticate!
+    logger.debug("Authenticating with auth0 strategy")
+
+    user = prep_user(request.env["omniauth.auth"])
+    fail!("Couldn't process credentials") unless user
+    success!(user)
+  end
+
+private
+
+  def prep_user(auth_hash)
+    User.find_for_auth(
+      provider: auth_hash[:provider],
+      uid: auth_hash[:uid],
+      email: auth_hash[:info][:email],
+      name: auth_hash[:info][:name],
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "forms#index"
 
+  # OmniAuth user authentication routes
+  get "auth/:provider/callback" => "authentication#callback_from_omniauth"
+  get "auth/:provider/sign_out" => "authentication#sign_out", as: :sign_out
+
   get "forms/new" => "forms/change_name#new", as: :new_form
   post "forms/new" => "forms/change_name#create"
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,6 +32,11 @@ sentry:
 # How we authenticate users
 auth_provider: # use default auth_provider from environment
 
+auth0:
+  client_id: changeme
+  client_secret:
+  domain: changeme.uk.auth0.com
+
 basic_auth:
   username: basic_auth_user
   password:

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -35,6 +35,7 @@ describe ApplicationController, type: :controller do
     end
 
     %w[
+      auth0
       basic_auth
       gds_sso
     ].each do |provider|

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -34,43 +34,27 @@ describe ApplicationController, type: :controller do
       request.env["warden"] = instance_double(Warden::Proxy)
     end
 
-    context "when Signon is enabled" do
-      before do
-        # Mock GDS SSO
-        allow(warden_spy).to receive(:authenticate!).and_return(true)
-        allow(controller).to receive(:current_user).and_return(user)
+    %w[
+      basic_auth
+      gds_sso
+    ].each do |provider|
+      context "when #{provider} auth is enabled" do
+        before do
+          allow(warden_spy).to receive(:authenticate!).and_return(true)
+          allow(controller).to receive(:current_user).and_return(user)
 
-        allow(Settings).to receive(:auth_provider).and_return("gds_sso")
+          allow(Settings).to receive(:auth_provider).and_return(provider)
 
-        get :index
-      end
+          get :index
+        end
 
-      it "uses GOV.UK Signon" do
-        expect(warden_spy).to have_received(:authenticate!).with(:gds_sso)
-      end
+        it "uses the #{provider} Warden strategy" do
+          expect(warden_spy).to have_received(:authenticate!).with(provider.to_sym)
+        end
 
-      it "sets @current_user" do
-        expect(assigns[:current_user]).to eq user
-      end
-    end
-
-    context "when basic auth is enabled" do
-      before do
-        # Mock Warden
-        allow(warden_spy).to receive(:authenticate!).and_return(true)
-        allow(controller).to receive(:current_user).and_return(user)
-
-        allow(Settings).to receive(:auth_provider).and_return("basic_auth")
-
-        get :index
-      end
-
-      it "uses HTTP Basic Authentication" do
-        expect(warden_spy).to have_received(:authenticate!).with(:basic_auth)
-      end
-
-      it "sets @current_user" do
-        expect(assigns[:current_user]).to eq user
+        it "sets @current_user" do
+          expect(assigns[:current_user]).to eq user
+        end
       end
     end
   end

--- a/spec/integration/auth0_spec.rb
+++ b/spec/integration/auth0_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "usage of omniauth-auth0 gem" do
+  before do
+    allow(Settings).to receive(:auth_provider).and_return("auth0")
+  end
+
+  let(:omniauth_hash) do
+    Faker::Omniauth.auth0(
+      uid: "123456",
+      email: "test@example.com",
+    )
+  end
+
+  describe "authentication" do
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:auth0] = nil
+    end
+
+    after do
+      OmniAuth.config.test_mode = false
+    end
+
+    it "redirects to OmniAuth when no user is logged in" do
+      logout
+
+      get root_path
+
+      expect(response).to redirect_to("/auth/auth0")
+    end
+
+    it "authenticates with OmniAuth and Warden" do
+      OmniAuth.config.mock_auth[:auth0] = omniauth_hash
+
+      get "/auth/auth0"
+
+      expect(response).to redirect_to("/auth/auth0/callback")
+
+      get "/auth/auth0/callback"
+
+      expect(request.env["warden"].authenticated?).to be true
+    end
+  end
+
+  describe "signing out" do
+    it "signs the user out of auth0" do
+      allow(Settings.auth0).to receive(:domain).and_return("test")
+      allow(Settings.auth0).to receive(:client_id).and_return("baz")
+
+      get sign_out_path(:auth0)
+
+      expect(response).to redirect_to("https://test/v2/logout?client_id=baz&returnTo=http%3A%2F%2Fwww.example.com%2F")
+    end
+  end
+
+  describe User do
+    describe ".find_for_auth" do
+      it "is called by the auth0 Warden strategy" do
+        allow(described_class).to receive(:find_for_auth).and_call_original
+
+        auth0 = Warden::Strategies[:auth0].new({
+          "omniauth.auth" => omniauth_hash,
+        })
+        auth0.authenticate!
+
+        expect(described_class).to have_received(:find_for_auth).with(
+          provider: "auth0",
+          uid: "123456",
+          email: "test@example.com",
+        )
+
+        expect(auth0.successful?).to be true
+      end
+    end
+  end
+end

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe AuthenticationController, type: :request do
+  before do
+    OmniAuth.config.test_mode = true
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+  end
+
+  let(:controller_spy) do
+    controller_spy = described_class.new
+    allow(described_class).to receive(:new).and_return(controller_spy)
+    controller_spy
+  end
+
+  describe "#redirect_to_omniauth" do
+    before do
+      allow(controller_spy).to receive(:redirect_to_omniauth).and_call_original
+
+      logout
+    end
+
+    it "is called by Warden if user is not logged in" do
+      get root_path
+
+      expect(controller_spy).to have_received(:redirect_to_omniauth)
+    end
+
+    it "redirects to OmniAuth request phase" do
+      get root_path
+
+      expect(response).to redirect_to("/auth/mock_gds_sso")
+    end
+
+    it "uses the configured OmniAuth provider" do
+      allow(Settings).to receive(:auth_provider).and_return("auth0")
+
+      get root_path
+
+      expect(response).to redirect_to("/auth/auth0")
+    end
+
+    it "stores the URL the user is trying to reach for after they have signed in" do
+      allow(Settings).to receive(:auth_provider).and_return("auth0")
+
+      get live_form_pages_path(42)
+
+      expect(response).to redirect_to("/auth/auth0")
+      get "/auth/auth0"
+
+      expect(response).to redirect_to("/auth/auth0/callback")
+      get "/auth/auth0/callback"
+
+      expect(response).to redirect_to(live_form_pages_path(42))
+    end
+  end
+
+  describe "#callback_from_omniauth" do
+    it "is called by OmniAuth provider" do
+      get "/auth/gds"
+
+      expect(response).to redirect_to("/auth/gds/callback")
+
+      allow(controller_spy).to receive(:callback_from_omniauth).and_call_original
+
+      get "/auth/gds/callback"
+
+      expect(controller_spy).to have_received :callback_from_omniauth
+    end
+
+    it "calls Warden strategy" do
+      allow(controller_spy).to receive(:authenticate_user!).and_call_original
+
+      get "/auth/test/callback"
+
+      expect(controller_spy).to have_received(:authenticate_user!)
+    end
+  end
+
+  describe "#sign_out" do
+    let(:warden_spy) do
+      warden_spy = instance_spy(Warden::Proxy)
+      allow(controller_spy).to receive(:warden).and_return(warden_spy)
+      warden_spy
+    end
+
+    it "calls Warden to clear the session" do
+      expect(warden_spy).to receive(:logout)
+
+      get sign_out_path(:auth0)
+    end
+
+    it "raises error if sign out URL not defined for provider" do
+      expect { get sign_out_path(:not_a_provider) }.to raise_error NoMethodError
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?

Trello card: https://trello.com/c/KoHbF6Xc

This commit adds a Warden strategy and configures an OmniAuth provider so that if we want to we can use the [Auth0] service for authenticating users.

GOV.UK Signon remains the default, however using Auth0 instead is possible by changing some environment variables:

```
# Use Auth0
SETTINGS__AUTH_PROVIDER=auth0

# Auth0 credentials
SETTINGS__AUTH0__DOMAIN=
SETTINGS__AUTH0__CLIENT_ID=
SETTINGS__AUTH0__CLIENT_KEY=
```

You will need the Auth0 credentials to be able to properly test this PR, ping me if you want them.

[Auth0]: https://auth0.com