### PR TITLE
Implement trial role and initial restrictions

### DIFF
--- a/app/controllers/forms/change_name_controller.rb
+++ b/app/controllers/forms/change_name_controller.rb
@@ -10,6 +10,7 @@ module Forms
       form = Form.new({
         name: params[:name],
         org: @current_user.organisation.slug,
+        creator_id: @current_user.id,
       })
 
       authorize form, :can_view_form?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   enum :role, {
     super_admin: "super_admin",
     editor: "editor",
+    trial: "trial",
   }
 
   validates :role, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,4 +50,8 @@ class User < ApplicationRecord
       create!(attributes)
     end
   end
+
+  def organisation_valid?
+    trial? || organisation.present?
+  end
 end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -14,8 +14,12 @@ class FormPolicy
     end
 
     def resolve
-      scope
-        .where(org: user.organisation.slug)
+      if user.trial?
+        scope.where(creator_id: user.id)
+      else
+        scope
+          .where(org: user.organisation.slug)
+      end
     end
   end
 
@@ -44,6 +48,10 @@ class FormPolicy
   alias_method :can_delete_page_routing_conditions?, :can_edit_page_routing_conditions?
 
 private
+
+  def user_is_form_creator
+    form.respond_to?(:creator_id) ? user.id == form.creator_id : false
+  end
 
   def users_organisation_owns_form
     user.organisation.slug == form.org

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -7,7 +7,7 @@ class FormPolicy
     attr_reader :user, :form, :scope
 
     def initialize(user, scope)
-      raise UserMissingOrganisationError, "Missing required attribute organisation_id" if user.organisation.blank?
+      raise UserMissingOrganisationError, "Missing required attribute organisation_id" unless user.organisation_valid?
 
       @user = user
       @scope = scope
@@ -24,7 +24,7 @@ class FormPolicy
   end
 
   def initialize(user, form)
-    raise UserMissingOrganisationError, "Missing required attribute organisation_id" if user.organisation.blank?
+    raise UserMissingOrganisationError, "Missing required attribute organisation_id" unless user.organisation_valid?
 
     @user = user
     @form = form
@@ -54,6 +54,6 @@ private
   end
 
   def users_organisation_owns_form
-    user.organisation.slug == form.org
+    user.organisation&.slug == form.org
   end
 end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -31,7 +31,7 @@ class FormPolicy
   end
 
   def can_view_form?
-    users_organisation_owns_form
+    users_organisation_owns_form || (user.trial? && user_is_form_creator)
   end
 
   def can_add_page_routing_conditions?
@@ -50,10 +50,10 @@ class FormPolicy
 private
 
   def user_is_form_creator
-    form.respond_to?(:creator_id) ? user.id == form.creator_id : false
+    form.creator_id.present? ? user.id == form.creator_id : false
   end
 
   def users_organisation_owns_form
-    user.organisation&.slug == form.org
+    user.organisation.present? ? user.organisation.slug == form.org : false
   end
 end

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -11,7 +11,7 @@
 
 <% if @forms.any? %>
   <%= govuk_table do |table| %>
-    <%= table.with_caption(size: 'm', text: @current_user.organisation ? t("home.form_table_caption", organisation_name: @current_user.organisation.name) : t("home.your_forms")) %>
+    <%= table.with_caption(size: 'm', text: @current_user.trial? || @current_user.organisation.blank? ? t("home.your_forms") : t("home.form_table_caption", organisation_name: @current_user.organisation.name)) %>
 
     <%= table.with_head do |head|
        head.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -579,4 +579,7 @@ en:
       super_admin:
         description: Can create forms and manage users
         name: Super admin
+      trial:
+        description: Can create forms but cannot make them live
+        name: Trial
     save: Save

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
     question_section_completed { false }
     declaration_section_completed { false }
     has_routing_errors { false }
+    creator_id { nil }
 
     trait :new_form do
       submission_email { "" }

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
       role { :super_admin }
     end
 
+    trait :with_trial do
+      role { :trial }
+    end
+
     organisation_slug { "test-org" }
     organisation { association :organisation, slug: organisation_slug }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,8 +10,8 @@ describe User do
 
   describe "role enum" do
     it "returns a list of roles" do
