### PR TITLE
Change uses of `@current_user` to `current_user` in controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,10 +28,10 @@ class ApplicationController < ActionController::Base
   def append_info_to_payload(payload)
     super
     payload[:host] = request.host
-    if @current_user.present?
-      payload[:user_id] = @current_user.id
-      payload[:user_email] = @current_user.email
-      payload[:user_organisation_slug] = @current_user.organisation&.slug
+    if current_user.present?
+      payload[:user_id] = current_user.id
+      payload[:user_email] = current_user.email
+      payload[:user_organisation_slug] = current_user.organisation&.slug
     end
     payload[:request_id] = request.request_id
     payload[:user_ip] = user_ip(request.env.fetch("HTTP_X_FORWARDED_FOR", ""))
@@ -100,7 +100,7 @@ private
     authenticate_user!
 
     # check access
-    unless @current_user.has_access?
+    unless current_user.has_access?
       render "errors/access_denied", status: :forbidden, formats: :html
     end
   end

--- a/app/controllers/forms/change_name_controller.rb
+++ b/app/controllers/forms/change_name_controller.rb
@@ -9,8 +9,8 @@ module Forms
     def create
       form = Form.new({
         name: params[:name],
-        org: @current_user.organisation.slug,
-        creator_id: @current_user.id,
+        org: current_user.organisation.slug,
+        creator_id: current_user.id,
       })
 
       authorize form, :can_view_form?

--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -44,11 +44,11 @@ module Forms
   private
 
     def set_email_form_params
-      params.require(:forms_submission_email_form).permit(:temporary_submission_email, :notify_response_id).merge(form: current_form).merge(current_user: @current_user)
+      params.require(:forms_submission_email_form).permit(:temporary_submission_email, :notify_response_id).merge(form: current_form).merge(current_user:)
     end
 
     def set_email_code_form_params
-      params.require(:forms_submission_email_form).permit(:email_code).merge(form: current_form).merge(current_user: @current_user)
+      params.require(:forms_submission_email_form).permit(:email_code).merge(form: current_form).merge(current_user:)
     end
 
     def submission_email_form

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,17 +7,17 @@ class UsersController < ApplicationController
   end
 
   def index
-    authorize @current_user, :can_manage_user?
+    authorize current_user, :can_manage_user?
     render template: "users/index", locals: { users: policy_scope(User) }
   end
 
   def edit
-    authorize @current_user, :can_manage_user?
+    authorize current_user, :can_manage_user?
     user
   end
 
   def update
-    authorize @current_user, :can_manage_user?
+    authorize current_user, :can_manage_user?
 
     if user.update(user_params)
       redirect_to users_path

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe AuthenticationController, type: :request do
   describe "#sign_out" do
     let(:warden_spy) do
       warden_spy = instance_spy(Warden::Proxy)
+      allow(warden_spy).to receive(:user).and_return(instance_spy(User))
       allow(controller_spy).to receive(:warden).and_return(warden_spy)
       warden_spy
     end


### PR DESCRIPTION
`current_user` should be available in all cases in controllers, whereas the instance variable `@current_user` is set only when `authenticate_and_check_access` has run. Prefer to use `current_user`.