### PR TITLE
Fix errors on GOV.UK Signon push updates

### DIFF
--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -15,6 +15,7 @@ Rails.application.config.before_initialize do
   # Configure Warden session management middleware
   # swap out the Warden::Manager installed by `gds-sso` gem
   Rails.application.config.app_middleware.swap Warden::Manager, Warden::Manager do |warden|
+    warden.default_strategies(Settings.auth_provider.to_sym, :gds_bearer_token)
     warden.failure_app = AuthenticationController
   end
 end


### PR DESCRIPTION
Trello ticket: https://trello.com/c/zUsFXD9Y

The team that manage Signon have reported that since we deployed PR #472 they've been getting errors from the `/auth/gds/api/users/:uid/reauth` endpoint. This route is handled by the `gds-sso` gem [[1], [2]], and is used by Signon to update us when a users permissions change.

Testing locally, it looks like the issue is that they're not being authorised, and the Warden failure app is being reached. They should be being authorised using the `:gds_bearer_token` Warden strategy, which in the gds-sso gem is included in the list of default strategies [[3]], but in #472 we overrode the Warden middleware and did not set that[[4]].

Adding that strategy back into the list of default strategies is sufficient to fix this locally, even though we never use the Warden default strategies in our own code, because the gds-sso controller has its own `authenticate_user!` method.

[1]: https://github.com/alphagov/gds-sso/blob/a9c2a018dbebd07c35682b1523a2ad27a41d1185/config/routes.rb#L8
[2]: https://github.com/alphagov/gds-sso/blob/a9c2a018dbebd07c35682b1523a2ad27a41d1185/app/controllers/api/user_controller.rb
[3]: https://github.com/alphagov/gds-sso/blob/a9c2a018dbebd07c35682b1523a2ad27a41d1185/lib/gds-sso.rb#L48-L55
[4]: https://github.com/alphagov/forms-admin/pull/472/files#diff-b5224e97c3a9a105e9d12aafa5c157918930b3786a2ac169001250386316c0df
