### PR TITLE
Add trial user's forms to their new organisation when changing from the trial role

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -59,6 +59,10 @@ class Form < ActiveResource::Base
     post "make-live"
   end
 
+  def self.update_org_for_creator(creator_id, org)
+    patch("update-org-for-creator", creator_id:, org:)
+  end
+
   def form_submission_email
     FormSubmissionEmail.find_by_form_id(id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@ class User < ApplicationRecord
   validates :organisation_id, presence: true, if: :requires_organisation?
   validates :has_access, inclusion: [true, false]
 
+  before_save :update_org
+
   def self.find_for_gds_oauth(auth_hash)
     find_for_auth(
       provider: auth_hash["provider"],
@@ -59,5 +61,11 @@ private
 
   def requires_organisation?
     organisation_id_was.present? || role_changed?(to: :editor)
+  end
+
+  def update_org
+    if role_changed?(from: :trial)
+      Form.update_org_for_creator(id, organisation.slug)
+    end
   end
 end

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+describe "Set or change a user's role", type: :feature do
+  let(:org_forms) do
+    [build(:form, id: 1, creator_id: 1, org: "test-org", name: "Org form")]
+  end
+
+  let(:trial_forms) do
+    [build(:form, id: 2, creator_id: 2, org: nil, name: "Trial form")]
+  end
+
+  let(:super_admin_user) do
+    build(:user, :with_super_admin, id: 1)
+  end
+
+  let(:trial_user) do
+    build(:user, :with_no_org, :with_trial, id: 2)
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  before do
+    Rails.application.load_seed
+
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?org=test-org", req_headers, org_forms.to_json, 200
+      mock.get "/api/v1/forms?creator_id=2", req_headers, trial_forms.to_json, 200
+    end
+  end
+
+  it "A trial user sees only forms they have created" do
+    login_as trial_user
+    then_i_can_see_the_trial_user_forms
+    then_i_cannot_see_the_org_forms
+  end
+
+  it "A trial user's forms move to their organisation on role upgrade" do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?org=test-org", req_headers, (org_forms + trial_forms).to_json, 200
+    end
+
+    login_as super_admin_user
+    when_i_change_a_trial_users_role_to_editor
+    login_as trial_user
+    then_i_can_see_the_trial_user_forms
+    then_i_can_see_the_org_forms
+  end
+
+private
+
+  def when_i_change_a_trial_users_role_to_editor
+    visit users_path
+    edit_user_path_re = %r{/users/(?<id>\d+)/edit}
+    edit_user_link = page.find_all(:link, href: edit_user_path_re).sample
+    @user = User.find(edit_user_path_re.match(edit_user_link[:href])[:id])
+
+    edit_user_link.click
+    expect(page).to have_css "h1.govuk-heading-l", text: "Edit user"
+    expect(page).to have_text @user.name
+
+    choose("Editor")
+    click_button "Save"
+  end
+
+  def then_i_can_see_the_trial_user_forms
+    visit root_path
+    expect(page).to have_text "Trial form"
+  end
+
+  def then_i_cannot_see_the_org_forms
+    visit root_path
+    expect(page).not_to have_text "Org form"
+  end
+
+  def then_i_can_see_the_org_forms
+    visit root_path
+    expect(page).to have_text "Org form"
+  end
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -129,4 +129,28 @@ describe Form do
       expect(form.qualifying_route_pages).to eq(selection_pages_with_routes_excluding_last_page)
     end
   end
+
+  describe "#update_org_for_creator" do
+    let(:headers) do
+      {
+        "X-API-Token" => Settings.forms_api.auth_key,
+        "Content-Type" => "application/json",
+      }
+    end
+
+    it "makes patch request to the API" do
+      creator_id = 123
+      org = "org"
+      expected_path = "/api/v1/forms/update-org-for-creator?creator_id=123&org=org"
+
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.patch expected_path, headers, {}.to_json, 204
+      end
+
+      described_class.update_org_for_creator(creator_id, org)
+
+      request = ActiveResource::Request.new(:patch, expected_path, {}, headers)
+      expect(ActiveResource::HttpMock.requests).to include request
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,5 +119,27 @@ describe User do
         },
       )
     end
+
+    context "when changing role" do
+      described_class.roles.reject { |role| role == "trial" }.each do |_role_name, role_value|
+        it "updates org when changing from trial to #{role_value}" do
+          user = create(:user, :with_trial)
+
+          expect(Form).to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
+
+          user.role = role_value
+          user.save!
+        end
+
+        it "does not update org when changing from #{role_value} to editor" do
+          user = create :user, role: role_value
+
+          expect(Form).not_to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
+
+          user.role = :editor
+          user.save!
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
When a user gets their account changed from trial to editor we want to have their forms added to their new organisation. This PR uses a new endpoint on forms-api to update the `org` for forms with the same `creator_id` as the trial user who have had their role changed to editor.

Trello card: https://trello.com/c/esvZIXnn

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
