### PR TITLE
Add environment tag and matching border

### DIFF
--- a/app/components/header_component/_index.scss
+++ b/app/components/header_component/_index.scss
@@ -1,0 +1,36 @@
+.app-header__product-name {
+  display: inline-flex;
+  align-items: center;
+  gap: .25em;
+  flex-wrap: wrap;
+}
+
+.app-header :is(.govuk-header__logo, .govuk-header__content) {
+  @include govuk-media-query($from: desktop) {
+    width: 50%;
+  }
+}
+
+.app-header--pink {
+  .govuk-header__container {
+    border-bottom-color: govuk-colour("pink");
+  }
+}
+
+.app-header--green {
+  .govuk-header__container {
+    border-bottom-color: govuk-colour("green");
+  }
+}
+
+.app-header--yellow {
+  .govuk-header__container {
+    border-bottom-color: govuk-colour("yellow");
+  }
+}
+
+.app-header--blue {
+  .govuk-header__container {
+    border-bottom-color: govuk-colour("blue");
+  }
+}

--- a/app/components/header_component/view.html.erb
+++ b/app/components/header_component/view.html.erb
@@ -1,12 +1,12 @@
 <% if is_signed_in? %>
-  <%= govuk_header navigation_classes: ["govuk-header__navigation--end"] do |header|
-    header.with_product_name(name: t("header.product_name"))
-    header.with_navigation_item(text: t('header.users'), href: list_of_users_path, active: false) if list_of_users_path.present?
+  <%= govuk_header classes: ["app-header", app_header_class_for_environment],  navigation_classes: ["govuk-header__navigation--end"] do |header|
+    header.with_product_name(name: "#{t("header.product_name")} #{render(environment_tag)}".html_safe, classes: ["app-header__product-name"])
+    header.with_navigation_item(text: t('header.users'), href: list_of_users_path, active: current_page?(controller: "users")) if list_of_users_path.present?
     header.with_navigation_item(text: user_name, href: user_profile_link, active: false) if user_name.present?
     header.with_navigation_item(text: t("header.sign_out"), href: signout_link, active: false)
   end %>
 <% else %>
-  <%= govuk_header do |header|
-    header.with_product_name(name: t("header.product_name"))
+  <%= govuk_header classes: ["app-header", app_header_class_for_environment] do |header|
+    header.with_product_name(name: "#{t("header.product_name")} #{render(environment_tag)}".html_safe, classes: ["app-header__product-name"])
   end %>
 <% end %>

--- a/app/components/header_component/view.rb
+++ b/app/components/header_component/view.rb
@@ -2,19 +2,48 @@
 
 module HeaderComponent
   class View < ViewComponent::Base
-    attr_accessor :is_signed_in, :user_name, :user_profile_link, :signout_link, :list_of_users_path
+    attr_accessor :is_signed_in, :user_name, :user_profile_link, :signout_link, :list_of_users_path, :hosting_environment
 
-    def initialize(is_signed_in:, user_name:, user_profile_link:, signout_link:, list_of_users_path:)
+    def initialize(is_signed_in:, user_name:, user_profile_link:, signout_link:, list_of_users_path:, hosting_environment: HostingEnvironment)
       super
       @is_signed_in = is_signed_in
       @user_name = user_name
       @user_profile_link = user_profile_link
       @signout_link = signout_link
       @list_of_users_path = list_of_users_path
+      @hosting_environment = hosting_environment
     end
 
     def is_signed_in?
       is_signed_in
+    end
+
+    def environment_name
+      hosting_environment.friendly_environment_name
+    end
+
+    def app_header_class_for_environment
+      "app-header--#{colour_for_environment}"
+    end
+
+    def colour_for_environment
+      case environment_name
+      when "local"
+        "pink"
+      when "development"
+        "green"
+      when "staging"
+        "yellow"
+      else
+        "blue"
+      end
+    end
+
+    def environment_tag
+      # Don't render a tag if this is the production environment
+      return { body: nil } if environment_name == "production"
+
+      GovukComponent::TagComponent.new(text: environment_name, colour: colour_for_environment)
     end
   end
 end

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -8,3 +8,4 @@ $govuk-global-styles: true;
 @import "../styles/app_summary_card";
 @import "../../components/task_list_component/";
 @import "../../components/page_list_component/";
