### PR TITLE
Add notification banner for users with trial role

### DIFF
--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -7,6 +7,13 @@
   </p>
 <% end %>
 
+<% if @current_user.trial?  %>
+  <%= govuk_notification_banner(title_text: t("trial_role_warning.title")) do |banner| %>
+    <% banner.with_heading(text: t("trial_role_warning.heading")) %>
+    <%= t("trial_role_warning.content") %>
+  <% end %>
+<% end %>
+
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_form_path) %>
 
 <% if @forms.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -530,6 +530,10 @@ en:
     completed: completed
     in_progress: in progress
     not_started: not started
+  trial_role_warning:
+    content: You can create a form and test it, but you cannot make a form live.
+    heading: You have a trial account
+    title: Important
   type_of_answer:
     routing_warning_about_change_answer_type_heading: Your existing question route may be deleted
     routing_warning_about_change_answer_type_html: |

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -98,5 +98,25 @@ describe "forms/index.html.erb" do
         expect(rendered).to have_link("Form 2", href: live_form_path(2))
       end
     end
+
+    context "and a user has the trial role" do
+      let(:user) { build :user, :with_trial }
+
+      it "displays a banner informing the user they have a trial account" do
+        banner = Capybara.string(rendered).find(".govuk-notification-banner__content")
+
+        expect(rendered).to have_selector(".govuk-notification-banner__content")
+        expect(banner).to have_text(I18n.t("trial_role_warning.heading"))
+        expect(banner).to have_text(I18n.t("trial_role_warning.content"))
+      end
+    end
+
+    context "and a user does not have the trial role" do
+      let(:user) { build :user }
+
+      it "does not display a banner" do
+        expect(rendered).not_to have_selector(".govuk-notification-banner__content")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
We want to be able to give new users a ‘trial’ role so they have permissions to do a limited number of things while deciding whether GOV.UK Forms is a good fit for their team.

For this ticket we want to add a banner to the homepage telling trial users that they have a trial account.

Trello card: https://trello.com/c/xDujFEXU

#### Screenshot:
![image](https://github.com/alphagov/forms-admin/assets/29330450/6159f04f-a493-4731-b5a0-232420fe0837)

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
