### PR TITLE
Refactor make live validation and task status

### DIFF
--- a/app/forms/forms/make_live_form.rb
+++ b/app/forms/forms/make_live_form.rb
@@ -30,28 +30,28 @@ private
     return unless made_live?
     return if form.ready_for_live?
 
-    task_status_service = TaskStatusService.new(form:)
+    missing_sections = form.missing_sections
 
-    if task_status_service.missing_sections.include?(:missing_pages)
+    if missing_sections.include?(:missing_pages)
       errors.add(:confirm_make_live, :missing_pages)
       return false
     end
 
-    if task_status_service.missing_sections.include?(:missing_submission_email)
+    if missing_sections.include?(:missing_submission_email)
       errors.add(:confirm_make_live, :missing_submission_email)
       return false
     end
 
-    if task_status_service.missing_sections.include?(:missing_privacy_policy_url)
+    if missing_sections.include?(:missing_privacy_policy_url)
       errors.add(:confirm_make_live, :missing_privacy_policy_url)
     end
 
-    if task_status_service.missing_sections.include?(:missing_contact_details)
+    if missing_sections.include?(:missing_contact_details)
       errors.add(:confirm_make_live, :missing_contact_details)
       return false
     end
 
-    if task_status_service.missing_sections.include?(:missing_what_happens_next)
+    if missing_sections.include?(:missing_what_happens_next)
       errors.add(:confirm_make_live, :missing_what_happens_next)
       false
     end

--- a/app/forms/forms/make_live_form.rb
+++ b/app/forms/forms/make_live_form.rb
@@ -30,26 +30,28 @@ private
     return unless made_live?
     return if form.ready_for_live?
 
-    if form.missing_sections.include?(:missing_pages)
+    task_status_service = TaskStatusService.new(form:)
+
+    if task_status_service.missing_sections.include?(:missing_pages)
       errors.add(:confirm_make_live, :missing_pages)
       return false
     end
 
-    if form.missing_sections.include?(:missing_submission_email)
+    if task_status_service.missing_sections.include?(:missing_submission_email)
       errors.add(:confirm_make_live, :missing_submission_email)
       return false
     end
 
-    if form.missing_sections.include?(:missing_privacy_policy_url)
+    if task_status_service.missing_sections.include?(:missing_privacy_policy_url)
       errors.add(:confirm_make_live, :missing_privacy_policy_url)
     end
 
-    if form.missing_sections.include?(:missing_contact_details)
+    if task_status_service.missing_sections.include?(:missing_contact_details)
       errors.add(:confirm_make_live, :missing_contact_details)
       return false
     end
 
-    if form.missing_sections.include?(:missing_what_happens_next)
+    if task_status_service.missing_sections.include?(:missing_what_happens_next)
       errors.add(:confirm_make_live, :missing_what_happens_next)
       false
     end

--- a/app/forms/forms/make_live_form.rb
+++ b/app/forms/forms/make_live_form.rb
@@ -30,30 +30,10 @@ private
     return unless made_live?
     return if form.ready_for_live?
 
-    missing_sections = form.missing_sections
-
-    if missing_sections.include?(:missing_pages)
-      errors.add(:confirm_make_live, :missing_pages)
-      return false
+    form.missing_sections.each do |section|
+      errors.add(:confirm_make_live, section)
     end
 
-    if missing_sections.include?(:missing_submission_email)
-      errors.add(:confirm_make_live, :missing_submission_email)
-      return false
-    end
-
-    if missing_sections.include?(:missing_privacy_policy_url)
-      errors.add(:confirm_make_live, :missing_privacy_policy_url)
-    end
-
-    if missing_sections.include?(:missing_contact_details)
-      errors.add(:confirm_make_live, :missing_contact_details)
-      return false
-    end
-
-    if missing_sections.include?(:missing_what_happens_next)
-      errors.add(:confirm_make_live, :missing_what_happens_next)
-      false
-    end
+    errors.empty?
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -42,8 +42,12 @@ class Form < ActiveResource::Base
   end
 
   def ready_for_live?
-    TaskStatusService.new(form: self).mandatory_tasks_completed?
+    task_status_service.mandatory_tasks_completed?
   end
