### PR TITLE
Default to trial role for new users

### DIFF
--- a/db/migrate/20230626091901_update_default_value_for_user_role.rb
+++ b/db/migrate/20230626091901_update_default_value_for_user_role.rb
@@ -1,0 +1,5 @@
+class UpdateDefaultValueForUserRole < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :users, :role, from: "editor", to: "trial"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_133847) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_26_091901) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,7 +53,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_133847) do
     t.boolean "disabled", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "role", default: "editor"
+    t.string "role", default: "trial"
     t.bigint "organisation_id"
     t.boolean "has_access", default: true
     t.string "provider"

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     email { Faker::Internet.email(name:, domain: "example.gov.uk") }
     uid { Faker::Internet.uuid }
     provider { "factory_bot" }
-    role { :editor }
+    role { :trial }
     has_access { true }
 
     trait :with_trial_role do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -144,4 +144,9 @@ describe User do
       end
     end
   end
+
+  it "defaults to the trial role" do
+    user = described_class.new
+    expect(user.role).to eq("trial")
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
We want to allow anyone to be able to use [GOV.UK](http://gov.uk/) Forms, with some restrictions if they are signing up for the first time. The trial user role implements those restrictions, so we should make sure new users get a trial account.

Trello card: https://trello.com/c/KkZfWSar

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
