### PR TITLE
Require an organisation to be set when changing a user to editor role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   }
 
   validates :role, presence: true
-  validates :organisation_id, presence: true, if: -> { organisation_id_was.present? }
+  validates :organisation_id, presence: true, if: :requires_organisation?
   validates :has_access, inclusion: [true, false]
 
   def self.find_for_gds_oauth(auth_hash)
@@ -53,5 +53,11 @@ class User < ApplicationRecord
 
   def organisation_valid?
     trial? || organisation.present?
+  end
+
+private
+
+  def requires_organisation?
+    organisation_id_was.present? || role_changed?(to: :editor)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,6 +45,12 @@ describe User do
       user.organisation_id = nil
       expect(user.valid?).to be false
     end
+
+    it "is not valid to leave organisation unset if changing role to editor" do
+      user = create :user, :with_no_org, role: :trial
+      user.role = :editor
+      expect(user.valid?).to be false
+    end
   end
 
   describe ".find_for_auth" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -111,6 +111,22 @@ RSpec.describe UsersController, type: :request do
         end
       end
 
+      context "with a trial user with no organisation set" do
+        let(:user) { create(:user, :with_no_org, role: :trial) }
+
+        it "does not return error if organisation is not chosen and role is not changed" do
+          put user_path(user), params: { user: { role: "trial", organisation_id: nil } }
+          expect(response).to redirect_to(users_path)
+          expect(user.reload.organisation).to eq(nil)
+        end
+
+        it "returns an error if organisation is not chosen and role is changed to editor" do
+          put user_path(user), params: { user: { role: "editor", organisation_id: nil } }
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(user.reload.role).to eq("trial")
+        end
+      end
+
       [
         ["with an unknown organisation", :with_unknown_org],
         ["with no organisation set", :with_no_org],


### PR DESCRIPTION
### What problem does the pull request solve?

Trello card: https://trello.com/c/myv5aZuf

We want to make sure all editor users belong to an organisation. To make it easier for admins to remember, when changing a user's role from trial to editor, if an organisation has not be chosen, show an error.