### PR TITLE
Refactor our form objects to inherit from a base form object

### DIFF
--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -1,0 +1,4 @@
+class BaseForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+end

--- a/app/forms/forms/address_settings_form.rb
+++ b/app/forms/forms/address_settings_form.rb
@@ -1,7 +1,4 @@
-class Forms::AddressSettingsForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::AddressSettingsForm < BaseForm
   attr_accessor :uk_address, :international_address, :form, :page
 
   INPUT_TYPES = %w[uk_address international_address].freeze

--- a/app/forms/forms/change_email_form.rb
+++ b/app/forms/forms/change_email_form.rb
@@ -1,7 +1,4 @@
-class Forms::ChangeEmailForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::ChangeEmailForm < BaseForm
   attr_accessor :form, :submission_email
 
   EMAIL_REGEX = /.*@.*/

--- a/app/forms/forms/change_name_form.rb
+++ b/app/forms/forms/change_name_form.rb
@@ -1,7 +1,4 @@
-class Forms::ChangeNameForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::ChangeNameForm < BaseForm
   attr_accessor :form, :name
 
   validates :name, presence: true

--- a/app/forms/forms/contact_details_form.rb
+++ b/app/forms/forms/contact_details_form.rb
@@ -1,7 +1,4 @@
-class Forms::ContactDetailsForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::ContactDetailsForm < BaseForm
   attr_accessor :form, :email, :phone, :link_text, :link_href, :contact_details_supplied
 
   EMAIL_REGEX = /.*@.*/

--- a/app/forms/forms/date_settings_form.rb
+++ b/app/forms/forms/date_settings_form.rb
@@ -1,7 +1,4 @@
-class Forms::DateSettingsForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::DateSettingsForm < BaseForm
   attr_accessor :input_type, :form, :page
 
   INPUT_TYPES = %w[date_of_birth other_date].freeze

--- a/app/forms/forms/declaration_form.rb
+++ b/app/forms/forms/declaration_form.rb
@@ -1,7 +1,4 @@
-class Forms::DeclarationForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::DeclarationForm < BaseForm
   attr_accessor :form, :declaration_text, :mark_complete
 
   validates :declaration_text, length: { maximum: 2000 }

--- a/app/forms/forms/delete_confirmation_form.rb
+++ b/app/forms/forms/delete_confirmation_form.rb
@@ -1,7 +1,4 @@
-class Forms::DeleteConfirmationForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::DeleteConfirmationForm < BaseForm
   attr_accessor :confirm_deletion
 
   validates :confirm_deletion, presence: true

--- a/app/forms/forms/make_live_form.rb
+++ b/app/forms/forms/make_live_form.rb
@@ -1,7 +1,4 @@
-class Forms::MakeLiveForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::MakeLiveForm < BaseForm
   attr_accessor :form, :confirm_make_live
 
   CONFIRM_LIVE_VALUES = { made_live: "made_live", not_made_live: "not_made_live" }.freeze

--- a/app/forms/forms/mark_complete_form.rb
+++ b/app/forms/forms/mark_complete_form.rb
@@ -1,7 +1,4 @@
-class Forms::MarkCompleteForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::MarkCompleteForm < BaseForm
   attr_accessor :mark_complete, :form
 
   validates :mark_complete, presence: true

--- a/app/forms/forms/name_settings_form.rb
+++ b/app/forms/forms/name_settings_form.rb
@@ -1,7 +1,4 @@
-class Forms::NameSettingsForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::NameSettingsForm < BaseForm
   attr_accessor :input_type, :title_needed, :form, :page
 
   INPUT_TYPES = %w[full_name first_and_last_name first_middle_and_last_name].freeze

--- a/app/forms/forms/privacy_policy_form.rb
+++ b/app/forms/forms/privacy_policy_form.rb
@@ -1,9 +1,6 @@
 require "uri"
 
