### PR TITLE
Update additional_guidance.yml

### DIFF
--- a/config/locales/pages/additional_guidance.yml
+++ b/config/locales/pages/additional_guidance.yml
@@ -12,4 +12,4 @@ en:
             page_heading:
               blank: Enter a page heading
             additional_guidance_markdown:
-              blank: Enter additional guidance text
+              blank: Enter guidance text


### PR DESCRIPTION
Updated second error message content: it now says 'Enter guidance text' instead of 'Enter additional guidance text'.

### What problem does this pull request solve?

Trello card: (https://trello.com/c/kSfhsGhx/944-update-detailed-guidance-content-in-development-placeholder-copy-currently-being-used)

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?

