### PR TITLE
Explicitly set role in tests

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
   end
 
   def update_user_forms
-    if role_previously_changed?(from: :trial)
+    if role_previously_changed?(from: :trial, to: :editor) || role_previously_changed?(from: :trial, to: :super_admin)
       Form.update_org_for_creator(id, organisation.slug)
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,7 +31,7 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create_list :user, 3, role: :editor
 
   # create extra super admins
-  FactoryBot.create_list :user, 3, :with_super_admin
+  FactoryBot.create_list :user, 3, role: :super_admin
 
   # while we're using Signon it is possible to have users who aren't linked to
   # the same organisation as in Signon, or who have an organisation that isn't
@@ -43,5 +43,5 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create :user, :with_no_org
 
   # create a trial user
-  FactoryBot.create :user, :with_no_org, :with_trial
+  FactoryBot.create :user, :with_trial_role
 end

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -7,12 +7,9 @@ FactoryBot.define do
     role { :editor }
     has_access { true }
 
-    trait :with_super_admin do
-      role { :super_admin }
-    end
-
-    trait :with_trial do
+    trait :with_trial_role do
       role { :trial }
+      with_no_org
     end
 
     organisation_slug { "test-org" }

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -49,7 +49,7 @@ describe "Set or change a user's role", type: :feature do
   it "A trial user's forms move to their organisation on role upgrade" do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms?org=test-org", req_headers, (org_forms + trial_forms).to_json, 200
-      mock.patch "/api/v1/forms/update-org-for-creator?creator_id=2&org=test-org", post_headers, { success: true }.to_json, 204
+      mock.patch "/api/v1/forms/update-org-for-creator?creator_id=2&org=test-org", post_headers, { success: true }.to_json, 200
     end
 
     login_as super_admin_user

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -10,11 +10,11 @@ describe "Set or change a user's role", type: :feature do
   end
 
   let(:super_admin_user) do
-    create(:user, :with_super_admin, id: 1, organisation_slug: "gds")
+    create(:user, role: :super_admin, id: 1, organisation_slug: "gds")
   end
 
   let(:trial_user) do
-    create(:user, :with_no_org, :with_trial, id: 2)
+    create(:user, :with_trial_role, id: 2)
   end
 
   let(:req_headers) do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -175,7 +175,7 @@ describe Form do
       expected_path = "/api/v1/forms/update-org-for-creator?creator_id=123&org=org"
 
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.patch expected_path, headers, {}.to_json, 204
+        mock.patch expected_path, headers, {}.to_json, 200
       end
 
       described_class.update_org_for_creator(creator_id, org)

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -4,11 +4,11 @@ describe FormPolicy do
   subject(:policy) { described_class.new(user, form) }
 
   let(:form) { build :form, org: "gds", creator_id: 123 }
-  let(:user) { build :user, organisation_slug: "gds" }
+  let(:user) { build :user, role: :editor, organisation_slug: "gds" }
 
   context "with no organisation set" do
     context "with editor role" do
-      let(:user) { build :user, :with_no_org }
+      let(:user) { build :user, :with_no_org, role: :editor }
 
       it "raises an error" do
         expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
@@ -16,7 +16,7 @@ describe FormPolicy do
     end
 
     context "with trial role" do
-      let(:user) { build :user, :with_no_org, :with_trial }
+      let(:user) { build :user, :with_trial_role }
 
       it "does not raise an error" do
         expect { policy }.not_to raise_error
@@ -29,13 +29,13 @@ describe FormPolicy do
       it { is_expected.to permit_actions(%i[can_view_form]) }
 
       context "but from another organisation" do
-        let(:user) { build :user, organisation_slug: "non-gds" }
+        let(:user) { build :user, role: :editor, organisation_slug: "non-gds" }
 
         it { is_expected.to forbid_actions(%i[can_view_form]) }
       end
 
       context "with an organisation not in the organisation table" do
-        let(:user) { build :user, :with_unknown_org, organisation_slug: "gds" }
+        let(:user) { build :user, :with_unknown_org, role: :editor, organisation_slug: "gds" }
 
         it "raises an error" do
           expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