+@import "../../components/header_component/";

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -3,6 +3,12 @@ module HostingEnvironment
     ENV.fetch("PAAS_ENVIRONMENT", "unknown-environment")
   end
 
+  def self.friendly_environment_name
+    key = local_development? ? "local" : environment_name
+
+    I18n.t("environment_names.#{key}", default: key)
+  end
+
   def self.local_development?
     environment_name == "unknown-environment" && !Rails.env.production?
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,16 @@ en:
   email_code_success:
     body_html: "<p>Completed forms will be sent to %{submission_email}.</p>\n"
     continue: Continue creating a form
+  environment_names:
+    aws-dev: development
+    aws-production: production
+    aws-staging: staging
+    aws-user-research: user research
+    dev: development
+    local: local
+    production: production
+    staging: staging
+    user-research: user research
   error_summary:
     heading: There is a problem
   footer:

--- a/spec/components/header_component/header_component_preview.rb
+++ b/spec/components/header_component/header_component_preview.rb
@@ -7,12 +7,49 @@ class HeaderComponent::HeaderComponentPreview < ViewComponent::Preview
                                      signout_link: nil))
   end
 
-  def with_user
+  def with_user_on_production
     render(HeaderComponent::View.new(is_signed_in: true,
                                      list_of_users_path: nil,
                                      user_name: "Joe Smith",
                                      user_profile_link: "http://www.example.com/",
-                                     signout_link: "http://www.example.com/"))
+                                     signout_link: "http://www.example.com/",
+                                     hosting_environment: OpenStruct.new(friendly_environment_name: "production")))
+  end
+
+  def with_user_on_staging
+    render(HeaderComponent::View.new(is_signed_in: true,
+                                     list_of_users_path: nil,
+                                     user_name: "Joe Smith",
+                                     user_profile_link: "http://www.example.com/",
+                                     signout_link: "http://www.example.com/",
+                                     hosting_environment: OpenStruct.new(friendly_environment_name: "staging")))
+  end
+
+  def with_user_on_dev
+    render(HeaderComponent::View.new(is_signed_in: true,
+                                     list_of_users_path: nil,
+                                     user_name: "Joe Smith",
+                                     user_profile_link: "http://www.example.com/",
+                                     signout_link: "http://www.example.com/",
+                                     hosting_environment: OpenStruct.new(friendly_environment_name: "development")))
+  end
+
+  def with_user_on_user_research
+    render(HeaderComponent::View.new(is_signed_in: true,
+                                     list_of_users_path: nil,
+                                     user_name: "Joe Smith",
+                                     user_profile_link: "http://www.example.com/",
+                                     signout_link: "http://www.example.com/",
+                                     hosting_environment: OpenStruct.new(friendly_environment_name: "user research")))
+  end
+
+  def with_user_on_local_machine
+    render(HeaderComponent::View.new(is_signed_in: true,
+                                     list_of_users_path: nil,
+                                     user_name: "Joe Smith",
+                                     user_profile_link: "http://www.example.com/",
+                                     signout_link: "http://www.example.com/",
+                                     hosting_environment: OpenStruct.new(friendly_environment_name: "local")))
   end
 
   def with_user_logged_in_using_basic_http_auth

--- a/spec/components/header_component/view_spec.rb
+++ b/spec/components/header_component/view_spec.rb
@@ -1,13 +1,33 @@
 require "rails_helper"
 
 RSpec.describe HeaderComponent::View, type: :component do
