### PR TITLE
Fix flaky spec with delete route confirmation

### DIFF
--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -10,7 +10,7 @@ end
 
 FactoryBot.define do
   factory :page, class: "Page" do
-    id { Faker::Number.number(digits: 2) }
+    sequence(:id) { |n| n }
     question_text { Faker::Lorem.question }
     answer_type { Page::ANSWER_TYPES.reject { |item| Page::ANSWER_TYPES_WITH_SETTINGS.include? item }.sample }
     is_optional { nil }


### PR DESCRIPTION
#### What problem does the pull request solve?
Fixes https://github.com/alphagov/forms-admin/actions/runs/5209197611/jobs/9398726757?pr=474

In our factory, we were using Faker to generate a 2-digit id. In some instances, it meant that more than one page could have the same id. This was the issue with this flakey spec.

The method being tested was searching for the first id in the collection that matched and returning that. In production, this would work because pages could never have the same id.

```
form.pages.filter { |p| p.id == goto_page_id }.first&.question_text
```

With the test data in some instances, it meant the method being tested was finding the wrong page in the order. This was an error with the test data, not the method being tested

eg. of when the tests failed
```
form.pages.map(&:id)
[62, 20, 34, 73, 34]
```
The method being tested i.e. the `result` was returning the 3 items in the collection but then comparing it to the last item which was a completely different page.

The solution was instead of using Faker to generate a random id, it would be better to use the FactoryBot sequence method, which automatically increments with every instance built/created as part of the spec.

I run this over 1000 times on my machine with no failures

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
