### PR TITLE
Create guidance

### DIFF
--- a/app/controllers/pages/additional_guidance_controller.rb
+++ b/app/controllers/pages/additional_guidance_controller.rb
@@ -2,20 +2,35 @@ require "govuk_forms_markdown"
 
 class Pages::AdditionalGuidanceController < PagesController
   def new
-    additional_guidance_form = Pages::AdditionalGuidanceForm.new
+    page_heading = session.dig(:page, "page_heading")
+    additional_guidance_markdown = session.dig(:page, "additional_guidance_markdown")
+    additional_guidance_form = Pages::AdditionalGuidanceForm.new(page_heading:, additional_guidance_markdown:)
     render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: nil }
   end
 
   def create
     additional_guidance_form = Pages::AdditionalGuidanceForm.new(additional_guidance_form_params)
-    preview_html = GovukFormsMarkdown.render(additional_guidance_form.additional_guidance_markdown)
 
-    render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: }
+    case route_to
+    when :preview
+      preview_html = GovukFormsMarkdown.render(additional_guidance_form.additional_guidance_markdown)
+      render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: }
+    when :save_and_continue
+      if additional_guidance_form.submit(session)
+        redirect_to new_page_path(@form)
+      else
+        render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: }, status: :unprocessable_entity
+      end
+    end
   end
 
 private
 
   def additional_guidance_form_params
     params.require(:pages_additional_guidance_form).permit(:page_heading, :additional_guidance_markdown)
+  end
+
+  def route_to
+    params[:route_to].to_sym
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,13 +14,16 @@ class PagesController < ApplicationController
     question_text = session.dig(:page, "question_text")
     answer_settings = session.dig(:page, "answer_settings")
     is_optional = session.dig(:page, "is_optional") == "true"
-    @page = Page.new(form_id: @form.id, question_text:, answer_type:, answer_settings:, is_optional:)
+    page_heading = session.dig(:page, "page_heading")
+    additional_guidance_markdown = session.dig(:page, "additional_guidance_markdown")
+    @page = Page.new(form_id: @form.id, question_text:, answer_type:, answer_settings:, is_optional:, page_heading:, additional_guidance_markdown:)
   end
 
   def create
     answer_settings = session.dig(:page, "answer_settings")
     page_heading = session.dig(:page, "page_heading")
     additional_guidance_markdown = session.dig(:page, "additional_guidance_markdown")
+
     @page = Page.new(page_params.merge(answer_settings:, page_heading:, additional_guidance_markdown:))
 
     if @page.save
@@ -34,7 +37,7 @@ class PagesController < ApplicationController
   def edit
     reset_session_if_answer_settings_not_present
     @page = Page.find(params[:page_id], params: { form_id: @form.id })
-    @page.load_from_session(session, %w[answer_settings answer_type is_optional])
+    @page.load_from_session(session, %w[answer_settings answer_type is_optional page_heading additional_guidance_markdown])
   end
 
   def update

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,7 +19,9 @@ class PagesController < ApplicationController
 
   def create
     answer_settings = session.dig(:page, "answer_settings")
-    @page = Page.new(page_params.merge(answer_settings:))
+    page_heading = session.dig(:page, "page_heading")
+    additional_guidance_markdown = session.dig(:page, "additional_guidance_markdown")
+    @page = Page.new(page_params.merge(answer_settings:, page_heading:, additional_guidance_markdown:))
 
     if @page.save
       clear_questions_session_data

--- a/app/forms/pages/additional_guidance_form.rb
+++ b/app/forms/pages/additional_guidance_form.rb
@@ -2,4 +2,12 @@ class Pages::AdditionalGuidanceForm < BaseForm
   attr_accessor :page_heading, :additional_guidance_markdown
 
   validates :page_heading, :additional_guidance_markdown, presence: true
+
+  def submit(session)
+    return false if invalid?
+
+    session[:page] = {} if session[:page].blank?
+    session[:page][:page_heading] = page_heading
+    session[:page][:additional_guidance_markdown] = additional_guidance_markdown
+  end
 end

