### PR TITLE
Refactor add route UI logic

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -1,5 +1,5 @@
 class Pages::ConditionsController < PagesController
-  before_action :can_add_page_routing, only: %i[routing_page new create]
+  before_action :can_add_page_routing, only: %i[new create]
 
   def routing_page
     routing_page_form = Pages::RoutingPageForm.new(routing_page_id: params[:routing_page_id])

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -19,6 +19,10 @@ class Form < ActiveResource::Base
     pages.filter { |p| p.answer_type == "selection" && p.answer_settings.only_one_option == "true" && p.position != pages.length && p.conditions.empty? }
   end
 
+  def has_no_remaining_routes_available?
+    qualifying_route_pages.none? && has_routing_conditions
+  end
+
   def status
     has_live_version ? :live : :draft
   end
@@ -87,5 +91,11 @@ class Form < ActiveResource::Base
 
     index = pages.index { |existing_page| existing_page.attributes == page.attributes }
     (index.nil? ? pages.length : index) + 1
+  end
+
+private
+
+  def has_routing_conditions
+    pages.filter { |p| p.conditions.any? }.any?
   end
 end

--- a/app/views/pages/conditions/_routing_options.html.erb
+++ b/app/views/pages/conditions/_routing_options.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: routing_page_form, url: set_routing_page_path(form.id), method: 'POST') do |f| %>
+  <% if routing_page_form&.errors.any? %>
+    <%= f.govuk_error_summary %>
+  <% end %>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= form.name %> </span>
+    <%= t("page_titles.routing_page") %>
+  </h1>
+
+  <p>
+    <%= t("routing_page.body_text") %>
+  </p>
+
+  <% if form.qualifying_route_pages.length <= 10 %>
+    <%= f.govuk_collection_radio_buttons :routing_page_id,
+                                         form.qualifying_route_pages,
+                                         :id, :question_text,
+                                         legend: { text: t("routing_page.legend_text"), size: 'm' },
+                                         hint:{ text: t("routing_page.legend_hint_text") }
+    %>
+  <% else %>
+    <%= f.govuk_collection_select :routing_page_id,
+                                  form.qualifying_route_pages,
+                                  :id, :question_with_number,
+                                  label: { text: t("routing_page.legend_text"), size: 'm' },
+                                  hint: { text: t("routing_page.legend_hint_text") },
+                                  options: { include_blank: t("routing_page.dropdown_default_text") }
+    %>
+  <% end %>
+
+  <%= f.govuk_submit t("continue") %>
+<% end %>

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -15,9 +15,13 @@
         <%= t("routing_page.body_text") %>
       </p>
 
-      <h2 class="govuk-heading-m"><%= t("routing_page.routing_requirements_not_met_heading") %></h2>
-
-      <%= t('routing_page.routing_requirements_not_met_html') %>
+      <% if form.has_no_remaining_routes_available? %>
+        <h2 class="govuk-heading-m"><%= t("routing_page.no_remaining_routes_heading") %></h2>
+        <p><%= t("routing_page.no_remaining_routes") %></p>
+      <% else %>
+        <h2 class="govuk-heading-m"><%= t("routing_page.routing_requirements_not_met_heading") %></h2>
+        <%= t('routing_page.routing_requirements_not_met_html') %>
+      <% end %>
     <% end %>
     <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(form.id) %>

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -2,10 +2,10 @@
 <% content_for :back_link, govuk_back_link_to(form_pages_path(form.id)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: routing_page_form, url: set_routing_page_path(form.id), method: 'POST') do |f| %>
-      <% if routing_page_form&.errors.any? %>
-        <%= f.govuk_error_summary %>
-      <% end %>
+
+    <% if policy(form).can_add_page_routing_conditions? %>
+      <%= render partial: "pages/conditions/routing_options", locals: {form:, routing_page_form:} %>
+    <% else %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= form.name %> </span>
         <%= t("page_titles.routing_page") %>
@@ -15,24 +15,12 @@
         <%= t("routing_page.body_text") %>
       </p>
 
