### PR TITLE
Add translation content for additional guidance pages

### DIFF
--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -12,12 +12,12 @@
   <% if FeatureService.enabled? :detailed_guidance_enabled %>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
-    <h2 class="govuk-heading-m">Guidance</h2>
+    <h2 class="govuk-heading-m"><%= t("guidance.guidance") %></h2>
 
-    <p>Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content. For example, you can use paragraphs, links or lists.</p>
+    <p><%= t("guidance.instructions") %></p>
 
     <p>
-      <%= govuk_button_link_to "Add guidance", additional_guidance_new_path(form_id: form_object.id), {secondary: true} %>
+      <%= govuk_button_link_to t("guidance.add_guidance"), additional_guidance_new_path(form_id: form_object.id), {secondary: true} %>
     </p>
   <% end %>
 

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(title_with_error_prefix(t("page_titles.new_page_form"), additional_guidance_form.errors&.any?)) %>
+<% set_page_title(title_with_error_prefix(t("page_titles.add_guidance"), additional_guidance_form.errors&.any?)) %>
 <% content_for :back_link, govuk_back_link_to(form_pages_path(form)) %>
 
 <div class="govuk-grid-row">
@@ -9,75 +9,30 @@
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= t("pages.question") %> <%= form.page_number(page) %></span>
         <span class="govuk-visually-hidden"> - </span>
-        Add guidance
+        <%= t("guidance.add_guidance") %>
       </h1>
 
-      <p>
-        Use guidance if you need to:
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>explain how to answer the question in more detail</li>
-        <li>provide more context</li>
-        <li>format your content - for example, with links, sub-headings or lists</li>
-      </ul>
+      <%= t("guidance.when_to_use_guidance_html") %>
 
-      <%= f.govuk_text_field( :page_heading, label: { size: 'm' }, hint: { text: "Use a heading that’s a statement rather than a question - for example, ‘Interview needs’. This will be your main page heading."})  %>
+      <%= f.govuk_text_field( :page_heading, label: { size: 'm' })  %>
 
       <%= f.govuk_text_area( :additional_guidance_markdown,
                              label: { size: 'm' },
-                             hint: { text: "Use Markdown if you need to format your guidance content. Formatting help can be found below."},
                              rows: 15)  %>
 
       <%= f.govuk_submit (additional_guidance_form.additional_guidance_markdown.blank? ? "Preview guidance" : "Update preview"), secondary: true,  name: :preview_markdown %>
 
-      <%= govuk_details(summary_text: "<h2 class='govuk-!-font-size-19 govuk-!-margin-0 govuk-!-font-weight-regular'>Formatting help</h2>".html_safe) do %>
+      <%= govuk_details(summary_text: "<h2 class='govuk-!-font-size-19 govuk-!-margin-0 govuk-!-font-weight-regular'>#{t("guidance.formatting_help.heading")}</h2>".html_safe) do %>
 
-        <h3 class="govuk-heading-m">Links and URLs</h3>
+        <% %w[links second_level_headings third_level_headings bulleted_lists numbered_lists].each do |format_name| %>
+          <h3 class="govuk-heading-m"><%= t("guidance.formatting_help.#{format_name}.heading") %></h3>
 
-        <p>To add a link, use square brackets [ ] around the link text, and round brackets ( ) around the full URL. For example:</p>
+          <p><%= simple_format(t("guidance.formatting_help.#{format_name}.instructions")) %></p>
 
-        <%= govuk_inset_text(text: "[Link text](https://www.gov.uk/link-text-url)") %>
-
-        <h3 class="govuk-heading-m">Second-level headings</h3>
-
-        <p>To add a second-level heading, use 2 hashtags followed by a space. For example:</p>
-
-        <%= govuk_inset_text(text: "## This is a second-level heading") %>
-
-        <h3 class="govuk-heading-m">Third-level headings</h3>
-
-        <p>To add a third-level heading, use 3 hashtags followed by a space. For example:</p>
-
-        <%= govuk_inset_text(text: "### This is a third-level heading") %>
-
-        <h3 class="govuk-heading-m">Bulleted lists</h3>
-
-        <p>To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash.</p>
-
-        <p>You need one empty line space before the bullets start, and one at the end. For example:</p>
-
-        <%= govuk_inset_text do %>
-          <ul class="govuk-list">
-            <li>* First bullet point</li>
-            <li>* Second bullet point</li>
-            <li>* Third bullet point</li>
-          </ul>
+          <%= govuk_inset_text do %>
+            <%= simple_format(t("guidance.formatting_help.#{format_name}.example")) %>
+          <% end %>
         <% end %>
-
-        <h3 class="govuk-heading-s">Numbered lists</h3>
-
-        <p>Use numbers for each list item, followed by a full stop. Make sure there is one space after the full stop.</p>
-
-        <p>You need one empty line space before the numbers start, and one at the end. For example:</p>
-
-        <%= govuk_inset_text do %>
-          <ol class="govuk-list govuk-list--number">
-            <li>First item</li>
-            <li>Second item</li>
-            <li>Third item</li>
-          </ol>
-        <% end %>
-
       <% end %>
 
       <% if preview_html.present? %>

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -20,7 +20,7 @@
                              label: { size: 'm' },
                              rows: 15)  %>
 
