### PR TITLE
Remove Webdrivers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       # Add or replace dependency steps here
-      - name: Install Chrome for integration/e2e tests
-        uses: nanasess/setup-chromedriver@v2.0.0
-        with:
-          chromedriver-version: "114.0.5735.90"
       # The ruby version is taken from the .ruby-version file, no need to specify here.
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939

--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,6 @@ group :test do
   # Code coverage reporter
   gem "simplecov", "~> 0.22.0", require: false
 
-  gem "webdrivers"
   gem "webmock"
 
   # axe-core for running automated accessibility checks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -426,7 +426,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.9.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -492,10 +492,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webfinger (2.1.2)
       activesupport
       faraday (~> 2.0)
@@ -560,7 +556,6 @@ DEPENDENCIES
   vite_rails
   warden
   web-console
-  webdrivers
   webmock
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
-    capybara (3.39.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -312,7 +312,7 @@ GEM
       ast (~> 2.4.1)
     pg (1.5.3)
     plek (5.0.0)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (6.3.0)
       nio4r (~> 2.0)
     pundit (2.3.1)
@@ -371,7 +371,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.8.0)
+    regexp_parser (2.8.1)
     reline (0.3.3)
       io-console (~> 0.5)
     request_store (1.5.1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ require "view_component/test_helpers"
 require "validate_url/rspec_matcher"
 require "selenium/webdriver"
 require "axe-rspec"
-require "webdrivers"
 
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
@@ -14,11 +13,6 @@ require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require_relative "support/capybara_headless_chrome"
-
-# TODO: this is only required whilst we need to pin Chromedriver to v114 until the
-# https://github.com/nanasess/setup-chromedriver supports installing Chromedriver
-# version 115 from the new location.
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
webdrivers isn't necessary with selenium-webdriver versions greater than 4.10. Also remove setup-chromedriver which shouldn't be necessary and align with our test setup in forms-runner.

Necessary to bump the minor version of Capybara for this to work (now same version as in forms-runner).

#### What problem does the pull request solve?
Aligns forms-runner and forms-admin setup. Get CI working again without pinning to a particular chromedriver version.

webdrivers isn't necessary with selenium-webdrivers >4.10 https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1641139415

Github runners already include chrome and chromedriver v115 https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#browsers-and-drivers

v 4.11 of selenium-webdriver will include downloading browsers and drivers as necessary: https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1650315937



#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
