### PR TITLE
Add markdown gem validations to guidance form

### DIFF
--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -13,6 +13,7 @@ class Pages::GuidanceController < PagesController
 
     case route_to
     when :preview
+      guidance_form.valid?
       render "pages/guidance", locals: view_locals(nil, guidance_form)
     when :save_and_continue
       if guidance_form.submit(session)
@@ -37,6 +38,7 @@ class Pages::GuidanceController < PagesController
 
     case route_to
     when :preview
+      guidance_form.valid?
       render "pages/guidance", locals: view_locals(page, guidance_form)
     when :save_and_continue
       if guidance_form.submit(session)

--- a/app/forms/pages/guidance_form.rb
+++ b/app/forms/pages/guidance_form.rb
@@ -1,7 +1,10 @@
+require "govuk_forms_markdown"
+
 class Pages::GuidanceForm < BaseForm
   attr_accessor :page_heading, :guidance_markdown
 
   validate :guidance_fields_presence
+  validate :markdown_length_and_tags
 
   def submit(session)
     return false if invalid?
@@ -12,6 +15,22 @@ class Pages::GuidanceForm < BaseForm
   end
 
 private
+
+  def markdown_length_and_tags
+    return true if guidance_markdown.blank?
+
+    markdown_validation = GovukFormsMarkdown.validate(guidance_markdown)
+
+    return true if markdown_validation[:errors].empty?
+
+    tag_errors = markdown_validation[:errors].excluding(:too_long)
+
+    if tag_errors.any?
+      errors.add(:guidance_markdown, :unsupported_markdown_syntax)
+    elsif markdown_validation[:errors].include?(:too_long)
+      errors.add(:guidance_markdown, :too_long)
+    end
+  end
 
   def guidance_fields_presence
     if page_heading.present? && guidance_markdown.blank?

--- a/config/locales/pages/guidance.yml
+++ b/config/locales/pages/guidance.yml
@@ -17,3 +17,5 @@ en:
               blank: Enter a page heading
             guidance_markdown:
               blank: Enter guidance text
+              unsupported_markdown_syntax: Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
+              too_long: Guidance text must be 5,000 characters or less

--- a/spec/forms/pages/guidance_form_spec.rb
+++ b/spec/forms/pages/guidance_form_spec.rb
@@ -20,13 +20,27 @@ RSpec.describe Pages::GuidanceForm, type: :model do
       expect(guidance_form.errors.full_messages_for(:guidance_markdown)).to include("Guidance markdown #{error_message}")
     end
 
-    context "when page_heading and guidance_markdown are blank" do
+    context "when page_heading and guidance_markdown are not blank" do
       let(:page_heading) { "New guidance heading" }
       let(:guidance_markdown) { "## Level heading 2" }
 
-      it "is validate" do
+      it "is valid" do
         expect(guidance_form).to be_valid
       end
+    end
+
+    it "is invalid if guidance markdown contains unsupported tags" do
+      error_message = I18n.t("activemodel.errors.models.pages/guidance_form.attributes.guidance_markdown.unsupported_markdown_syntax")
+      guidance_form.guidance_markdown = "# Heading level 1"
+      expect(guidance_form).to be_invalid
+      expect(guidance_form.errors.full_messages_for(:guidance_markdown)).to include("Guidance markdown #{error_message}")
+    end
+
+    it "is invalid if guidance markdown is over 5000 characters" do
+      error_message = I18n.t("activemodel.errors.models.pages/guidance_form.attributes.guidance_markdown.too_long")
+      guidance_form.guidance_markdown = "A" * 5001
+      expect(guidance_form).to be_invalid
+      expect(guidance_form.errors.full_messages_for(:guidance_markdown)).to include("Guidance markdown #{error_message}")
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/TkQH9Cd1/997-add-markdown-gem-validation-to-forms-admin

This adds validations via the `govuk_forms_markdown` gem to the guidance page. This means that if invalid markdown tags are used, or the length of the guidance is greater than 4999 chars, it'll be considered invalid and prevent submission. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