--- a/app/service/page_summary_data/guidance_service.rb
+++ b/app/service/page_summary_data/guidance_service.rb
@@ -1,0 +1,46 @@
+module PageSummaryData
+  class GuidanceService
+    include Rails.application.routes.url_helpers
+    include ActionView::Helpers::OutputSafetyHelper
+
+    class << self
+      def call(**args)
+        new(**args)
+      end
+    end
+
+    attr_reader :form, :page
+
+    def initialize(form:, page:)
+      @form = form
+      @page = page
+    end
+
+    def build_data
+      return nil unless page.page_heading.present? && page.additional_guidance_markdown.present?
+
+      { rows: options }
+    end
+
+  private
+
+    def options
+      [{
+        key: { text: "Page heading" },
+        value: { text: page.page_heading },
+        actions: [{ href: additional_guidance_new_path(form_id: form.id), visually_hidden_text: "page heading" }],
+      },
+       {
+         key: { text: "Guidance text" },
+         value: {
+           text: markdown_content,
+         },
+         actions: [{ href: additional_guidance_new_path(form_id: form.id), visually_hidden_text: "guidance text" }],
+       }]
+    end
+
+    def markdown_content
+      safe_join(['<pre class="app-markdown-example-block">'.html_safe, page.additional_guidance_markdown, "</pre>".html_safe])
+    end
+  end
+end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -9,32 +9,37 @@
 
   <%= f.govuk_text_area :hint_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("hint_text", page_object.answer_type, page_object.answer_settings) } %>
 
-  <% if FeatureService.enabled? :detailed_guidance_enabled %>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-
-    <h2 class="govuk-heading-m"><%= t("guidance.guidance") %></h2>
-
-    <p><%= t("guidance.instructions") %></p>
-
-    <p>
-      <%= govuk_button_link_to t("guidance.add_guidance"), additional_guidance_new_path(form_id: form_object.id), {secondary: true} %>
-    </p>
-  <% end %>
-
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
+  <% if FeatureService.enabled? :detailed_guidance_enabled %>
+    <h2 class="govuk-heading-m"><%= t("guidance.guidance") %></h2>
+    <% if page_object.page_heading.present? && page_object.additional_guidance_markdown.present? %>
+      <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, page: page_object).build_data) %>
+
+    <% else %>
+      <p><%= t("guidance.instructions") %></p>
+
+      <p>
+        <%= govuk_button_link_to t("guidance.add_guidance"), additional_guidance_new_path(form_id: form_object.id), {secondary: true} %>
+      </p>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+    <% end %>
+  <% end %>
 
   <% if page_object.answer_type == 'selection' %>
     <%= f.hidden_field :is_optional %>
   <% else %>
-    <%= f.govuk_check_boxes_fieldset :is_optional, multiple: false, legend: { text: t("pages.add_rules_legend") , size: 'm' } do %>
+    <%= f.govuk_check_boxes_fieldset :is_optional, multiple: false, legend: { tag: "h2", text: t("pages.add_rules_legend") , size: 'm' } do %>
       <%= f.govuk_check_box :is_optional, true,0, multiple: false,
                             small: true,
                             label: { text: t("pages.make_optional_text")  },
                             hint: { text: t("pages.make_optional_hint") } %>
 
     <% end %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
   <% end %>
 
+  <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
   <%= render PageSettingsSummaryComponent::View.new(page_object, change_answer_type_path:, change_selections_settings_path:, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -20,7 +20,7 @@
                              label: { size: 'm' },
                              rows: 15)  %>
 
-      <%= f.govuk_submit (additional_guidance_form.additional_guidance_markdown.blank? ? t("guidance.preview_guidance") : t("guidance.update_preview")), secondary: true,  name: :preview_markdown %>
+      <%= f.govuk_submit (additional_guidance_form.additional_guidance_markdown.blank? ? t("guidance.preview_guidance") : t("guidance.update_preview")), secondary: true,  name: "route_to", value: "preview" %>
 
       <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">
@@ -52,6 +52,8 @@
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       <% end %>
+
+      <%= f.govuk_submit t("continue"), name: "route_to", value: "save_and_continue" %>
 
     <% end %>
     <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,6 +490,7 @@ en:
     your_form_is_live: Your form is live
   pages:
     add_rules_legend: Question settings
