### PR TITLE
Fix sign up action when not using auth0

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -18,11 +18,11 @@ class AuthenticationController < ApplicationController
   end
 
   def sign_up
+    store_location root_path
     if default_provider == "auth0"
-      store_location root_path
       redirect_to "/auth/auth0?screen_hint=signup"
     else
-      redirect_to_omniauth
+      redirect_to "/auth/#{default_provider}"
     end
   end
 

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -91,6 +91,66 @@ RSpec.describe AuthenticationController, type: :request do
     end
   end
 
+  describe "#sign_up" do
+    it "redirects to auth0 sign up page when using auth0" do
+      allow(Settings).to receive(:auth_provider).and_return("auth0")
+
+      get sign_up_path
+
+      expect(response).to redirect_to "/auth/auth0?screen_hint=signup"
+    end
+
+    it "redirects user to homepage after they have signed up" do
+      allow(Settings).to receive(:auth_provider).and_return("auth0")
+
+      get sign_up_path
+
+      expect(response).to redirect_to "/auth/auth0?screen_hint=signup"
+      get "/auth/auth0?screen_hint=signup"
+
+      expect(response).to redirect_to("/auth/auth0/callback?screen_hint=signup")
+      get "/auth/auth0/callback?screen_hint=signup"
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "signs the user in after they have signed up" do
+      allow(Settings).to receive(:auth_provider).and_return("auth0")
+
+      get sign_up_path
+
+      expect(response).to redirect_to "/auth/auth0?screen_hint=signup"
+      get "/auth/auth0?screen_hint=signup"
+
+      expect(response).to redirect_to("/auth/auth0/callback?screen_hint=signup")
+      get "/auth/auth0/callback?screen_hint=signup"
+
+      expect(request.env["warden"]).to be_authenticated
+    end
+
+    it "redirects to sign in page when not using auth0" do
+      allow(Settings).to receive(:auth_provider).and_return("mock_not_logged_in")
+
+      get sign_up_path
+
+      expect(response).to redirect_to "/auth/mock_not_logged_in"
+    end
+
+    it "redirects user to homepage after they have signed in" do
+      allow(Settings).to receive(:auth_provider).and_return("cddo_sso")
+
+      get sign_up_path
+
+      expect(response).to redirect_to "/auth/cddo_sso"
+      get "/auth/cddo_sso"
+
+      expect(response).to redirect_to("/auth/cddo_sso/callback")
+      get "/auth/cddo_sso/callback"
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
   describe "#sign_out" do
     let(:user) do
       create :user, provider: :test_provider


### PR DESCRIPTION
### What problem does the pull request solve?

Closes https://governmentdigitalservice.pagerduty.com/incidents/Q0TMFSI4QHG0GD

Just calling `redirect_to_omniauth` is not the right way to send the user to the sign in page; that action expects to be called after Warden has done its thing. Instead we do the the redirect ourselves.