### PR TITLE
Update copy on "Add a new route" hint text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,7 +501,7 @@ en:
     routing_requirements_not_met_html: |
       <p>Before you can add a route you’ll need:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>at least 2 questions</li>
+        <li>2 or more questions</li>
         <li>at least one question where people must select a single item from a list of options</li>
       </ul>
       <p>


### PR DESCRIPTION
#### What problem does the pull request solve?
Update "Add a route" hint copy to help users understand limitations of routing.

Trello card:https://trello.com/c/X3D9272a/870-routing-hone-existing-content-to-clarify-what-is-and-isnt-possible-with-basic-routing-the-rules

#### Screenshots

#### No pages to route from
![image](https://github.com/alphagov/forms-admin/assets/3441519/ee3d1dfe-044a-483d-bf11-7e6885555ef0)

#### At least 1 page to route from
![image](https://github.com/alphagov/forms-admin/assets/3441519/c581cc15-a7df-4bf9-b7bc-d53b2159a8e3)

#### No more pages to routes from
![image](https://github.com/alphagov/forms-admin/assets/3441519/c4fda970-fa66-4ded-9afa-fe1e99ff171e)

More than 10 options which uses a select list, shares the same copy as 1 or more options

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