-      <% if form.qualifying_route_pages.length <= 10 %>
-        <%= f.govuk_collection_radio_buttons :routing_page_id,
-                                            form.qualifying_route_pages,
-                                            :id, :question_text,
-                                            legend: { text: t("routing_page.legend_text"), size: 'm' },
-                                            hint:{ text: t("routing_page.legend_hint_text") }
-        %>
-      <% else %>
-        <%= f.govuk_collection_select :routing_page_id,
-                                            form.qualifying_route_pages,
-                                            :id, :question_with_number,
-                                            label: { text: t("routing_page.legend_text"), size: 'm' },
-                                            hint: { text: t("routing_page.legend_hint_text") },
-                                            options: { include_blank: t("routing_page.dropdown_default_text") }
-        %>
-      <% end %>
+      <h2 class="govuk-heading-m"><%= t("routing_page.routing_requirements_not_met_heading") %></h2>
 
-      <%= f.govuk_submit t("continue") %>
+      <%= t('routing_page.routing_requirements_not_met_html') %>
     <% end %>
+    <p>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(form.id) %>
+    </p>
   </div>
 </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -20,9 +20,8 @@
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), type_of_answer_new_path(@form), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
-      <% if policy(@form).can_add_page_routing_conditions? %>
-        <%= govuk_button_link_to t("pages.index.add_a_question_route"), routing_page_path(@form), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
-      <% end %>
+      <%= govuk_button_link_to t("pages.index.add_a_question_route"), routing_page_path(@form), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
+
       <%= render PreviewLinkComponent::View.new(@pages, link_to_runner(Settings.forms_runner.url, @form.id, @form.form_slug)) %>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -487,7 +487,7 @@ en:
     no_remaining_routes_heading: You have no more questions to start a route from
     routing_requirements_not_met_heading: What you need to create a route
     routing_requirements_not_met_html: |
-      <p>Before you can add a route you'll need:</p>
+      <p>Before you can add a route you’ll need:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>2 or more questions</li>
         <li>at least one question where people must select a single item from a list of options</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,6 +483,16 @@ en:
     dropdown_default_text: Select a question to start your route from
     legend_hint_text: A route can only start from a question where people select one item from a list
     legend_text: Which question do you want your route to start from?
+    routing_requirements_not_met_heading: What you need to create a route
+    routing_requirements_not_met_html: |
+      <p>Before you can add a route you'll need:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>2 or more questions</li>
+        <li>at least one question where people must select a single item from a list of options</li>
+      </ul>
+      <p>
+        You can only add one route per question.
+      </p>
   save_and_continue: Save and continue
   selections_settings:
     add_another: Add another option

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,6 +483,8 @@ en:
     dropdown_default_text: Select a question to start your route from
     legend_hint_text: A route can only start from a question where people select one item from a list
     legend_text: Which question do you want your route to start from?
+    no_remaining_routes: A route can only start from a question where people select one item from a list. You can only add one route per question.
+    no_remaining_routes_heading: You have no more questions to start a route from
     routing_requirements_not_met_heading: What you need to create a route
     routing_requirements_not_met_html: |
       <p>Before you can add a route you'll need:</p>

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -130,6 +130,33 @@ describe Form do
     end
   end
 
