### PR TITLE
Add routing warning banner to selections settings view

### DIFF
--- a/app/views/pages/selections_settings.html.erb
+++ b/app/views/pages/selections_settings.html.erb
@@ -4,6 +4,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if @page.present? && @page.conditions.any? %>
+      <%= govuk_notification_banner(title_text: t("selections_settings.routing_warning_notification_title")) do |banner| %>
+        <% banner.with_heading(text: t("selections_settings.routing_warning_about_change_only_one_option_heading")) %>
+        <%= t("selections_settings.routing_warning_about_change_only_one_option_html", pages_link_url: form_pages_path(@form)) %>
+      <% end %>
+    <% end %>
+
     <%= form_with model: [@form, @selections_settings_form], url: @selections_settings_path do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/pages/type-of-answer.html.erb
+++ b/app/views/pages/type-of-answer.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @page.present? && @page.answer_type.to_sym == :selection && @page.conditions.any?  %>
+    <% if @page.present? && @page.conditions.any?  %>
       <%= govuk_notification_banner(title_text: t("type_of_answer.routing_warning_notification_title")) do |banner| %>
         <% banner.with_heading(text: t("type_of_answer.routing_warning_about_change_answer_type_heading")) %>
         <%= t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(@form)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,6 +476,15 @@ en:
     option: Option %{number}
     options_title: Options
     remove_html: Remove <span class="govuk-visually-hidden">option %{option_number}</span>
+    routing_warning_about_change_only_one_option_heading: Your existing question route may be deleted
+    routing_warning_about_change_only_one_option_html: |
+      <p>
+        Removing the “People can only select one option” setting means your route will no longer work and will be deleted.
+      </p>
+      <p>
+        If you do not want to lose your question route you can cancel this change by using the back button or <a href="%{pages_link_url}">go to your questions</a>.
+      </p>
+    routing_warning_notification_title: Important
     'yes': 'Yes'
   service_unavailable:
     body_html: "%{link} if you need to make changes to your forms or speak to someone about the service."

--- a/spec/views/pages/selections_settings.html.erb_spec.rb
+++ b/spec/views/pages/selections_settings.html.erb_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe "pages/selections_settings.html.erb", type: :view do
+  let(:form) { build :form, id: 1 }
+  let(:selections_settings_form) { build :selections_settings_form }
+  let(:page) { OpenStruct.new(conditions:, answer_type: "selection", answer_settings:) }
+  let(:answer_settings) { OpenStruct.new(only_one_option:) }
+  let(:only_one_option) { "true" }
+  let(:page_number) { 1 }
+  let(:back_link_url) { "type-of-answers" }
+  let(:selections_settings_path) { "edit" }
+  let(:conditions) { [] }
+
+  before do
+    # # mock the form.page_number method
+    allow(form).to receive(:page_number).and_return(page_number)
+
+    # # mock the path helper
+    without_partial_double_verification do
+      allow(view).to receive(:form_pages_path).and_return("/type-of-answer")
+    end
+
+    # # setup instance variables
+    assign(:form, form)
+    assign(:page, page)
+    assign(:selections_settings_path, selections_settings_path)
+    assign(:back_link_url, back_link_url)
+    assign(:selections_settings_form, selections_settings_form)
+
+    render(template: "pages/selections_settings")
+  end
+
+  context "when editing an existing page" do
+    let(:form) { build :form, id: 1, pages: [page] }
+
+    context "when no routing conditions set" do
+      it "does not display a warning about routes being deleted if only one option changes" do
+        expect(rendered).not_to have_selector(".govuk-notification-banner__content")
+      end
+    end
+
+    context "when a routing condition is set" do
+      let(:conditions) { [(build :condition)] }
+
+      it "displays a warning" do
+        expect(rendered).to have_selector(".govuk-notification-banner__content")
+      end
+    end
+  end
+end

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -81,14 +81,6 @@ describe "pages/type_of_answer.html.erb", type: :view do
                         .text(normalize_ws: true))
     end
 
-    context "when answer type is not a selection" do
-      let(:answer_type) { "number" }
-
-      it "does not display a warning about routes being deleted if answer type changes" do
-        expect(rendered).not_to have_selector(".govuk-notification-banner__content")
-      end
-    end
-
     context "when no routing conditions set" do
       let(:conditions) { [] }
 


### PR DESCRIPTION
#### What problem does the pull request solve?

Adding a warning banner when editing the selection settings for an existing page while there is an associated condition. 

Trello card: https://trello.com/c/u1H03C9s/805-add-routing-warning-to-edit-select-from-a-list-page-and-remove-route-if-no-longer-valid

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
