### PR TITLE
Add success messages to various user journeys

### DIFF
--- a/app/controllers/forms/change_name_controller.rb
+++ b/app/controllers/forms/change_name_controller.rb
@@ -38,7 +38,7 @@ module Forms
       @change_name_form = ChangeNameForm.new(change_name_form_params(current_form))
 
       if @change_name_form.submit
-        redirect_to form_path(@change_name_form.form)
+        redirect_to form_path(@change_name_form.form), success: t("banner.success.form.change_name")
       else
         render :edit
       end

--- a/app/controllers/forms/contact_details_controller.rb
+++ b/app/controllers/forms/contact_details_controller.rb
@@ -11,7 +11,7 @@ module Forms
       @contact_details_form = ContactDetailsForm.new(**contact_details_form_params)
 
       if @contact_details_form.submit
-        redirect_to form_path(@contact_details_form.form)
+        redirect_to form_path(@contact_details_form.form), success: t("banner.success.form.support_details_saved")
       else
         render :new
       end

--- a/app/controllers/forms/declaration_controller.rb
+++ b/app/controllers/forms/declaration_controller.rb
@@ -11,7 +11,13 @@ module Forms
       @declaration_form = DeclarationForm.new(**declaration_form_params)
 
       if @declaration_form.submit
-        redirect_to form_path(@declaration_form.form)
+        success_message = if @declaration_form.mark_complete == "true"
+                            t("banner.success.form.declaration_saved_and_completed")
+                          else
+                            t("banner.success.form.declaration_saved")
+                          end
+
+        redirect_to form_path(@declaration_form.form), success: success_message
       else
         render :new
       end

--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -68,8 +68,7 @@ module Forms
 
       authorize form, :can_view_form?
       if form.destroy
-        flash[:message] = "Successfully deleted #{form.name}"
-        redirect_to success_url, status: :see_other
+        redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{form.name}’"
       else
         raise StandardError, "Deletion unsuccessful"
       end
@@ -80,8 +79,7 @@ module Forms
 
       authorize form, :can_view_form?
       if page.destroy
-        flash[:message] = "Successfully deleted #{page.question_text}"
-        redirect_to success_url, status: :see_other
+        redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{page.question_text}’"
       else
         raise StandardError, "Deletion unsuccessful"
       end

--- a/app/controllers/forms/privacy_policy_controller.rb
+++ b/app/controllers/forms/privacy_policy_controller.rb
@@ -11,7 +11,7 @@ module Forms
       @privacy_policy_form = PrivacyPolicyForm.new(privacy_policy_form_params)
 
       if @privacy_policy_form.submit
-        redirect_to form_path(@privacy_policy_form.form)
+        redirect_to form_path(@privacy_policy_form.form), success: t("banner.success.form.privacy_details_saved")
       else
         render :new
       end

--- a/app/controllers/forms/what_happens_next_controller.rb
+++ b/app/controllers/forms/what_happens_next_controller.rb
@@ -11,7 +11,7 @@ module Forms
       @what_happens_next_form = WhatHappensNextForm.new(**what_happens_next_form_params)
 
       if @what_happens_next_form.submit
-        redirect_to form_path(@what_happens_next_form.form)
+        redirect_to form_path(@what_happens_next_form.form), success: t("banner.success.form.what_happens_next_saved")
       else
         render :new
       end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -20,7 +20,12 @@ class FormsController < ApplicationController
     @mark_complete_form = Forms::MarkCompleteForm.new(mark_complete_form_params)
 
     if @mark_complete_form.mark_section
-      redirect_to form_path(@form)
+      success_message = if @mark_complete_form.mark_complete == "true"
+                          t("banner.success.form.pages_saved_and_section_completed")
+                        else
+                          t("banner.success.form.pages_saved")
+                        end
+      redirect_to form_path(@form), success: success_message
     else
       @mark_complete_form.mark_complete = "false"
       render "pages/index", status: :unprocessable_entity

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -48,8 +48,17 @@ class PagesController < ApplicationController
   end
 
   def move_page
