### PR TITLE
Move bulk form org update to user controller

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,7 @@ class UsersController < ApplicationController
     authorize current_user, :can_manage_user?
 
     if user.update(user_params)
+      user.update_org
       redirect_to users_path
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
     authorize current_user, :can_manage_user?
 
     if user.update(user_params)
-      user.update_org
+      user.update_user_forms
       redirect_to users_path
     else
       render :edit, status: :unprocessable_entity

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -64,7 +64,9 @@ class Form < ActiveResource::Base
   end
 
   def self.update_org_for_creator(creator_id, org)
-    patch("update-org-for-creator", creator_id:, org:)
+    if creator_id.present? && org.present?
+      patch("update-org-for-creator", creator_id:, org:)
+    end
   end
 
   def form_submission_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,6 @@ class User < ApplicationRecord
   validates :organisation_id, presence: true, if: :requires_organisation?
   validates :has_access, inclusion: [true, false]
 
-  before_save :update_org
-
   def self.find_for_gds_oauth(auth_hash)
     find_for_auth(
       provider: auth_hash["provider"],
@@ -57,15 +55,15 @@ class User < ApplicationRecord
     trial? || organisation.present?
   end
 
+  def update_org
+    if role_previously_changed?(from: :trial)
+      Form.update_org_for_creator(id, organisation.slug)
+    end
+  end
+
 private
 
   def requires_organisation?
     organisation_id_was.present? || role_changed?(to: :editor)
-  end
-
-  def update_org
-    if role_changed?(from: :trial)
-      Form.update_org_for_creator(id, organisation.slug)
-    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,7 @@ class User < ApplicationRecord
     trial? || organisation.present?
   end
 
-  def update_org
+  def update_user_forms
     if role_previously_changed?(from: :trial)
       Form.update_org_for_creator(id, organisation.slug)
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,4 +41,7 @@ if HostingEnvironment.local_development? && User.none?
 
   # create a user who hasn't been assigned to an organisation yet
   FactoryBot.create :user, :with_no_org
+
+  # create a trial user
+  FactoryBot.create :user, :with_no_org, :with_trial
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -165,6 +165,10 @@ describe Form do
       }
     end
 
+    before do
+      ActiveResource::HttpMock.reset!
+    end
+
     it "makes patch request to the API" do
       creator_id = 123
       org = "org"
@@ -178,6 +182,16 @@ describe Form do
 
       request = ActiveResource::Request.new(:patch, expected_path, {}, headers)
       expect(ActiveResource::HttpMock.requests).to include request
+    end
+
+    %w[creator_id org].each do |missing_param|
+      it "does not make request to the API with #{missing_param} missing" do
+        params = [missing_param == "creator_id" ? nil : 123, missing_param == "org" ? nil : "org"]
+
+        described_class.update_org_for_creator(*params)
+
+        expect(ActiveResource::HttpMock.requests).to match_array([])
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -123,24 +123,24 @@ describe User do
 
   context "when changing role" do
     described_class.roles.reject { |role| role == "trial" }.each do |_role_name, role_value|
-      it "updates org when changing from trial to #{role_value}" do
+      it "updates user's forms' org when changing role from trial to #{role_value}" do
         user = create(:user, role: :trial)
 
         expect(Form).to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
 
         user.role = role_value
         user.save!
-        user.update_org
+        user.update_user_forms
       end
 
-      it "does not update org when changing from #{role_value} to editor" do
+      it "does not update user's forms' org when changing role from #{role_value} to editor" do
         user = create :user, role: role_value
 
         expect(Form).not_to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
 
         user.role = :editor
         user.save!
-        user.update_org
+        user.update_user_forms
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,26 +119,28 @@ describe User do
         },
       )
     end
+  end
 
-    context "when changing role" do
-      described_class.roles.reject { |role| role == "trial" }.each do |_role_name, role_value|
-        it "updates org when changing from trial to #{role_value}" do
-          user = create(:user, :with_trial)
+  context "when changing role" do
+    described_class.roles.reject { |role| role == "trial" }.each do |_role_name, role_value|
+      it "updates org when changing from trial to #{role_value}" do
+        user = create(:user, role: :trial)
 
-          expect(Form).to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
+        expect(Form).to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
 
-          user.role = role_value
-          user.save!
-        end
+        user.role = role_value
+        user.save!
+        user.update_org
+      end
 
-        it "does not update org when changing from #{role_value} to editor" do
-          user = create :user, role: role_value
+      it "does not update org when changing from #{role_value} to editor" do
+        user = create :user, role: role_value
 
-          expect(Form).not_to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
+        expect(Form).not_to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
 
-          user.role = :editor
-          user.save!
-        end
+        user.role = :editor
+        user.save!
+        user.update_org
       end
     end
   end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -158,5 +158,50 @@ RSpec.describe UsersController, type: :request do
         expect(response).to have_http_status(:forbidden)
       end
     end
+
+    context "when changing role" do
+      before do
+        login_as_super_admin_user
+      end
+
+      User.roles.reject { |role| role == "trial" }.each do |_role_name, role_value|
+        it "updates user's forms' org when changing role from trial to #{role_value}" do
+          user = create(:user, role: :trial)
+          expect(Form).to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
+
+          patch user_path(user), params: { user: { role: role_value } }
+
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(users_path)
+        end
+
+        it "does not update user's forms' org when changing role from #{role_value} to editor" do
+          user = create :user, role: role_value
+
+          expect(Form).not_to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
+
+          patch user_path(user), params: { user: { role: "editor" } }
+
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(users_path)
+        end
+
+        it "does not update user's forms' org when role is unchanged" do
+          user = create :user, role: :trial
+
+          expect(Form).to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
+
+          patch user_path(user), params: { user: { role: "editor" } }
+
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(users_path)
+
+          expect(Form).not_to receive(:update_org_for_creator).with(user.id, user.organisation.slug)
+          patch user_path(user), params: { user: { role: "editor" } }
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(users_path)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
Previously a trial user's forms would have their org set via a patch request to a bulk update endpoint in forms-api, triggered by a `before_save` filter in the User model. This overly coupled the User model and Form active resource, such that tests would require mocking of the forms-api requests etc. This how now been avoided by only updating a trial user's forms in the user controller update action.

This is a precursor to making the trial role the default (since doing so means lots of tests would need mocking of the `update_org_for_creator` in forms-api.

Trello card: https://trello.com/c/KkZfWSar
