### PR TITLE
Add question text form to selection settings journey

### DIFF
--- a/app/controllers/pages/question_text_controller.rb
+++ b/app/controllers/pages/question_text_controller.rb
@@ -1,0 +1,32 @@
+class Pages::QuestionTextController < PagesController
+  def new
+    question_text = session.dig(:page, "question_text")
+    @question_text_form = Forms::QuestionTextForm.new(question_text:)
+    @question_text_path = question_text_create_path(@form)
+    @back_link_url = type_of_answer_new_path(@form)
+    render "pages/question_text"
+  end
+
+  def create
+    @question_text_form = Forms::QuestionTextForm.new(question_text_form_params)
+    @question_text_path = question_text_create_path(@form)
+    @back_link_url = type_of_answer_new_path(@form)
+
+    if @question_text_form.submit(session)
+      redirect_to next_page_path(@form, :create)
+    else
+      render "pages/question_text"
+    end
+  end
+
+private
+
+  def question_text_form_params
+    form = Form.find(params[:form_id])
+    params.require(:forms_question_text_form).permit(:question_text).merge(form:)
+  end
+
+  def next_page_path(form, action)
+    action == :create ? selections_settings_new_path(form) : selections_settings_edit_path(form)
+  end
+end

--- a/app/controllers/pages/question_text_controller.rb
+++ b/app/controllers/pages/question_text_controller.rb
@@ -13,7 +13,7 @@ class Pages::QuestionTextController < PagesController
     @back_link_url = type_of_answer_new_path(@form)
 
     if @question_text_form.submit(session)
-      redirect_to next_page_path(@form, :create)
+      redirect_to selections_settings_new_path(@form)
     else
       render "pages/question_text"
     end
@@ -22,11 +22,6 @@ class Pages::QuestionTextController < PagesController
 private
 
   def question_text_form_params
-    form = Form.find(params[:form_id])
-    params.require(:forms_question_text_form).permit(:question_text).merge(form:)
-  end
-
-  def next_page_path(form, action)
-    action == :create ? selections_settings_new_path(form) : selections_settings_edit_path(form)
+    params.require(:forms_question_text_form).permit(:question_text)
   end
 end

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -3,7 +3,7 @@ class Pages::SelectionsSettingsController < PagesController
     answer_settings = load_answer_settings_from_session
     @selections_settings_form = Forms::SelectionsSettingsForm.new(answer_settings)
     @selections_settings_path = selections_settings_create_path(@form)
-    @back_link_url = type_of_answer_new_path(@form)
+    @back_link_url = question_text_new_path(@form)
     render selection_settings_view
   end
 
@@ -11,7 +11,7 @@ class Pages::SelectionsSettingsController < PagesController
     answer_settings = load_answer_settings_from_params(selections_settings_form_params)
     @selections_settings_form = Forms::SelectionsSettingsForm.new(answer_settings)
     @selections_settings_path = selections_settings_create_path(@form)
-    @back_link_url = type_of_answer_new_path(@form)
+    @back_link_url = question_text_new_path(@form)
 
     if params[:add_another]
       @selections_settings_form.add_another

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -40,7 +40,7 @@ class Pages::TypeOfAnswerController < PagesController
 private
 
   def selection_path(form, action)
-    action == :create ? selections_settings_new_path(form) : selections_settings_edit_path(form)
+    action == :create ? question_text_new_path(form) : selections_settings_edit_path(form)
   end
 
   def text_path(form, action)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,9 +11,10 @@ class PagesController < ApplicationController
 
   def new
     answer_type = session.dig(:page, "answer_type")
+    question_text = session.dig(:page, "question_text")
     answer_settings = session.dig(:page, "answer_settings")
     is_optional = session.dig(:page, "is_optional") == "true"
-    @page = Page.new(form_id: @form.id, answer_type:, answer_settings:, is_optional:)
+    @page = Page.new(form_id: @form.id, question_text:, answer_type:, answer_settings:, is_optional:)
   end
 
   def create

--- a/app/forms/forms/question_text_form.rb
+++ b/app/forms/forms/question_text_form.rb
@@ -1,0 +1,15 @@
+class Forms::QuestionTextForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :question_text, :form, :page
+
+  validates :question_text, presence: true
+
+  def submit(session)
+    return false if invalid?
+
+    session[:page] = {} if session[:page].blank?
+    session[:page][:question_text] = question_text
+  end
+end

