### PR TITLE
Add govuk-forms-markdown gem & enable previewing additional guidance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apk update
 RUN apk upgrade --available
-RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=~18 npm
+RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=~18 npm git
 RUN adduser -D ruby
 RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ gem "govuk_design_system_formbuilder", "~> 4.1.1"
 # Our own custom markdown renderer
 gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.1.0"
 
-
 # For structured logging
 gem "lograge"
 

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,10 @@ gem "vite_rails"
 gem "govuk-components", "~> 4.1.0"
 gem "govuk_design_system_formbuilder", "~> 4.1.1"
 
+# Our own custom markdown renderer
+gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.1.0"
+
+
 # For structured logging
 gem "lograge"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/alphagov/govuk-forms-markdown.git
+  revision: 726bc74cd828bdce382ea681d5c5f71fa8dd68e1
+  tag: 0.1.0
+  specs:
+    govuk-forms-markdown (0.1.0)
+      redcarpet (~> 3.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -371,6 +379,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redcarpet (3.6.0)
     regexp_parser (2.8.1)
     reline (0.3.3)
       io-console (~> 0.5)
@@ -530,6 +539,7 @@ DEPENDENCIES
   faker
   gds-sso
   govuk-components (~> 4.1.0)
+  govuk-forms-markdown!
   govuk_design_system_formbuilder (~> 4.1.1)
   govuk_notify_rails
   i18n-tasks (~> 1.0.11)

--- a/app/controllers/pages/additional_guidance_controller.rb
+++ b/app/controllers/pages/additional_guidance_controller.rb
@@ -1,6 +1,21 @@
+require "govuk_forms_markdown"
+
 class Pages::AdditionalGuidanceController < PagesController
   def new
     additional_guidance_form = Pages::AdditionalGuidanceForm.new
-    render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form: }
+    render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: nil }
+  end
+
+  def create
+    additional_guidance_form = Pages::AdditionalGuidanceForm.new(additional_guidance_form_params)
+    preview_html = GovukFormsMarkdown.render(additional_guidance_form.additional_guidance_markdown)
+
+    render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: }
+  end
+
+private
+
+  def additional_guidance_form_params
+    params.require(:pages_additional_guidance_form).permit(:page_heading, :additional_guidance_markdown)
   end
 end

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -28,6 +28,8 @@
                              hint: { text: "Use Markdown if you need to format your guidance content. Formatting help can be found below."},
                              rows: 15)  %>
 
+      <%= f.govuk_submit (additional_guidance_form.additional_guidance_markdown.blank? ? "Preview guidance" : "Update preview"), secondary: true,  name: :preview_markdown %>
+
       <%= govuk_details(summary_text: "<h2 class='govuk-!-font-size-19 govuk-!-margin-0 govuk-!-font-weight-regular'>Formatting help</h2>".html_safe) do %>
 
         <h3 class="govuk-heading-m">Links and URLs</h3>
@@ -78,12 +80,18 @@
 
       <% end %>
 
+      <% if preview_html.present? %>
+        <h2 class="govuk-heading-m">Preview your guidance below</h2>
 
+        <p>Below is a preview of how your guidance content will be shown to the person completing your form.</p>
 
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
+        <%= preview_html.html_safe %>
 
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <% end %>
 
-      <%= f.govuk_submit t('continue'), value: "true", name: :set_answer_type %>
     <% end %>
     <p>
       <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(@form) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
 
       scope "/new" do
         get "/additional-guidance" => "pages/additional_guidance#new", as: :additional_guidance_new
+        post "/additional-guidance" => "pages/additional_guidance#create", as: :additional_guidance_create
         get "/type-of-answer" => "pages/type_of_answer#new", as: :type_of_answer_new
         post "/type-of-answer" => "pages/type_of_answer#create", as: :type_of_answer_create
         get "/text-settings" => "pages/text_settings#new", as: :text_settings_new

--- a/spec/requests/pages/additional_guidance_controller_spec.rb
+++ b/spec/requests/pages/additional_guidance_controller_spec.rb
@@ -44,4 +44,30 @@ RSpec.describe Pages::AdditionalGuidanceController, type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "#create" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      end
+      post additional_guidance_new_path(form_id: form.id), params: { pages_additional_guidance_form: { page_heading: "Page heading", additional_guidance_markdown: "## Heading level 2" } }
+    end
+
+    it "reads the existing form" do
+      expect(form).to have_been_read
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("pages/additional_guidance")
+    end
+
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the additional guidance markdown as html" do
+      expect(response.body).to include('<h2 class="govuk-heading-l">Heading level 2</h2>')
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card:  https://trello.com/c/JJzr1Iv8/947-add-govuk-forms-markdown-gem-to-forms-admin-for-non-js-version-of-previewing



### Things to consider when reviewing

Try the following:

While creating a new page:
- View "Additional guidance" page
- Add some markdown and check preview is shown with the rendered html (already aware that our gem doesn't escape code blocks, will fix that in another gem release)

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
