### PR TITLE
Fix signing out

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -24,8 +24,15 @@ class AuthenticationController < ApplicationController
   end
 
   def sign_out
-    warden.logout
-    redirect_to send(:"#{params[:provider]}_sign_out_url"), allow_other_host: true
+    # get current_user before user is logged out of warden
+    auth_provider = current_user&.provider
+
+    if user_signed_in
+      warden.logout
+      redirect_to send(:"#{auth_provider}_sign_out_url"), allow_other_host: true
+    else
+      redirect_to root_path
+    end
   end
 
 private

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -59,4 +59,8 @@ private
 
     URI::HTTPS.build(host: Settings.auth0.domain, path: "/v2/logout", query: request_params.to_query).to_s
   end
+
+  def mock_gds_sso_sign_out_url
+    "https://signon.integration.publishing.service.gov.uk/users/sign_out"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,15 +68,15 @@ module ApplicationHelper
     auth_links = {
       auth0: {
         user_profile_link: nil,
-        signout_link: sign_out_path(:auth0),
+        signout_link: sign_out_path,
       },
-      gds_sso: {
+      gds: {
         user_profile_link: GDS::SSO::Config.oauth_root_url,
         signout_link: gds_sign_out_path,
       },
     }
     auth_links.default = {}
-    links = auth_links[Settings.auth_provider.to_sym]
+    links = auth_links[user&.provider&.to_sym]
 
     { is_signed_in: user.present?,
       user_name: user&.name.presence,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,6 +74,10 @@ module ApplicationHelper
         user_profile_link: GDS::SSO::Config.oauth_root_url,
         signout_link: gds_sign_out_path,
       },
+      mock_gds_sso: {
+        user_profile_link: nil,
+        signout_link: sign_out_path,
+      },
     }
     auth_links.default = {}
     links = auth_links[user&.provider&.to_sym]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,10 @@ Rails.application.routes.draw do
 
   root "forms#index"
 
+  get "/sign_out" => "authentication#sign_out", as: :sign_out
+
   scope "auth/:provider" do
     get "/callback" => "authentication#callback_from_omniauth"
-    get "/sign_out" => "authentication#sign_out", as: :sign_out
   end
 
   get "forms/new" => "forms/change_name#new", as: :new_form

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,8 @@ if HostingEnvironment.local_development? && User.none?
                  organisation: gds,
                  name: "A User",
                  role: :super_admin,
-                 uid: "123456" })
+                 uid: "123456",
+                 provider: :mock_gds_sso })
 
   # create extra organisations
   test_org = FactoryBot.create :organisation, slug: "test-org"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -163,9 +163,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     context "when a user is signed in with GOV.UK Signon" do
-      before do
-        allow(Settings).to receive(:auth_provider).and_return("gds_sso")
-      end
+      let(:user) { build :user, provider: :gds }
 
       it "returns the following options" do
         expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: true,
@@ -187,14 +185,26 @@ RSpec.describe ApplicationHelper, type: :helper do
         end
       end
 
-      context "when http basic auth is enabled" do
-        it "returns the following options" do
-          allow(Settings).to receive(:auth_provider).and_return("basic_auth")
+      context "when a user is signed in with http basic auth" do
+        let(:user) { build :user, provider: :basic_auth }
 
+        it "returns the following options" do
           expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: true,
                                                                                     list_of_users_path: nil,
                                                                                     signout_link: nil,
                                                                                     user_name: user.name,
+                                                                                    user_profile_link: nil })
+        end
+      end
+
+      context "when a user is signed in with auth0" do
+        let(:user) { build :user, provider: :auth0, name: nil }
+
+        it "returns the following options" do
+          expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: true,
+                                                                                    list_of_users_path: nil,
+                                                                                    signout_link: "/sign_out",
+                                                                                    user_name: nil,
                                                                                     user_profile_link: nil })
         end
       end

--- a/spec/integration/gds_sso_spec.rb
+++ b/spec/integration/gds_sso_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe "usage of gds-sso gem" do
     end
   end
 
+  describe "signing out" do
+    it "signs the user out of GOV.UK Signon" do
+      get gds_sign_out_path
+
+      expect(response).to redirect_to("http://signon.dev.gov.uk/users/sign_out")
+    end
+  end
+
   describe User do
     describe ".find_for_gds_oauth" do
       it "is called by the gds_sso Warden strategy" do


### PR DESCRIPTION
#### What problem does the pull request solve?

This PR fixes signing out now we support multiple identity providers; it also fixes a bug with signing out of GOV.UK Signon currently in production.

When a user is signed in a key for their user record is stored in their session cookie; this cookie is valid across app restarts and upgrades, and also remains valid if the identity provider used by the app changes. In testing we found that if a user was signed in and then the app was subsequently re-configured to use a different identity provider, the user profile/sign out links in the header would not be valid for them.

This PR fixes things by using the configured authentication provider only at the point of signing in; currently signed in users will instead see the links for the provider they are signed in with.

This also fixes an issue we noticed in production with signing out of GOV.UK Signon; because our app's sign out route no longer needs a provider parameter, it no longer collides with the `/auth/gds/sign_out` route from the gds-sso gem, and no longer causes an infinite redirect loop.