--- a/app/forms/forms/question_text_form.rb
+++ b/app/forms/forms/question_text_form.rb
@@ -2,7 +2,7 @@ class Forms::QuestionTextForm
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :question_text, :form, :page
+  attr_accessor :question_text
 
   validates :question_text, presence: true
 

--- a/app/views/pages/question_text.html.erb
+++ b/app/views/pages/question_text.html.erb
@@ -1,0 +1,17 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.date_settings"), @question_text_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(@back_link_url) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: [@form, @question_text_form], url: @question_text_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <%# TODO: do translations properly %>
+      <%= f.govuk_text_field :question_text, label: { tag: 'h1', size: 'l', text: "What's your question?"  }, hint: { text: t("helpers.hint.page.question_text.checkbox") } %>
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+
+    <p>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>
+    </p>
+  </div>
+</div>

--- a/app/views/pages/question_text.html.erb
+++ b/app/views/pages/question_text.html.erb
@@ -5,8 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [@form, @question_text_form], url: @question_text_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%# TODO: do translations properly %>
-      <%= f.govuk_text_field :question_text, label: { tag: 'h1', size: 'l', text: "What's your question?"  }, hint: { text: t("helpers.hint.page.question_text.checkbox") } %>
+      <%= f.govuk_text_field :question_text, label: { tag: 'h1', size: 'l' }, hint: { text: t("helpers.hint.page.question_text.checkbox") } %>
       <%= f.govuk_submit t('continue') %>
     <% end %>
 

--- a/config/locales/forms/question_text.yml
+++ b/config/locales/forms/question_text.yml
@@ -1,4 +1,8 @@
 en:
+  helpers:
+    label:
+      forms_question_text_form:
+        question_text: What's your question?
   activemodel:
     errors:
       models:

--- a/config/locales/forms/question_text.yml
+++ b/config/locales/forms/question_text.yml
@@ -2,7 +2,7 @@ en:
   helpers:
     label:
       forms_question_text_form:
-        question_text: What's your question?
+        question_text: What’s your question?
   activemodel:
     errors:
       models:

--- a/config/locales/forms/question_text.yml
+++ b/config/locales/forms/question_text.yml
@@ -1,0 +1,8 @@
+en:
+  activemodel:
+    errors:
+      models:
+        forms/question_text_form:
+          attributes:
+            question_text:
+              blank: Question text cannot be blank

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,8 +93,6 @@ Rails.application.routes.draw do
           post "/address-settings" => "pages/address_settings#update", as: :address_settings_update
           get "/name-settings" => "pages/name_settings#edit", as: :name_settings_edit
           post "/name-settings" => "pages/name_settings#update", as: :name_settings_update
-          get "/question_text" => "pages/question_text#edit", as: :question_text_edit
-          post "/question_text" => "pages/question_text#update", as: :question_text_update
           get "/" => "pages#edit", as: :edit_page
           patch "/" => "pages#update", as: :update_page
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do
         post "/address-settings" => "pages/address_settings#create", as: :address_settings_create
         get "/name-settings" => "pages/name_settings#new", as: :name_settings_new
         post "/name-settings" => "pages/name_settings#create", as: :name_settings_create
+        get "/question_text" => "pages/question_text#new", as: :question_text_new
+        post "/question_text" => "pages/question_text#create", as: :question_text_create
         get "/" => "pages#new", as: :new_page
         post "/" => "pages#create", as: :create_page
       end
@@ -91,6 +93,8 @@ Rails.application.routes.draw do
           post "/address-settings" => "pages/address_settings#update", as: :address_settings_update
           get "/name-settings" => "pages/name_settings#edit", as: :name_settings_edit
           post "/name-settings" => "pages/name_settings#update", as: :name_settings_update
+          get "/question_text" => "pages/question_text#edit", as: :question_text_edit
+          post "/question_text" => "pages/question_text#update", as: :question_text_update
           get "/" => "pages#edit", as: :edit_page
           patch "/" => "pages#update", as: :update_page
         end

--- a/spec/factories/forms/question_text_form.rb
+++ b/spec/factories/forms/question_text_form.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :question_text_form, class: "Forms::QuestionTextForm" do
+    question_text { Faker::Lorem.question }
+  end
+end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
         selection_options { [Forms::SelectionOption.new({ name: "Option 1" }), Forms::SelectionOption.new({ name: "Option 2" })] }
       end
 