-      <%= f.govuk_submit (additional_guidance_form.additional_guidance_markdown.blank? ? "Preview guidance" : "Update preview"), secondary: true,  name: :preview_markdown %>
+      <%= f.govuk_submit (additional_guidance_form.additional_guidance_markdown.blank? ? t("guidance.preview_guidance") : t("guidance.update_preview")), secondary: true,  name: :preview_markdown %>
 
       <%= govuk_details(summary_text: "<h2 class='govuk-!-font-size-19 govuk-!-margin-0 govuk-!-font-weight-regular'>#{t("guidance.formatting_help.heading")}</h2>".html_safe) do %>
 
@@ -36,9 +36,9 @@
       <% end %>
 
       <% if preview_html.present? %>
-        <h2 class="govuk-heading-m">Preview your guidance below</h2>
+        <h2 class="govuk-heading-m"><%= t("guidance.preview.heading") %></h2>
 
-        <p>Below is a preview of how your guidance content will be shown to the person completing your form.</p>
+        <p><%= t("guidance.preview.description") %></p>
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,6 +183,53 @@ en:
     confirm_deletion_form: Are you sure you want to delete this draft?
     confirm_deletion_form_live_form: Deleting this draft will not remove the live form.
     confirm_deletion_page: Are you sure you want to delete this page?
+  guidance:
+    add_guidance: Add guidance
+    formatting_help:
+      bulleted_lists:
+        example: |
+          * First bullet point
+          * Second bullet point
+          * Third bullet point
+        heading: Bulleted lists
+        instructions: |
+          To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash.
+
+          You need one empty line space before the bullets start, and one at the end. For example:
+      heading: Formatting help
+      links:
+        example: "[Link text](https://www.gov.uk/link-text-url)"
+        heading: Links and URLs
+        instructions: 'To add a link, use square brackets [ ] around the link text, and round brackets ( ) around the full URL. For example:'
+      numbered_lists:
+        example: |
+          1. First item
+          2. Second item
+          3. Third item
+        heading: Numbered lists
+        instructions: |
+          Use numbers for each list item, followed by a full stop. Make sure there is one space after the full stop.
+
+          You need one empty line space before the numbers start, and one at the end. For example:
+      second_level_headings:
+        example: "## This is a second-level heading"
+        heading: Second-level headings
+        instructions: 'To add a second-level heading, use 2 hashtags followed by a space. For example:'
+      third_level_headings:
+        example: "## This is a third-level heading"
+        heading: Third-level headings
+        instructions: 'To add a third-level heading, use 3 hashtags followed by a space. For example:'
+    guidance: Guidance
+    instructions: Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content. For example, you can use paragraphs, links or lists.
+    when_to_use_guidance_html: |
+      <p>
+        Use guidance if you need to:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>explain how to answer the question in more detail</li>
+        <li>provide more context</li>
+        <li>format your content - for example, with links, sub-headings or lists</li>
+      </ul>
   header:
     product_name: Forms
     sign_out: Sign out
@@ -406,6 +453,7 @@ en:
       only_one_option: Selection from a list, one option only.
   page_titles:
     access_denied: You do not have permission to access GOV.UK Forms
+    add_guidance: Add guidance
     address_settings: What kind of addresses do you expect to receive?
     change_name_form: Name your form
     confirm_email_form: Enter the confirmation code

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,11 @@ en:
         instructions: 'To add a third-level heading, use 3 hashtags followed by a space. For example:'
     guidance: Guidance
     instructions: Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content. For example, you can use paragraphs, links or lists.
+    preview:
+      description: Below is a preview of how your guidance content will be shown to the person completing your form.
+      heading: Preview your guidance below
+    preview_guidance: Preview guidance
+    update_preview: Update preview
     when_to_use_guidance_html: |
       <p>
         Use guidance if you need to:

--- a/config/locales/pages/additional_guidance.yml
+++ b/config/locales/pages/additional_guidance.yml
@@ -1,5 +1,9 @@
 en:
   helpers:
+    hint:
+      pages_additional_guidance_form:
+        page_heading: Use a heading that’s a statement rather than a question - for example, ‘Interview needs’. This will be your main page heading.
+        additional_guidance_markdown: Use Markdown if you need to format your guidance content. Formatting help can be found below.
     label:
       pages_additional_guidance_form:
         page_heading: Give your page a heading

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -51,19 +51,19 @@ describe "pages/_form.html.erb", type: :view do
   end
 
   it "does not contain a link to add guidance" do
-    expect(rendered).to have_no_link(text: "Add guidance", href: additional_guidance_new_path(form_id: form.id))
+    expect(rendered).to have_no_link(text: I18n.t("guidance.add_guidance"), href: additional_guidance_new_path(form_id: form.id))
   end
 
   context "when detailed_guidance feature flag enabled", feature_detailed_guidance_enabled: true do
     it "contains a link to add guidance" do
-      expect(rendered).to have_link(text: "Add guidance", href: additional_guidance_new_path(form_id: form.id))
+      expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: additional_guidance_new_path(form_id: form.id))
     end
 
     context "when it is not a new page" do
       let(:is_new_page) { false }
 
       it "contains a link to add guidance" do
-        expect(rendered).to have_link(text: "Add guidance", href: additional_guidance_new_path(form_id: form.id))
+        expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: additional_guidance_new_path(form_id: form.id))
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?
Trello card: Not directly on a card but part of the detailed guidance epic

Takes some of the text from the existing additional guidance view and the guidance section of the edit question page, and moves it into the local files so our content is organised nicely now and we can internationalise more easily later.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
