### PR TITLE
Improve HTML structure for additional guidance

### DIFF
--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -6,6 +6,7 @@ $govuk-global-styles: true;
 @import "govuk/all";
 @import "../styles/app_select_options";
 @import "../styles/app_summary_card";
+@import "../styles/app_markdown_example_block";
 @import "../../components/task_list_component/";
 @import "../../components/page_list_component/";
 @import "../../components/header_component/";

--- a/app/frontend/styles/_app_markdown_example_block.scss
+++ b/app/frontend/styles/_app_markdown_example_block.scss
@@ -1,0 +1,10 @@
+.app-markdown-example-block {
+  white-space: pre-wrap;
+  font-size: inherit;
+  font-family: inherit;
+
+  &__code {
+    font-size: inherit;
+    font-family: inherit;
+  }
+}

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -29,8 +29,9 @@
 
           <p><%= simple_format(t("guidance.formatting_help.#{format_name}.instructions")) %></p>
 
-          <%= govuk_inset_text do %>
-            <%= simple_format(t("guidance.formatting_help.#{format_name}.example")) %>
+            <%= govuk_inset_text do %>
+              <pre class="app-markdown-example-block"><code class="app-markdown-example-block__code"><%= t("guidance.formatting_help.#{format_name}.example") %></code ></pre>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -22,10 +22,15 @@
 
       <%= f.govuk_submit (additional_guidance_form.additional_guidance_markdown.blank? ? t("guidance.preview_guidance") : t("guidance.update_preview")), secondary: true,  name: :preview_markdown %>
 
-      <%= govuk_details(summary_text: "<h2 class='govuk-!-font-size-19 govuk-!-margin-0 govuk-!-font-weight-regular'>#{t("guidance.formatting_help.heading")}</h2>".html_safe) do %>
-
-        <% %w[links second_level_headings third_level_headings bulleted_lists numbered_lists].each do |format_name| %>
-          <h3 class="govuk-heading-m"><%= t("guidance.formatting_help.#{format_name}.heading") %></h3>
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <h2 class='govuk-details__summary-text govuk-!-font-size-19 govuk-!-margin-0 govuk-!-font-weight-regular'>
+            <%= t("guidance.formatting_help.heading") %>
+          </h2>
+        </summary>
+        <div class="govuk-details__text">
+          <% %w[links second_level_headings third_level_headings bulleted_lists numbered_lists].each do |format_name| %>
+            <h3 class="govuk-heading-m"><%= t("guidance.formatting_help.#{format_name}.heading") %></h3>
 
             <%= simple_format(t("guidance.formatting_help.#{format_name}.instructions")) %>
 
@@ -33,8 +38,8 @@
               <pre class="app-markdown-example-block"><code class="app-markdown-example-block__code"><%= t("guidance.formatting_help.#{format_name}.example") %></code ></pre>
             <% end %>
           <% end %>
-        <% end %>
-      <% end %>
+        </div>
+      </details>
 
       <% if preview_html.present? %>
         <h2 class="govuk-heading-m"><%= t("guidance.preview.heading") %></h2>

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -27,7 +27,7 @@
         <% %w[links second_level_headings third_level_headings bulleted_lists numbered_lists].each do |format_name| %>
           <h3 class="govuk-heading-m"><%= t("guidance.formatting_help.#{format_name}.heading") %></h3>
 
-          <p><%= simple_format(t("guidance.formatting_help.#{format_name}.instructions")) %></p>
+            <%= simple_format(t("guidance.formatting_help.#{format_name}.instructions")) %>
 
             <%= govuk_inset_text do %>
               <pre class="app-markdown-example-block"><code class="app-markdown-example-block__code"><%= t("guidance.formatting_help.#{format_name}.example") %></code ></pre>


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: None but part of the detailed guidance work

Includes two tweaks to fix some invalid HTML:
- Fixes an issue where `<p>` tags were being rendered inside `<p>` tags
- customises the govuk-details component HTML so that we're not rendering a `h2` inside a `span`

Also includes a change to make our markdown examples more semantic:
- Wraps our markdown examples in `pre` and `code` tags as this is more semantically appropriate for code samples
  -  includes some styling to make these look the same as they do now

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
