### PR TITLE
Fix lint error in paste-to-html-markdown

### DIFF
--- a/app/frontend/javascript/paste-html-to-markdown/index.js
+++ b/app/frontend/javascript/paste-html-to-markdown/index.js
@@ -5,7 +5,7 @@ import htmlToMarkdown from './html-to-markdown'
 const insertTextAtCursor = (field, contentToInsert) => {
   const selectionStart = field.selectionStart
   const selectionEnd = field.selectionEnd
-  if (selectionStart || selectionStart == '0') {
+  if (selectionStart || selectionStart === '0') {
     const contentBeforeSelection = field.value.substring(0, selectionStart)
     const contentAfterSelection = field.value.substring(
       selectionEnd,
@@ -27,9 +27,7 @@ const textFromPasteEvent = event => {
 
 const triggerPasteEvent = (element, eventName, detail) => {
   const params = { bubbles: false, cancelable: false, detail: detail || null }
-  let event
-
-  event = new window.CustomEvent(eventName, params)
+  const event = new window.CustomEvent(eventName, params)
 
   element.dispatchEvent(event)
 }


### PR DESCRIPTION
### What problem does this pull request solve?

Addresses issues reported by the linter:

```
8:40  error  Expected '===' and instead saw '=='
32:3  error  'event' is never reassigned. Use 'const' instead
```
