### PR TITLE
Add Edit/update journey for guidance

### DIFF
--- a/app/controllers/pages/additional_guidance_controller.rb
+++ b/app/controllers/pages/additional_guidance_controller.rb
@@ -5,7 +5,7 @@ class Pages::AdditionalGuidanceController < PagesController
     page_heading = session.dig(:page, "page_heading")
     additional_guidance_markdown = session.dig(:page, "additional_guidance_markdown")
     additional_guidance_form = Pages::AdditionalGuidanceForm.new(page_heading:, additional_guidance_markdown:)
-    render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: preview_html(additional_guidance_form) }
+    render "pages/additional_guidance", locals: view_locals(additional_guidance_form)
   end
 
   def create
@@ -13,12 +13,12 @@ class Pages::AdditionalGuidanceController < PagesController
 
     case route_to
     when :preview
-      render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: preview_html(additional_guidance_form)}
+      render "pages/additional_guidance", locals: view_locals(additional_guidance_form)
     when :save_and_continue
       if additional_guidance_form.submit(session)
         redirect_to new_page_path(@form)
       else
-        render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: preview_html(additional_guidance_form) }, status: :unprocessable_entity
+        render "pages/additional_guidance", locals: view_locals(additional_guidance_form), status: :unprocessable_entity
       end
     end
   end
@@ -37,5 +37,9 @@ private
     return nil if guidance_form.additional_guidance_markdown.blank?
 
     GovukFormsMarkdown.render(guidance_form.additional_guidance_markdown)
+  end
+
+  def view_locals(guidance_form)
+    { form: @form, page: @page, additional_guidance_form: guidance_form, preview_html: preview_html(guidance_form) }
   end
 end

--- a/app/controllers/pages/additional_guidance_controller.rb
+++ b/app/controllers/pages/additional_guidance_controller.rb
@@ -5,7 +5,7 @@ class Pages::AdditionalGuidanceController < PagesController
     page_heading = session.dig(:page, "page_heading")
     additional_guidance_markdown = session.dig(:page, "additional_guidance_markdown")
     additional_guidance_form = Pages::AdditionalGuidanceForm.new(page_heading:, additional_guidance_markdown:)
-    render "pages/additional_guidance", locals: view_locals(additional_guidance_form)
+    render "pages/additional_guidance", locals: view_locals(nil, additional_guidance_form)
   end
 
   def create
@@ -13,12 +13,12 @@ class Pages::AdditionalGuidanceController < PagesController
 
     case route_to
     when :preview
-      render "pages/additional_guidance", locals: view_locals(additional_guidance_form)
+      render "pages/additional_guidance", locals: view_locals(nil, additional_guidance_form)
     when :save_and_continue
       if additional_guidance_form.submit(session)
         redirect_to new_page_path(@form)
       else
-        render "pages/additional_guidance", locals: view_locals(additional_guidance_form), status: :unprocessable_entity
+        render "pages/additional_guidance", locals: view_locals(nil, additional_guidance_form), status: :unprocessable_entity
       end
     end
   end
@@ -29,7 +29,7 @@ class Pages::AdditionalGuidanceController < PagesController
     additional_guidance_form = Pages::AdditionalGuidanceForm.new(page_heading: page.page_heading,
                                                                  additional_guidance_markdown: page.additional_guidance_markdown)
 
-    render "pages/additional_guidance", locals: view_locals(additional_guidance_form)
+    render "pages/additional_guidance", locals: view_locals(page, additional_guidance_form)
   end
 
   def update
@@ -37,12 +37,12 @@ class Pages::AdditionalGuidanceController < PagesController
 
     case route_to
     when :preview
-      render "pages/additional_guidance", locals: view_locals(additional_guidance_form)
+      render "pages/additional_guidance", locals: view_locals(page, additional_guidance_form)
     when :save_and_continue
       if additional_guidance_form.submit(session)
         redirect_to edit_page_path(@form.id, page.id)
       else
-        render "pages/additional_guidance", locals: view_locals(additional_guidance_form), status: :unprocessable_entity
+        render "pages/additional_guidance", locals: view_locals(page, additional_guidance_form), status: :unprocessable_entity
       end
     end
   end