+    answer_settings: Answer settings
     delete_question: Delete question
     go_to_your_questions: Go to your questions
     heading: Edit question

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -20,9 +20,16 @@ FactoryBot.define do
     sequence(:position) { |n| n }
     question_with_text { "#{position}. #{question_text}" }
     has_routing_errors { false }
+    page_heading { nil }
+    additional_guidance_markdown { nil }
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda }
+    end
+
+    trait :with_guidance do
+      page_heading { Faker::Quote.yoda }
+      additional_guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
     end
 
     trait :with_simple_answer_type do

--- a/spec/forms/pages/additional_guidance_form_spec.rb
+++ b/spec/forms/pages/additional_guidance_form_spec.rb
@@ -1,21 +1,47 @@
 require "rails_helper"
 
 RSpec.describe Pages::AdditionalGuidanceForm, type: :model do
-  let(:additional_guidance_form) { described_class.new }
+  let(:additional_guidance_form) { described_class.new(page_heading:, additional_guidance_markdown:) }
+  let(:page_heading) { nil }
+  let(:additional_guidance_markdown) { nil }
 
   describe "validations" do
-    it "is invalid if answer_value is nil" do
+    it "is invalid if page heading is nil" do
       error_message = I18n.t("activemodel.errors.models.pages/additional_guidance_form.attributes.page_heading.blank")
       additional_guidance_form.page_heading = nil
       expect(additional_guidance_form).to be_invalid
       expect(additional_guidance_form.errors.full_messages_for(:page_heading)).to include("Page heading #{error_message}")
     end
 
-    it "is invalid if goto_page_id is nil" do
+    it "is invalid if additional_guidance_markdown is nil" do
       error_message = I18n.t("activemodel.errors.models.pages/additional_guidance_form.attributes.additional_guidance_markdown.blank")
       additional_guidance_form.additional_guidance_markdown = nil
       expect(additional_guidance_form).to be_invalid
       expect(additional_guidance_form.errors.full_messages_for(:additional_guidance_markdown)).to include("Additional guidance markdown #{error_message}")
+    end
+  end
+
+  describe "#submit" do
+    let(:session_mock) { {} }
+
+    it "returns false if the form is invalid" do
+      expect(additional_guidance_form.submit(session_mock)).to eq false
+      expect(additional_guidance_form.errors.any?).to eq true
+    end
+
+    context "when page_heading and additional_guidance_markdown are valid" do
+      let(:page_heading) { "My new page heading" }
+      let(:additional_guidance_markdown) { "Extra guidance needed to answer this question" }
+
+      it "sets a session key called 'page' as a hash with the page heading in it" do
+        additional_guidance_form.submit(session_mock)
+        expect(session_mock[:page][:page_heading]).to eq page_heading
+      end
+
+      it "sets a session key called 'page' as a hash with the additional_guidance_markdown in it" do
+        additional_guidance_form.submit(session_mock)
+        expect(session_mock[:page][:additional_guidance_markdown]).to eq additional_guidance_markdown
+      end
     end
   end
 end

