### PR TITLE
Don't use mock_gds_sso for tests

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -12,5 +12,5 @@ forms_runner:
   # Base URL to point users to the app in the UI
   url: runner-host
 
-# Use mock authentication
-auth_provider: mock_gds_sso
+# No default strategy as Warden test mode is used
+auth_provider: ""

--- a/spec/factories/models/organisations.rb
+++ b/spec/factories/models/organisations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :organisation do
-    govuk_content_id { Faker::Internet.uuid }
+    govuk_content_id { nil }
     slug { "test-org" }
     name { ActiveSupport::Inflector.titleize slug }
 

--- a/spec/factories/models/organisations.rb
+++ b/spec/factories/models/organisations.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     name { ActiveSupport::Inflector.titleize slug }
 
     initialize_with do
-      Organisation.create_with(govuk_content_id:, name:).find_or_create_by(slug:)
+      Organisation.create_with(govuk_content_id:, name:).find_or_initialize_by(slug:)
     end
   end
 end

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -21,6 +21,8 @@ feature "Add/editing a single question", type: :feature do
       mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       mock.post "/api/v1/forms/1/pages", post_headers
     end
+
+    login_as_editor_user
   end
 
   context "when a form has no existing pages" do

--- a/spec/features/form/create_or_edit_a_form_spec.rb
+++ b/spec/features/form/create_or_edit_a_form_spec.rb
@@ -17,6 +17,10 @@ feature "Create or edit a form", type: :feature do
     }
   end
 
+  before do
+    login_as_editor_user
+  end
+
   context "when creating a form" do
     let(:pages) { [] }
 

--- a/spec/features/form/make_changes_live_spec.rb
+++ b/spec/features/form/make_changes_live_spec.rb
@@ -26,6 +26,8 @@ feature "Make changes live", type: :feature do
       mock.get "/api/v1/forms/1/live", req_headers, form.to_json(include: [:pages]), 200
       mock.post "/api/v1/forms/1/make-live", post_headers, { success: true }.to_json, 200
     end
+
+    login_as_editor_user
   end
 
   scenario "Form creator makes changes after making form live" do

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -10,11 +10,11 @@ describe "Set or change a user's role", type: :feature do
   end
 
   let(:super_admin_user) do
-    build(:user, :with_super_admin, id: 1)
+    build(:user, :with_super_admin, id: 1, organisation_slug: "gds")
   end
 
   let(:trial_user) do
-    build(:user, :with_no_org, :with_trial, id: 2)
+    create(:user, :with_no_org, :with_trial, id: 2)
   end
 
   let(:req_headers) do
@@ -24,8 +24,15 @@ describe "Set or change a user's role", type: :feature do
     }
   end
 
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
   before do
-    Rails.application.load_seed
+    create :organisation, slug: "test-org"
 
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms?org=test-org", req_headers, org_forms.to_json, 200
@@ -42,27 +49,27 @@ describe "Set or change a user's role", type: :feature do
   it "A trial user's forms move to their organisation on role upgrade" do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms?org=test-org", req_headers, (org_forms + trial_forms).to_json, 200
+      mock.patch "/api/v1/forms/update-org-for-creator?creator_id=2&org=test-org", post_headers, { success: true }.to_json, 204
     end
 
     login_as super_admin_user
-    when_i_change_a_trial_users_role_to_editor
-    login_as trial_user
+    when_i_change_the_trial_users_role_to_editor
+    reset_session!
+
+    login_as trial_user.reload
     then_i_can_see_the_trial_user_forms
     then_i_can_see_the_org_forms
   end
 
 private
 
-  def when_i_change_a_trial_users_role_to_editor
-    visit users_path
-    edit_user_path_re = %r{/users/(?<id>\d+)/edit}
-    edit_user_link = page.find_all(:link, href: edit_user_path_re).sample
-    @user = User.find(edit_user_path_re.match(edit_user_link[:href])[:id])
+  def when_i_change_the_trial_users_role_to_editor
+    visit edit_user_path(trial_user.id)
 
-    edit_user_link.click
     expect(page).to have_css "h1.govuk-heading-l", text: "Edit user"
-    expect(page).to have_text @user.name
+    expect(page).to have_text trial_user.name
 
+    select("Test Org", from: "Organisation")
     choose("Editor")
     click_button "Save"
   end

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -10,7 +10,7 @@ describe "Set or change a user's role", type: :feature do
   end
 
   let(:super_admin_user) do
-    build(:user, :with_super_admin, id: 1, organisation_slug: "gds")
+    create(:user, :with_super_admin, id: 1, organisation_slug: "gds")
   end
 
   let(:trial_user) do

