### PR TITLE
Update Submission email confirmation pages

### DIFF
--- a/app/views/forms/submission_email/submission_email_code_sent.html.erb
+++ b/app/views/forms/submission_email/submission_email_code_sent.html.erb
@@ -1,8 +1,14 @@
-<h1 class="govuk-heading-l">
-  <span class="govuk-caption-l"><%= @submission_email_form.form.name %></span>
-  <%= t("page_titles.email_code_sent") %>
-</h1>
-<%= t('email_code_sent.body_html', temp_email: @submission_email_form.temporary_submission_email) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(title_text:  t("page_titles.email_code_sent")) %>
+    <%= t('email_code_sent.body_html', temp_email: @submission_email_form.temporary_submission_email) %>
 
-<p><%= govuk_link_to "Enter the email address confirmation code", submission_email_code_path( @submission_email_form.form) %></p>
-<p><%= govuk_link_to(t('email_code_sent.continue'), form_path) %></p>
+    <h2 class="govuk-heading-m"><%= t("email_code_sent.sub_heading") %></h2>
+
+    <%= t("email_code_sent.what_happens_next_body_html") %>
+
+    <p><%= govuk_link_to "Enter the email address confirmation code", submission_email_code_path( @submission_email_form.form) %></p>
+
+    <p><%= govuk_link_to(t('email_code_sent.continue'), form_path) %></p>
+  </div>
+</div>

--- a/app/views/forms/submission_email/submission_email_confirmed.html.erb
+++ b/app/views/forms/submission_email/submission_email_confirmed.html.erb
@@ -1,8 +1,9 @@
-<h1 class="govuk-heading-l">
-  <span class="govuk-caption-l"><%= @submission_email_form.form.name %></span>
-  <%= t("page_titles.confirm_email_success") %>
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(title_text:  t("page_titles.confirm_email_success")) %>
 
-<%= t('email_code_success.body_html', submission_email: @submission_email_form.form.submission_email) %>
+    <%= t('email_code_success.body_html', submission_email: @submission_email_form.form.submission_email) %>
 
-<p><%= govuk_link_to(t('email_code_success.continue'), form_path) %></p>
+    <p><%= govuk_link_to(t('email_code_success.continue'), form_path) %></p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,10 +78,10 @@ en:
       </p>
     delete_condition_legend: Are you sure you want to delete this question route?
   email_code_sent:
-    body_html: |
-      <p>We've sent a confirmation code and your email address to %{temp_email}.</p>
-      <p>The recipient will be asked to give you the code. You need to enter the code to confirm the email address.</p>
+    body_html: "<p>We've sent a confirmation code and your email address to %{temp_email}.</p>\n"
     continue: Continue creating a form
+    sub_heading: What you need to do next
+    what_happens_next_body_html: "<p>The recipient will be asked to give you the code. You need to enter the code to confirm the email address.</p>\n"
   email_code_success:
     body_html: "<p>Completed forms will be sent to %{submission_email}.</p>\n"
     continue: Continue creating a form


### PR DESCRIPTION
#### What problem does the pull request solve?

We need to update the submission emails address page designs to bring them closer to what is used in the prototype.

### Submission email code sent 
#### before:
![image](https://github.com/alphagov/forms-admin/assets/3441519/49ce8706-27e7-43cf-8ad6-81576feaa474)


#### After:
![image](https://github.com/alphagov/forms-admin/assets/3441519/f4250f37-bf5e-42db-a780-85c6f1230fef)


### Submission email address confirmed

#### Before:
![image](https://github.com/alphagov/forms-admin/assets/3441519/0faa624c-8378-46c3-b555-e82fffcf88b3)

#### After:
![image](https://github.com/alphagov/forms-admin/assets/3441519/3cd62982-6f20-4650-9912-8aefbcbfb45e)

Trello card: https://trello.com/c/4CcBs5vL/914-update-confirmation-pages-for-email-loop

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