-      expect(described_class.roles.keys).to eq(%w[super_admin editor])
-      expect(described_class.roles.values).to eq(%w[super_admin editor])
+      expect(described_class.roles.keys).to eq(%w[super_admin editor trial])
+      expect(described_class.roles.values).to eq(%w[super_admin editor trial])
     end
   end
 

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -7,10 +7,20 @@ describe FormPolicy do
   let(:user) { build :user, organisation_slug: "gds" }
 
   context "with no organisation set" do
-    let(:user) { build :user, :with_no_org }
+    context "with editor role" do
+      let(:user) { build :user, :with_no_org }
 
-    it "raises an error" do
-      expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+      it "raises an error" do
+        expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+      end
+    end
+
+    context "with trial role" do
+      let(:user) { build :user, :with_no_org, :with_trial }
+
+      it "does not raise an error" do
+        expect { policy }.not_to raise_error
+      end
     end
   end
 
@@ -35,18 +45,10 @@ describe FormPolicy do
 
     context "with a trial role" do
       context "when the user created the form" do
-        context "with an organisation" do
-          let(:user) { build :user, :with_trial, organisation_slug: "gds" }
+        let(:form) { build :form, creator_id: 1234 }
+        let(:user) { build :user, :with_no_org, :with_trial, id: 1234 }
 
-          it { is_expected.to permit_actions(%i[can_view_form]) }
-        end
-
-        context "without an organisation" do
-          let(:form) { build :form, creator_id: 1234 }
-          let(:user) { build :user, :with_no_org, :with_trial, id: 1234 }
-
-          it { is_expected.to permit_actions(%i[can_view_form]) }
-        end
+        it { is_expected.to permit_actions(%i[can_view_form]) }
       end
 
       context "when the user didn't create the form" do
@@ -66,7 +68,7 @@ describe FormPolicy do
   end
 
   describe "#can_add_page_routing_conditions?" do
-    let(:form) { build :form, pages:, org: "gds", creator_id: 123 }
+    let(:form) { build :form, pages:, org: "gds" }
     let(:pages) { [] }
 
     describe "when basic_routing feature flag is not enabled", feature_basic_routing: false do
@@ -167,10 +169,20 @@ describe FormPolicy do
     end
 
     context "with no organisation set" do
-      let(:user) { build :user, :with_no_org }
+      context "with editor role" do
+        let(:user) { build :user, :with_no_org }
 
-      it "raises an error" do
-        expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+        it "raises an error" do
+          expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+        end
+      end
+
+      context "with trial role" do
+        let(:user) { build :user, :with_no_org, :with_trial }
+
+        it "does not an error" do
+          expect { policy }.not_to raise_error
+        end
       end
     end
 

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -44,9 +44,10 @@ describe FormPolicy do
     end
 
     context "with a trial role" do
+      let(:form) { build :form, org: nil, creator_id: 123 }
+
       context "when the user created the form" do
-        let(:form) { build :form, creator_id: 1234 }
-        let(:user) { build :user, :with_no_org, :with_trial, id: 1234 }
+        let(:user) { build :user, :with_no_org, :with_trial, id: 123 }
 
         it { is_expected.to permit_actions(%i[can_view_form]) }
       end
@@ -59,7 +60,7 @@ describe FormPolicy do
         end
 
         context "without a form creator" do
-          let(:form) { build :form }
+          let(:form) { build :form, org: nil, creator_id: nil }
 
           it { is_expected.to forbid_actions(%i[can_view_form]) }
         end
@@ -140,7 +141,7 @@ describe FormPolicy do
 
     context "with a trial user role" do
       let(:user) { build :user, :with_no_org, :with_trial, id: 123 }
-      let(:form) { build(:form, creator_id: 123) }
+      let(:form) { build(:form, creator_id: 123, org: nil) }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -1,18 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Forms::ChangeNameController, type: :request do
-  let(:form_data) do
-    {
-      name: "Form name",
-      org: "test-org",
-    }
-  end
-
   let(:form_response_data) do
     {
       id: 2,
       name: "Form name",
       org: "test-org",
+      creator_id: 123,
     }.to_json
   end
 
@@ -40,7 +34,18 @@ RSpec.describe Forms::ChangeNameController, type: :request do
   end
 
   describe "#create" do
+    let(:user) { build :user, id: 1 }
+    let(:form_data) do
+      {
+        name: "Form name",
+        org: "test-org",
+        creator_id: user.id,
+      }
+    end
+
     before do
+      login_as user
+
       ActiveResource::HttpMock.reset!
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/", req_headers, form_response_data, 200
@@ -74,8 +79,8 @@ RSpec.describe Forms::ChangeNameController, type: :request do
 
   describe "#update" do
     it "renames form" do
