### PR TITLE
revert text on maintenance page

### DIFF
--- a/app/views/errors/maintenance.html.erb
+++ b/app/views/errors/maintenance.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('maintenance.title') %></h1>
-    <%= simple_format(t('maintenance.body_html', link: contact_link)) %>
+    <%= t('maintenance.body_html', link: contact_link) %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
         </p>
       hint: Select at least one option
       title: How can people get help with filling in this form?
-  contact_govuk_forms: Contact the GOV.UK Forms team
+  contact_govuk_forms: contact the GOV.UK Forms team
   continue: Continue
   declaration_form:
     new:
@@ -316,7 +316,9 @@ en:
       immediately.
     notification_title: Important
   maintenance:
-    body_html: You’ll be able to use the service on Wednesday 5 July 2023.
+    body_html: |
+      <p>You’ll be able to use the service later.</p>
+      <p>If you need urgent help with your forms you can %{link}.</p>
     title: Sorry, the service is unavailable
   make_changes_live:
     url_will_remain_same: The URL for the live form will remain the same.

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "contact_link" do
     it "returns a link to the contact email address with default text" do
-      expect(helper.contact_link).to eq '<a class="govuk-link" href="mailto:govuk-forms-support@govuk.zendesk.com">Contact the GOV.UK Forms team</a>'
+      expect(helper.contact_link).to eq '<a class="govuk-link" href="mailto:govuk-forms-support@govuk.zendesk.com">contact the GOV.UK Forms team</a>'
     end
 
     it "returns a link to the contact email address with custom text" do


### PR DESCRIPTION
https://trello.com/c/kdBnaSzQ/84-change-the-content-for-the-maintenance-page-to-be-generic

This PR is to change the content for the maintenance page to be generic

paired with @alice-carr 