### PR TITLE
Fix spacing under status tag form task list page

### DIFF
--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -15,9 +15,12 @@
       <p><%= flash[:message] %></p>
     <% end %>
 
-    <p class="govuk-!-margin-bottom-9">
-      <%= render PreviewLinkComponent::View.new(@form.pages, link_to_runner(Settings.forms_runner.url, @form.id, @form.form_slug)) %>
-    </p>
+    <% preview_link = PreviewLinkComponent::View.new(@form.pages, link_to_runner(Settings.forms_runner.url, @form.id, @form.form_slug)) %>
+    <% if preview_link.render? %>
+      <p class="govuk-!-margin-bottom-9">
+        <%= render preview_link %>
+      </p>
+    <% end %>
 
     <% if @form.has_live_version %>
       <div class="govuk-inset-text">


### PR DESCRIPTION
### What problem does the pull request solve?

When there are no questions there is unnecessary extra space under the draft tag. This happens because we're including a paragraph with lots of margin for the preview link, but there's no preview link (because there are no pages to preview).

This commit changes the template to only render the container for the preview link if preview link will be rendered.

### Screenshots

#### Before

<img width="646" alt="Screenshot of task list page heading area before change" src="https://github.com/alphagov/forms-admin/assets/503614/0826cc67-711a-4300-873d-d9102009db2f">


#### After

<img width="642" alt="Screenshot of task list page heading area after change" src="https://github.com/alphagov/forms-admin/assets/503614/9e384905-c840-4f7b-826f-eabd9044eed4">