--- a/spec/requests/pages/additional_guidance_controller_spec.rb
+++ b/spec/requests/pages/additional_guidance_controller_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe Pages::AdditionalGuidanceController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
+  let(:page_heading) { "Page heading" }
+  let(:additional_guidance_markdown) { "## Heading level 2" }
 
   let(:req_headers) do
     {
@@ -46,28 +48,63 @@ RSpec.describe Pages::AdditionalGuidanceController, type: :request do
   end
 
   describe "#create" do
+    let(:route_to) { "preview" }
+
     before do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       end
-      post additional_guidance_new_path(form_id: form.id), params: { pages_additional_guidance_form: { page_heading: "Page heading", additional_guidance_markdown: "## Heading level 2" } }
+      post additional_guidance_new_path(form_id: form.id), params: { pages_additional_guidance_form: { page_heading:, additional_guidance_markdown: }, route_to: }
     end
 
-    it "reads the existing form" do
-      expect(form).to have_been_read
+    context "when previewing markdown" do
+      let(:route_to) { "preview" }
+
+      it "reads the existing form" do
+        expect(form).to have_been_read
+      end
+
+      it "renders the template" do
+        expect(response).to have_rendered("pages/additional_guidance")
+      end
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the additional guidance markdown as html" do
+        expect(response.body).to include('<h2 class="govuk-heading-l">Heading level 2</h2>')
+      end
     end
 
-    it "renders the template" do
-      expect(response).to have_rendered("pages/additional_guidance")
-    end
+    context "when saving markdown" do
+      let(:route_to) { "save_and_continue" }
 
-    it "returns 200" do
-      expect(response).to have_http_status(:ok)
-    end
+      it "reads the existing form" do
+        expect(form).to have_been_read
+      end
 
-    it "renders the additional guidance markdown as html" do
-      expect(response.body).to include('<h2 class="govuk-heading-l">Heading level 2</h2>')
+      it "saves the page_heading and additional_guidance_markdown to session" do
+        expect(session[:page][:page_heading]).to eq("Page heading")
+        expect(session[:page][:additional_guidance_markdown]).to eq("## Heading level 2")
+      end
+
+      it "redirects the user to the new question page" do
+        expect(response).to redirect_to new_page_path(form.id)
+      end
+
+      context "when data is invalid" do
+        let(:page_heading) { nil }
+
+        it "returns 422" do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "renders the template" do
+          expect(response).to have_rendered("pages/additional_guidance")
+        end
+      end
     end
   end
 end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -241,6 +241,8 @@ RSpec.describe PagesController, type: :request do
           answer_type: "address",
           is_optional: nil,
           answer_settings: nil,
+          page_heading: nil,
+          additional_guidance_markdown: nil,
         }
       end
 

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -93,6 +93,8 @@ RSpec.describe PagesController, type: :request do
           answer_type: "address",
           answer_settings: nil,
           is_optional: false,
+          page_heading: nil,
+          additional_guidance_markdown: nil,
         }.to_json
       end
 

--- a/spec/service/page_summary_data/guidance_service_spec.rb
+++ b/spec/service/page_summary_data/guidance_service_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe PageSummaryData::GuidanceService do
+  include Rails.application.routes.url_helpers
+
+  let(:service) { described_class.call(form:, page:) }
+  let(:form) { build :form, id: 1 }
+  let(:page) { build :page, :with_guidance, form: }
+
+  describe "#build_data" do
+    let(:result) { service.build_data }
+
+    it "returns an array of rows" do
+      expect(result[:rows].size).to eq 2
+    end
+
+    describe "first row of summary list" do
+      let(:row) { result[:rows].first }
+
+      it "has key" do
+        expect(row[:key][:text]).to eq "Page heading"
+      end
+
+      it "has a value" do
+        expect(row[:value][:text]).to eq page.page_heading
+      end
+
+      it "has an action to take the user back to change the value" do
+        expect(row[:actions].first[:href]).to eq(additional_guidance_new_path(form_id: form.id))
+      end
+    end
+
+    describe "second row of summary list" do
+      let(:row) { result[:rows].second }
+
+      it "has key" do
+        expect(row[:key][:text]).to eq "Guidance text"
+      end
+
+      it "has a value" do
+        expect(row[:value][:text]).to eq("<pre class=\"app-markdown-example-block\">#{page.additional_guidance_markdown}</pre>")
+      end
+
+      it "has an action to take the user back to change the value" do
+        expect(row[:actions].first[:href]).to eq(additional_guidance_new_path(form_id: form.id))
+      end
+    end
+
+    context "when page doesn't have guidance or page heading" do
+      let(:page) { build :page, form: }
+
+      it "returns nil" do
+        expect(result).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Cui39aea/949-save-markdown-from-forms-admin-to-forms-api

- Stores `page_heading` and `additional_guidance_markdown` in the session
- Passes the two new values in the create page api call
- retrieves the values for forms-api and plays it back to users

**Editing/Updating the actual page_heading/additional_guidance_markdown is out of scope for this PR.**

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
