### PR TITLE
Move additional guidance "Formatting help" to details components

### DIFF
--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -28,9 +28,7 @@
                              hint: { text: "Use Markdown if you need to format your guidance content. Formatting help can be found below."},
                              rows: 15)  %>
 
-      <%= govuk_details(summary_text: "Formatting help") do %>
-
-        <h2 class="govuk-visually-hidden">Formatting help</h2>
+      <%= govuk_details(summary_text: "<h2 class='govuk-!-font-size-19 govuk-!-margin-0 govuk-!-font-weight-regular'>Formatting help</h2>".html_safe) do %>
 
         <h3 class="govuk-heading-m">Links and URLs</h3>
 

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -28,52 +28,59 @@
                              hint: { text: "Use Markdown if you need to format your guidance content. Formatting help can be found below."},
                              rows: 15)  %>
 
+      <%= govuk_details(summary_text: "Formatting help") do %>
 
-      <h2 class="govuk-heading-m">Formatting help</h2>
+        <h2 class="govuk-visually-hidden">Formatting help</h2>
 
-      <h3 class="govuk-heading-s">Links and URLs</h3>
+        <h3 class="govuk-heading-m">Links and URLs</h3>
 
-      <p>To add a link, use square brackets [ ] around the link text, and round brackets ( ) around the full URL. For example:</p>
+        <p>To add a link, use square brackets [ ] around the link text, and round brackets ( ) around the full URL. For example:</p>
 
-      <%= govuk_inset_text(text: "[Link text](https://www.gov.uk/link-text-url)") %>
+        <%= govuk_inset_text(text: "[Link text](https://www.gov.uk/link-text-url)") %>
 
-      <h3 class="govuk-heading-s">Second-level headings</h3>
+        <h3 class="govuk-heading-m">Second-level headings</h3>
 
-      <p>To add a second-level heading, use 2 hashtags followed by a space. For example:</p>
+        <p>To add a second-level heading, use 2 hashtags followed by a space. For example:</p>
 
-      <%= govuk_inset_text(text: "## This is a second-level heading") %>
+        <%= govuk_inset_text(text: "## This is a second-level heading") %>
 
-      <h3 class="govuk-heading-s">Third-level headings</h3>
+        <h3 class="govuk-heading-m">Third-level headings</h3>
 
-      <p>To add a third-level heading, use 3 hashtags followed by a space. For example:</p>
+        <p>To add a third-level heading, use 3 hashtags followed by a space. For example:</p>
 
-      <%= govuk_inset_text(text: "### This is a third-level heading") %>
+        <%= govuk_inset_text(text: "### This is a third-level heading") %>
 
-      <h3 class="govuk-heading-s">Bulleted lists</h3>
+        <h3 class="govuk-heading-m">Bulleted lists</h3>
 
-      <p>To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash. For example:</p>
+        <p>To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash. For example:</p>
 
-      <%= govuk_inset_text do %>
-        <ul class="govuk-list">
-          <li>* First bullet point</li>
-          <li>* Second bullet point</li>
-          <li>* Third bullet point 3</li>
-        </ul>
+        <%= govuk_inset_text do %>
+          <ul class="govuk-list">
+            <li>* First bullet point</li>
+            <li>* Second bullet point</li>
+            <li>* Third bullet point 3</li>
+          </ul>
+        <% end %>
+
+        <h3 class="govuk-heading-s">Numbered lists</h3>
+
+        <p>Use numbers for each list item, followed by a full stop. Make sure there is one space after the full stop.</p>
+
+        <p>You need one empty line space before the numbers start, and one at the end. For example:</p>
+
+        <%= govuk_inset_text do %>
+          <ol class="govuk-list govuk-list--number">
+            <li>* First item</li>
+            <li>* Second item</li>
+            <li>* Third item</li>
+          </ol>
+        <% end %>
+
       <% end %>
 
-     <h3 class="govuk-heading-s">Numbered lists</h3>
 
-     <p>Use numbers for each list item, followed by a full stop. Make sure there is one space after the full stop.</p> 
 
-     <p>You need one empty line space before the numbers start, and one at the end. For example:</p>
 
-      <%= govuk_inset_text do %>
-        <ol class="govuk-list govuk-list--number">
-          <li>* First item</li>
-          <li>* Second item</li>
-          <li>* Third item</li>
-        </ol>
-      <% end %>
 
 
       <%= f.govuk_submit t('continue'), value: "true", name: :set_answer_type %>

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -2,7 +2,7 @@
 <% content_for :back_link, govuk_back_link_to(form_pages_path(form)) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full-from-desktop">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <%= form_with model: [@form, additional_guidance_form], url: additional_guidance_new_path do |f| %>
       <%= f.govuk_error_summary %>
@@ -50,13 +50,15 @@
 
         <h3 class="govuk-heading-m">Bulleted lists</h3>
 
-        <p>To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash. For example:</p>
+        <p>To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash.</p>
+
+        <p>You need one empty line space before the bullets start, and one at the end. For example:</p>
 
         <%= govuk_inset_text do %>
           <ul class="govuk-list">
             <li>* First bullet point</li>
             <li>* Second bullet point</li>
-            <li>* Third bullet point 3</li>
+            <li>* Third bullet point</li>
           </ul>
         <% end %>
 
@@ -68,9 +70,9 @@
 
         <%= govuk_inset_text do %>
           <ol class="govuk-list govuk-list--number">
-            <li>* First item</li>
-            <li>* Second item</li>
-            <li>* Third item</li>
+            <li>First item</li>
+            <li>Second item</li>
+            <li>Third item</li>
           </ol>
         <% end %>
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/NWfwzkJc/946-wrap-all-formatting-help-into-a-details-component-for-forms-admin

Moves existing "Formatting help" into the details component

#### Before
![image](https://github.com/alphagov/forms-admin/assets/3441519/4314bc1d-e2df-4af5-970b-dac5d2619006)

#### After - Collapsed
![image](https://github.com/alphagov/forms-admin/assets/3441519/db1508b1-2d1f-46e6-b082-7d00f31e0561)


#### After - Expanded
![image](https://github.com/alphagov/forms-admin/assets/3441519/c5edebb6-d6ae-446b-aa87-91201987e384)

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
