### PR TITLE
Tweak content for routing dropdowns

### DIFF
--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -36,12 +36,14 @@ class Pages::ConditionsForm
     options = page.answer_settings.selection_options.map { |option| OpenStruct.new(value: option.name, label: option.name) }
     options << OpenStruct.new(value: I18n.t("page_options_service.selection_type.none_of_the_above"), label: I18n.t("page_options_service.selection_type.none_of_the_above")) if page.is_optional
 
-    [OpenStruct.new(value: nil, label: I18n.t("helpers.label.pages_conditions_form.default_answer_value")), options].flatten
+    options
   end
 
   def goto_page_options
     page_options = pages_after_current_page(form.pages, page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
-    [OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")), page_options, OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))].flatten
+    page_options << OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))
+
+    page_options
   end
 
   def check_errors_from_api

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -20,8 +20,8 @@
         end;
       end %>
 
-      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label %>
-      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text %>
+      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label, options: { include_blank: t("helpers.label.pages_conditions_form.default_answer_value") } %>
+      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text, options: { include_blank: t("helpers.label.pages_conditions_form.default_goto_page_id") } %>
       <%= f.govuk_submit t("save_and_continue") do
         govuk_button_link_to "Delete question route", delete_condition_path(condition_form.form.id, condition_form.page.id, condition_form.record.id), warning: true
       end %>

--- a/app/views/pages/conditions/new.html.erb
+++ b/app/views/pages/conditions/new.html.erb
@@ -21,8 +21,8 @@
         end;
       end %>
 
-      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label %>
-      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text %>
+      <%= f.govuk_collection_select :answer_value, condition_form.routing_answer_options, :value, :label, options: { include_blank: t("helpers.label.pages_conditions_form.default_answer_value") } %>
+      <%= f.govuk_collection_select :goto_page_id, condition_form.goto_page_options, :id, :question_text, options: { include_blank: t("helpers.label.pages_conditions_form.default_goto_page_id") } %>
       <%= f.govuk_submit t("save_and_continue") %>
     <% end %>
   </div>

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -19,21 +19,16 @@
         <%= f.govuk_collection_radio_buttons :routing_page_id,
                                             form.qualifying_route_pages,
                                             :id, :question_text,
-                                            legend: {
-                                              text: t("routing_page.legend_text"),
-                                              size: 'm' },
-                                            hint:{
-                                              text: t("routing_page.legend_hint_text") }
+                                            legend: { text: t("routing_page.legend_text"), size: 'm' },
+                                            hint:{ text: t("routing_page.legend_hint_text") }
         %>
       <% else %>
         <%= f.govuk_collection_select :routing_page_id,
                                             form.qualifying_route_pages,
                                             :id, :question_with_number,
-                                            label: {
-                                              text: t("routing_page.legend_text"),
-                                              size: 'm' },
-                                            hint:{
-                                              text: t("routing_page.legend_hint_text") }
+                                            label: { text: t("routing_page.legend_text"), size: 'm' },
+                                            hint: { text: t("routing_page.legend_hint_text") },
+                                            options: { include_blank: t("routing_page.dropdown_default_text") }
         %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -460,6 +460,7 @@ en:
     submit_button: Save and continue
   routing_page:
     body_text: "You can send people directly to the question or page you want, based on their previous answer. \nThis means they’ll only see questions that are relevant to them.\n"
+    dropdown_default_text: Select a question to start your route from
     legend_hint_text: A route can only start from a question where people select one item from a list
     legend_text: Which question do you want your route to start from?
   save_and_continue: Save and continue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,12 +340,12 @@ en:
       If you pasted the web address, check you copied the entire address.
     title: Page not found
   page_conditions:
-    check_your_answers: Check your answers
+    check_your_answers: Check your answers before submitting
     condition_answer_value_text: is answered as “%{answer_value}”
     condition_answer_value_text_with_errors: is answered as [Answer not selected]
     condition_check_page_text: If the question “%{check_page_text}”
     condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to question %{goto_page_number}: “%{goto_page_text}”'
