### PR TITLE
Add paper trail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,9 @@ gem "govuk_notify_rails"
 # Use validate_url so we don't have to write custom URL validation
 gem "validate_url"
 
+# For auditing tables
+gem "paper_trail"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,9 @@ GEM
       validate_url
       webfinger (~> 2.0)
     pagy (6.0.4)
+    paper_trail (14.0.0)
+      activerecord (>= 6.0)
+      request_store (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -559,6 +562,7 @@ DEPENDENCIES
   omniauth
   omniauth-auth0
   omniauth_openid_connect
+  paper_trail
   pg (~> 1.5)
   puma (~> 6.3.0)
   pundit

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
   before_action :set_request_id
   before_action :check_maintenance_mode_is_enabled
   before_action :authenticate_and_check_access
+  before_action :set_paper_trail_whodunnit
+
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :clear_questions_session_data

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,6 @@
 class Organisation < ApplicationRecord
+  has_paper_trail
+
   has_many :forms
   has_many :users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   include GDS::SSO::User
+  has_paper_trail only: %i[role organisation_id has_access]
 
   class UserAuthenticationException < StandardError; end
 

--- a/db/migrate/20230802102229_create_versions.rb
+++ b/db/migrate/20230802102229_create_versions.rb
@@ -1,0 +1,31 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, null: false
+      t.bigint   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.jsonb    :object
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20230802102230_add_object_changes_to_versions.rb
+++ b/db/migrate/20230802102230_add_object_changes_to_versions.rb
@@ -1,0 +1,8 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :versions, :object_changes, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_26_091901) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_02_102230) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,6 +59,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_26_091901) do
     t.string "provider"
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.jsonb "object"
+    t.datetime "created_at"
+    t.jsonb "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "users", "organisations"

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -21,4 +21,10 @@ RSpec.describe Organisation, type: :model do
       expect(new_organisation).to eq(existing_organisation)
     end
   end
+
+  describe "versioning", versioning: true do
+    it "enables paper trail" do
+      expect(described_class.new).to be_versioned
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require "paper_trail/frameworks/rspec"
 require_relative "support/capybara_headless_chrome"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: [add paper trail to admin](https://trello.com/c/xB8vHrAU/938-add-paper-trail-gem-to-forms-admin-to-track-changes-to-users-orgs-objects)

Add paper_trail gem to to allow us to track changes to the User and Organisation models. This will allow us to keep a history of changes to role.

The 'whodunnit' hook is added to the controller to add the current user id into the versions table to allow tracing. I think this should be fine across all our environments and login methods, now that current_user is defined. It's possible to set this for rake tasks and console use - there is a link in the commit message to the paper_trail docs.

I've set paper_trail to only track the fields super_admins can change for now - role, organisation and has_access. I've done this because I was concerned that a lot of irrelevant information would get scooped up into the versions table every time a user logged in. I could be wrong - it might be useful to track changes to name/email/provider and tracking other info won't be an issue. I'd like opinions on this :) It also captures create events on user, we might find that using the paper_trail :skip attribute is useful to keep login specific attributes out of the version table.

I've checked the behaviour of the `rake organisations:fetch` task. It works, so we don't need to change it. It only adds versions when organisations are created/updated/deleted, not when there are no changes. When the task is run, no whodunnit user is set.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
