### PR TITLE
Configure Webdriver only For Testing

### DIFF
--- a/config/initializers/webdrivers.rb
+++ b/config/initializers/webdrivers.rb
@@ -1,2 +1,0 @@
-require "webdrivers"
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ require "view_component/test_helpers"
 require "validate_url/rspec_matcher"
 require "selenium/webdriver"
 require "axe-rspec"
+require "webdrivers"
 
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
@@ -13,6 +14,11 @@ require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require_relative "support/capybara_headless_chrome"
+
+# TODO: this is only required whilst we need to pin Chromedriver to v114 until the
+# https://github.com/nanasess/setup-chromedriver supports installing Chromedriver
+# version 115 from the new location.
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
Move the configuration of webdriver to pin to Chromedriver into rails_helper so it is only invoked during testing.

#### What problem does the pull request solve?
We shouldn't need to configure web driver in non test environments. Interestingly this deploys ok to AWS. This is because we run `bundle install` in the docker file before setting `RAILS_ENV=production` so we're installing the test scope also. This will be fixed shortly in a separate PR because I'd like to get this fix out, and changes to the Dockerfile may require greater consideration.

```
GDS11321:forms-admin dan.worth$ docker run --rm -it my_admin gem query --local | grep webdriver
selenium-webdriver (4.9.0)
webdrivers (5.2.0)
```

This was failing to deploy to PaaS which doesn't use the Docker image and hence webdriver gem was not available when running with `RAILS_ENV = production` https://govuk-forms.sentry.io/issues/4341441044/?project=6576190&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

