### PR TITLE
Rename content_id and make it nullable

### DIFF
--- a/config/initializers/warden/strategies/basic_auth.rb
+++ b/config/initializers/warden/strategies/basic_auth.rb
@@ -27,7 +27,7 @@ Warden::Strategies.add(:basic_auth) do
         organisation: Organisation.find_or_initialize_by(
           name: Settings.basic_auth.organisation.name,
           slug: Settings.basic_auth.organisation.slug,
-          content_id: Settings.basic_auth.organisation.content_id,
+          govuk_content_id: Settings.basic_auth.organisation.govuk_content_id,
         ),
       )
     else

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,4 +43,4 @@ basic_auth:
   organisation:
     name: GDS User Research
     slug: gds-user-research
-    content_id: "00000000-0000-0000-0000-000000000000"
+    govuk_content_id: "00000000-0000-0000-0000-000000000000"

--- a/db/migrate/20230613133847_make_organisation_content_id_nullable.rb
+++ b/db/migrate/20230613133847_make_organisation_content_id_nullable.rb
@@ -1,0 +1,6 @@
+class MakeOrganisationContentIdNullable < ActiveRecord::Migration[7.0]
+  def change
+    rename_column(:organisations, :content_id, :govuk_content_id)
+    change_column_null(:organisations, :govuk_content_id, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_31_131201) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_133847) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,14 +27,33 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_131201) do
     t.index ["form_id"], name: "index_form_submission_emails_on_form_id"
   end
 
+  create_table "forms", id: :bigint, default: nil, force: :cascade do |t|
+    t.text "name"
+    t.text "submission_email"
+    t.text "org"
+  end
+
   create_table "organisations", force: :cascade do |t|
-    t.string "content_id", null: false
+    t.string "govuk_content_id"
     t.string "slug", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["content_id"], name: "index_organisations_on_content_id", unique: true
+    t.index ["govuk_content_id"], name: "index_organisations_on_govuk_content_id", unique: true
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
+  end
+
+  create_table "pages", id: :bigint, default: nil, force: :cascade do |t|
+    t.bigint "form_id"
+    t.text "question_text"
+    t.text "question_short_name"
+    t.text "hint_text"
+    t.text "answer_type"
+    t.text "next"
+  end
+
+  create_table "schema_info", id: false, force: :cascade do |t|
+    t.integer "version", default: 0, null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -57,5 +76,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_131201) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 
+  add_foreign_key "pages", "forms", name: "pages_form_id_fkey"
   add_foreign_key "users", "organisations"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,7 @@ require "factory_bot"
 
 if HostingEnvironment.local_development? && User.none?
 
-  gds = Organisation.find_or_create_by!(content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9", slug: "government-digital-service", name: "Government Digital Service")
+  gds = Organisation.find_or_create_by!(govuk_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9", slug: "government-digital-service", name: "Government Digital Service")
 
   # Create default super-admin
   User.create!({ email: "example@example.com",
@@ -35,7 +35,7 @@ if HostingEnvironment.local_development? && User.none?
   # while we're using Signon it is possible to have users who aren't linked to
   # the same organisation as in Signon, or who have an organisation that isn't
   # in the organisation table
-  FactoryBot.create :user, :with_unknown_org, organisation_slug: test_org.slug, organisation_content_id: test_org.content_id
+  FactoryBot.create :user, :with_unknown_org, organisation_slug: test_org.slug, organisation_content_id: test_org.govuk_content_id
   FactoryBot.create :user, :with_unknown_org
 
   # create a user who hasn't been assigned to an organisation yet

--- a/spec/factories/models/organisations.rb
+++ b/spec/factories/models/organisations.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :organisation do
-    content_id { Faker::Internet.uuid }
+    govuk_content_id { Faker::Internet.uuid }
     slug { "test-org" }
     name { ActiveSupport::Inflector.titleize slug }
 
     initialize_with do
-      Organisation.create_with(content_id:, name:).find_or_create_by(slug:)
+      Organisation.create_with(govuk_content_id:, name:).find_or_create_by(slug:)
     end
   end
 end

--- a/spec/integration/basic_auth_spec.rb
+++ b/spec/integration/basic_auth_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "using basic auth" do
       organisation: Config::Options.new(
         slug: "test-org",
         name: "Test Org",
-        content_id: organisation.content_id,
+        govuk_content_id: organisation.govuk_content_id,
       ),
       username:,
       password:,

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Organisation, type: :model do
     organisation = create(:organisation, slug: "duplicate-org")
 
     expect {
-      described_class.create!(content_id: Faker::Internet.uuid, slug: organisation.slug, name: organisation.name)
+      described_class.create!(govuk_content_id: Faker::Internet.uuid, slug: organisation.slug, name: organisation.name)
     }.to raise_error ActiveRecord::RecordNotUnique
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
The `content_id` field on the organisation table is used for identifying which item in the [GOV.UK Organisations API](https://www.api.gov.uk/gds/gov-uk-organisations/#gov-uk-organisations) the organisation belongs to. Currently this doesn't support null values, however, we need to create a custom organisation - i.e. one that doesn't correspond to an existing GOV.UK Organisation.

This PR also renames the field to `govuk_content_id`, to make it more explicit that this field is only used for identifying the corresponding GOV.UK Organisations API item.

Trello card: https://trello.com/c/XbxSosPw/842-create-a-new-temporary-org-called-govuk-forms-adoption-team-and-change-iain-charan-safiya-to-it

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