+
+  delegate :missing_sections, to: :task_status_service
+
+  delegate :task_statuses, to: :task_status_service
 
   def make_live!
     post "make-live"
@@ -85,5 +89,9 @@ private
 
   def has_routing_conditions
     pages.filter { |p| p.conditions.any? }.any?
+  end
+
+  def task_status_service
+    @task_status_service ||= TaskStatusService.new(form: self)
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,8 +6,6 @@ class Form < ActiveResource::Base
   belongs_to :organisation
   has_many :pages
 
-  attr_accessor :missing_sections
-
   def self.find_live(id)
     find(:one, from: "#{prefix}forms/#{id}/live")
   end
@@ -44,20 +42,7 @@ class Form < ActiveResource::Base
   end
 
   def ready_for_live?
-    @missing_sections = []
-
-    task_list_statuses = TaskStatusService.new(form: self)
-    @missing_sections << :missing_pages unless task_list_statuses.pages_status == :completed
-    @missing_sections << :missing_submission_email unless task_list_statuses.submission_email_status == :completed
-    @missing_sections << :missing_privacy_policy_url unless task_list_statuses.privacy_policy_status == :completed
-    @missing_sections << :missing_contact_details unless task_list_statuses.support_contact_details_status == :completed
-    @missing_sections << :missing_what_happens_next unless task_list_statuses.what_happens_next_status == :completed
-
-    if @missing_sections.any?
-      false
-    else
-      true
-    end
+    TaskStatusService.new(form: self).mandatory_tasks_completed?
   end
 
   def make_live!

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -3,12 +3,6 @@ class TaskStatusService
     @form = form
   end
 
-  def status_counts(current_user)
-    all_task_status_compact = all_task_status(current_user).compact
-    { completed: all_task_status_compact.count(:completed),
-      total: all_task_status_compact.count }
-  end
-
   def name_status
     :completed
   end
@@ -83,11 +77,7 @@ class TaskStatusService
   end
 
   def mandatory_tasks_completed?
-    [pages_status,
-     what_happens_next_status,
-     submission_email_status,
-     privacy_policy_status,
-     support_contact_details_status].all? { |task| task == :completed }
+    missing_sections.empty?
   end
 
   def missing_sections
@@ -98,25 +88,17 @@ class TaskStatusService
       missing_contact_details: support_contact_details_status }.reject { |_k, v| v == :completed }.map { |k, _v| k }
   end
 
-  def can_enter_submission_email_code
-    @form.email_confirmation_status == :sent
-  end
-
-private
-
-  def all_task_status(current_user)
-    status = [
-      name_status,
-      pages_status,
-      declaration_status,
-      what_happens_next_status,
-      privacy_policy_status,
-      support_contact_details_status,
-    ]
-
-    status.push(submission_email_status, confirm_submission_email_status) if Pundit.policy(current_user, @form).can_change_form_submission_email?
-    status.push(make_live_status) if Pundit.policy(current_user, @form).can_make_form_live?
-
-    status
+  def task_statuses
+    {
+      name_status:,
+      pages_status:,
+      declaration_status:,
+      what_happens_next_status:,
+      submission_email_status:,
+      confirm_submission_email_status:,
+      privacy_policy_status:,
+      support_contact_details_status:,
+      make_live_status:,
+    }
   end
 end

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -90,6 +90,14 @@ class TaskStatusService
      support_contact_details_status].all? { |task| task == :completed }
   end
 
+  def missing_sections
+    { missing_pages: pages_status,
+      missing_what_happens_next: what_happens_next_status,
+      missing_submission_email: submission_email_status,
+      missing_privacy_policy_url: privacy_policy_status,
+      missing_contact_details: support_contact_details_status }.reject { |_k, v| v == :completed }.map { |k, _v| k }
+  end
+
   def can_enter_submission_email_code
     @form.email_confirmation_status == :sent
   end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
     organisation_id { 1 }
     live_at { nil }
-    missing_sections { nil }
     support_email { nil }
     support_phone { nil }
     support_url { nil }

--- a/spec/forms/make_live_form_spec.rb
+++ b/spec/forms/make_live_form_spec.rb
@@ -74,28 +74,40 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
         make_live_form.confirm_make_live = "made_live"
       end
 