@@ -63,7 +63,8 @@ private
     GovukFormsMarkdown.render(guidance_form.additional_guidance_markdown)
   end
 
-  def view_locals(guidance_form)
-    { form: @form, page: @page, additional_guidance_form: guidance_form, preview_html: preview_html(guidance_form) }
+  def view_locals(current_page, guidance_form)
+    post_url = current_page.present? && current_page.id.present? ? additional_guidance_edit_path : additional_guidance_new_path
+    { form: @form, page: @page, additional_guidance_form: guidance_form, preview_html: preview_html(guidance_form), post_url: }
   end
 end

--- a/app/controllers/pages/additional_guidance_controller.rb
+++ b/app/controllers/pages/additional_guidance_controller.rb
@@ -23,6 +23,30 @@ class Pages::AdditionalGuidanceController < PagesController
     end
   end
 
+  def edit
+    page.load_from_session(session, %w[answer_type page_heading additional_guidance_markdown])
+
+    additional_guidance_form = Pages::AdditionalGuidanceForm.new(page_heading: page.page_heading,
+                                                                 additional_guidance_markdown: page.additional_guidance_markdown)
+
+    render "pages/additional_guidance", locals: view_locals(additional_guidance_form)
+  end
+
+  def update
+    additional_guidance_form = Pages::AdditionalGuidanceForm.new(additional_guidance_form_params)
+
+    case route_to
+    when :preview
+      render "pages/additional_guidance", locals: view_locals(additional_guidance_form)
+    when :save_and_continue
+      if additional_guidance_form.submit(session)
+        redirect_to edit_page_path(@form.id, page.id)
+      else
+        render "pages/additional_guidance", locals: view_locals(additional_guidance_form), status: :unprocessable_entity
+      end
+    end
+  end
+
 private
 
   def additional_guidance_form_params

--- a/app/controllers/pages/additional_guidance_controller.rb
+++ b/app/controllers/pages/additional_guidance_controller.rb
@@ -5,7 +5,7 @@ class Pages::AdditionalGuidanceController < PagesController
     page_heading = session.dig(:page, "page_heading")
     additional_guidance_markdown = session.dig(:page, "additional_guidance_markdown")
     additional_guidance_form = Pages::AdditionalGuidanceForm.new(page_heading:, additional_guidance_markdown:)
-    render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: nil }
+    render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: preview_html(additional_guidance_form) }
   end
 
   def create
@@ -13,13 +13,12 @@ class Pages::AdditionalGuidanceController < PagesController
 
     case route_to
     when :preview
-      preview_html = GovukFormsMarkdown.render(additional_guidance_form.additional_guidance_markdown)
-      render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: }
+      render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: preview_html(additional_guidance_form)}
     when :save_and_continue
       if additional_guidance_form.submit(session)
         redirect_to new_page_path(@form)
       else
-        render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: }, status: :unprocessable_entity
+        render "pages/additional_guidance", locals: { form: @form, page: @page, additional_guidance_form:, preview_html: preview_html(additional_guidance_form) }, status: :unprocessable_entity
       end
     end
   end
@@ -32,5 +31,11 @@ private
 
   def route_to
     params[:route_to].to_sym
+  end
+
+  def preview_html(guidance_form)
+    return nil if guidance_form.additional_guidance_markdown.blank?
+
+    GovukFormsMarkdown.render(guidance_form.additional_guidance_markdown)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -40,9 +40,9 @@ class PagesController < ApplicationController
   end
 
   def update
-    page.load_from_session(session, %w[answer_type answer_settings]).load(page_params)
+    page.load_from_session(session, %w[answer_type answer_settings page_heading additional_guidance_markdown]).load(page_params)
 
-    if @page.save
+    if page.save
       clear_questions_session_data
       handle_submit_action
     else