@@ -47,7 +47,7 @@ describe FormPolicy do
       let(:form) { build :form, org: nil, creator_id: 123 }
 
       context "when the user created the form" do
-        let(:user) { build :user, :with_no_org, :with_trial, id: 123 }
+        let(:user) { build :user, :with_trial_role, id: 123 }
 
         it { is_expected.to permit_actions(%i[can_view_form]) }
       end
@@ -74,7 +74,7 @@ describe FormPolicy do
         it { is_expected.to permit_actions(permission) }
 
         context "but from another organisation" do
-          let(:user) { build :user, organisation_slug: "non-gds" }
+          let(:user) { build :user, role: :editor, organisation_slug: "non-gds" }
 
           it { is_expected.to forbid_actions(permission) }
         end
@@ -84,7 +84,7 @@ describe FormPolicy do
         let(:form) { build :form, org: nil, creator_id: 123 }
 
         context "when the user created the form" do
-          let(:user) { build :user, :with_no_org, :with_trial, id: 123 }
+          let(:user) { build :user, :with_trial_role, id: 123 }
 
           it { is_expected.to forbid_actions(permission) }
         end
@@ -172,7 +172,7 @@ describe FormPolicy do
     end
 
     context "with a trial user role" do
-      let(:user) { build :user, :with_no_org, :with_trial, id: 123 }
+      let(:user) { build :user, :with_trial_role, id: 123 }
       let(:form) { build(:form, creator_id: 123, org: nil) }
 
       before do
@@ -187,7 +187,7 @@ describe FormPolicy do
     end
 
     context "with a non-trial user role" do
-      let(:user) { build :user, organisation_slug: "test-org", id: 123 }
+      let(:user) { build :user, role: :editor, organisation_slug: "test-org", id: 123 }
       let(:form) { build(:form, org: "test-org", creator_id: 1234) }
 
       before do
@@ -203,7 +203,7 @@ describe FormPolicy do
 
     context "with no organisation set" do
       context "with editor role" do
-        let(:user) { build :user, :with_no_org }
+        let(:user) { build :user, :with_no_org, role: :editor }
 
         it "raises an error" do
           expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
@@ -211,7 +211,7 @@ describe FormPolicy do
       end
 
       context "with trial role" do
-        let(:user) { build :user, :with_no_org, :with_trial }
+        let(:user) { build :user, :with_trial_role }
 
         it "does not an error" do
           expect { policy }.not_to raise_error
@@ -234,7 +234,7 @@ describe FormPolicy do
     end
 
     context "with a user with no organisation" do
-      let(:user) { build :user, :with_no_org }
+      let(:user) { build :user, :with_no_org, role: :editor }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe UserPolicy do
   subject(:policy) { described_class.new(user, records) }
 
-  let(:user) { build :user, :with_super_admin }
+  let(:user) { build :user, role: :super_admin }
   let!(:records) { create_list :user, 5 }
 
   context "with super admin" do

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Forms::ChangeNameController, type: :request do
     }
   end
 
-  let(:user) { build :user, id: 1 }
+  let(:user) { build :user, role: :editor, id: 1 }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
@@ -68,7 +68,7 @@ RSpec.describe Forms::ChangeNameController, type: :request do
     end
 
     context "with a trial user" do
-      let(:user) { build(:user, :with_trial, :with_no_org, id: 1) }
+      let(:user) { build(:user, :with_trial_role, id: 1) }
       let(:form_data) do
         {
           name: "Form name",

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::MakeLiveController, type: :request do
-  let(:user) { build :user }
+  let(:user) { build :user, role: :editor }
 
   let(:form) do
     build(:form,
@@ -86,7 +86,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
     end
 
     context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial }
+      let(:user) { build :user, :with_trial_role }
 
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)
@@ -158,7 +158,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
     end
 
     context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial }
