### PR TITLE
Replace bullet characters on paste

### DIFF
--- a/app/frontend/javascript/paste-html-to-markdown/html-to-markdown.js
+++ b/app/frontend/javascript/paste-html-to-markdown/html-to-markdown.js
@@ -1,6 +1,7 @@
 // Adapted from the [Paste HTML to govspeak](https://github.com/alphagov/paste-html-to-govspeak) package
 
 import TurndownService from 'turndown'
+import replaceBulletCharacters from './replace-bullet-characters'
 
 const service = new TurndownService({
   bulletListMarker: '*',
@@ -344,7 +345,8 @@ const extractHeadingsFromLists = markdown => {
 
 const postProcess = markdown => {
   const markdownWithExtractedHeadings = extractHeadingsFromLists(markdown)
-  const brsRemoved = removeBrParagraphs(markdownWithExtractedHeadings)
+  const bulletsReplaced = replaceBulletCharacters(markdownWithExtractedHeadings)
+  const brsRemoved = removeBrParagraphs(bulletsReplaced)
   const whitespaceStripped = brsRemoved.trim()
   return whitespaceStripped
 }

--- a/app/frontend/javascript/paste-html-to-markdown/html-to-markdown.test.js
+++ b/app/frontend/javascript/paste-html-to-markdown/html-to-markdown.test.js
@@ -324,6 +324,13 @@ it('Converts a MS Word list that uses msoNormal classes', () => {
   expect(htmlToMarkdown(html)).toEqual('* Item 1\n' + '* Item 2')
 })
 
+it('Converts bullet characters to markdown bullets', () => {
+  const html = `<p>• bullet content</p>
+  <p>•bullet content</p>`
+
+  expect(htmlToMarkdown(html)).toEqual('* bullet content\n\n* bullet content')
+})
+
 it("Doesn't preserve markdown that is only a link with similar text to the link", () => {
   // If you paste the URL from the address bar of chrome this is the HTML created
   const html = `

--- a/app/frontend/javascript/paste-html-to-markdown/index.js
+++ b/app/frontend/javascript/paste-html-to-markdown/index.js
@@ -1,11 +1,12 @@
 // Adapted from the [Paste HTML to govspeak](https://github.com/alphagov/paste-html-to-govspeak) package.
 
 import htmlToMarkdown from './html-to-markdown'
+import replaceBulletCharacters from './replace-bullet-characters'
 
 const insertTextAtCursor = (field, contentToInsert) => {
   const selectionStart = field.selectionStart
   const selectionEnd = field.selectionEnd
-  if (selectionStart || selectionStart === '0') {
+  if (selectionStart || selectionStart === '0' || selectionStart === 0) {
     const contentBeforeSelection = field.value.substring(0, selectionStart)
     const contentAfterSelection = field.value.substring(
       selectionEnd,
@@ -34,6 +35,8 @@ const triggerPasteEvent = (element, eventName, detail) => {
 
 const pasteListener = event => {
   if (event.clipboardData) {
+    let contentToPaste
+    event.preventDefault()
     const element = event.target
 
     const html = htmlFromPasteEvent(event)
@@ -46,9 +49,11 @@ const pasteListener = event => {
       const markdown = htmlToMarkdown(html)
       triggerPasteEvent(element, 'markdown', markdown)
 
-      insertTextAtCursor(element, markdown)
-      event.preventDefault()
+      contentToPaste = markdown
+    } else if (text?.length) {
+      contentToPaste = replaceBulletCharacters(text)
     }
+    insertTextAtCursor(element, contentToPaste)
   }
 }
 

--- a/app/frontend/javascript/paste-html-to-markdown/index.test.js
+++ b/app/frontend/javascript/paste-html-to-markdown/index.test.js
@@ -40,6 +40,13 @@ it('converts HTML to govspeak if HTML is pasted', () => {
   expect(textarea.value).toEqual('## Hello')
 })
 
+it('converts bullet characters to markdown bullets if text is pasted', () => {
+  textarea.dispatchEvent(
+    createHtmlPasteEvent(null, '• bullet text\n•bullet text')
+  )
+  expect(textarea.value).toEqual('* bullet text\n* bullet text')
+})
+
 describe('htmlpaste event', () => {
   it('has raw HTML as the detail if HTML is pasted', () => {
     const listener = jest.fn()

--- a/app/frontend/javascript/paste-html-to-markdown/replace-bullet-characters.js
+++ b/app/frontend/javascript/paste-html-to-markdown/replace-bullet-characters.js
@@ -1,0 +1,5 @@
+const replaceBulletCharacters = markdown => {
+  return markdown.replaceAll(/[^\S\r\n]*•\s*/g, '* ')
+}
+
+export default replaceBulletCharacters

--- a/app/frontend/javascript/paste-html-to-markdown/replace-bullet-characters.test.js
+++ b/app/frontend/javascript/paste-html-to-markdown/replace-bullet-characters.test.js
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import replaceBulletCharacters from './replace-bullet-characters'
+
+it('converts bullet characters to markdown bullets', () => {
+  expect(replaceBulletCharacters('•')).toEqual('* ')
+})
+
+it('converts bullet characters with appended whitespace to markdown bullets', () => {
+  expect(replaceBulletCharacters('• ')).toEqual('* ')
+})


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/8ssqSgiJ/1008-convert-bullet-characters-into-markdown-bullets

Adds logic to convert the bullet character `• ` into a Markdown-compatible bullet `* `. We have to do this in two places (to handle HTML pasted with the character in, and to handle plain text content with the character in) so I've moved the replacement function out into its own tiny JS module.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
