### PR TITLE
Prevent trial user from viewing organisation forms

### DIFF
--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -31,7 +31,11 @@ class FormPolicy
   end
 
   def can_view_form?
-    users_organisation_owns_form || (user.trial? && user_is_form_creator)
+    if user.trial?
+      user_is_form_creator
+    else
+      users_organisation_owns_form
+    end
   end
 
   def can_change_form_submission_email?

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -44,23 +44,19 @@ describe FormPolicy do
     end
 
     context "with a trial role" do
-      let(:form) { build :form, org: nil, creator_id: 123 }
+      let(:user) { build :user, :with_trial_role, id: 123 }
 
       context "when the user created the form" do
-        let(:user) { build :user, :with_trial_role, id: 123 }
-
         it { is_expected.to permit_actions(%i[can_view_form]) }
       end
 
       context "when the user didn't create the form" do
-        context "with a different user" do
-          let(:user) { build :user, id: 321 }
+        let(:user) { build :user, :with_trial_role, id: 321 }
 
-          it { is_expected.to forbid_actions(%i[can_view_form]) }
-        end
+        it { is_expected.to forbid_actions(%i[can_view_form]) }
 
-        context "without a form creator" do
-          let(:form) { build :form, org: nil, creator_id: nil }
+        context "but the user belongs to the organisation that the form belongs to" do
+          let(:user) { build :user, role: :trial, organisation_slug: "gds", id: 321 }
 
           it { is_expected.to forbid_actions(%i[can_view_form]) }
         end


### PR DESCRIPTION
#### What problem does the pull request solve?
Previously a user with the trial role could view forms that belonged to an organisation if they had the same organisation set. They should only be able to view forms they created, regardless of their organisation.

Trello card: https://trello.com/c/hUoW5S1e
