### PR TITLE
Add shell command trace to container run command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ COPY --chown=ruby:ruby --from=build /app /app
 
 EXPOSE 3000
 
-CMD ["/bin/sh", "-c", "rake db:migrate && rails s -b 0.0.0.0"]
+CMD ["/bin/sh", "-o", "xtrace", "-c", "rake db:migrate && rails s -b 0.0.0.0"]


### PR DESCRIPTION
It is useful when looking at startup logs to be able to know what command was run, to understand the context of the log outputs.

This PR enables the `xtrace` option for the shell that runs the container start command, so that the command to be run is printed to the logs.

Example output from running locally:

```
local-forms-admin-1  | + rake db:migrate
local-forms-admin-1  | + rails s -b 0.0.0.0
local-forms-admin-1  | => Booting Puma
...
```

By default the xtrace output is prefixed with `+ `, we could change this if we wanted by setting the environment variable `PS4`.

If people like this idea and we merge this change to `forms-admin` I'll make a similar change in the other apps.