-      it "is invalid if submission_email is blank" do
-        error_message = I18n.t("activemodel.errors.models.forms/make_live_form.attributes.confirm_make_live.missing_submission_email")
-        make_live_form.form.submission_email = nil
-        expect(make_live_form).not_to be_valid
+      [
+        {
+          attribute: :pages,
+          attribute_value: [],
+          error_message: I18n.t("activemodel.errors.models.forms/make_live_form.attributes.confirm_make_live.missing_pages"),
+        },
+        {
+          attribute: :what_happens_next_text,
+          attribute_value: nil,
+          error_message: I18n.t("activemodel.errors.models.forms/make_live_form.attributes.confirm_make_live.missing_what_happens_next"),
+        },
+        {
+          attribute: :submission_email,
+          attribute_value: nil,
+          error_message: I18n.t("activemodel.errors.models.forms/make_live_form.attributes.confirm_make_live.missing_submission_email"),
+        },
+        {
+          attribute: :privacy_policy_url,
+          attribute_value: nil,
+          error_message: I18n.t("activemodel.errors.models.forms/make_live_form.attributes.confirm_make_live.missing_privacy_policy_url"),
+        },
+        {
+          attribute: :support_email,
+          attribute_value: nil,
+          error_message: I18n.t("activemodel.errors.models.forms/make_live_form.attributes.confirm_make_live.missing_contact_details"),
+        },
+      ].each do |scenario|
+        it "is invalid if #{scenario[:attribute]} is missing" do
+          # this just sets the attribute to the attribute_value for each test
+          make_live_form.form.send("#{scenario[:attribute]}=", scenario[:attribute_value])
 
-        expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include("Confirm make live #{error_message}")
-      end
-
-      it "is invalid is no privacy_policy" do
-        error_message = I18n.t("activemodel.errors.models.forms/make_live_form.attributes.confirm_make_live.missing_privacy_policy_url")
-        make_live_form.form.privacy_policy_url = nil
-        expect(make_live_form).not_to be_valid
-
-        expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include("Confirm make live #{error_message}")
-      end
-
-      it "is invalid if no questions have been added" do
-        error_message = I18n.t("activemodel.errors.models.forms/make_live_form.attributes.confirm_make_live.missing_pages")
-        make_live_form.form.pages = []
-        expect(make_live_form).not_to be_valid
-
-        expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include("Confirm make live #{error_message}")
+          expect(make_live_form).not_to be_valid
+          expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include("Confirm make live #{scenario[:error_message]}")
+        end
       end
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -51,6 +51,43 @@ describe Form, type: :model do
     end
   end
 
+  describe "#missing_sections" do
+    context "when a form is complete and ready to be made live" do
+      let(:completed_form) { build :form, :live }
+
+      it "returns no missing sections" do
+        expect(completed_form.missing_sections).to be_empty
+      end
+    end
+
+    context "when a form is incomplete and should still be in draft state" do
+      let(:new_form) { build :form, :new_form }
+
+      it "returns a set of keys related to missing fields" do
+        expect(new_form.missing_sections).to match_array(%i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details missing_what_happens_next])
+      end
+    end
+  end
+
+  describe "#task_statuses" do
+    let(:completed_form) { build :form, :live }
+
+    it "returns a hash with each of the task statuses" do
+      expected_hash = {
+        name_status: :completed,
+        pages_status: :completed,
+        declaration_status: :completed,
+        what_happens_next_status: :completed,
+        submission_email_status: :completed,
+        confirm_submission_email_status: :completed,
+        privacy_policy_status: :completed,
+        support_contact_details_status: :completed,
+        make_live_status: nil,
+      }
+      expect(completed_form.task_statuses).to eq expected_hash
+    end
+  end
+
   describe "#email_confirmation_status" do
     it "returns :not_started" do
       expect(form.email_confirmation_status).to eq(:not_started)

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -39,13 +39,6 @@ describe Form, type: :model do
       it "returns true" do
         expect(completed_form.ready_for_live?).to eq true
       end
-
-      it "returns no missing fields" do
-        results = completed_form
-        results.ready_for_live?
-
-        expect(results.missing_sections).to be_empty
-      end
     end
 
     context "when a form is incomplete and should still be in draft state" do