-    Page.find(move_params[:page_id], params: { form_id: move_params[:form_id] }).move_page(move_params[:direction])
-    redirect_to form_pages_path
+    page_to_move = Page.find(move_params[:page_id], params: { form_id: move_params[:form_id] })
+
+    page_to_move.move_page(move_params[:direction])
+
+    position = if move_params[:direction] == :up
+                 page_to_move.position - 1
+               else
+                 page_to_move.position + 1
+               end
+
+    redirect_to form_pages_path, success: t("banner.success.form.page_moved", question_text: page_to_move.question_text, direction: move_params[:direction], position:)
   end
 
 private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -99,7 +99,7 @@ private
 
   def handle_submit_action
     # if user chose to save and reload current page
-    return redirect_to edit_page_path(@form, @page) if params[:save_preview]
+    return redirect_to edit_page_path(@form, @page), success: "Your changes have been saved" if params[:save_preview]
 
     return redirect_to delete_page_path(@form, @page) if params[:delete]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
     forms: Back to your forms
   banner:
     success:
+      form:
+        change_name: Your form name has been saved
       route_created: Question %{question_position}’s route has been created
       route_deleted: Question %{question_position}’s route has been deleted
       route_updated: Question %{question_position}’s route has been updated

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
     success:
       form:
         change_name: Your form name has been saved
+        privacy_details_saved: Your privacy information link has been saved
         support_details_saved: Your contact details for support have been saved
       route_created: Question %{question_position}’s route has been created
       route_deleted: Question %{question_position}’s route has been deleted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
         change_name: Your form name has been saved
         privacy_details_saved: Your privacy information link has been saved
         support_details_saved: Your contact details for support have been saved
+        what_happens_next_saved: Your information about what happens next has been saved
       route_created: Question %{question_position}’s route has been created
       route_deleted: Question %{question_position}’s route has been deleted
       route_updated: Question %{question_position}’s route has been updated

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
         change_name: Your form name has been saved
         declaration_saved: Your declaration has been saved
         declaration_saved_and_completed: Your declaration has been saved and marked as complete
+        page_moved: "‘%{question_text}’ has moved %{direction} to number %{position}"
         privacy_details_saved: Your privacy information link has been saved
         support_details_saved: Your contact details for support have been saved
         what_happens_next_saved: Your information about what happens next has been saved

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
     success:
       form:
         change_name: Your form name has been saved
+        support_details_saved: Your contact details for support have been saved
       route_created: Question %{question_position}’s route has been created
       route_deleted: Question %{question_position}’s route has been deleted
       route_updated: Question %{question_position}’s route has been updated

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,8 @@ en:
         declaration_saved: Your declaration has been saved
         declaration_saved_and_completed: Your declaration has been saved and marked as complete
         page_moved: "‘%{question_text}’ has moved %{direction} to number %{position}"
+        pages_saved: Your questions have been saved
+        pages_saved_and_section_completed: Your questions have been saved and marked as complete
         privacy_details_saved: Your privacy information link has been saved
         support_details_saved: Your contact details for support have been saved
         what_happens_next_saved: Your information about what happens next has been saved

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,8 @@ en:
     success:
       form:
         change_name: Your form name has been saved
+        declaration_saved: Your declaration has been saved
+        declaration_saved_and_completed: Your declaration has been saved and marked as complete
         privacy_details_saved: Your privacy information link has been saved
         support_details_saved: Your contact details for support have been saved
         what_happens_next_saved: Your information about what happens next has been saved


### PR DESCRIPTION
#### What problem does the pull request solve?

Added all the success messages in https://docs.google.com/document/d/1MpxzrabkqY-st-RW78mdetXekpLgmprOfsvxpsB2kRk/edit except for 

>After a user saves a question, show the notification on the next page
>Question x has been saved
It will mean making more requests to find the pages position for newly created pages 

Trello card:https://trello.com/c/MXWkGpUw/900-add-banner-notifications-into-the-product-after-a-successful-action

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