+  describe "#has_no_remaining_routes_available?" do
+    let(:selection_pages_with_routes) do
+      (1..3).map do |index|
+        build :page, :with_selections_settings, id: index, position: index, routing_conditions: [(build :condition, id: index, check_page_id: index, goto_page_id: index + 2)]
+      end
+    end
+    let(:selection_pages_without_routes) do
+      (4..5).map do |index|
+        build :page, :with_selections_settings, id: index, position: index, routing_conditions: []
+      end
+    end
+
+    let(:form) { build :form, pages: selection_pages_with_routes }
+
+    it "returns true if no available routes" do
+      expect(form.has_no_remaining_routes_available?).to eq true
+    end
+
+    context "when there is at least on selection page with no route" do
+      let(:form) { build :form, pages: selection_pages_with_routes + selection_pages_without_routes }
+
+      it "returns false" do
+        expect(form.has_no_remaining_routes_available?).to eq false
+      end
+    end
+  end
+
   describe "#update_org_for_creator" do
     let(:headers) do
       {

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -148,7 +148,7 @@ describe Form do
       expect(form.has_no_remaining_routes_available?).to eq true
     end
 
-    context "when there is at least on selection page with no route" do
+    context "when there is at least one selection page with no route" do
       let(:form) { build :form, pages: selection_pages_with_routes + selection_pages_without_routes }
 
       it "returns false" do

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -31,12 +31,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       end
 
-      if expected_to_raise_error
-        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
-      else
-        allow(Pundit).to receive(:authorize).and_return(true)
-      end
-
       get routing_page_path(form_id: form.id)
     end
 
@@ -46,18 +40,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     it "renders the routing page template" do
       expect(response).to render_template("pages/conditions/routing_page")
-    end
-
-    context "when user should not be allowed to  add routes to pages" do
-      let(:expected_to_raise_error) { true }
-
-      it "Renders the forbidden page" do
-        expect(response).to render_template("errors/forbidden")
-      end
-
-      it "Returns a 403 status" do
-        expect(response.status).to eq(403)
-      end
     end
   end
 

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -5,6 +5,7 @@ describe "pages/conditions/routing_page.html.erb" do
   let(:pages) { build_list :page, 3, :with_selections_settings, form_id: 1 }
   let(:routing_page_form) { Pages::RoutingPageForm.new }
   let(:allowed_to_create_routes) { true }
+  let(:all_routes_created) { false }
 
   before do
     without_partial_double_verification do
@@ -15,6 +16,7 @@ describe "pages/conditions/routing_page.html.erb" do
     allow(view).to receive(:routing_page_path).and_return("/forms/1/new-condition")
     allow(view).to receive(:set_routing_page_path).and_return("/forms/1/new-condition")
     allow(form).to receive(:qualifying_route_pages).and_return(pages)
+    allow(form).to receive(:has_no_remaining_routes_available?).and_return(all_routes_created)
 
     render template: "pages/conditions/routing_page", locals: { form:, routing_page_form: }
   end
@@ -79,6 +81,15 @@ describe "pages/conditions/routing_page.html.erb" do
     it "explains to the user what is required for them to be able to add a new routes" do
       guidance = Capybara.string(I18n.t("routing_page.routing_requirements_not_met_html")).text(normalize_ws: true)
       expect(Capybara.string(rendered).text(normalize_ws: true)).to have_text(guidance)
+    end
+
+    context "when all qualifying questions have a route" do
+      let(:all_routes_created) { true }
+
+      it "explains to the user that they have created all available routes" do
+        guidance = Capybara.string(I18n.t("routing_page.no_remaining_routes")).text(normalize_ws: true)
+        expect(Capybara.string(rendered).text(normalize_ws: true)).to have_text(guidance)
+      end
     end
   end
 end

--- a/spec/views/pages/index.html.erb_spec.rb
+++ b/spec/views/pages/index.html.erb_spec.rb
@@ -3,14 +3,9 @@ require "rails_helper"
 describe "pages/index.html.erb" do
   let(:form) { build :form, id: 1, pages: }
   let(:pages) { [] }
-  let(:add_routing) { false }
 
   before do
     # mock the path helper
-    without_partial_double_verification do
-      allow(view).to receive(:policy).and_return(OpenStruct.new(can_add_page_routing_conditions?: add_routing))
-    end
-
     allow(view).to receive(:form_path).and_return("/forms/1")
     allow(view).to receive(:type_of_answer_new_path).and_return("/forms/1/pages/new/type-of-answer")
     allow(view).to receive(:edit_page_path).and_return("/forms/1/pages/2/edit")
@@ -47,14 +42,6 @@ describe "pages/index.html.erb" do
     it "does contain a summary list entry each page" do
       expect(rendered).to have_text I18n.t("forms.form_overview.your_questions")
       expect(rendered).to have_css ".govuk-summary-list__row", count: 3
-    end
-  end
-
-  describe "when the user can add page routing condition" do
-    let(:add_routing) { true }
-
-    it "does not contain a link to add page routing" do
-      expect(rendered).not_to have_link("Add a question route", href: routing_page_path(form.id))
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

Users were confused as to why sometimes they see an option to add a new route or if they hadn't seen it before they wouldn't know that the feature existed

- Display the "Add new route" button all the time with no restrictions
- 2 new sets of copy to help explain to the user why they cannot progress.
   1. [First time user] They have tried to create a new route when they dont have enough questions or questions that we can route from 
   2. [Returning user] They do have the minimum number of questions and one or more select-one-from-a-list answer type but they already have route setup for those questions.

Trello card: https://trello.com/c/x2rDK7ek/867-routing-consider-making-the-add-a-question-route-button-visible-at-all-times-development

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
