### PR TITLE
Bump govuk-forms-markdown from 0.2.0 to 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "govuk_design_system_formbuilder", "~> 4.1.1"
 gem "dfe-autocomplete", require: "dfe/autocomplete", github: "DFE-Digital/dfe-autocomplete", ref: "36d80e6b5bba67c92cd9ec6982a4e536d1889aed"
 
 # Our own custom markdown renderer
-gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.2.0"
+gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.2.1"
 
 # For structured logging
 gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GIT
 
 GIT
   remote: https://github.com/alphagov/govuk-forms-markdown.git
-  revision: 9f7c3953078ca636102d1cb0de0dfad792af16ee
-  tag: 0.2.0
+  revision: c1d9b83d7510b0f8d259238901de2bb9a5c2041c
+  tag: 0.2.1
   specs:
-    govuk-forms-markdown (0.2.0)
+    govuk-forms-markdown (0.2.1)
       redcarpet (~> 3.6)
 
 GEM


### PR DESCRIPTION
### What problem does this pull request solve?

Updates markdown heading sizes - see [the gem's release](https://github.com/alphagov/govuk-forms-markdown/releases/tag/0.2.1) for more details