+      let(:user) { build :user, :with_trial_role }
 
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::SubmissionEmailController, type: :request do
-  let(:user) { build :user, id: 1, organisation_slug: "test-org" }
+  let(:user) { build :user, role: :editor, id: 1, organisation_slug: "test-org" }
   let(:form) { build :form, id: 1, creator_id: 1, org: "test-org" }
 
   let(:submission_email_mailer_spy) do
@@ -56,7 +56,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when current user has a trial account" do
-      let(:user) { build :user, id: 1, role: :trial }
+      let(:user) { build :user, :with_trial_role, id: 1 }
 
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)
@@ -92,7 +92,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when current user has a trial account" do
-      let(:user) { build :user, id: 1, role: :trial }
+      let(:user) { build :user, :with_trial_role, id: 1 }
 
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)
@@ -122,7 +122,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when current user has a trial account" do
-      let(:user) { build :user, id: 1, role: :trial }
+      let(:user) { build :user, :with_trial_role, id: 1 }
 
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)
@@ -152,7 +152,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when current user has a trial account" do
-      let(:user) { build :user, id: 1, role: :trial }
+      let(:user) { build :user, :with_trial_role, id: 1 }
 
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)
@@ -192,7 +192,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when current user has a trial account" do
-      let(:user) { build :user, id: 1, role: :trial }
+      let(:user) { build :user, :with_trial_role, id: 1 }
 
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)
@@ -222,7 +222,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when current user has a trial account" do
-      let(:user) { build :user, id: 1, role: :trial }
+      let(:user) { build :user, :with_trial_role, id: 1 }
 
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe FormsController, type: :request do
           mock.get "/api/v1/forms/2/pages", headers, form.pages.to_json, 200
         end
 
-        login_as build(:user, :with_no_org)
+        login_as build(:user, :with_no_org, role: :editor)
 
         get form_path(2)
       end
@@ -114,7 +114,7 @@ RSpec.describe FormsController, type: :request do
     end
 
     context "with a user with a trial account" do
-      let(:user) { build(:user, role: :trial) }
+      let(:user) { build(:user, :with_trial_role, id: 123) }
       let(:form) { build(:form, :ready_for_live, id: 2, creator_id: user.id) }
 
       before do
@@ -245,7 +245,7 @@ RSpec.describe FormsController, type: :request do
           mock.get "/api/v1/forms?org=", headers, forms_response.to_json, 200
         end
 
-        login_as build(:user, :with_no_org)
+        login_as build(:user, :with_no_org, role: :editor)
 
         get root_path
       end
@@ -333,7 +333,7 @@ RSpec.describe FormsController, type: :request do
 
     context "with a user with no organisation" do
       let(:user) do
-        build :user, :with_no_org
+        build :user, :with_no_org, role: :editor
       end
 
       it "returns 403 Forbidden" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe UsersController, type: :request do
+  before do
+    ActiveResource::HttpMock.reset!
+  end
+
   describe "#index" do
     context "when logged in as a super admin" do
       before do
@@ -71,7 +75,7 @@ RSpec.describe UsersController, type: :request do
   end
 
   describe "#update" do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, role: :editor) }
     let(:role) { :super_admin }
 
     context "when logged in as a super admin" do
@@ -112,7 +116,7 @@ RSpec.describe UsersController, type: :request do
       end
 
       context "with a trial user with no organisation set" do
-        let(:user) { create(:user, :with_no_org, role: :trial) }
+        let(:user) { create(:user, :with_trial_role) }
 
         it "does not return error if organisation is not chosen and role is not changed" do
           put user_path(user), params: { user: { role: "trial", organisation_id: nil } }

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 RSpec.describe UsersController, type: :request do
-  before do
-    ActiveResource::HttpMock.reset!
-  end
-
   describe "#index" do
     context "when logged in as a super admin" do
       before do

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe FormTaskListService do
-  let(:current_user) { build(:user) }
+  let(:current_user) { build(:user, role: :editor) }
 
   describe ".task_counts" do
     let(:form) { build(:form) }
@@ -269,7 +269,7 @@ describe FormTaskListService do
       end
 
       context "when current user has a trial account" do
