### PR TITLE
Let task list component render section with body instead of rows

### DIFF
--- a/app/components/task_list_component/_index.scss
+++ b/app/components/task_list_component/_index.scss
@@ -30,6 +30,15 @@
   }
 }
 
+.app-task-list__body {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
+  padding-left: 0;
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(6);
+  }
+}
+
 .app-task-list__items {
   @include govuk-font($size: 19);
   @include govuk-responsive-margin(9, "bottom");

--- a/app/components/task_list_component/view.html.erb
+++ b/app/components/task_list_component/view.html.erb
@@ -5,11 +5,19 @@
 <% end %>
 <%= tag.ol(**html_attributes) do %>
   <% sections.each do |section| %>
-    <% unless section.rows.empty? %>
+    <% unless section.rows.empty? && section.body_text.blank? %>
       <li>
         <h2 class="app-task-list__section">
           <span class="app-task-list__section-number"><%= section.number %>. </span> <%= section.title %>
         </h2>
+
+        <% if section.body_text.present? %>
+        <div class="app-task-list__body">
+          <%= simple_format(section.body_text) %>
+        </div>
+        <% end %>
+
+        <% unless section.rows.empty? %>
         <ul class="app-task-list__items">
           <% section.rows.each do |row| %>
             <li class="app-task-list__item">
@@ -38,6 +46,8 @@
           </li>
         <% end %>
         </ul>
+        <% end %>
+
       </li>
     <% end %>
   <% end %>

--- a/app/components/task_list_component/view.rb
+++ b/app/components/task_list_component/view.rb
@@ -2,7 +2,7 @@ module TaskListComponent
   class View < GovukComponent::Base
     attr_accessor :sections, :completed_task_count, :total_task_count
 
-    Section = Struct.new(:rows, :title, :number, keyword_init: true)
+    Section = Struct.new(:rows, :title, :number, :body_text, keyword_init: true)
 
     def initialize(completed_task_count: nil, total_task_count: nil, sections: [], classes: [], html_attributes: {})
       @count = 0
@@ -30,7 +30,8 @@ module TaskListComponent
       title = section_fields.fetch(:title)
       rows = section_fields.fetch(:rows) { [] }
       number = counter
-      Section.new(rows: build_rows(rows), title:, number:)
+      body_text = section_fields[:body_text]
+      Section.new(rows: build_rows(rows), title:, number:, body_text:)
     end
 
     def build_rows(rows)

--- a/spec/components/task_list_component/task_list_component_preview.rb
+++ b/spec/components/task_list_component/task_list_component_preview.rb
@@ -8,7 +8,16 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
           { task_name: "Edit the email address", path: "#", status: :cannot_start },
           { task_name: "Confirm the submission email address", path: "#", status: :cannot_start, active: false },
         ] },
-      { title: "do something else with a form",
+      { title: "Do something else with a form",
+        rows: [
+          { task_name: "Edit the name of your form", path: "#", status: :completed, active: true },
+          { task_name: "Edit the questions of your form", path: "#", status: :not_started, active: true },
+          { task_name: "Edit the email address", path: "#", status: :cannot_start },
+          { task_name: "Confirm the submission email address", path: "#", status: :cannot_start, active: false },
+        ] },
+      { title: "Read this",
+        body_text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet ex nisl. Maecenas at erat mi. Nunc feugiat egestas ligula ac feugiat. Nam et dictum felis.\n\nCras cursus leo vitae vestibulum dictum. Donec sit amet turpis faucibus, bibendum leo vel, fermentum lacus." },
+      { title: "Do yet another thing with a form",
         rows: [
           { task_name: "Edit the name of your form", path: "#", status: :completed, active: true },
           { task_name: "Edit the questions of your form", path: "#", status: :not_started, active: true },
@@ -22,7 +31,14 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
     render(TaskListComponent::View.new)
   end
 
-  def section_without_rows
+  def section_with_body_instead_of_rows
+    render(TaskListComponent::View.new(sections: [{
+      title: "Section with body instead of rows",
+      body_text: "There are no tasks for you to do yet.\n\nMaybe there will be some later.",
+    }]))
+  end
+
+  def section_without_body_or_rows
     render(TaskListComponent::View.new(sections: [
       { title: "Make a form", rows: [] },
     ]))

--- a/spec/components/task_list_component/view_spec.rb
+++ b/spec/components/task_list_component/view_spec.rb
@@ -46,6 +46,31 @@ RSpec.describe TaskListComponent::View, type: :component do
     end
   end
 
+  context "when given a section body instead of any rows" do
+    before do
+      render_inline(described_class.new(sections: [
+        { title: "section title", body_text: "section body" },
+      ]))
+    end
+
+    it "renders the section title" do
+      expect(page).to have_text("section title")
+    end
+
+    it "renders the section body" do
+      expect(page).to have_text("section body")
+    end
+
+    it "can render HTML in the section body" do
+      render_inline(described_class.new(sections: [{
+        title: "section title",
+        body_text: "section\n\nbody",
+      }]))
+
+      expect(page).to have_css("p", exact_text: "body")
+    end
+  end
+
   context "when given an empty rows array" do
     before do
       render_inline(described_class.new(sections: [


### PR DESCRIPTION
#### What problem does the pull request solve?

For the trial user we want some of the form creation/editing task list sections to have text instead of tasks. See for example tickets https://trello.com/c/I44RySs9 and https://trello.com/c/zz3V7GLv.

This PR adds the optional `body_text` attribute to the task list section struct for this purpose.

If you have this branch checked out locally you can preview this feature at http://localhost:3000/preview/task_list_component/task_list_component/default. You may need to run `bin/vite build` first to rebuild the app stylesheets with the new CSS classes.

### Screenshot

![Screenshot of http://localhost:3000/preview/task_list_component/task_list_component/default](https://github.com/alphagov/forms-admin/assets/503614/41c88a3e-eb86-493c-ac2b-69534fc959c6)