-    condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to “Check your answers”
+    condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to “Check your answers before submitting”
     condition_goto_page_text: take the person to “%{goto_page_text}”
     condition_goto_page_text_with_errors: take the person to [Question not selected]
     condition_name: Question %{page_index}’s route

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,7 +394,7 @@ en:
     privacy_policy_form: Provide a link to privacy information for this form
     routing_page: Add a question route
     routing_page_delete: Delete question %{question_position}’s route
-    routing_page_edit: Edit question %{question_position}’s routes
+    routing_page_edit: Edit question %{question_position}’s route
     service_unavailable: Sorry, the service is unavailable
     set_email_form: Set the email address for completed forms
     text_settings: How much text will people need to provide?

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe Pages::ConditionsForm, type: :model do
     it "returns a list of answers for the given page" do
       result = conditions_form.routing_answer_options
       expect(result).to eq([
-        OpenStruct.new(value: nil, label: I18n.t("helpers.label.pages_conditions_form.default_answer_value")),
         OpenStruct.new(value: "Option 1", label: "Option 1"),
         OpenStruct.new(value: "Option 2", label: "Option 2"),
       ])
@@ -113,7 +112,6 @@ RSpec.describe Pages::ConditionsForm, type: :model do
       it "adds extra 'None of above' options to the end" do
         result = conditions_form.routing_answer_options
         expect(result).to eq([
-          OpenStruct.new(value: nil, label: I18n.t("helpers.label.pages_conditions_form.default_answer_value")),
           OpenStruct.new(value: "Option 1", label: "Option 1"),
           OpenStruct.new(value: "Option 2", label: "Option 2"),
           OpenStruct.new(value: I18n.t("page_options_service.selection_type.none_of_the_above"),
@@ -128,7 +126,6 @@ RSpec.describe Pages::ConditionsForm, type: :model do
       it "returns a list of all pages after the first page and includes 'Check your answers before submitting'" do
         result = described_class.new(form:, page: pages.first).goto_page_options
         expect(result).to eq([
-          OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")),
           form.pages.drop(1).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
           OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
         ].flatten)
@@ -140,7 +137,6 @@ RSpec.describe Pages::ConditionsForm, type: :model do
         routing_from_page_position = 3
         result = described_class.new(form:, page: pages[routing_from_page_position - 1]).goto_page_options
         expect(result).to eq([
-          OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")),
           form.pages.drop(routing_from_page_position).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
           OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
         ].flatten)

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Pages::ConditionsForm, type: :model do
 
   describe "#goto_page_options" do
     context "when routing from the first form page" do
-      it "returns a list of all pages after the first page and includes 'Check your answers'" do
+      it "returns a list of all pages after the first page and includes 'Check your answers before submitting'" do
         result = described_class.new(form:, page: pages.first).goto_page_options
         expect(result).to eq([
           OpenStruct.new(id: nil, question_text: I18n.t("helpers.label.pages_conditions_form.default_goto_page_id")),

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -55,8 +55,8 @@ describe "pages/conditions/routing_page.html.erb" do
       expect(rendered).to have_css("div.govuk-hint", text: t("routing_page.legend_hint_text"))
     end
 
-    it "has a select option for each routing pages" do
-      expect(rendered).to have_css("select > option", count: pages.length)
+    it "has a select option for each routing page and the default value" do
+      expect(rendered).to have_css("select > option", count: pages.length + 1)
     end
 
     it "includes the page number and question text" do


### PR DESCRIPTION
#### What problem does the pull request solve?
May be easier to read by going through each commit - this includes:
- Adding default value to routing page dropdown (previously it was just defaulting to the first item in the list)
- Changing 'Check your answers' to 'Check your answers before submitting' in the goto_page select box (to match the h1 on the CYA page)
- Changing 'routes' to 'route' on the edit route page (see https://gds.slack.com/archives/C048R8RJJBH/p1686129714380289?thread_ts=1683711412.643269&cid=C048R8RJJBH)
- Moving the default text for the goto_page and answer_value dropdowns into the prompt option (I only realised you could do this when adding the default value to the routing page dropdown)

Trello card: https://trello.com/c/WyFxtJJg/792-implement-drop-down-menu-content-for-simple-routing (plus some other small bits) which don't have cards

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
