### PR TITLE
Stop showing optional text on selection questions

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,7 +41,7 @@ module ApplicationHelper
   end
 
   def question_text_with_optional_suffix(page)
-    page.is_optional ? t("pages.optional", question_text: page.question_text) : page.question_text
+    page.show_optional_suffix? ? t("pages.optional", question_text: page.question_text) : page.question_text
   end
 
   def translation_key_for_answer_type(answer_type, answer_settings)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -54,6 +54,10 @@ class Page < ActiveResource::Base
     "#{position}. #{question_text}"
   end
 
+  def show_optional_suffix?
+    is_optional? && answer_type != "selection"
+  end
+
 private
 
   def is_optional_value

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -44,17 +44,25 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "question_text_with_optional_suffix" do
-    context "with an optional question" do
+    let(:page) { build :page }
+
+    context "when show_optional_suffix? returns true" do
+      before do
+        allow(page).to receive(:show_optional_suffix?).and_return(true)
+      end
+
       it "returns the title with the optional suffix" do
-        page = OpenStruct.new(question_text: "What is your name?", is_optional: true)
-        expect(helper.question_text_with_optional_suffix(page)).to eq(I18n.t("pages.optional", question_text: "What is your name?"))
+        expect(helper.question_text_with_optional_suffix(page)).to eq(I18n.t("pages.optional", question_text: page.question_text))
       end
     end
 
-    context "with a required question" do
+    context "when show_optional_suffix? returns false" do
+      before do
+        allow(page).to receive(:show_optional_suffix?).and_return(false)
+      end
+
       it "returns the title with the optional suffix" do
-        page = OpenStruct.new(question_text: "What is your name?", is_optional: false)
-        expect(helper.question_text_with_optional_suffix(page)).to eq("What is your name?")
+        expect(helper.question_text_with_optional_suffix(page)).to eq(page.question_text)
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -104,4 +104,32 @@ describe Page do
       expect(page.question_with_number).to eq("#{page.position}. #{page.question_text}")
     end
   end
+
+  describe "#show_optional_suffix?" do
+    let(:page) { described_class.new(is_optional:, answer_type:) }
+    let(:is_optional) { "true" }
+    let(:answer_type) { "national_insurance_number" }
+
+    context "when question is optional and answer type is not selection" do
+      it "returns true" do
+        expect(page.show_optional_suffix?).to be true
+      end
+    end
+
+    context "when question is optional and has answer_type selection" do
+      let(:answer_type) { "selection" }
+
+      it "returns false" do
+        expect(page.show_optional_suffix?).to be false
+      end
+    end
+
+    context "when question is not optional and answer type is not selection" do
+      let(:is_optional) { "false" }
+
+      it "returns false" do
+        expect(page.show_optional_suffix?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
Changes the question_text_with_optional_suffix helper to suppress the '(optional)' text for a selection question.

Trello card: https://trello.com/c/y2srjFOl/844-selection-questions-with-none-of-the-above-say-optional-next-to-them-in-the-questions-list-in-admin

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
