### PR TITLE
Pin to ChromeDriver v114

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
       # Add or replace dependency steps here
       - name: Install Chrome for integration/e2e tests
         uses: nanasess/setup-chromedriver@v2.0.0
+        with:
+          chromedriver-version: "114.0.5735.90"
       # The ruby version is taken from the .ruby-version file, no need to specify here.
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939

--- a/config/initializers/webdrivers.rb
+++ b/config/initializers/webdrivers.rb
@@ -1,0 +1,2 @@
+require "webdrivers"
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"


### PR DESCRIPTION
ChromeDriver v115 has moved to a different location which breaks the install action at present. We will need to address this properly once the install chrome driver action supports installing v115 from the new location.

#### What problem does the pull request solve?
Allows the browser tests to pass once again.

Note it is necessary to tell `webdriver` to use the pinned version.

