### PR TITLE
Add question number to new route view

### DIFF
--- a/app/views/pages/conditions/_routing_options.html.erb
+++ b/app/views/pages/conditions/_routing_options.html.erb
@@ -14,7 +14,7 @@
   <% if form.qualifying_route_pages.length <= 10 %>
     <%= f.govuk_collection_radio_buttons :routing_page_id,
                                          form.qualifying_route_pages,
-                                         :id, :question_text,
+                                         :id, :question_with_number,
                                          legend: { text: t("routing_page.legend_text"), size: 'm' },
                                          hint:{ text: t("routing_page.legend_hint_text") }
     %>

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -36,8 +36,10 @@ describe "pages/conditions/routing_page.html.erb" do
       expect(rendered).to have_css("div.govuk-hint", text: t("routing_page.legend_hint_text"))
     end
 
-    it "has a radio option for each routing pages" do
-      expect(rendered).to have_css(".govuk-radios__item", count: pages.length)
+    it "includes a radio button for each page, with the page number and question text" do
+      pages.each do |page|
+        expect(rendered).to have_css(".govuk-radios__item", text: page.question_with_number)
+      end
     end
   end
 
@@ -49,8 +51,10 @@ describe "pages/conditions/routing_page.html.erb" do
       expect(rendered).to have_css("div.govuk-hint", text: t("routing_page.legend_hint_text"))
     end
 
-    it "has a radio option for each routing pages" do
-      expect(rendered).to have_css(".govuk-radios__item", count: pages.length)
+    it "includes a radio button for each page, with the page number and question text" do
+      pages.each do |page|
+        expect(rendered).to have_css(".govuk-radios__item", text: page.question_with_number)
+      end
     end
   end
 
@@ -62,12 +66,14 @@ describe "pages/conditions/routing_page.html.erb" do
       expect(rendered).to have_css("div.govuk-hint", text: t("routing_page.legend_hint_text"))
     end
 
-    it "has a select option for each routing page and the default value" do
-      expect(rendered).to have_css("select > option", count: pages.length + 1)
+    it "has a select the default value" do
+      expect(rendered).to have_css("select > option", text: I18n.t("routing_page.dropdown_default_text"))
     end
 
-    it "includes the page number and question text" do
-      expect(rendered).to have_text(pages.first.question_with_number)
+    it "includes a select option for each page, with the page number and question text" do
+      pages.each do |page|
+        expect(rendered).to have_text(page.question_with_number)
+      end
     end
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
- Adds the question number to the question text on the new route page. We were already doing this for the select list view that appears when there are more than 10 options, but now we're doing it in the default radio button view as well. 
- Improves the tests a bit - they weren't actually testing for the question text previously, just the presence of the correct number of radio buttons.

Trello card: https://trello.com/c/pGxfm9Ne/906-add-question-number-to-possible-routing-questions-on-new-route-page

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