--- a/app/service/page_summary_data/guidance_service.rb
+++ b/app/service/page_summary_data/guidance_service.rb
@@ -28,19 +28,27 @@ module PageSummaryData
       [{
         key: { text: "Page heading" },
         value: { text: page.page_heading },
-        actions: [{ href: additional_guidance_new_path(form_id: form.id), visually_hidden_text: "page heading" }],
+        actions: [{ href: change_url, visually_hidden_text: "page heading" }],
       },
        {
          key: { text: "Guidance text" },
          value: {
            text: markdown_content,
          },
-         actions: [{ href: additional_guidance_new_path(form_id: form.id), visually_hidden_text: "guidance text" }],
+         actions: [{ href: change_url, visually_hidden_text: "guidance text" }],
        }]
     end
 
     def markdown_content
       safe_join(['<pre class="app-markdown-example-block">'.html_safe, page.additional_guidance_markdown, "</pre>".html_safe])
+    end
+
+    def change_url
+      if page.id.present?
+        additional_guidance_edit_path(form_id: form.id, page_id: page.id)
+      else
+        additional_guidance_new_path(form_id: form.id)
+      end
     end
   end
 end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -20,7 +20,12 @@
       <p><%= t("guidance.instructions") %></p>
 
       <p>
-        <%= govuk_button_link_to t("guidance.add_guidance"), additional_guidance_new_path(form_id: form_object.id), {secondary: true} %>
+        <% guidance_link = unless is_new_page
+                             additional_guidance_edit_path(form_id: form_object.id, page_id: page_object.id)
+                           else
+                             additional_guidance_new_path(form_id: form_object.id)
+                           end%>
+        <%= govuk_button_link_to t("guidance.add_guidance"), guidance_link, {secondary: true} %>
       </p>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
     <% end %>

--- a/app/views/pages/additional_guidance.html.erb
+++ b/app/views/pages/additional_guidance.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-    <%= form_with model: [@form, additional_guidance_form], url: additional_guidance_new_path do |f| %>
+    <%= form_with model: [@form, additional_guidance_form], url: post_url do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= t("pages.question") %> <%= form.page_number(page) %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,8 @@ Rails.application.routes.draw do
           post "/name-settings" => "pages/name_settings#update", as: :name_settings_update
           get "/" => "pages#edit", as: :edit_page
           patch "/" => "pages#update", as: :update_page
+          get "/additional-guidance" => "pages/additional_guidance#edit", as: :additional_guidance_edit
+          post "/additional-guidance" => "pages/additional_guidance#update", as: :additional_guidance_update
         end
 
         scope "/delete" do

--- a/spec/requests/pages/additional_guidance_controller_spec.rb
+++ b/spec/requests/pages/additional_guidance_controller_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Pages::AdditionalGuidanceController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
+  let(:page) { pages.first }
   let(:page_heading) { "Page heading" }
   let(:additional_guidance_markdown) { "## Heading level 2" }
 
@@ -92,6 +93,93 @@ RSpec.describe Pages::AdditionalGuidanceController, type: :request do
 
       it "redirects the user to the new question page" do
         expect(response).to redirect_to new_page_path(form.id)
+      end
+
+      context "when data is invalid" do
+        let(:page_heading) { nil }
+
+        it "returns 422" do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "renders the template" do
+          expect(response).to have_rendered("pages/additional_guidance")
+        end
+      end
+    end
+  end
+
+  describe "#edit" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/#{page.id}", req_headers, page.to_json, 200
+      end
+
+      get additional_guidance_edit_path(form_id: form.id, page_id: page.id)
+    end
+
+    it "reads the existing form" do
+      expect(form).to have_been_read
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("pages/additional_guidance")
+    end
+
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "#update" do
+    let(:pages) { build_list :page, 5, :with_guidance, form_id: form.id }
+    let(:route_to) { "preview" }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/#{page.id}", req_headers, page.to_json, 200
+      end
+      post additional_guidance_update_path(form_id: form.id, page_id: page.id), params: { pages_additional_guidance_form: { page_heading:, additional_guidance_markdown: }, route_to: }
+    end
+
+    context "when previewing markdown" do
+      let(:route_to) { "preview" }
+
+      it "reads the existing form" do
+        expect(form).to have_been_read
+      end
+
+      it "renders the template" do
+        expect(response).to have_rendered("pages/additional_guidance")
+      end
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the additional guidance markdown as html" do
+        expect(response.body).to include('<h2 class="govuk-heading-l">Heading level 2</h2>')
+      end
+    end
+
+    context "when saving markdown" do
+      let(:route_to) { "save_and_continue" }
+
+      it "reads the existing form" do
+        expect(form).to have_been_read
+      end
+
+      it "saves the page_heading and additional_guidance_markdown to session" do
+        expect(session[:page][:page_heading]).to eq("Page heading")
+        expect(session[:page][:additional_guidance_markdown]).to eq("## Heading level 2")
+      end
+
+      it "redirects the user to the edit question page" do
+        expect(response).to redirect_to edit_page_path(form.id, page.id)
       end
 
       context "when data is invalid" do

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe PagesController, type: :request do
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
           answer_settings: nil,
