### PR TITLE
Add task to update organisations table

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -45,7 +45,7 @@
         end
       end %>
 
-      <%= f.govuk_collection_select :organisation_id, Organisation.order(:slug), :id, :name,
+      <%= f.govuk_collection_select :organisation_id, Organisation.order(:name), :id, :name,
         class: ['govuk-!-width-three-quarters'],
         options: { prompt: t('users.edit.organisation_prompt') },
         label: { text: t('users.edit.organisation'), size: 'm', tag: 'h2' },

--- a/lib/advisory_lock.rb
+++ b/lib/advisory_lock.rb
@@ -1,0 +1,17 @@
+class AdvisoryLock
+  module DSL
+    def with_lock(key)
+      lock_id = Zlib.crc32(key)
+      connection = ActiveRecord::Base.connection
+
+      got_lock = connection.get_advisory_lock(lock_id)
+      if got_lock
+        yield
+      else
+        puts "Skipping task, couldn't obtain lock: #{key}"
+      end
+    ensure
+      connection.release_advisory_lock(lock_id) if got_lock
+    end
+  end
+end

--- a/lib/organisations_fetcher.rb
+++ b/lib/organisations_fetcher.rb
@@ -1,0 +1,58 @@
+# GOV.UK is the canonical source for organisations, so we need to keep our
+# organisations up-to-date in order to provide accurate information on user
+# membership of organisations.
+#
+# Based on similar code in Signon app:
+# https://github.com/alphagov/signon/blob/b7a53e282c55d8ef3ab6369a7cb358b6ae100d27/lib/organisations_fetcher.rb
+class OrganisationsFetcher
+  def call
+    organisations.each do |organisation_data|
+      update_or_create_organisation(organisation_data)
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    raise "Couldn't save organisation #{e.record.slug} because: #{e.record.errors.full_messages.join(',')}"
+  end
+
+private
+
+  def organisations
+    @organisations ||= get_json_with_subsequent_pages(URI("https://www.gov.uk/api/organisations"))
+  end
+
+  def update_or_create_organisation(organisation_data)
+    govuk_content_id = organisation_data[:details][:content_id]
+    slug = organisation_data[:details][:slug]
+
+    organisation = Organisation.find_by(govuk_content_id:) ||
+      Organisation.find_by(slug:) ||
+      Organisation.new(govuk_content_id:)
+
+    update_data = {
+      govuk_content_id:,
+      slug:,
+      name: organisation_data[:title],
+    }
+
+    organisation.update!(update_data)
+  end
+
+  def get_json_with_subsequent_pages(uri)
+    next_page_uri = uri
+    Enumerator.new do |yielder|
+      while next_page_uri
+        page = get_json(next_page_uri)
+        page[:results].each { |i| yielder << i }
+        next_page_uri = page.key?(:next_page_url) ? URI(page[:next_page_url]) : nil
+      end
+    end
+  end
+
+  def get_json(uri)
+    response = Net::HTTP.get_response(uri)
+    if response.is_a? Net::HTTPSuccess
+      JSON.parse(response.body, symbolize_names: true)
+    else
+      raise "error fetching organisations: #{response.code}: #{response.body}"
+    end
+  end
+end

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -1,8 +1,13 @@
+require_relative "../advisory_lock"
 require_relative "../organisations_fetcher"
 
 namespace :organisations do
   desc "Update organisations table using data from GOV.UK"
   task fetch: :environment do
-    OrganisationsFetcher.new.call
+    include AdvisoryLock::DSL
+
+    with_lock("forms-admin:organisations:fetch") do
+      OrganisationsFetcher.new.call
+    end
   end
 end

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -1,0 +1,8 @@
+require_relative "../organisations_fetcher"
+
+namespace :organisations do
+  desc "Update organisations table using data from GOV.UK"
+  task fetch: :environment do
+    OrganisationsFetcher.new.call
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WEhgdg25 <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR adds a Rake task that we can run to update the organisations table using the data from the [GOV.UK organisations API](https://docs.publishing.service.gov.uk/repos/collections/api.html). It is very heavily cribbed off of [what GOV.UK Signon does](https://github.com/alphagov/signon/blob/b7a53e282c55d8ef3ab6369a7cb358b6ae100d27/lib/organisations_fetcher.rb).

Note, we don't really have a way of running this in production yet, as we don't haven't got a way to run Rake commands, but I figured we might as well merge this now for when we do.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?