### PR TITLE
Guidance fields should only be required if either heading or markdown…

### DIFF
--- a/app/forms/pages/guidance_form.rb
+++ b/app/forms/pages/guidance_form.rb
@@ -1,7 +1,7 @@
 class Pages::GuidanceForm < BaseForm
   attr_accessor :page_heading, :guidance_markdown
 
-  validates :page_heading, :guidance_markdown, presence: true
+  validate :guidance_fields_presence
 
   def submit(session)
     return false if invalid?
@@ -9,5 +9,15 @@ class Pages::GuidanceForm < BaseForm
     session[:page] = {} if session[:page].blank?
     session[:page][:page_heading] = page_heading
     session[:page][:guidance_markdown] = guidance_markdown
+  end
+
+private
+
+  def guidance_fields_presence
+    if page_heading.present? && guidance_markdown.blank?
+      errors.add(:guidance_markdown, :blank)
+    elsif guidance_markdown.present? && page_heading.blank?
+      errors.add(:page_heading, :blank)
+    end
   end
 end

--- a/spec/forms/pages/guidance_form_spec.rb
+++ b/spec/forms/pages/guidance_form_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe Pages::GuidanceForm, type: :model do
   let(:guidance_form) { described_class.new(page_heading:, guidance_markdown:) }
-  let(:page_heading) { nil }
-  let(:guidance_markdown) { nil }
+  let(:page_heading) { "New guidance heading" }
+  let(:guidance_markdown) { "## Level heading 2" }
 
   describe "validations" do
     it "is invalid if page heading is nil" do
@@ -19,14 +19,23 @@ RSpec.describe Pages::GuidanceForm, type: :model do
       expect(guidance_form).to be_invalid
       expect(guidance_form.errors.full_messages_for(:guidance_markdown)).to include("Guidance markdown #{error_message}")
     end
+
+    context "when page_heading and guidance_markdown are blank" do
+      let(:page_heading) { "New guidance heading" }
+      let(:guidance_markdown) { "## Level heading 2" }
+
+      it "is validate" do
+        expect(guidance_form).to be_valid
+      end
+    end
   end
 
   describe "#submit" do
     let(:session_mock) { {} }
 
     it "returns false if the form is invalid" do
+      allow(guidance_form).to receive(:invalid?).and_return(true)
       expect(guidance_form.submit(session_mock)).to eq false
-      expect(guidance_form.errors.any?).to eq true
     end
 
     context "when page_heading and guidance_markdown are valid" do


### PR DESCRIPTION
### What problem does this pull request solve?

Guidance fields should only be required if either heading or markdown is provided. This means that users can remove both sets of values to remove guidance from the question

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
