### PR TITLE
Set correct none_of_the_above value in routes

### DIFF
--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -23,7 +23,8 @@ module PageListComponent
 
     def answer_value_text_for_condition(condition)
       if condition.answer_value.present?
-        I18n.t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
+        answer_value = condition.answer_value == :none_of_the_above.to_s ? I18n.t("page_conditions.none_of_the_above") : condition.answer_value
+        I18n.t("page_conditions.condition_answer_value_text", answer_value:)
       else
         I18n.t("page_conditions.condition_answer_value_text_with_errors")
       end

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -34,7 +34,7 @@ class Pages::ConditionsForm
 
   def routing_answer_options
     options = page.answer_settings.selection_options.map { |option| OpenStruct.new(value: option.name, label: option.name) }
-    options << OpenStruct.new(value: I18n.t("page_options_service.selection_type.none_of_the_above"), label: I18n.t("page_options_service.selection_type.none_of_the_above")) if page.is_optional
+    options << OpenStruct.new(value: :none_of_the_above.to_s, label: I18n.t("page_conditions.none_of_the_above")) if page.is_optional
 
     options
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,6 +365,7 @@ en:
         cannot_have_goto_page_before_routing_page: The question you’re taking the person to is now above the route - edit question %{page_index}’s route
         cannot_route_to_next_page: Question %{page_index}’s route is now next to the route’s end question - this makes the route unnecessary. Edit question %{page_index}’s route.
         goto_page_doesnt_exist: The question you’re taking the person to no longer exists - edit question %{page_index}’s route
+    none_of_the_above: None of the above
     route: Route
   page_options_service:
     answer_type: Answer type

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -226,6 +226,14 @@ RSpec.describe PageListComponent::View, type: :component do
         end
       end
 
+      context "when the answer value is set to 'None of the above'" do
+        let(:condition) { (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "none_of_the_above", goto_page_id: 3) }
+
+        it "returns the answer value text" do
+          expect(answer_value_text).to eq I18n.t("page_conditions.condition_answer_value_text", answer_value: I18n.t("page_conditions.none_of_the_above"))
+        end
+      end
+
       context "when the answer value is not set" do
         let(:condition) { (build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3) }
 

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Pages::ConditionsForm, type: :model do
         expect(result).to eq([
           OpenStruct.new(value: "Option 1", label: "Option 1"),
           OpenStruct.new(value: "Option 2", label: "Option 2"),
-          OpenStruct.new(value: I18n.t("page_options_service.selection_type.none_of_the_above"),
-                         label: I18n.t("page_options_service.selection_type.none_of_the_above")),
+          OpenStruct.new(value: :none_of_the_above.to_s,
+                         label: I18n.t("page_conditions.none_of_the_above")),
         ])
       end
     end


### PR DESCRIPTION
#### What problem does the pull request solve?
Sets the routing answer_value for None of the above to "none_of_the_above", which is what the runner uses, rather than "None of the above". Without this, routes based on None of the Above won't skip correctly.

Trello card: https://trello.com/c/uqnosctc/826-choosing-none-of-the-above-answered-as-should-not-display-a-validation-error

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