+      question_text { Faker::Lorem.question }
       answer_type { "selection" }
       answer_settings { DataStruct.new(only_one_option:, selection_options:) }
     end

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -73,6 +73,7 @@ private
     expect(page.find("h1")).to have_text "What kind of answer do you need to this question?"
     choose I18n.t("helpers.label.page.answer_type_options.names.#{answer_type}")
     click_button "Continue"
+    fill_in_question_text if answer_type == "selection"
     fill_in_selection_settings if answer_type == "selection"
     fill_in_text_settings if answer_type == "text"
     fill_in_date_settings if answer_type == "date"
@@ -98,6 +99,12 @@ private
 
   def and_i_start_adding_a_new_question
     click_link "Add a question"
+  end
+
+  def fill_in_question_text
+    expect(page.find("h1")).to have_text "What's your question?"
+    fill_in "What's your question?", with: "What is your name?"
+    click_button "Continue"
   end
 
   def fill_in_selection_settings

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -102,8 +102,8 @@ private
   end
 
   def fill_in_question_text
-    expect(page.find("h1")).to have_text "What's your question?"
-    fill_in "What's your question?", with: "What is your name?"
+    expect(page.find("h1")).to have_text "What’s your question?"
+    fill_in "What’s your question?", with: "What is your name?"
     click_button "Continue"
   end
 

--- a/spec/forms/question_text_form_spec.rb
+++ b/spec/forms/question_text_form_spec.rb
@@ -10,18 +10,13 @@ RSpec.describe Forms::QuestionTextForm, type: :model do
   end
 
   describe "validations" do
-    it "is invalid if not given question text" do
-      error_message = I18n.t("activemodel.errors.models.forms/question_text_form.attributes.question_text.blank")
-      question_text_form.question_text = nil
-      expect(question_text_form).to be_invalid
-      expect(question_text_form.errors.full_messages_for(:question_text)).to include("Question text #{error_message}")
-    end
-
-    it "is invalid given an empty string question_text" do
-      error_message = I18n.t("activemodel.errors.models.forms/question_text_form.attributes.question_text.blank")
-      question_text_form.question_text = ""
-      expect(question_text_form).to be_invalid
-      expect(question_text_form.errors.full_messages_for(:question_text)).to include("Question text #{error_message}")
+    [nil, ""].each do |question_text|
+      it "is invalid given {question_text} question text" do
+        error_message = I18n.t("activemodel.errors.models.forms/question_text_form.attributes.question_text.blank")
+        question_text_form.question_text = question_text
+        expect(question_text_form).to be_invalid
+        expect(question_text_form.errors.full_messages_for(:question_text)).to include("Question text #{error_message}")
+      end
     end
 
     it "is valid if input type is a valid input type" do

--- a/spec/forms/question_text_form_spec.rb
+++ b/spec/forms/question_text_form_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Forms::QuestionTextForm, type: :model do
+  let(:form) { build :form, id: 1 }
+  let(:question_text_form) { described_class.new }
+
+  it "has a valid factory" do
+    question_text_form = build :question_text_form
+    expect(question_text_form).to be_valid
+  end
+
+  describe "validations" do
+    it "is invalid if not given question text" do
+      error_message = I18n.t("activemodel.errors.models.forms/question_text_form.attributes.question_text.blank")
+      question_text_form.question_text = nil
+      expect(question_text_form).to be_invalid
+      expect(question_text_form.errors.full_messages_for(:question_text)).to include("Question text #{error_message}")
+    end
+
+    it "is invalid given an empty string question_text" do
+      error_message = I18n.t("activemodel.errors.models.forms/question_text_form.attributes.question_text.blank")
+      question_text_form.question_text = ""
+      expect(question_text_form).to be_invalid
+      expect(question_text_form.errors.full_messages_for(:question_text)).to include("Question text #{error_message}")
+    end
+
+    it "is valid if input type is a valid input type" do
+      question_text_form.question_text = "Do you want to be contacted?"
+      expect(question_text_form).to be_valid
+    end
+  end
+
+  describe "#submit" do
+    let(:session_mock) { {} }
+
+    it "returns false if the form is invalid" do
+      expect(question_text_form.submit(session_mock)).to be_falsey
+    end
+
+    it "sets a session key called 'page' as a hash with the answer type in it" do
+      question_text_form.question_text = "date_of_birth"
+      question_text_form.submit(session_mock)
+      expect(session_mock[:page][:question_text]).to eq "date_of_birth"
+    end
+  end
+end

