### PR TITLE
Stop trial users from being able to change a form submission email address

### DIFF
--- a/app/controllers/forms/change_name_controller.rb
+++ b/app/controllers/forms/change_name_controller.rb
@@ -13,6 +13,10 @@ module Forms
         creator_id: current_user.id,
       })
 
+      if @current_user.trial?
+        form.submission_email = @current_user.email
+      end
+
       authorize form, :can_view_form?
       @change_name_form = ChangeNameForm.new(change_name_form_params(form))
 

--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -4,11 +4,11 @@ module Forms
     after_action :verify_authorized
 
     def new
-      authorize current_form, :can_view_form?
+      authorize current_form, :can_change_form_submission_email?
     end
 
     def create
-      authorize current_form, :can_view_form?
+      authorize current_form, :change_form_submission_email?
       @submission_email_form = SubmissionEmailForm.new(set_email_form_params)
 
       if @submission_email_form.submit
@@ -19,15 +19,15 @@ module Forms
     end
 
     def submission_email_code_sent
-      authorize current_form, :can_view_form?
+      authorize current_form, :change_form_submission_email?
     end
 
     def submission_email_code
-      authorize current_form, :can_view_form?
+      authorize current_form, :change_form_submission_email?
     end
 
     def confirm_submission_email_code
-      authorize current_form, :can_view_form?
+      authorize current_form, :change_form_submission_email?
       @submission_email_form = SubmissionEmailForm.new(set_email_code_form_params).assign_form_values
 
       if @submission_email_form.confirm_confirmation_code
@@ -38,7 +38,7 @@ module Forms
     end
 
     def submission_email_confirmed
-      authorize current_form, :can_view_form?
+      authorize current_form, :change_form_submission_email?
     end
 
   private

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -34,6 +34,10 @@ class FormPolicy
     users_organisation_owns_form || (user.trial? && user_is_form_creator)
   end
 
+  def can_change_form_submission_email?
+    can_view_form? && !user.trial?
+  end
+
   def can_add_page_routing_conditions?
     form_has_two_or_more_pages = form.pages.length >= 2
     form_has_qualifying_pages = form.qualifying_route_pages.any?

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -53,10 +53,20 @@ private
   end
 
   def section_2
-    {
+    section = {
       title: I18n.t("forms.task_list_#{create_or_edit}.section_2.title"),
-      rows: section_2_tasks,
     }
+
+    if @current_user.trial?
+      section[:body_text] = I18n.t(
+        "forms.task_list_create.section_2.if_trial_user.body_text",
+        submission_email: @form.submission_email,
+      )
+    else
+      section[:rows] = section_2_tasks
+    end
+
+    section
   end
 
   def section_2_tasks

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,11 @@ en:
         confirm_email: Enter the email address confirmation code
         email: Set the email address completed forms will be sent to
         hint_text_html: Completed forms will be sent to:<br> %{submission_email}
+        if_trial_user:
+          body_text: |
+            For a trial account, completed draft forms will be sent to your email address: %{submission_email}
+
+            Editor accounts can change the email address for completed forms to be sent to.
         title: Set email address for completed forms
       section_3:
         contact_details: Provide contact details for support

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -68,6 +68,42 @@ describe FormPolicy do
     end
   end
 
+  describe "#can_change_form_submission_email?" do
+    context "with a form editor" do
+      it { is_expected.to permit_actions(%i[can_change_form_submission_email]) }
+
+      context "but from another organisation" do
+        let(:user) { build :user, organisation_slug: "non-gds" }
+
+        it { is_expected.to forbid_actions(%i[can_change_form_submission_email]) }
+      end
+    end
+
+    context "with a trial role" do
+      let(:form) { build :form, org: nil, creator_id: 123 }
+
+      context "when the user created the form" do
+        let(:user) { build :user, :with_no_org, :with_trial, id: 123 }
+
+        it { is_expected.to forbid_actions(%i[can_change_form_submission_email]) }
+      end
+
+      context "when the user didn't create the form" do
+        context "with a different user" do
+          let(:user) { build :user, id: 321 }
+
+          it { is_expected.to forbid_actions(%i[can_change_form_submission_email]) }
+        end
+
+        context "without a form creator" do
+          let(:form) { build :form, org: nil, creator_id: nil }
+
+          it { is_expected.to forbid_actions(%i[can_change_form_submission_email]) }
+        end
+      end
+    end
+  end
+
   describe "#can_add_page_routing_conditions?" do
     let(:form) { build :form, pages:, org: "gds" }
     let(:pages) { [] }

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe Forms::ChangeNameController, type: :request do
       form = Form.new(form_data)
       expect(form).to have_been_created
     end
+
+    context "with a trial user" do
+      let(:user) { build(:user, role: :trial, id: 1) }
+
+      it "sets the submission email address" do
+        form_data[:submission_email] = user.email
+        form = Form.new(form_data)
+        expect(form).to have_been_created
+      end
+    end
   end
 
   describe "#edit" do

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -176,6 +176,26 @@ describe FormTaskListService do
           expect(section_rows[1][:status]).to eq :completed
         end
       end
+
+      context "when current user has a trial account" do
+        let(:current_user) { build :user, role: :trial }
+
+        before do
+          form.submission_email = current_user.email
+        end
+
+        it "has no tasks" do
+          expect(section).not_to include(:rows)
+        end
+
+        it "has text explaining where completed forms will be sent to" do
+          expect(section[:body_text])
+            .to eq I18n.t(
+              "forms.task_list_create.section_2.if_trial_user.body_text",
+              submission_email: form.submission_email,
+            )
+        end
+      end
     end
 
     describe "section 3 tasks" do


### PR DESCRIPTION
### What problem does the pull request solve?

Trello card: https://trello.com/c/I44RySs9

For users with trial accounts, we want to restrict them so that they can only use their own email address for draft form submissions. This PR sets the email address to the user's email address if the user has a trial account, updates the task list following the designs in the ticket, and adds a new permission check to the form policy, restricting who can access the submission email pages.

### Screenshots

![Screenshot of form task list page for trial user](https://github.com/alphagov/forms-admin/assets/503614/72b4e21c-0bb7-4da1-9fdd-d5d02df1bc7e)