--- a/spec/integration/organisation_factory_spec.rb
+++ b/spec/integration/organisation_factory_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "organisation factory" do
+  it "does not duplicate organisations with same slug" do
+    org1 = create :organisation, slug: "org-slug"
+    org2 = create :organisation, slug: "org-slug"
+
+    expect(org1.id).to eq org2.id
+  end
+
+  it "does not persist the organisation" do
+    org = build :organisation
+
+    expect(org).not_to be_persisted
+  end
+end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ApplicationController, type: :request do
     }
   end
 
-  let(:user) { build :user, :super_admin, has_access: false }
   let(:form) { build :form, id: 1 }
 
   before do
@@ -17,6 +16,8 @@ RSpec.describe ApplicationController, type: :request do
       mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, form.pages.to_json, 200
     end
+
+    login_as_editor_user
   end
 
   context "when the service is in maintenance mode" do
@@ -67,6 +68,8 @@ RSpec.describe ApplicationController, type: :request do
   end
 
   context "when a user is logged in who does not have access" do
+    let(:user) { build :user, :super_admin, has_access: false }
+
     before do
       login_as user
     end

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -2,6 +2,18 @@ require "rails_helper"
 
 RSpec.describe AuthenticationController, type: :request do
   before do
+    Warden::Strategies.add(:mock_not_logged_in) do
+      def valid?
+        false
+      end
+
+      def authenticate!
+        raise NotImplementedError
+      end
+    end
+
+    allow(Settings).to receive(:auth_provider).and_return("mock_not_logged_in")
+
     OmniAuth.config.test_mode = true
   end
 
@@ -31,7 +43,7 @@ RSpec.describe AuthenticationController, type: :request do
     it "redirects to OmniAuth request phase" do
       get root_path
 
-      expect(response).to redirect_to("/auth/mock_gds_sso")
+      expect(response).to redirect_to("/auth/#{Settings.auth_provider}")
     end
 
     it "uses the configured OmniAuth provider" do

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -24,17 +24,21 @@ RSpec.describe Forms::ChangeNameController, type: :request do
     }
   end
 
+  let(:user) { build :user, id: 1 }
+
   before do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/2", req_headers, form_response_data, 200
       mock.post "/api/v1/forms", post_headers, { id: 2 }.to_json, 200
       mock.put "/api/v1/forms/2", post_headers
     end
+
     allow(Pundit).to receive(:authorize).and_return(true)
+
+    login_as user
   end
 
   describe "#create" do
-    let(:user) { build :user, id: 1 }
     let(:form_data) do
       {
         name: "Form name",
@@ -44,8 +48,6 @@ RSpec.describe Forms::ChangeNameController, type: :request do
     end
 
     before do
-      login_as user
-
       ActiveResource::HttpMock.reset!
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/", req_headers, form_response_data, 200

--- a/spec/requests/forms/contact_details_controller_spec.rb
+++ b/spec/requests/forms/contact_details_controller_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Forms::ContactDetailsController, type: :request do
     }
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#new" do
     let(:form) do
       build :form, :with_support, id: 2

--- a/spec/requests/forms/live_controller_spec.rb
+++ b/spec/requests/forms/live_controller_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Forms::LiveController, type: :request do
     build(:form, :live, id: 2)
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#show_form" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/forms/privacy_policy_controller_spec.rb
+++ b/spec/requests/forms/privacy_policy_controller_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Forms::PrivacyPolicyController, type: :request do
                                        read: { response: form, status: 200 },
                                        update: { response: updated_form, status: 200 },
                                      })
+
+    login_as_editor_user
   end
 
   describe "#new" do

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
                                        read: { response: form, status: 200 },
                                        update: { response: updated_form, status: 200 },
                                      })
+
+    login_as_editor_user
   end
 
   describe "#new" do

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe FormsController, type: :request do
 
   let(:form) { build(:form, id: 2) }
 
+  before do
+    login_as_editor_user
+  end
+
   describe "Showing an existing form" do
     describe "Given a live form" do
       let(:form) { build(:form, :live, id: 2) }

--- a/spec/requests/pages/address_settings_controller_spec.rb
+++ b/spec/requests/pages/address_settings_controller_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
     }
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
   let(:expected_to_raise_error) { false }
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#routing_page" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/pages/date_settings_controller_spec.rb
+++ b/spec/requests/pages/date_settings_controller_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Pages::DateSettingsController, type: :request do
     }
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/pages/name_settings_controller_spec.rb
+++ b/spec/requests/pages/name_settings_controller_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Pages::NameSettingsController, type: :request do
     }
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/pages/question_text_controller_spec.rb
+++ b/spec/requests/pages/question_text_controller_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Pages::QuestionTextController, type: :request do
     }
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/pages/selections_settings_controller_spec.rb
+++ b/spec/requests/pages/selections_settings_controller_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
     }
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/pages/text_settings_controller_spec.rb
+++ b/spec/requests/pages/text_settings_controller_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Pages::TextSettingsController, type: :request do
     }
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
     }
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe PagesController, type: :request do
     (build :form, id: 2)
   end
 