--- a/spec/requests/pages/question_text_controller_spec.rb
+++ b/spec/requests/pages/question_text_controller_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe Pages::QuestionTextController, type: :request do
+  let(:form) { build :form, id: 1 }
+  let(:pages) { build_list :page, 5, form_id: form.id }
+
+  let(:question_text_form) { build :question_text_form, form: }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  describe "#new" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+
+      get question_text_new_path(form_id: question_text_form.form.id)
+    end
+
+    it "reads the existing form" do
+      expect(form).to have_been_read
+    end
+
+    it "sets an instance variable for question_text_path" do
+      path = assigns(:question_text_path)
+      expect(path).to eq question_text_new_path(question_text_form.form.id)
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("pages/question_text")
+    end
+  end
+
+  describe "#create" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+    end
+
+    context "when form is invalid" do
+      before do
+        post question_text_create_path form_id: form.id, params: { forms_question_text_form: { question_text: nil } }
+      end
+
+      it "renders the date settings view if there are errors" do
+        expect(response).to have_rendered("pages/question_text")
+      end
+    end
+
+    context "when form is valid and ready to store" do
+      before do
+        post question_text_create_path form_id: form.id, params: { forms_question_text_form: { question_text: "Are you a higher rate taxpayer?" } }
+      end
+
+      let(:question_text_form) { build :question_text_form, form: }
+
+      it "saves the input type to session" do
+        expect(session[:page][:question_text]).to eq "Are you a higher rate taxpayer?"
+      end
+
+      it "redirects the user to the edit question page" do
+        expect(response).to redirect_to selections_settings_new_path(form.id)
+      end
+    end
+  end
+end

--- a/spec/requests/pages/question_text_controller_spec.rb
+++ b/spec/requests/pages/question_text_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Pages::QuestionTextController, type: :request do
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       end
 
-      get question_text_new_path(form_id: question_text_form.form.id)
+      get question_text_new_path(form_id: form.id)
     end
 
     it "reads the existing form" do
@@ -36,7 +36,7 @@ RSpec.describe Pages::QuestionTextController, type: :request do
 
     it "sets an instance variable for question_text_path" do
       path = assigns(:question_text_path)
-      expect(path).to eq question_text_new_path(question_text_form.form.id)
+      expect(path).to eq question_text_new_path(form.id)
     end
 
     it "renders the template" do
@@ -67,7 +67,7 @@ RSpec.describe Pages::QuestionTextController, type: :request do
         post question_text_create_path form_id: form.id, params: { forms_question_text_form: { question_text: "Are you a higher rate taxpayer?" } }
       end
 
-      let(:question_text_form) { build :question_text_form, form: }
+      let(:question_text_form) { build :question_text_form }
 
       it "saves the input type to session" do
         expect(session[:page][:question_text]).to eq "Are you a higher rate taxpayer?"

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -206,8 +206,10 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
     end
 
     context "when form is valid and ready to update in the DB" do
+      let(:forms_type_of_answer_form) { { answer_type: "number" } }
+
       before do
-        post type_of_answer_update_path(form_id: page.form_id, page_id: page.id), params: { forms_type_of_answer_form: { answer_type: "number" } }
+        post type_of_answer_update_path(form_id: page.form_id, page_id: page.id), params: { forms_type_of_answer_form: }
       end
 
       it "saves the updated answer type to DB" do
@@ -217,6 +219,19 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
       it "redirects the user to the question details page " do
         expect(response).to redirect_to edit_page_path(form.id, page.id)
+      end
+
+      context "when answer type is selection" do
+        let(:forms_type_of_answer_form) { { answer_type: "selection" } }
+
+        it "saves the answer type to session" do
+          form = assigns(:type_of_answer_form)
+          expect(form.answer_type).to eq "selection"
+        end
+
+        it "redirects the user to the question text page" do
+          expect(response).to redirect_to selections_settings_edit_path(form.id, page.id)
+        end
       end
     end
 

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
           expect(session[:page]).to eq({ answer_type: type_of_answer_form.answer_type, answer_settings: nil })
         end
 
-        it "redirects the user to the selection settings page" do
-          expect(response).to redirect_to selections_settings_new_path(form.id)
+        it "redirects the user to the question text page" do
+          expect(response).to redirect_to question_text_new_path(form.id)
         end
       end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds a new question text form to the selection question journey so the user adds the question before they add their selection options.

The new form only appears when the user is adding a new page - existing pages will already have `question_text`, and the user can edit this on the edit question page, so the form is unnecessary. 

Trello card: https://trello.com/c/RBGKvaBI/838-add-question-first-for-select-from-options-answer-type

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
