### PR TITLE
Fix typo in submisison email controller

### DIFF
--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -8,7 +8,7 @@ module Forms
     end
 
     def create
-      authorize current_form, :change_form_submission_email?
+      authorize current_form, :can_change_form_submission_email?
       @submission_email_form = SubmissionEmailForm.new(set_email_form_params)
 
       if @submission_email_form.submit
@@ -19,15 +19,15 @@ module Forms
     end
 
     def submission_email_code_sent
-      authorize current_form, :change_form_submission_email?
+      authorize current_form, :can_change_form_submission_email?
     end
 
     def submission_email_code
-      authorize current_form, :change_form_submission_email?
+      authorize current_form, :can_change_form_submission_email?
     end
 
     def confirm_submission_email_code
-      authorize current_form, :change_form_submission_email?
+      authorize current_form, :can_change_form_submission_email?
       @submission_email_form = SubmissionEmailForm.new(set_email_code_form_params).assign_form_values
 
       if @submission_email_form.confirm_confirmation_code
@@ -38,7 +38,7 @@ module Forms
     end
 
     def submission_email_confirmed
-      authorize current_form, :change_form_submission_email?
+      authorize current_form, :can_change_form_submission_email?
     end
 
   private

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -1,0 +1,232 @@
+require "rails_helper"
+
+RSpec.describe Forms::SubmissionEmailController, type: :request do
+  let(:user) { build :user, id: 1, organisation_slug: "test-org" }
+  let(:form) { build :form, id: 1, creator_id: 1, org: "test-org" }
+
+  let(:submission_email_mailer_spy) do
+    submission_email_mailer = instance_spy(SubmissionEmailMailer)
+    allow(SubmissionEmailMailer).to receive(:new).and_return(submission_email_mailer)
+    submission_email_mailer
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms", req_headers, [form].to_json, 200
+      mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+      mock.put "/api/v1/forms/1", post_headers, { success: true }.to_json, 200
+    end
+
+    login_as user
+  end
+
+  describe "#new" do
+    before do
+      get submission_email_form_path(form.id)
+    end
+
+    it "returns HTTP code 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct page" do
+      expect(response).to render_template(:new)
+    end
+
+    context "when current user does not own form" do
+      let(:form) { build :form, id: 1, creator_id: 2, org: "other-org" }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when current user has a trial account" do
+      let(:user) { build :user, id: 1, role: :trial }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "#create" do
+    before do
+      allow(submission_email_mailer_spy).to receive(:confirmation_code_email)
+
+      post(
+        submission_email_path(form.id),
+        params: {
+          forms_submission_email_form: {
+            temporary_submission_email: user.email,
+            notify_response_id: Faker::Internet.uuid,
+          },
+        },
+      )
+    end
+
+    it "redirects to the email code sent page" do
+      expect(response).to redirect_to(submission_email_code_sent_path(form.id))
+    end
+
+    context "when current user does not own form" do
+      let(:form) { build :form, id: 1, creator_id: 2, org: "other-org" }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when current user has a trial account" do
+      let(:user) { build :user, id: 1, role: :trial }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "#submission_email_code_sent" do
+    before do
+      get submission_email_code_sent_path(form.id)
+    end
+
+    it "returns HTTP code 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct page" do
+      expect(response).to render_template(:submission_email_code_sent)
+    end
+
+    context "when current user does not own form" do
+      let(:form) { build :form, id: 1, creator_id: 2, org: "other-org" }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when current user has a trial account" do
+      let(:user) { build :user, id: 1, role: :trial }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "#submission_email_code" do
+    before do
+      get submission_email_code_path(form.id)
+    end
+
+    it "returns HTTP code 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct page" do
+      expect(response).to render_template(:submission_email_code)
+    end
+
+    context "when current user does not own form" do
+      let(:form) { build :form, id: 1, creator_id: 2, org: "other-org" }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when current user has a trial account" do
+      let(:user) { build :user, id: 1, role: :trial }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "#confirm_submission_email_code" do
+    before do
+      allow(FormSubmissionEmail).to receive(:find_by_form_id).and_return(build(
+                                                                           :form_submission_email,
+                                                                           form_id: 1,
+                                                                           temporary_submission_email: user.email,
+                                                                           confirmation_code: "123456",
+                                                                         ))
+
+      post(
+        confirm_submission_email_code_path(form.id),
+        params: {
+          forms_submission_email_form: {
+            email_code: "123456",
+          },
+        },
+      )
+    end
+
+    it "redirects to the confirmation page" do
+      expect(response).to redirect_to(submission_email_confirmed_path(form.id))
+    end
+
+    context "when current user does not own form" do
+      let(:form) { build :form, id: 1, creator_id: 2, org: "other-org" }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when current user has a trial account" do
+      let(:user) { build :user, id: 1, role: :trial }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "#submission_email_confirmed" do
+    before do
+      get submission_email_confirmed_path(form.id)
+    end
+
+    it "returns HTTP code 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct page" do
+      expect(response).to render_template(:submission_email_confirmed)
+    end
+
+    context "when current user does not own form" do
+      let(:form) { build :form, id: 1, creator_id: 2, org: "other-org" }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when current user has a trial account" do
+      let(:user) { build :user, id: 1, role: :trial }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does the pull request solve?

Correct name of permission check from `:change_form_submission_email?` to `:can_change_form_submission_email?`. This mistake was introduced in PR #483, partly because there were no tests for the controller, so this commit also adds tests.

Trello card: https://trello.com/c/I44RySs9