-class Forms::PrivacyPolicyForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::PrivacyPolicyForm < BaseForm
   attr_accessor :form, :privacy_policy_url
 
   validates :privacy_policy_url, url: true, if: -> { privacy_policy_url.present? }

--- a/app/forms/forms/question_text_form.rb
+++ b/app/forms/forms/question_text_form.rb
@@ -1,7 +1,4 @@
-class Forms::QuestionTextForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::QuestionTextForm < BaseForm
   attr_accessor :question_text
 
   validates :question_text, presence: true

--- a/app/forms/forms/selection_option.rb
+++ b/app/forms/forms/selection_option.rb
@@ -1,7 +1,4 @@
-class Forms::SelectionOption
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::SelectionOption < BaseForm
   attr_accessor :name
 
   def init(name)

--- a/app/forms/forms/selections_settings_form.rb
+++ b/app/forms/forms/selections_settings_form.rb
@@ -1,6 +1,4 @@
-class Forms::SelectionsSettingsForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
+class Forms::SelectionsSettingsForm < BaseForm
   include ActiveModel::Validations::Callbacks
 
   DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }].map { |hash| Forms::SelectionOption.new(hash) }, only_one_option: false, include_none_of_the_above: false }.freeze

--- a/app/forms/forms/submission_email_form.rb
+++ b/app/forms/forms/submission_email_form.rb
@@ -1,7 +1,4 @@
-class Forms::SubmissionEmailForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::SubmissionEmailForm < BaseForm
   attr_accessor :form, :temporary_submission_email, :email_code, :confirmation_code, :current_user, :notify_response_id
 
   EMAIL_REGEX = /.*@.*/

--- a/app/forms/forms/text_settings_form.rb
+++ b/app/forms/forms/text_settings_form.rb
@@ -1,7 +1,4 @@
-class Forms::TextSettingsForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::TextSettingsForm < BaseForm
   attr_accessor :input_type, :form, :page
 
   INPUT_TYPES = %w[single_line long_text].freeze

--- a/app/forms/forms/type_of_answer_form.rb
+++ b/app/forms/forms/type_of_answer_form.rb
@@ -1,7 +1,4 @@
-class Forms::TypeOfAnswerForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::TypeOfAnswerForm < BaseForm
   attr_accessor :answer_type, :form, :page
 
   validates :answer_type, presence: true, inclusion: { in: Page::ANSWER_TYPES }

--- a/app/forms/forms/what_happens_next_form.rb
+++ b/app/forms/forms/what_happens_next_form.rb
@@ -1,7 +1,4 @@
-class Forms::WhatHappensNextForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Forms::WhatHappensNextForm < BaseForm
   attr_accessor :form, :what_happens_next_text
 
   validates :what_happens_next_text, length: { maximum: 2000 }

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -1,7 +1,4 @@
-class Pages::ConditionsForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Pages::ConditionsForm < BaseForm
   attr_accessor :form, :page, :check_page_id, :routing_page_id, :answer_value, :goto_page_id, :record, :skip_to_end
 
   validates :answer_value, :goto_page_id, presence: true

--- a/app/forms/pages/delete_condition_form.rb
+++ b/app/forms/pages/delete_condition_form.rb
@@ -1,7 +1,4 @@
-class Pages::DeleteConditionForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Pages::DeleteConditionForm < BaseForm
   attr_accessor :form, :page, :check_page_id, :routing_page_id, :answer_value, :goto_page_id, :record, :confirm_deletion
 
   validates :confirm_deletion, presence: true, inclusion: { in: %w[true false] }

--- a/app/forms/pages/routing_page_form.rb
+++ b/app/forms/pages/routing_page_form.rb
@@ -1,7 +1,4 @@
-class Pages::RoutingPageForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
+class Pages::RoutingPageForm < BaseForm
   attr_accessor :routing_page_id
 
   validates :routing_page_id, presence: true


### PR DESCRIPTION
#### What problem does the pull request solve?

Simplifies all our form objects by pulling in all the ActiveModel modules that we always need into a base class
and then let each form object inherit from the base form class.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