+  before do
+    login_as_editor_user
+  end
+
   describe "#index" do
     let(:pages) do
       [build(:page, id: 99),

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -16,15 +16,15 @@ module AuthenticationFeatureHelpers
   end
 
   def super_admin_user
-    @super_admin_user ||= FactoryBot.build(:user, :super_admin)
+    @super_admin_user ||= FactoryBot.create(:user, role: :super_admin)
   end
 
   def editor_user
-    @editor_user ||= FactoryBot.build(:user)
+    @editor_user ||= FactoryBot.create(:user, role: :editor)
   end
 
   def trial_user
-    @trial_user ||= FactoryBot.build(:user, :trial)
+    @trial_user ||= FactoryBot.create(:user, role: :trial)
   end
 
   def login_as_super_admin_user
@@ -43,10 +43,11 @@ end
 RSpec.configure do |config|
   config.include AuthenticationFeatureHelpers, type: :feature
   config.include AuthenticationFeatureHelpers, type: :request
-  config.before(:example, type: :feature) do
-    login_as_editor_user
+
+  config.after(:example, type: :feature) do
+    logout
   end
-  config.before(:example, type: :request) do
-    login_as_editor_user
+  config.after(:example, type: :request) do
+    logout
   end
 end

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -1,18 +1,31 @@
+require "warden"
+
 module AuthenticationFeatureHelpers
+  include Warden::Test::Helpers
+
   @cached_gds_sso_mock_invalid = ENV["GDS_SSO_MOCK_INVALID"]
 
-  def login_as(user)
-    ENV["GDS_SSO_MOCK_INVALID"] = @cached_gds_sso_mock_invalid
+  def login_as(user, opts = {})
+    if %i[gds_sso mock_gds_sso].include? Settings.auth_provider.to_sym
+      ENV["GDS_SSO_MOCK_INVALID"] = @cached_gds_sso_mock_invalid
+      GDS::SSO.test_user = user
+    else
+      opts[:run_callbacks] ||= false # Callbacks are from gds-sso gem
+    end
 
-    GDS::SSO.test_user = user
+    super user, opts
   end
 
   def logout
-    # If GDS_SSO_MOCK_INVALID is not present the gds-sso mock strategy will get
-    # the first user from the database when authenticate! is called
-    ENV["GDS_SSO_MOCK_INVALID"] = "true"
+    if %i[gds_sso mock_gds_sso].include? Settings.auth_provider.to_sym
+      # If GDS_SSO_MOCK_INVALID is not present the gds-sso mock strategy will get
+      # the first user from the database when authenticate! is called
+      ENV["GDS_SSO_MOCK_INVALID"] = "true"
 
-    GDS::SSO.test_user = nil
+      GDS::SSO.test_user = nil
+    end
+
+    super
   end
 
   def super_admin_user
@@ -44,10 +57,17 @@ RSpec.configure do |config|
   config.include AuthenticationFeatureHelpers, type: :feature
   config.include AuthenticationFeatureHelpers, type: :request
 
+  config.before(:example, type: :feature) do
+    Warden.test_mode!
+  end
+  config.before(:example, type: :request) do
+    Warden.test_mode!
+  end
+
   config.after(:example, type: :feature) do
-    logout
+    Warden.test_reset!
   end
   config.after(:example, type: :request) do
-    logout
+    Warden.test_reset!
   end
 end

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -6,9 +6,9 @@ describe "users/edit.html.erb" do
   end
 
   before do
-    build :organisation, slug: "test-org"
-    build :organisation, slug: "ministry-of-testing"
-    build :organisation, slug: "department-for-tests"
+    create :organisation, slug: "test-org"
+    create :organisation, slug: "ministry-of-testing"
+    create :organisation, slug: "department-for-tests"
 
     assign(:user, user)
     render template: "users/edit"


### PR DESCRIPTION
#### What problem does the pull request solve?

Our tests currently rely on the gds-sso gem for user management during tests. However, the way the `mock_gds_sso` provider works is a little difficult to follow, and has some surprising side effects. This has been causing me an issue when trying to work on tests, both for the CDDO SSO provider, and for changing the API to use organisation IDs instead of slugs.

This PR changes our tests to use Warden's own test mode instead of relying on the `mock_gds_sso` provider. To achieve this we had to clean up a lot of not obviously related stuff, so this PR is quite long.

I've been working on this as part of https://trello.com/c/75nMIWFC.