-      post change_form_name_path(form_id: 2), params: { forms_change_name_form: { name: "new_form_name", org: "test-org" } }
-      expected_request = ActiveResource::Request.new(:put, "/api/v1/forms/2", { "id": 2, "name": "new_form_name", org: "test-org" }.to_json, post_headers)
+      post change_form_name_path(form_id: 2), params: { forms_change_name_form: { name: "new_form_name", org: "test-org", creator_id: 123 } }
+      expected_request = ActiveResource::Request.new(:put, "/api/v1/forms/2", { "id": 2, "name": "new_form_name", org: "test-org", creator_id: 123 }.to_json, post_headers)
       expect(ActiveResource::HttpMock.requests).to include expected_request
       expect(ActiveResource::HttpMock.requests[1].body).to eq expected_request.body
       expect(response).to redirect_to(form_path(form_id: 2))

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -18,9 +18,17 @@ RSpec.describe UsersController, type: :request do
       end
     end
 
-    context "when logged in without super admin role" do
+    context "when logged in with editor role" do
       it "is forbidden" do
         login_as_editor_user
+        get users_path
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when logged in with trial role" do
+      it "is forbidden" do
+        login_as_trial_user
         get users_path
         expect(response).to have_http_status(:forbidden)
       end
@@ -45,9 +53,17 @@ RSpec.describe UsersController, type: :request do
       end
     end
 
-    context "when logged in without super admin role" do
+    context "when logged in with editor role" do
       it "is forbidden" do
         login_as_editor_user
+        get edit_user_path(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when logged in with trial role" do
+      it "is forbidden" do
+        login_as_trial_user
         get edit_user_path(user)
         expect(response).to have_http_status(:forbidden)
       end
@@ -111,9 +127,17 @@ RSpec.describe UsersController, type: :request do
       end
     end
 
-    context "when logged in without super admin role" do
+    context "when logged in with editor role" do
       it "is forbidden" do
         login_as_editor_user
+        put user_path(user), params: { user: { role: "super_admin" } }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when logged in with trial role" do
+      it "is forbidden" do
+        login_as_trial_user
         put user_path(user), params: { user: { role: "super_admin" } }
         expect(response).to have_http_status(:forbidden)
       end

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -15,20 +15,28 @@ module AuthenticationFeatureHelpers
     GDS::SSO.test_user = nil
   end
 
+  def super_admin_user
+    @super_admin_user ||= FactoryBot.build(:user, :super_admin)
+  end
+
   def editor_user
     @editor_user ||= FactoryBot.build(:user)
   end
 
-  def super_admin_user
-    @super_admin_user ||= FactoryBot.build(:user, :super_admin)
+  def trial_user
+    @trial_user ||= FactoryBot.build(:user, :trial)
+  end
+
+  def login_as_super_admin_user
+    login_as super_admin_user
   end
 
   def login_as_editor_user
     login_as editor_user
   end
 
-  def login_as_super_admin_user
-    login_as super_admin_user
+  def login_as_trial_user
+    login_as trial_user
   end
 end
 

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -74,6 +74,14 @@ describe "forms/index.html.erb" do
       end
     end
 
+    context "with a user with a trial role" do
+      let(:user) { build :user, :with_no_org, :with_trial }
+
+      it "has a table caption without an organisation name" do
+        expect(rendered).to have_css(".govuk-table__caption", text: "Your forms")
+      end
+    end
+
     context "when a form is live renders link to 'live' form readonly view" do
       let(:forms) { [OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", has_live_version: false), OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2", status: "live", has_live_version: true)] }
 

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -52,6 +52,7 @@ describe "users/edit.html.erb" do
     it "has role fields" do
       expect(rendered).to have_checked_field("Editor")
       expect(rendered).to have_unchecked_field("Super admin")
+      expect(rendered).to have_unchecked_field("Trial")
     end
 
     it "has organisation fields" do


### PR DESCRIPTION
#### What problem does the pull request solve?
We want to be able to give new users a ‘trial’ role so they have permissions to do a limited number of things while deciding whether GOV.UK Forms is a good fit for their team.

This PR:
- adds the trial role to the User model
- allows super-admins to assign the trial role to users
- sets the creator_id on new form creation
- makes organisation optional for trial users
- allows trial users to create, view, and edit only forms they have created

Trello card: https://trello.com/c/Bfl4ckBp

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
