### PR TITLE
Prevent setting of form org data for trial users

### DIFF
--- a/app/controllers/forms/change_name_controller.rb
+++ b/app/controllers/forms/change_name_controller.rb
@@ -7,16 +7,17 @@ module Forms
     end
 
     def create
-      form = Form.new({
-        name: params[:name],
-        org: current_user.organisation&.slug,
-        organisation_id: current_user.organisation_id,
-        creator_id: current_user.id,
-      })
+      form_args = { name: params[:name], creator_id: @current_user.id }
 
+      # don't set organisation data for forms created by trial users
       if @current_user.trial?
-        form.submission_email = @current_user.email
+        form_args[:submission_email] = @current_user.email
+      else
+        form_args[:org] = @current_user.organisation&.slug
+        form_args[:organisation_id] = @current_user.organisation_id
       end
+
+      form = Form.new(form_args)
 
       authorize form, :can_view_form?
       @change_name_form = ChangeNameForm.new(change_name_form_params(form))

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe Forms::ChangeNameController, type: :request do
     let(:form_data) do
       {
         name: "Form name",
+        creator_id: user.id,
         org: "test-org",
         organisation_id: 1,
-        creator_id: user.id,
       }
     end
 
@@ -75,8 +75,6 @@ RSpec.describe Forms::ChangeNameController, type: :request do
       let(:form_data) do
         {
           name: "Form name",
-          org: nil,
-          organisation_id: nil,
           creator_id: user.id,
           submission_email: user.email,
         }


### PR DESCRIPTION
#### What problem does the pull request solve?
Currently, if a trial user has organisation data, this will get set on any forms that user creates. We want to prevent that so that other non-trial users in the same organisation don't see the trial user's forms.

Trello card: https://trello.com/c/aZo4snWS

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