-        let(:current_user) { build :user, :with_trial }
+        let(:current_user) { build :user, :with_trial_role }
 
         it "has no tasks" do
           expect(section).not_to include(:rows)

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -5,7 +5,7 @@ describe TaskStatusService do
     described_class.new(form:)
   end
 
-  let(:current_user) { build(:user) }
+  let(:current_user) { build(:user, role: :editor) }
 
   describe "statuses" do
     describe "name status" do
@@ -208,7 +208,7 @@ describe TaskStatusService do
     end
 
     context "when user has trial role" do
-      let(:current_user) { build :user, :with_trial }
+      let(:current_user) { build :user, :with_trial_role }
 
       it "excludes status for restricted tasks" do
         expect(task_status_service.status_counts(current_user)).to include(total: 6)

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -37,7 +37,7 @@ module AuthenticationFeatureHelpers
   end
 
   def trial_user
-    @trial_user ||= FactoryBot.create(:user, role: :trial)
+    @trial_user ||= FactoryBot.create(:user, :with_trial_role)
   end
 
   def login_as_super_admin_user

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "forms/index.html.erb" do
-  let(:user) { build :user }
+  let(:user) { build :user, role: :editor }
   let(:forms) { [] }
 
   before do
@@ -67,7 +67,7 @@ describe "forms/index.html.erb" do
     end
 
     context "with a user has no organisation" do
-      let(:user) { build :user, :with_no_org }
+      let(:user) { build :user, :with_no_org, role: :editor }
 
       it "has a table caption without an organisation name" do
         expect(rendered).to have_css(".govuk-table__caption", text: "Your forms")
@@ -75,7 +75,7 @@ describe "forms/index.html.erb" do
     end
 
     context "with a user with a trial role" do
-      let(:user) { build :user, :with_no_org, :with_trial }
+      let(:user) { build :user, :with_trial_role }
 
       it "has a table caption without an organisation name" do
         expect(rendered).to have_css(".govuk-table__caption", text: "Your forms")
@@ -100,7 +100,7 @@ describe "forms/index.html.erb" do
     end
 
     context "and a user has the trial role" do
-      let(:user) { build :user, :with_trial }
+      let(:user) { build :user, :with_trial_role }
 
       it "displays a banner informing the user they have a trial account" do
         banner = Capybara.string(rendered).find(".govuk-notification-banner__content")
@@ -112,7 +112,7 @@ describe "forms/index.html.erb" do
     end
 
     context "and a user does not have the trial role" do
-      let(:user) { build :user }
+      let(:user) { build :user, role: :editor }
 
       it "does not display a banner" do
         expect(rendered).not_to have_selector(".govuk-notification-banner__content")

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "users/edit.html.erb" do
   let(:user) do
-    build :user, id: 1
+    build :user, role: :editor, id: 1
   end
 
   before do
@@ -68,7 +68,7 @@ describe "users/edit.html.erb" do
   end
 
   context "with a user with an unknown organisation" do
-    let(:user) { build(:user, :with_unknown_org, id: 1) }
+    let(:user) { build(:user, :with_unknown_org, role: :editor, id: 1) }
 
     it "shows the organisation slug" do
       expect(rendered).to have_text("unknown-org")
@@ -84,7 +84,7 @@ describe "users/edit.html.erb" do
   end
 
   context "with a user with no organisation set" do
-    let(:user) { build(:user, :with_no_org, id: 1) }
+    let(:user) { build(:user, :with_no_org, role: :editor, id: 1) }
 
     it "shows no organisation set" do
       expect(rendered).to have_text("No organisation set")

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -4,6 +4,7 @@ describe "users/index.html.erb" do
   let(:users) do
     build_list(:user, 3) do |user, i|
       user.id = i
+      user.role = :editor
     end
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
Prior to making the trial role the default for new users (which is blocked by the migration), we need to explicitly set the user role for tests that currently use the default of `editor` as this default will be changing to `trial`.

This PR also makes the role transitions that will trigger an update of a user's forms' org more explicit, to avoid unexpected role transitions causing requests to be made to the `update-org-for-creator` endpoint incorrectly.

Trello card: https://trello.com/c/KkZfWSar
