### PR TITLE
Add link to sign up page for auth0

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -8,14 +8,8 @@ class AuthenticationController < ApplicationController
   end
 
   def redirect_to_omniauth
-    provider = if Settings.auth_provider == "gds_sso"
-                 "gds"
-               else
-                 Settings.auth_provider
-               end
-
     store_location(attempted_path) if request.get?
-    redirect_to "/auth/#{provider}"
+    redirect_to "/auth/#{default_provider}"
   end
 
   def callback_from_omniauth
@@ -49,6 +43,14 @@ private
 
   def stored_location
     session["user_return_to"]
+  end
+
+  def default_provider
+    if Settings.auth_provider == "gds_sso"
+      "gds"
+    else
+      Settings.auth_provider
+    end
   end
 
   def auth0_sign_out_url

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -17,6 +17,15 @@ class AuthenticationController < ApplicationController
     redirect_to stored_location || "/"
   end
 
+  def sign_up
+    if default_provider == "auth0"
+      store_location root_path
+      redirect_to "/auth/auth0?screen_hint=signup"
+    else
+      redirect_to_omniauth
+    end
+  end
+
   def sign_out
     # get current_user before user is logged out of warden
     auth_provider = current_user&.provider

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   root "forms#index"
 
-  get "/sign_out" => "authentication#sign_out", as: :sign_out
+  get "/sign-out" => "authentication#sign_out", as: :sign_out
 
   scope "auth/:provider" do
     get "/callback" => "authentication#callback_from_omniauth"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   root "forms#index"
 
+  get "/sign-up" => "authentication#sign_up", as: :sign_up
   get "/sign-out" => "authentication#sign_out", as: :sign_out
 
   scope "auth/:provider" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         it "returns the following options" do
           expect(helper.header_component_options(user:, can_manage_users:)).to eq({ is_signed_in: true,
                                                                                     list_of_users_path: nil,
-                                                                                    signout_link: "/sign_out",
+                                                                                    signout_link: "/sign-out",
                                                                                     user_name: nil,
                                                                                     user_profile_link: nil })
         end

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe AuthenticationController, type: :request do
       without_partial_double_verification do
         allow(controller_spy)
           .to receive(:test_provider_sign_out_url)
-          .and_return("http://test.org/sign_out")
+          .and_return("http://test.org/sign-out")
 
         expect(session).to include("warden.user.default.key")
 
@@ -120,11 +120,11 @@ RSpec.describe AuthenticationController, type: :request do
       without_partial_double_verification do
         allow(controller_spy)
           .to receive(:test_provider_sign_out_url)
-          .and_return("http://test.org/sign_out")
+          .and_return("http://test.org/sign-out")
 
         get sign_out_path
 
-        expect(response).to redirect_to("http://test.org/sign_out")
+        expect(response).to redirect_to("http://test.org/sign-out")
       end
     end
 


### PR DESCRIPTION
### What problem does the pull request solve?

Trello card: https://trello.com/c/8uiP1nGw

We want to be able to direct users to the Auth0 page which reads "Create an account" instead of just "Sign in".