### PR TITLE
Update en.yml - changing 'make question optional' text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,7 +501,7 @@ en:
         legend: Have you finished editing your questions?
       title: Add and edit your questions
     make_optional_hint: "‘(optional)’ will be added to the end of the question text"
-    make_optional_text: Make this question optional so people can skip it
+    make_optional_text: Make this question optional so people can leave it blank
     optional: "%{question_text} (optional)"
     question: Question
     submit_add: Save and add next question


### PR DESCRIPTION
Minor change to the wording used for choosing to make a question optional, following usability testing. 

Change is from 'Make this question optional so people can skip it' to 'Make this question optional so people can leave it blank'.

### What problem does this pull request solve?

Trello card: https://trello.com/c/xv3uVzLm/933-routing-help-form-creators-differentiate-between-optional-questions-and-routing

This is to try and help form creators differentiate between optional questions and question routing.

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Is this the only place this wording needs to be changed?
- Any typos or grammatical errors?