+          page_heading: nil,
+          additional_guidance_markdown: nil,
         }].to_json
       end
 
@@ -151,6 +153,8 @@ RSpec.describe PagesController, type: :request do
           answer_type: "address",
           answer_settings: nil,
           is_optional: false,
+          page_heading: "New page heading",
+          additional_guidance_markdown: "## Heading level 2",
         }.to_json
       end
 
@@ -162,6 +166,8 @@ RSpec.describe PagesController, type: :request do
           answer_type: "address",
           answer_settings: nil,
           is_optional: nil,
+          page_heading: "New page heading",
+          additional_guidance_markdown: "## Heading level 2",
         }
       end
 
@@ -192,6 +198,8 @@ RSpec.describe PagesController, type: :request do
           question_text: "What is your home address?",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
+          page_heading: "New page heading",
+          additional_guidance_markdown: "## Heading level 2",
         } }
       end
 

--- a/spec/service/page_summary_data/guidance_service_spec.rb
+++ b/spec/service/page_summary_data/guidance_service_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe PageSummaryData::GuidanceService do
 
   let(:service) { described_class.call(form:, page:) }
   let(:form) { build :form, id: 1 }
-  let(:page) { build :page, :with_guidance, form: }
+  let(:page) { build :page, :with_guidance, id: page_id, form: }
+  let(:page_id) { nil }
 
   describe "#build_data" do
     let(:result) { service.build_data }
@@ -28,6 +29,14 @@ RSpec.describe PageSummaryData::GuidanceService do
       it "has an action to take the user back to change the value" do
         expect(row[:actions].first[:href]).to eq(additional_guidance_new_path(form_id: form.id))
       end
+
+      context "when editing guidance for an existing page" do
+        let(:page_id) { 1 }
+
+        it "has an action to take the user back to change the value" do
+          expect(row[:actions].first[:href]).to eq(additional_guidance_edit_path(form_id: form.id, page_id:))
+        end
+      end
     end
 
     describe "second row of summary list" do
@@ -43,6 +52,14 @@ RSpec.describe PageSummaryData::GuidanceService do
 
       it "has an action to take the user back to change the value" do
         expect(row[:actions].first[:href]).to eq(additional_guidance_new_path(form_id: form.id))
+      end
+
+      context "when editing guidance for an existing page" do
+        let(:page_id) { 1 }
+
+        it "has an action to take the user back to change the value" do
+          expect(row[:actions].first[:href]).to eq(additional_guidance_edit_path(form_id: form.id, page_id:))
+        end
       end
     end
 

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -63,7 +63,7 @@ describe "pages/_form.html.erb", type: :view do
       let(:is_new_page) { false }
 
       it "contains a link to add guidance" do
-        expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: additional_guidance_new_path(form_id: form.id))
+        expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: additional_guidance_edit_path(form_id: form.id, page_id: question.id))
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/7yDopG2V/963-update-page-heading-and-guidance-markdown-from-forms-admin-to-forms-api

This PR allows users to fetch, edit and update existing additional guidance markdown and page heading. It will temporarily store the values in the session until the user attempts to "save" the question in the final call to action. 

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
