### PR TITLE
Let specific IP addresses bypass the maintenance page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -307,7 +307,7 @@ en:
       immediately.
     notification_title: Important
   maintenance:
-    body_html: "%{link} if you need to make changes to your forms or speak to someone about the service."
+    body_html: You’ll be able to use the service on Wednesday 5 July 2023.
     title: Sorry, the service is unavailable
   make_changes_live:
     url_will_remain_same: The URL for the live form will remain the same.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,7 +22,7 @@ show_browser_during_tests: false
 maintenance_mode:
   # When set to true, All pages will render 'Maintenance mode' message
   enabled: false
-  # List of IP addresses which will bypass the maintenance mode message
+  # List of IP addresses which will bypass the maintenance mode message as a comma seperated string, optionally using CIDR notation eq. "127.0.0.1, 192.192.192.192/32, 0.0.0.0/24"
   bypass_ips:
 
 # Configuration for Sentry

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,42 +1,73 @@
 require "rails_helper"
 
 RSpec.describe ApplicationController, type: :request do
-  context "when the service is unavailable" do
-    before do
-      logout # service unavailable page should be visible even if user is not logged in
+  let(:headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
 
+  let(:user) { build :user, :super_admin, has_access: false }
+  let(:form) { build :form, id: 1 }
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?org=test-org", headers, [form].to_json, 200
+      mock.get "/api/v1/forms/1", headers, form.to_json, 200
+      mock.get "/api/v1/forms/1/pages", headers, form.pages.to_json, 200
+    end
+  end
+
+  context "when the service is in maintenance mode" do
+    let(:bypass_ips) { " " }
+    let(:expect_response_to_redirect) { true }
+    let(:user_ip) { "192.0.0.2" }
+
+    before do
       allow(Settings.maintenance_mode).to receive(:enabled).and_return(true)
-      get root_path
-      follow_redirect!
+      allow(Settings.maintenance_mode).to receive(:bypass_ips).and_return(bypass_ips)
+
+      get root_path, headers: { "HTTP_X_FORWARDED_FOR": user_ip }
+      follow_redirect! if expect_response_to_redirect
     end
 
-    it "returns http code 503" do
+    it "returns http code 200" do
       expect(response).to have_http_status(:ok)
     end
 
-    it "renders the service unavailable page" do
+    it "renders the maintenance page" do
       expect(response).to render_template("errors/maintenance")
+    end
+
+    context "when bypass ip range does not cover the user's ip" do
+      let(:bypass_ips) { "192.0.0.0/32, 123.123.123.123/32" }
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the maintenance page" do
+        expect(response).to render_template("errors/maintenance")
+      end
+    end
+
+    context "when the  bypass ip range does include the user's ip" do
+      let(:bypass_ips) { "192.0.0.0/29, 123.123.123.123/32" }
+      let(:expect_response_to_redirect) { false }
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the root page" do
+        expect(response).to render_template("forms/index")
+      end
     end
   end
 
   context "when a user is logged in who does not have access" do
-    let(:headers) do
-      {
-        "X-API-Token" => Settings.forms_api.auth_key,
-        "Accept" => "application/json",
-      }
-    end
-
-    let(:user) { build :user, :super_admin, has_access: false }
-    let(:form) { build :form, id: 1 }
-
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms?org=test-org", headers, [form].to_json, 200
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
-        mock.get "/api/v1/forms/1/pages", headers, form.pages.to_json, 200
-      end
-
       login_as user
     end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

We need some way of bypassing the maintenance page if the users IP is in a specific list of IPs. 
These changes allow us to let the user bypass the maintenance page if their IP matches any single IP
address or is included within a specific CIDR notation range of IP

Trello card: https://trello.com/c/P9CEz21c/824-test-and-update-holding-page

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
