### PR TITLE
Temporary Fix for Installing Chrome Driver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
       # Add or replace dependency steps here
       - name: Install Chrome for integration/e2e tests
         uses: nanasess/setup-chromedriver@v2.0.0
+        with:
+          chromedriver-version: "114.0.5735.90"
       # The ruby version is taken from the .ruby-version file, no need to specify here.
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939

--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,6 @@ group :test do
   # Code coverage reporter
   gem "simplecov", "~> 0.22.0", require: false
 
-  gem "webdrivers"
   gem "webmock"
 
   # axe-core for running automated accessibility checks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,7 +426,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.9.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -492,10 +492,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webfinger (2.1.2)
       activesupport
       faraday (~> 2.0)
@@ -560,7 +556,6 @@ DEPENDENCIES
   vite_rails
   warden
   web-console
-  webdrivers
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
JUST SEEING IF THIS WORKS AS TEMP FIX

Chrome have changed where the latest version of Chrome Driver v115 is published and webdriver gem cannot install form it. The selenium-webdriver gem from version 4.10 can correctly install v114 of Chromedriver which will work with version 115 of Chrome.

We will need to address this again since it is not expected to work with v116 of Chrome when it is released.

#### What problem does the pull request solve?
Largely based upon the advice in https://github.com/titusfortner/webdrivers/issues/247

Seeing if this works....


#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
