### PR TITLE
Bump govuk-forms-markdown from 0.1.0 to 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "govuk_design_system_formbuilder", "~> 4.1.1"
 gem "dfe-autocomplete", require: "dfe/autocomplete", github: "DFE-Digital/dfe-autocomplete", ref: "36d80e6b5bba67c92cd9ec6982a4e536d1889aed"
 
 # Our own custom markdown renderer
-gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.1.0"
+gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.2.0"
 
 # For structured logging
 gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GIT
 
 GIT
   remote: https://github.com/alphagov/govuk-forms-markdown.git
-  revision: 726bc74cd828bdce382ea681d5c5f71fa8dd68e1
-  tag: 0.1.0
+  revision: 9f7c3953078ca636102d1cb0de0dfad792af16ee
+  tag: 0.2.0
   specs:
-    govuk-forms-markdown (0.1.0)
+    govuk-forms-markdown (0.2.0)
       redcarpet (~> 3.6)
 
 GEM


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/BMAWYkoW/971-govuk-forms-markdown-links-created-by-users-should-always-open-in-a-new-tab
