### PR TITLE
Add guidance details to live pages summary cards

### DIFF
--- a/app/service/page_options_service.rb
+++ b/app/service/page_options_service.rb
@@ -15,6 +15,8 @@ class PageOptionsService
 
   def all_options_for_answer_type
     options = []
+    options.concat(page_heading_options) if @page.page_heading.present?
+    options.concat(guidance_markdown_options) if @page.guidance_markdown.present?
 
     options.concat(hint_options) if @page.hint_text?.present?
     options.concat(generic_options) if @read_only && %w[address date text selection name].exclude?(@page.answer_type)
@@ -29,6 +31,24 @@ class PageOptionsService
   end
 
 private
+
+  def page_heading_options
+    [{
+      key: { text: I18n.t("page_options_service.page_heading") },
+      value: { text: @page.page_heading },
+    }]
+  end
+
+  def markdown_content
+    safe_join(['<pre class="app-markdown-example-block">'.html_safe, @page.guidance_markdown, "</pre>".html_safe])
+  end
+
+  def guidance_markdown_options
+    [{
+      key: { text: I18n.t("page_options_service.guidance_markdown") },
+      value: { text: markdown_content },
+    }]
+  end
 
   def hint_options
     [{

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -445,10 +445,12 @@ en:
   page_options_service:
     answer_type: Answer type
     date: Date
+    guidance_markdown: Guidance
     hint_text: Hint text
     name_type:
       title_not_selected: Title not needed
       title_selected: Title needed
+    page_heading: Page heading
     selection_type:
       default: Selection from a list
       none_of_the_above: None of the above

--- a/spec/service/page_options_service_spec.rb
+++ b/spec/service/page_options_service_spec.rb
@@ -235,5 +235,23 @@ describe PageOptionsService do
         end
       end
     end
+
+    context "with guidance" do
+      let(:page) { build :page, :with_guidance }
+
+      it "returns the correct page heading" do
+        expect(page_options_service.all_options_for_answer_type).to include(
+          { key: { text: I18n.t("page_options_service.page_heading") },
+            value: { text: page.page_heading } },
+        )
+      end
+
+      it "returns the correct guidance markdown" do
+        expect(page_options_service.all_options_for_answer_type).to include(
+          { key: { text: I18n.t("page_options_service.guidance_markdown") },
+            value: { text: "<pre class=\"app-markdown-example-block\">#{page.guidance_markdown}</pre>" } },
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?
Add two extra lines to summary card if question has guidance markdown and page heading.

Trello card: https://trello.com/c/UUlncEXu/1000-add-guidance-to-live-questions-page-in-forms-admin
![image](https://github.com/alphagov/forms-admin/assets/3441519/b17cf34d-d9fe-4f14-9be1-23a26afedab1)

### Things to consider when reviewing


- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
