### PR TITLE
Allow forms without an organisation set

### DIFF
--- a/app/controllers/forms/change_name_controller.rb
+++ b/app/controllers/forms/change_name_controller.rb
@@ -9,7 +9,7 @@ module Forms
     def create
       form = Form.new({
         name: params[:name],
-        org: current_user.organisation.slug,
+        org: current_user.organisation&.slug,
         creator_id: current_user.id,
       })
 

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -66,10 +66,17 @@ RSpec.describe Forms::ChangeNameController, type: :request do
     end
 
     context "with a trial user" do
-      let(:user) { build(:user, role: :trial, id: 1) }
+      let(:user) { build(:user, :with_trial, :with_no_org, id: 1) }
+      let(:form_data) do
+        {
+          name: "Form name",
+          org: nil,
+          creator_id: user.id,
+          submission_email: user.email,
+        }
+      end
 
       it "sets the submission email address" do
-        form_data[:submission_email] = user.email
         form = Form.new(form_data)
         expect(form).to have_been_created
       end


### PR DESCRIPTION
#### What problem does the pull request solve?
Allow users without an organisation to create forms without an organisation. This is required so that trial users (who usually won't yet belong to an organisation) can create forms.

Trello card: https://trello.com/c/8kysclWz

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