+  let(:is_signed_in) { true }
+  let(:list_of_users_path) { "https://forms.users" }
+  let(:user_name) { "Joe Smith" }
+  let(:user_profile_link) { "http://signon.dev.gov.uk" }
+  let(:signout_link) { "/auth/gds/sign_out" }
+  let(:hosting_environment) { OpenStruct.new(friendly_environment_name:) }
+  let(:local_development) { false }
+  let(:friendly_environment_name) { "production" }
+
+  let(:header_component) do
+    described_class.new(is_signed_in:,
+                        list_of_users_path:,
+                        user_name:,
+                        user_profile_link:,
+                        signout_link:,
+                        hosting_environment:)
+  end
+
   describe "default status" do
+    let(:is_signed_in) { false }
+    let(:list_of_users_path) { nil }
+    let(:user_name) { nil }
+    let(:user_profile_link) { nil }
+    let(:signout_link) { nil }
+
     before do
-      render_inline(described_class.new(is_signed_in: false,
-                                        list_of_users_path: nil,
-                                        user_name: nil,
-                                        user_profile_link: nil,
-                                        signout_link: nil))
+      render_inline(header_component)
     end
 
     it "contains the service name" do
@@ -24,12 +44,10 @@ RSpec.describe HeaderComponent::View, type: :component do
   end
 
   describe "logged in status" do
+    let(:list_of_users_path) { nil }
+
     before do
-      render_inline(described_class.new(is_signed_in: true,
-                                        list_of_users_path: nil,
-                                        user_name: "Joe Smith",
-                                        user_profile_link: "http://signon.dev.gov.uk",
-                                        signout_link: "/auth/gds/sign_out"))
+      render_inline(header_component)
     end
 
     it "contains the service name" do
@@ -46,12 +64,12 @@ RSpec.describe HeaderComponent::View, type: :component do
   end
 
   context "when no profile link or signout in passed in" do
+    let(:list_of_users_path) { nil }
+    let(:user_profile_link) { nil }
+    let(:signout_link) { nil }
+
     before do
-      render_inline(described_class.new(is_signed_in: true,
-                                        list_of_users_path: nil,
-                                        user_name: "Joe Smith",
-                                        user_profile_link: nil,
-                                        signout_link: nil))
+      render_inline(header_component)
     end
 
     it "the user name appears without a link" do
@@ -67,11 +85,7 @@ RSpec.describe HeaderComponent::View, type: :component do
 
   context "when user has permission to view list of users" do
     before do
-      render_inline(described_class.new(is_signed_in: true,
-                                        list_of_users_path: "https://forms.users",
-                                        user_name: "Joe Smith",
-                                        user_profile_link: "http://signon.dev.gov.uk",
-                                        signout_link: "/auth/gds/sign_out"))
+      render_inline(header_component)
     end
 
     it "contains the service name" do
@@ -88,6 +102,100 @@ RSpec.describe HeaderComponent::View, type: :component do
 
     it "contains the sign out link" do
       expect(page).to have_link(I18n.t("header.sign_out"), href: "/auth/gds/sign_out")
