### PR TITLE
Remove 'question' from live form playback

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,7 +363,7 @@ en:
     condition_answer_value_text: is answered as “%{answer_value}”
     condition_answer_value_text_with_errors: is answered as [Answer not selected]
     condition_check_page_text: If the question “%{check_page_text}”
-    condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to question %{goto_page_number}: “%{goto_page_text}”'
+    condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to %{goto_page_number}: “%{goto_page_text}”'
     condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to “Check your answers before submitting”
     condition_goto_page_text: take the person to “%{goto_page_text}”
     condition_goto_page_text_with_errors: take the person to [Question not selected]


### PR DESCRIPTION
#### What problem does the pull request solve?
The word 'question' is superfluous so we're removing it.

Trello card: https://trello.com/c/9ZcfxQDM/874-remove-the-word-question-from-live-form-routing-playback

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