@@ -54,14 +47,6 @@ describe Form, type: :model do
       it "returns false" do
         new_form.pages = []
         expect(new_form.ready_for_live?).to eq false
-      end
-
-      it "returns a set of keys related to missing fields" do
-        new_form.pages = []
-        results = new_form
-        results.ready_for_live?
-
-        expect(results.missing_sections).to eq %i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details missing_what_happens_next]
       end
     end
   end

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -193,6 +193,28 @@ describe TaskStatusService do
     end
   end
 
+  describe "#missing_sections" do
+    context "when mandatory tasks have not been completed" do
+      let(:form) { build(:form, :new_form) }
+
+      it "returns missing sections" do
+        expect(task_status_service.missing_sections).to eq %i[missing_pages
+                                                              missing_what_happens_next
+                                                              missing_submission_email
+                                                              missing_privacy_policy_url
+                                                              missing_contact_details]
+      end
+    end
+
+    context "when mandatory tasks have been completed" do
+      let(:form) { build(:form, :ready_for_live) }
+
+      it "returns true" do
+        expect(task_status_service.missing_sections).to eq []
+      end
+    end
+  end
+
   describe "#status_counts" do
     let(:form) { build :form }
 

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -194,47 +194,39 @@ describe TaskStatusService do
   end
 
   describe "#missing_sections" do
-    context "when mandatory tasks have not been completed" do
-      let(:form) { build(:form, :new_form) }
+    context "when mandatory tasks are complete" do
+      let(:form) { build :form, :live }
 
-      it "returns missing sections" do
-        expect(task_status_service.missing_sections).to eq %i[missing_pages
-                                                              missing_what_happens_next
-                                                              missing_submission_email
-                                                              missing_privacy_policy_url
-                                                              missing_contact_details]
+      it "returns no missing sections" do
+        expect(task_status_service.missing_sections).to be_empty
       end
     end
 
-    context "when mandatory tasks have been completed" do
-      let(:form) { build(:form, :ready_for_live) }
+    context "when a form is incomplete and should still be in draft state" do
+      let(:form) { build :form, :new_form }
 
-      it "returns true" do
-        expect(task_status_service.missing_sections).to eq []
+      it "returns a set of keys related to missing fields" do
+        expect(task_status_service.missing_sections).to match_array(%i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details missing_what_happens_next])
       end
     end
   end
 
-  describe "#status_counts" do
-    let(:form) { build :form }
+  describe "#task_statuses" do
+    let(:form) { build :form, :live }
 
-    context "when user has editor role" do
-      it "returns a hash containing count of completed tasks and total number of tasks" do
-        allow(task_status_service).to receive(:all_task_status).and_return(%i[completed completed something_else])
-        expect(task_status_service.status_counts(current_user)).to eq({ completed: 2, total: 3 })
-      end
-
-      it "includes all status" do
-        expect(task_status_service.status_counts(current_user)).to include(total: 9)
-      end
-    end
-
-    context "when user has trial role" do
-      let(:current_user) { build :user, :with_trial_role }
-
-      it "excludes status for restricted tasks" do
-        expect(task_status_service.status_counts(current_user)).to include(total: 6)
-      end
+    it "returns a hash with each of the task statuses" do
+      expected_hash = {
+        name_status: :completed,
+        pages_status: :completed,
+        declaration_status: :completed,
+        what_happens_next_status: :completed,
+        submission_email_status: :completed,
+        confirm_submission_email_status: :completed,
+        privacy_policy_status: :completed,
+        support_contact_details_status: :completed,
+        make_live_status: nil,
+      }
+      expect(task_status_service.task_statuses).to eq expected_hash
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?
Currently we have validation in forms-admin that prevents making a form live until certain conditions are met. However the api will happily make a form live if those conditions aren’t met. 

Prior to adding the validation to forms-api, I wanted to refactor the existing validation in forms-admin to make it more straightforward to move to forms-api, and allow forms-admin to consume the validation result from forms-api.

 I'll add comments to the diff, but in summary this means:
- refactoring the task status service to be user agnostic
- moving accessing task status service functionality via the form model (in preparation for that data to be in the form data itself)

Trello card: https://trello.com/c/xEyusUhB

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
