### PR TITLE
Move exception rescue block to ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,14 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :success
 
+  rescue_from ActiveResource::ResourceNotFound do
+    render template: "errors/not_found", status: :not_found
+  end
+
+  rescue_from FormPolicy::UserMissingOrganisationError do
+    render template: "errors/user_missing_organisation_error", status: :forbidden
+  end
+
   rescue_from Pundit::NotAuthorizedError do |_exception|
     # Useful when we start adding more policies that require custom errors
     # policy_name = exception.policy.class.to_s.underscore

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,15 +1,6 @@
 class FormsController < ApplicationController
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
-
-  rescue_from ActiveResource::ResourceNotFound do
-    render template: "errors/not_found", status: :not_found
-  end
-
-  rescue_from FormPolicy::UserMissingOrganisationError do
-    render template: "errors/user_missing_organisation_error", status: :forbidden
-  end
-
   def index
     @forms = policy_scope(Form) || []
   end


### PR DESCRIPTION
#### What problem does the pull request solve?
We should handle all ActiveResource::ResourceNotFound all the same across the app. Previously, this would have only have handle this error raises from the home page or the form show page.

The same issue with FormPolicy::UserMissingOrganisationError error if the policy is called in other controllers this ends up bubbling up and becoming a sentry alert.

Trello card: 
- https://trello.com/c/odjI7mjV/883-if-user-doesnt-have-an-organisation-this-can-raise-a-sentry-error
- https://trello.com/c/yglKqLFb/884-handle-all-forms-admin-activeresourceresourcenotfound-in-the-same-way
#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
