### PR TITLE
Remove unused tables erroneously added to schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,12 +27,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_133847) do
     t.index ["form_id"], name: "index_form_submission_emails_on_form_id"
   end
 
-  create_table "forms", id: :bigint, default: nil, force: :cascade do |t|
-    t.text "name"
-    t.text "submission_email"
-    t.text "org"
-  end
-
   create_table "organisations", force: :cascade do |t|
     t.string "govuk_content_id"
     t.string "slug", null: false
@@ -41,15 +35,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_133847) do
     t.datetime "updated_at", null: false
     t.index ["govuk_content_id"], name: "index_organisations_on_govuk_content_id", unique: true
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
-  end
-
-  create_table "pages", id: :bigint, default: nil, force: :cascade do |t|
-    t.bigint "form_id"
-    t.text "question_text"
-    t.text "question_short_name"
-    t.text "hint_text"
-    t.text "answer_type"
-    t.text "next"
   end
 
   create_table "schema_info", id: false, force: :cascade do |t|
@@ -76,6 +61,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_133847) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 
-  add_foreign_key "pages", "forms", name: "pages_form_id_fkey"
   add_foreign_key "users", "organisations"
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

I had some old, unused tables in my local database (`forms` and `pages`, neither of which we store in admin) and these got erroneously added to the schema in #491. This PR removes them from the schema.

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