+    end
+  end
+
+  context "when user is on a non-production environment" do
+    let(:friendly_environment_name) { "local" }
+
+    before do
+      render_inline(header_component)
+    end
+
+    it "contains the service name with tag" do
+      expect(page).to have_text("#{I18n.t('header.product_name')} local")
+    end
+  end
+
+  context "when user is on the production environment" do
+    let(:local_development) { false }
+    let(:friendly_environment_name) { "production" }
+
+    before do
+      render_inline(header_component)
+    end
+
+    it "contains the service name without tag" do
+      expect(page).to have_text(I18n.t("header.product_name"))
+      expect(page).not_to have_css(".govuk_tag", text: "production")
+    end
+  end
+
+  describe "#environment_name" do
+    it "returns the friendly environment name" do
+      expect(header_component.environment_name).to eq(hosting_environment.friendly_environment_name)
+    end
+  end
+
+  describe "#app_header_class_for_environment" do
+    [
+      { colour: "pink" },
+      { colour: "green" },
+      { colour: "yellow" },
+      { colour: "blue" },
+    ].each do |scenario|
+      context "when colour_for_environment is #{scenario[:colour]}" do
+        before do
+          allow(header_component).to receive(:colour_for_environment).and_return(scenario[:colour])
+        end
+
+        it "returns 'app-header--#{scenario[:colour]}'" do
+          expect(header_component.app_header_class_for_environment).to eq("app-header--#{scenario[:colour]}")
+        end
+      end
+    end
+  end
+
+  describe "#colour_for_environment" do
+    [
+      { friendly_environment_name: "local", expected_result: "pink" },
+      { friendly_environment_name: "development", expected_result: "green" },
+      { friendly_environment_name: "staging", expected_result: "yellow" },
+      { friendly_environment_name: "production", expected_result: "blue" },
+      { friendly_environment_name: "user research", expected_result: "blue" },
+    ].each do |scenario|
+      context "when environment_name is #{scenario[:friendly_environment_name]}" do
+        let(:friendly_environment_name) { scenario[:friendly_environment_name] }
+
+        it "returns '#{scenario[:expected_result]}'" do
+          expect(header_component.colour_for_environment).to eq(scenario[:expected_result])
+        end
+      end
+    end
+  end
+
+  describe "#environment_tag" do
+    context "when environment_name is production" do
+      let(:friendly_environment_name) { "production" }
+
+      it "returns a govuk tag component with the appropriate text and colour" do
+        expect(header_component.environment_tag).to eq({ body: nil })
+      end
+    end
+
+    [
+      { friendly_environment_name: "local", colour_for_environment: "pink" },
+      { friendly_environment_name: "development", colour_for_environment: "green" },
+      { friendly_environment_name: "staging", colour_for_environment: "yellow" },
+      { friendly_environment_name: "user-research", colour_for_environment: "blue" },
+    ].each do |scenario|
+      context "when environment_name is #{scenario[:friendly_environment_name]}" do
+        let(:friendly_environment_name) { scenario[:friendly_environment_name] }
+
+        it "returns a govuk tag component with the appropriate text and colour" do
+          expect(header_component.environment_tag).to have_attributes(text: scenario[:friendly_environment_name], colour: scenario[:colour_for_environment])
+        end
+      end
     end
   end
 end

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -43,4 +43,37 @@ RSpec.describe HostingEnvironment do
       end
     end
   end
+
+  describe "#friendly_environment_name" do
+    before do
+      allow(described_class).to receive(:environment_name).and_return(environment_name)
+      allow(described_class).to receive(:local_development?).and_return(is_local_development)
+    end
+
+    [
+      { environment_name: "unknown_environment", is_local_development: true, expected_key: "local" },
+      { environment_name: "dev", is_local_development: false, expected_key: "dev" },
+      { environment_name: "production", is_local_development: false, expected_key: "production" },
+      { environment_name: "aws-staging", is_local_development: false, expected_key: "aws-staging" },
+      { environment_name: "aws-user-research", is_local_development: false, expected_key: "aws-user-research" },
+    ].each do |scenario|
+      context "with environment name set to '#{scenario[:environment_name]}' and is_local_development set to '#{scenario[:is_local_development]}" do
+        let(:environment_name) { scenario[:environment_name] }
+        let(:is_local_development) { scenario[:is_local_development] }
+
+        it "returns the correct translation" do
+          expect(described_class.friendly_environment_name).to eq(I18n.t("environment_names.#{scenario[:expected_key]}"))
+        end
+      end
+    end
+
+    context "with environment name set to an unknown value and rails_env set to production" do
+      let(:environment_name) { "some_unknown_environemnt_string" }
+      let(:is_local_development) { false }
+
+      it "returns the environment name as default text" do
+        expect(described_class.friendly_environment_name).to eq(environment_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

- Changes the colour of the header's bottom-border depending on the environment. 
- Adds a tag of the same colour containing the environment name to the header on all environments except production.

The colours for each environment are:

- Pink for local
- Green for dev
- Yellow for staging
- Blue for produuction and user research

Trello card: https://trello.com/c/DFOs5YuI/858-display-which-environment-a-user-is-accessing

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
