### PR TITLE
Only Bundle Install Production Scope Only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ USER ruby
 
 COPY --chown=ruby:ruby Gemfile* ./
 RUN gem install bundler -v 2.4.10
-RUN bundle install --jobs "$(nproc)"
+RUN bundle config set --local without development:test \
+  && bundle config set --local jobs "$(nproc)"
+
+RUN bundle install
 
 COPY --chown=ruby:ruby package.json ./
 RUN npm install --ignore-scripts


### PR DESCRIPTION
We do not need to install the development and test scoped dependencies into our docker image.

#### What problem does the pull request solve?
We shouldn't install non production scoped dependencies into the docker image we use to run the app in production.

I noticed this because of a change to configure the test dependeny `webdriver`: https://github.com/alphagov/forms-admin/pull/560

Before this change `webdriver` was installed in our docker image:
```
GDS11321:forms-admin dan.worth$ docker run --rm -it my_admin gem query --local | grep webdriver
selenium-webdriver (4.9.0)
webdrivers (5.2.0)
```
After this change it is not:
```
GDS11321:forms-admin dan.worth$ docker run --rm -it my_admin gem query --local | grep webdriver
GDS11321:forms-admin dan.worth$

```

I have deployed this to dev and the end-to-end tests pass

I'll make similar changes to the other apps shortly.
#### Checklist

- [ x] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
