### PR TITLE
Move page related form objects to pages directory

### DIFF
--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -2,14 +2,14 @@ class Pages::AddressSettingsController < PagesController
   def new
     uk_address = session.dig(:page, "answer_settings", "input_type", "uk_address")
     international_address = session.dig(:page, "answer_settings", "input_type", "international_address")
-    @address_settings_form = Forms::AddressSettingsForm.new(uk_address:, international_address:)
+    @address_settings_form = Pages::AddressSettingsForm.new(uk_address:, international_address:)
     @address_settings_path = address_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
     render address_settings_view
   end
 
   def create
-    @address_settings_form = Forms::AddressSettingsForm.new(address_settings_form_params)
+    @address_settings_form = Pages::AddressSettingsForm.new(address_settings_form_params)
     @address_settings_path = address_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
 
@@ -25,7 +25,7 @@ class Pages::AddressSettingsController < PagesController
     input_type = @page&.answer_settings&.input_type
     uk_address = input_type&.uk_address
     international_address = input_type&.international_address
-    @address_settings_form = Forms::AddressSettingsForm.new(uk_address:, international_address:, page: @page)
+    @address_settings_form = Pages::AddressSettingsForm.new(uk_address:, international_address:, page: @page)
     @address_settings_path = address_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render address_settings_view
@@ -33,7 +33,7 @@ class Pages::AddressSettingsController < PagesController
 
   def update
     page
-    @address_settings_form = Forms::AddressSettingsForm.new(address_settings_form_params)
+    @address_settings_form = Pages::AddressSettingsForm.new(address_settings_form_params)
     @address_settings_path = address_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
 
@@ -48,7 +48,7 @@ private
 
   def address_settings_form_params
     form = Form.find(params[:form_id])
-    params.require(:forms_address_settings_form).permit(:uk_address, :international_address).merge(form:)
+    params.require(:pages_address_settings_form).permit(:uk_address, :international_address).merge(form:)
   end
 
   def address_settings_view

--- a/app/controllers/pages/date_settings_controller.rb
+++ b/app/controllers/pages/date_settings_controller.rb
@@ -1,14 +1,14 @@
 class Pages::DateSettingsController < PagesController
   def new
     input_type = session.dig(:page, "answer_settings", "input_type")
-    @date_settings_form = Forms::DateSettingsForm.new(input_type:)
+    @date_settings_form = Pages::DateSettingsForm.new(input_type:)
     @date_settings_path = date_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
     render "pages/date_settings"
   end
 
   def create
-    @date_settings_form = Forms::DateSettingsForm.new(date_settings_form_params)
+    @date_settings_form = Pages::DateSettingsForm.new(date_settings_form_params)
     @date_settings_path = date_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
 
@@ -22,7 +22,7 @@ class Pages::DateSettingsController < PagesController
   def edit
     page.load_from_session(session, %w[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
-    @date_settings_form = Forms::DateSettingsForm.new(input_type:, page: @page)
+    @date_settings_form = Pages::DateSettingsForm.new(input_type:, page: @page)
     @date_settings_path = date_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render "pages/date_settings"
@@ -30,7 +30,7 @@ class Pages::DateSettingsController < PagesController
 
   def update
     page
-    @date_settings_form = Forms::DateSettingsForm.new(date_settings_form_params)
+    @date_settings_form = Pages::DateSettingsForm.new(date_settings_form_params)
     @date_settings_path = date_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
 
@@ -45,6 +45,6 @@ private
 
   def date_settings_form_params
     form = Form.find(params[:form_id])
-    params.require(:forms_date_settings_form).permit(:input_type).merge(form:)
+    params.require(:pages_date_settings_form).permit(:input_type).merge(form:)
   end
 end

--- a/app/controllers/pages/name_settings_controller.rb
+++ b/app/controllers/pages/name_settings_controller.rb
@@ -2,14 +2,14 @@ class Pages::NameSettingsController < PagesController
   def new
     input_type = session.dig(:page, "answer_settings", "input_type")
     title_needed = session.dig(:page, "answer_settings", "title_needed")
-    @name_settings_form = Forms::NameSettingsForm.new(input_type:, title_needed:)
+    @name_settings_form = Pages::NameSettingsForm.new(input_type:, title_needed:)
     @name_settings_path = name_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
     render name_settings_view
   end
 
   def create
-    @name_settings_form = Forms::NameSettingsForm.new(name_settings_form_params)
+    @name_settings_form = Pages::NameSettingsForm.new(name_settings_form_params)
     @name_settings_path = name_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
 
@@ -24,7 +24,7 @@ class Pages::NameSettingsController < PagesController
     page.load_from_session(session, %w[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
     title_needed = @page&.answer_settings&.title_needed
-    @name_settings_form = Forms::NameSettingsForm.new(input_type:, title_needed:, page: @page)
+    @name_settings_form = Pages::NameSettingsForm.new(input_type:, title_needed:, page: @page)
     @name_settings_path = name_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render name_settings_view
@@ -32,7 +32,7 @@ class Pages::NameSettingsController < PagesController
 
   def update
     page
-    @name_settings_form = Forms::NameSettingsForm.new(name_settings_form_params)
+    @name_settings_form = Pages::NameSettingsForm.new(name_settings_form_params)
     @name_settings_path = name_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
 
@@ -47,7 +47,7 @@ private
 
   def name_settings_form_params
     form = Form.find(params[:form_id])
-    params.require(:forms_name_settings_form).permit(:input_type, :title_needed).merge(form:)
+    params.require(:pages_name_settings_form).permit(:input_type, :title_needed).merge(form:)
   end
 
   def name_settings_view

--- a/app/controllers/pages/question_text_controller.rb
+++ b/app/controllers/pages/question_text_controller.rb
@@ -1,14 +1,14 @@
 class Pages::QuestionTextController < PagesController
   def new
     question_text = session.dig(:page, "question_text")
-    @question_text_form = Forms::QuestionTextForm.new(question_text:)
+    @question_text_form = Pages::QuestionTextForm.new(question_text:)
     @question_text_path = question_text_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
     render "pages/question_text"
   end
 
   def create
-    @question_text_form = Forms::QuestionTextForm.new(question_text_form_params)
+    @question_text_form = Pages::QuestionTextForm.new(question_text_form_params)
     @question_text_path = question_text_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
 
@@ -22,6 +22,6 @@ class Pages::QuestionTextController < PagesController
 private
 
   def question_text_form_params
-    params.require(:forms_question_text_form).permit(:question_text)
+    params.require(:pages_question_text_form).permit(:question_text)
   end
 end

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -57,7 +57,7 @@ class Pages::SelectionsSettingsController < PagesController
 private
 
   def convert_to_selection_option(hash)
-    Forms::SelectionOption.new(hash)
+    Pages::SelectionOption.new(hash)
   end
 
   def load_answer_settings_from_params(params)

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -1,7 +1,7 @@
 class Pages::SelectionsSettingsController < PagesController
   def new
     answer_settings = load_answer_settings_from_session
-    @selections_settings_form = Forms::SelectionsSettingsForm.new(answer_settings)
+    @selections_settings_form = Pages::SelectionsSettingsForm.new(answer_settings)
     @selections_settings_path = selections_settings_create_path(@form)
     @back_link_url = question_text_new_path(@form)
     render selection_settings_view
@@ -9,7 +9,7 @@ class Pages::SelectionsSettingsController < PagesController
 
   def create
     answer_settings = load_answer_settings_from_params(selections_settings_form_params)
-    @selections_settings_form = Forms::SelectionsSettingsForm.new(answer_settings)
+    @selections_settings_form = Pages::SelectionsSettingsForm.new(answer_settings)
     @selections_settings_path = selections_settings_create_path(@form)
     @back_link_url = question_text_new_path(@form)
 
@@ -29,7 +29,7 @@ class Pages::SelectionsSettingsController < PagesController
   def edit
     page.load_from_session(session, %w[answer_type answer_settings is_optional])
     @selections_settings_path = selections_settings_update_path(@form)
-    @selections_settings_form = Forms::SelectionsSettingsForm.new(load_answer_settings_from_page_object(page))
+    @selections_settings_form = Pages::SelectionsSettingsForm.new(load_answer_settings_from_page_object(page))
     @back_link_url = edit_page_path(@form, page)
     render selection_settings_view
   end
@@ -37,7 +37,7 @@ class Pages::SelectionsSettingsController < PagesController
   def update
     @selections_settings_path = selections_settings_update_path(@form)
     answer_settings = load_answer_settings_from_params(selections_settings_form_params)
-    @selections_settings_form = Forms::SelectionsSettingsForm.new(answer_settings)
+    @selections_settings_form = Pages::SelectionsSettingsForm.new(answer_settings)
     @back_link_url = edit_page_path(@form, page)
 
     if params[:add_another]
@@ -76,7 +76,7 @@ private
 
       { only_one_option:, selection_options:, include_none_of_the_above: }
     else
-      Forms::SelectionsSettingsForm::DEFAULT_OPTIONS
+      Pages::SelectionsSettingsForm::DEFAULT_OPTIONS
     end
   end
 
@@ -89,7 +89,7 @@ private
   end
 
   def selections_settings_form_params
-    params.require(:forms_selections_settings_form).permit(:only_one_option, :include_none_of_the_above, selection_options: [:name])
+    params.require(:pages_selections_settings_form).permit(:only_one_option, :include_none_of_the_above, selection_options: [:name])
   end
 
   def selection_settings_view

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -1,14 +1,14 @@
 class Pages::TextSettingsController < PagesController
   def new
     input_type = session.dig(:page, "answer_settings", "input_type")
-    @text_settings_form = Forms::TextSettingsForm.new(input_type:)
+    @text_settings_form = Pages::TextSettingsForm.new(input_type:)
     @text_settings_path = text_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
     render "pages/text_settings"
   end
 
   def create
-    @text_settings_form = Forms::TextSettingsForm.new(text_settings_form_params)
+    @text_settings_form = Pages::TextSettingsForm.new(text_settings_form_params)
     @text_settings_path = text_settings_create_path(@form)
     @back_link_url = type_of_answer_new_path(@form)
 
@@ -22,7 +22,7 @@ class Pages::TextSettingsController < PagesController
   def edit
     page.load_from_session(session, %w[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
-    @text_settings_form = Forms::TextSettingsForm.new(input_type:, page: @page)
+    @text_settings_form = Pages::TextSettingsForm.new(input_type:, page: @page)
     @text_settings_path = text_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render "pages/text_settings"
@@ -30,7 +30,7 @@ class Pages::TextSettingsController < PagesController
 
   def update
     page
-    @text_settings_form = Forms::TextSettingsForm.new(text_settings_form_params)
+    @text_settings_form = Pages::TextSettingsForm.new(text_settings_form_params)
     @text_settings_path = text_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
 
@@ -45,6 +45,6 @@ private
 
   def text_settings_form_params
     form = Form.find(params[:form_id])
-    params.require(:forms_text_settings_form).permit(:input_type).merge(form:)
+    params.require(:pages_text_settings_form).permit(:input_type).merge(form:)
   end
 end

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -91,7 +91,7 @@ private
   def default_answer_settings_for_answer_type(answer_type)
     case answer_type
     when "selection"
-      Forms::SelectionsSettingsForm::DEFAULT_OPTIONS
+      Pages::SelectionsSettingsForm::DEFAULT_OPTIONS
     when "text", "date", "address"
       { input_type: nil }
     when "name"

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -1,13 +1,13 @@
 class Pages::TypeOfAnswerController < PagesController
   def new
     answer_type = session.dig(:page, "answer_type")
-    @type_of_answer_form = Forms::TypeOfAnswerForm.new(answer_type:)
+    @type_of_answer_form = Pages::TypeOfAnswerForm.new(answer_type:)
     @type_of_answer_path = type_of_answer_create_path(@form)
     render "pages/type-of-answer"
   end
 
   def create
-    @type_of_answer_form = Forms::TypeOfAnswerForm.new(answer_type_form_params)
+    @type_of_answer_form = Pages::TypeOfAnswerForm.new(answer_type_form_params)
 
     if @type_of_answer_form.submit(session)
       redirect_to next_page_path(@form, @type_of_answer_form.answer_type, :create)
@@ -20,7 +20,7 @@ class Pages::TypeOfAnswerController < PagesController
   def edit
     page.load_from_session(session, %w[answer_type])
 
-    @type_of_answer_form = Forms::TypeOfAnswerForm.new(answer_type: @page.answer_type, page: @page)
+    @type_of_answer_form = Pages::TypeOfAnswerForm.new(answer_type: @page.answer_type, page: @page)
     @type_of_answer_path = type_of_answer_update_path(@form)
     render "pages/type-of-answer"
   end
@@ -30,7 +30,7 @@ class Pages::TypeOfAnswerController < PagesController
     answer_type = session.dig(:page, "answer_type")
 
     @page.load(answer_type:)
-    @type_of_answer_form = Forms::TypeOfAnswerForm.new(answer_type_form_params)
+    @type_of_answer_form = Pages::TypeOfAnswerForm.new(answer_type_form_params)
     return redirect_to edit_page_path(@form) unless answer_type_changed?
 
     save_to_session(session)
@@ -81,7 +81,7 @@ private
 
   def answer_type_form_params
     form = Form.find(params[:form_id])
-    params.require(:forms_type_of_answer_form).permit(:answer_type).merge(form:)
+    params.require(:pages_type_of_answer_form).permit(:answer_type).merge(form:)
   end
 
   def answer_type_changed?

--- a/app/forms/forms/selections_settings_form.rb
+++ b/app/forms/forms/selections_settings_form.rb
@@ -1,7 +1,7 @@
 class Forms::SelectionsSettingsForm < BaseForm
   include ActiveModel::Validations::Callbacks
 
-  DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }].map { |hash| Forms::SelectionOption.new(hash) }, only_one_option: false, include_none_of_the_above: false }.freeze
+  DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }].map { |hash| Pages::SelectionOption.new(hash) }, only_one_option: false, include_none_of_the_above: false }.freeze
 
   attr_accessor :selection_options, :only_one_option, :include_none_of_the_above
 
@@ -10,11 +10,11 @@ class Forms::SelectionsSettingsForm < BaseForm
   validate :selection_options, :validate_selection_options
 
   def convert_to_selection_option(hash)
-    Forms::SelectionOption.new(hash)
+    Pages::SelectionOption.new(hash)
   end
 
   def add_another
-    selection_options.append(Forms::SelectionOption.new({ name: "" }))
+    selection_options.append(Pages::SelectionOption.new({ name: "" }))
   end
 
   def remove(index)

--- a/app/forms/pages/address_settings_form.rb
+++ b/app/forms/pages/address_settings_form.rb
@@ -1,4 +1,4 @@
-class Forms::AddressSettingsForm < BaseForm
+class Pages::AddressSettingsForm < BaseForm
   attr_accessor :uk_address, :international_address, :form, :page
 
   INPUT_TYPES = %w[uk_address international_address].freeze

--- a/app/forms/pages/date_settings_form.rb
+++ b/app/forms/pages/date_settings_form.rb
@@ -1,4 +1,4 @@
-class Forms::DateSettingsForm < BaseForm
+class Pages::DateSettingsForm < BaseForm
   attr_accessor :input_type, :form, :page
 
   INPUT_TYPES = %w[date_of_birth other_date].freeze

--- a/app/forms/pages/name_settings_form.rb
+++ b/app/forms/pages/name_settings_form.rb
@@ -1,4 +1,4 @@
-class Forms::NameSettingsForm < BaseForm
+class Pages::NameSettingsForm < BaseForm
   attr_accessor :input_type, :title_needed, :form, :page
 
   INPUT_TYPES = %w[full_name first_and_last_name first_middle_and_last_name].freeze

--- a/app/forms/pages/question_text_form.rb
+++ b/app/forms/pages/question_text_form.rb
@@ -1,4 +1,4 @@
-class Forms::QuestionTextForm < BaseForm
+class Pages::QuestionTextForm < BaseForm
   attr_accessor :question_text
 
   validates :question_text, presence: true

--- a/app/forms/pages/selection_option.rb
+++ b/app/forms/pages/selection_option.rb
@@ -1,4 +1,4 @@
-class Forms::SelectionOption < BaseForm
+class Pages::SelectionOption < BaseForm
   attr_accessor :name
 
   def init(name)

--- a/app/forms/pages/selections_settings_form.rb
+++ b/app/forms/pages/selections_settings_form.rb
@@ -1,4 +1,4 @@
-class Forms::SelectionsSettingsForm < BaseForm
+class Pages::SelectionsSettingsForm < BaseForm
   include ActiveModel::Validations::Callbacks
 
   DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }].map { |hash| Pages::SelectionOption.new(hash) }, only_one_option: false, include_none_of_the_above: false }.freeze

--- a/app/forms/pages/text_settings_form.rb
+++ b/app/forms/pages/text_settings_form.rb
@@ -1,4 +1,4 @@
-class Forms::TextSettingsForm < BaseForm
+class Pages::TextSettingsForm < BaseForm
   attr_accessor :input_type, :form, :page
 
   INPUT_TYPES = %w[single_line long_text].freeze

--- a/app/forms/pages/type_of_answer_form.rb
+++ b/app/forms/pages/type_of_answer_form.rb
@@ -1,4 +1,4 @@
-class Forms::TypeOfAnswerForm < BaseForm
+class Pages::TypeOfAnswerForm < BaseForm
   attr_accessor :answer_type, :form, :page
 
   validates :answer_type, presence: true, inclusion: { in: Page::ANSWER_TYPES }

--- a/app/views/pages/date_settings.html.erb
+++ b/app/views/pages/date_settings.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
             :input_type,
-            Forms::DateSettingsForm::INPUT_TYPES,
+            Pages::DateSettingsForm::INPUT_TYPES,
             ->(option) { option },
             ->(option) { t('helpers.label.page.date_settings_options.names.' + option) },
             legend: { text: t('page_titles.date_settings'), size: 'l', tag: 'h1' },

--- a/app/views/pages/name_settings.html.erb
+++ b/app/views/pages/name_settings.html.erb
@@ -12,7 +12,7 @@
 
       <%= f.govuk_collection_radio_buttons(
             :input_type,
-            Forms::NameSettingsForm::INPUT_TYPES,
+            Pages::NameSettingsForm::INPUT_TYPES,
             ->(option) { option },
             ->(option) { t('helpers.label.page.name_settings_options.names.' + option) },
             ->(option) { t('helpers.label.page.name_settings_options.hints.' + option) },
@@ -22,7 +22,7 @@
             )  %>
       <%= f.govuk_collection_radio_buttons(
             :title_needed,
-            Forms::NameSettingsForm::TITLE_NEEDED,
+            Pages::NameSettingsForm::TITLE_NEEDED,
             ->(option) { option },
             ->(option) { t('helpers.label.page.name_settings_options.names.' + option) },
             legend: { text: t("helpers.label.page.name_settings_options.legends.title") },

--- a/app/views/pages/text_settings.html.erb
+++ b/app/views/pages/text_settings.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
             :input_type,
-            Forms::TextSettingsForm::INPUT_TYPES,
+            Pages::TextSettingsForm::INPUT_TYPES,
             ->(option) { option },
             ->(option) { t('helpers.label.page.text_settings_options.names.' + option) },
             legend: { text: t('page_titles.text_settings'), size: 'l', tag: 'h1' },

--- a/config/locales/forms/address_settings.yml
+++ b/config/locales/forms/address_settings.yml
@@ -2,7 +2,7 @@ en:
   activemodel:
     errors:
       models:
-        forms/address_settings_form:
+        pages/address_settings_form:
           attributes:
             base:
               blank: Select the kind of addresses you expect to receive

--- a/config/locales/forms/date_settings.yml
+++ b/config/locales/forms/date_settings.yml
@@ -2,7 +2,7 @@ en:
   activemodel:
     errors:
       models:
-        forms/date_settings_form:
+        pages/date_settings_form:
           attributes:
             input_type:
               blank: Select yes if you’re asking for a date of birth

--- a/config/locales/forms/name_settings.yml
+++ b/config/locales/forms/name_settings.yml
@@ -2,7 +2,7 @@ en:
   activemodel:
     errors:
       models:
-        forms/name_settings_form:
+        pages/name_settings_form:
           attributes:
             input_type:
               blank: Select how you need to collect the name

--- a/config/locales/forms/question_text.yml
+++ b/config/locales/forms/question_text.yml
@@ -1,12 +1,12 @@
 en:
   helpers:
     label:
-      forms_question_text_form:
+      pages_question_text_form:
         question_text: What’s your question?
   activemodel:
     errors:
       models:
-        forms/question_text_form:
+        pages/question_text_form:
           attributes:
             question_text:
               blank: Question text cannot be blank

--- a/config/locales/forms/selections_settings_form.yml
+++ b/config/locales/forms/selections_settings_form.yml
@@ -2,7 +2,7 @@ en:
   activemodel:
     errors:
       models:
-        forms/selections_settings_form:
+        pages/selections_settings_form:
           attributes:
             selection_options:
               blank: Add text for all of your options

--- a/config/locales/forms/text_settings.yml
+++ b/config/locales/forms/text_settings.yml
@@ -2,7 +2,7 @@ en:
   activemodel:
     errors:
       models:
-        forms/text_settings_form:
+        pages/text_settings_form:
           attributes:
             input_type:
               blank: Select how much text people will need to provide

--- a/config/locales/forms/type_of_answer.yml
+++ b/config/locales/forms/type_of_answer.yml
@@ -2,7 +2,7 @@ en:
   activemodel:
     errors:
       models:
-        forms/type_of_answer_form:
+        pages/type_of_answer_form:
           attributes:
             answer_type:
               blank: Select the type of answer you need

--- a/spec/factories/forms/date_settings_form.rb
+++ b/spec/factories/forms/date_settings_form.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :date_settings_form, class: "Forms::DateSettingsForm" do
-    input_type { Forms::DateSettingsForm::INPUT_TYPES.sample }
-  end
-end

--- a/spec/factories/forms/pages/address_settings_form.rb
+++ b/spec/factories/forms/pages/address_settings_form.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :address_settings_form, class: "Forms::AddressSettingsForm" do
+  factory :address_settings_form, class: "Pages::AddressSettingsForm" do
     uk_address { "true" }
     international_address { "true" }
   end

--- a/spec/factories/forms/pages/date_settings_form.rb
+++ b/spec/factories/forms/pages/date_settings_form.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :date_settings_form, class: "Pages::DateSettingsForm" do
+    input_type { Pages::DateSettingsForm::INPUT_TYPES.sample }
+  end
+end

--- a/spec/factories/forms/pages/name_settings_form.rb
+++ b/spec/factories/forms/pages/name_settings_form.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :name_settings_form, class: "Forms::NameSettingsForm" do
+  factory :name_settings_form, class: "Pages::NameSettingsForm" do
     input_type { "full_name" }
     title_needed { "true" }
   end

--- a/spec/factories/forms/pages/question_text_form.rb
+++ b/spec/factories/forms/pages/question_text_form.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :question_text_form, class: "Forms::QuestionTextForm" do
+  factory :question_text_form, class: "Pages::QuestionTextForm" do
     question_text { Faker::Lorem.question }
   end
 end

--- a/spec/factories/forms/pages/selections_settings_form.rb
+++ b/spec/factories/forms/pages/selections_settings_form.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :selections_settings_form, class: "Forms::SelectionsSettingsForm" do
+  factory :selections_settings_form, class: "Pages::SelectionsSettingsForm" do
     selection_options { [Pages::SelectionOption.new({ name: "Option 1" }), Pages::SelectionOption.new({ name: "Option 2" })] }
     only_one_option { "true" }
     include_none_of_the_above { true }

--- a/spec/factories/forms/pages/text_settings_form.rb
+++ b/spec/factories/forms/pages/text_settings_form.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :text_settings_form, class: "Pages::TextSettingsForm" do
+    input_type { Pages::TextSettingsForm::INPUT_TYPES.sample }
+  end
+end

--- a/spec/factories/forms/pages/type_of_answer_form.rb
+++ b/spec/factories/forms/pages/type_of_answer_form.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :type_of_answer_form, class: "Forms::TypeOfAnswerForm" do
+  factory :type_of_answer_form, class: "Pages::TypeOfAnswerForm" do
     answer_type { Page::ANSWER_TYPES.sample }
     form { build :form }
 

--- a/spec/factories/forms/selections_settings_form.rb
+++ b/spec/factories/forms/selections_settings_form.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :selections_settings_form, class: "Forms::SelectionsSettingsForm" do
-    selection_options { [Forms::SelectionOption.new({ name: "Option 1" }), Forms::SelectionOption.new({ name: "Option 2" })] }
+    selection_options { [Pages::SelectionOption.new({ name: "Option 1" }), Pages::SelectionOption.new({ name: "Option 2" })] }
     only_one_option { "true" }
     include_none_of_the_above { true }
   end

--- a/spec/factories/forms/text_settings_form.rb
+++ b/spec/factories/forms/text_settings_form.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :text_settings_form, class: "Forms::TextSettingsForm" do
-    input_type { Forms::TextSettingsForm::INPUT_TYPES.sample }
-  end
-end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
 
     trait :with_text_settings do
       transient do
-        input_type { Forms::TextSettingsForm::INPUT_TYPES.sample }
+        input_type { Pages::TextSettingsForm::INPUT_TYPES.sample }
       end
 
       answer_type { "text" }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
     trait :with_selections_settings do
       transient do
         only_one_option { "true" }
-        selection_options { [Forms::SelectionOption.new({ name: "Option 1" }), Forms::SelectionOption.new({ name: "Option 2" })] }
+        selection_options { [Pages::SelectionOption.new({ name: "Option 1" }), Pages::SelectionOption.new({ name: "Option 2" })] }
       end
 
       question_text { Faker::Lorem.question }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -77,8 +77,8 @@ FactoryBot.define do
 
     trait :with_name_settings do
       transient do
-        input_type { Forms::NameSettingsForm::INPUT_TYPES.sample }
-        title_needed { Forms::NameSettingsForm::TITLE_NEEDED.sample }
+        input_type { Pages::NameSettingsForm::INPUT_TYPES.sample }
+        title_needed { Pages::NameSettingsForm::TITLE_NEEDED.sample }
       end
 
       answer_type { "name" }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
 
     trait :with_date_settings do
       transient do
-        input_type { Forms::DateSettingsForm::INPUT_TYPES.sample }
+        input_type { Pages::DateSettingsForm::INPUT_TYPES.sample }
       end
 
       answer_type { "date" }

--- a/spec/forms/pages/address_settings_form_spec.rb
+++ b/spec/forms/pages/address_settings_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Forms::AddressSettingsForm, type: :model do
+RSpec.describe Pages::AddressSettingsForm, type: :model do
   let(:form) { build :form, id: 1 }
   let(:address_settings_form) { described_class.new }
 
@@ -11,7 +11,7 @@ RSpec.describe Forms::AddressSettingsForm, type: :model do
 
   describe "validations" do
     it "is invalid if no options are selected" do
-      error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.base.blank")
+      error_message = I18n.t("activemodel.errors.models.pages/address_settings_form.attributes.base.blank")
       address_settings_form.uk_address = "false"
       address_settings_form.international_address = "false"
       expect(address_settings_form).to be_invalid
@@ -19,8 +19,8 @@ RSpec.describe Forms::AddressSettingsForm, type: :model do
     end
 
     it "is invalid given a value which is neither true nor false" do
-      uk_error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.uk_address.inclusion")
-      international_error_message = I18n.t("activemodel.errors.models.forms/address_settings_form.attributes.international_address.inclusion")
+      uk_error_message = I18n.t("activemodel.errors.models.pages/address_settings_form.attributes.uk_address.inclusion")
+      international_error_message = I18n.t("activemodel.errors.models.pages/address_settings_form.attributes.international_address.inclusion")
       address_settings_form.uk_address = "maybe"
       address_settings_form.international_address = "possibly"
       expect(address_settings_form).to be_invalid

--- a/spec/forms/pages/date_settings_form_spec.rb
+++ b/spec/forms/pages/date_settings_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Forms::DateSettingsForm, type: :model do
+RSpec.describe Pages::DateSettingsForm, type: :model do
   let(:form) { build :form, id: 1 }
   let(:date_settings_form) { described_class.new }
 
@@ -11,21 +11,21 @@ RSpec.describe Forms::DateSettingsForm, type: :model do
 
   describe "validations" do
     it "is invalid if not given an input type" do
-      error_message = I18n.t("activemodel.errors.models.forms/date_settings_form.attributes.input_type.blank")
+      error_message = I18n.t("activemodel.errors.models.pages/date_settings_form.attributes.input_type.blank")
       date_settings_form.input_type = nil
       expect(date_settings_form).to be_invalid
       expect(date_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
     end
 
     it "is invalid given an empty string input_type" do
-      error_message = I18n.t("activemodel.errors.models.forms/date_settings_form.attributes.input_type.blank")
+      error_message = I18n.t("activemodel.errors.models.pages/date_settings_form.attributes.input_type.blank")
       date_settings_form.input_type = ""
       expect(date_settings_form).to be_invalid
       expect(date_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
     end
 
     it "is invalid given an input_type which is not in the list" do
-      error_message = I18n.t("activemodel.errors.models.forms/date_settings_form.attributes.input_type.inclusion")
+      error_message = I18n.t("activemodel.errors.models.pages/date_settings_form.attributes.input_type.inclusion")
       date_settings_form.input_type = "some_random_string"
       expect(date_settings_form).to be_invalid
       expect(date_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")

--- a/spec/forms/pages/name_settings_form_spec.rb
+++ b/spec/forms/pages/name_settings_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Forms::NameSettingsForm, type: :model do
+RSpec.describe Pages::NameSettingsForm, type: :model do
   let(:form) { build :form, id: 1 }
   let(:name_settings_form) { described_class.new }
 
@@ -11,21 +11,21 @@ RSpec.describe Forms::NameSettingsForm, type: :model do
 
   describe "validations" do
     it "is invalid if no input_type is selected" do
-      error_message = I18n.t("activemodel.errors.models.forms/name_settings_form.attributes.input_type.blank")
+      error_message = I18n.t("activemodel.errors.models.pages/name_settings_form.attributes.input_type.blank")
       name_settings_form.input_type = nil
       expect(name_settings_form).to be_invalid
       expect(name_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
     end
 
     it "is invalid if no title_needed is selected" do
-      error_message = I18n.t("activemodel.errors.models.forms/name_settings_form.attributes.title_needed.blank")
+      error_message = I18n.t("activemodel.errors.models.pages/name_settings_form.attributes.title_needed.blank")
       name_settings_form.title_needed = nil
       expect(name_settings_form).to be_invalid
       expect(name_settings_form.errors.full_messages_for(:title_needed)).to include("Title needed #{error_message}")
     end
 
     it "is invalid if input_type is given a value which is not in the list" do
-      error_message = I18n.t("activemodel.errors.models.forms/name_settings_form.attributes.input_type.inclusion")
+      error_message = I18n.t("activemodel.errors.models.pages/name_settings_form.attributes.input_type.inclusion")
 
       name_settings_form.input_type = "username"
       expect(name_settings_form).to be_invalid
@@ -33,7 +33,7 @@ RSpec.describe Forms::NameSettingsForm, type: :model do
     end
 
     it "is invalid if title_needed is given a value which is not in the list" do
-      error_message = I18n.t("activemodel.errors.models.forms/name_settings_form.attributes.title_needed.inclusion")
+      error_message = I18n.t("activemodel.errors.models.pages/name_settings_form.attributes.title_needed.inclusion")
 
       name_settings_form.title_needed = "maybe"
       expect(name_settings_form).to be_invalid

--- a/spec/forms/pages/question_text_form_spec.rb
+++ b/spec/forms/pages/question_text_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Forms::QuestionTextForm, type: :model do
+RSpec.describe Pages::QuestionTextForm, type: :model do
   let(:form) { build :form, id: 1 }
   let(:question_text_form) { described_class.new }
 
@@ -12,7 +12,7 @@ RSpec.describe Forms::QuestionTextForm, type: :model do
   describe "validations" do
     [nil, ""].each do |question_text|
       it "is invalid given {question_text} question text" do
-        error_message = I18n.t("activemodel.errors.models.forms/question_text_form.attributes.question_text.blank")
+        error_message = I18n.t("activemodel.errors.models.pages/question_text_form.attributes.question_text.blank")
         question_text_form.question_text = question_text
         expect(question_text_form).to be_invalid
         expect(question_text_form.errors.full_messages_for(:question_text)).to include("Question text #{error_message}")

--- a/spec/forms/pages/selections_settings_form_spec.rb
+++ b/spec/forms/pages/selections_settings_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Forms::SelectionsSettingsForm, type: :model do
+RSpec.describe Pages::SelectionsSettingsForm, type: :model do
   let(:selections_settings_form) { described_class.new }
 
   it "has a valid factory" do
@@ -11,7 +11,7 @@ RSpec.describe Forms::SelectionsSettingsForm, type: :model do
   describe "validations" do
     it "is invalid if fewer than 2 selection options are provided" do
       selections_settings_form.selection_options = []
-      error_message = I18n.t("activemodel.errors.models.forms/selections_settings_form.attributes.selection_options.minimum")
+      error_message = I18n.t("activemodel.errors.models.pages/selections_settings_form.attributes.selection_options.minimum")
       expect(selections_settings_form).not_to be_valid
 
       expect(selections_settings_form.errors.full_messages_for(:selection_options)).to include("Selection options #{error_message}")
@@ -19,7 +19,7 @@ RSpec.describe Forms::SelectionsSettingsForm, type: :model do
 
     it "is invalid if more than 20 selection options are provided" do
       selections_settings_form.selection_options = (1..21).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
-      error_message = I18n.t("activemodel.errors.models.forms/selections_settings_form.attributes.selection_options.maximum")
+      error_message = I18n.t("activemodel.errors.models.pages/selections_settings_form.attributes.selection_options.maximum")
       expect(selections_settings_form).not_to be_valid
 
       expect(selections_settings_form.errors.full_messages_for(:selection_options)).to include("Selection options #{error_message}")
@@ -27,7 +27,7 @@ RSpec.describe Forms::SelectionsSettingsForm, type: :model do
 
     it "is invalid if selection options are not unique" do
       selections_settings_form.selection_options = [Pages::SelectionOption.new({ name: "option 1" }), Pages::SelectionOption.new({ name: "option 2" }), Pages::SelectionOption.new({ name: "option 1" })]
-      error_message = I18n.t("activemodel.errors.models.forms/selections_settings_form.attributes.selection_options.uniqueness")
+      error_message = I18n.t("activemodel.errors.models.pages/selections_settings_form.attributes.selection_options.uniqueness")
       expect(selections_settings_form).not_to be_valid
 
       expect(selections_settings_form.errors.full_messages_for(:selection_options)).to include("Selection options #{error_message}")

--- a/spec/forms/pages/text_settings_form_spec.rb
+++ b/spec/forms/pages/text_settings_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Forms::TextSettingsForm, type: :model do
+RSpec.describe Pages::TextSettingsForm, type: :model do
   let(:form) { build :form, id: 1 }
   let(:text_settings_form) { described_class.new }
 
@@ -11,21 +11,21 @@ RSpec.describe Forms::TextSettingsForm, type: :model do
 
   describe "validations" do
     it "is invalid if not given an input type" do
-      error_message = I18n.t("activemodel.errors.models.forms/text_settings_form.attributes.input_type.blank")
+      error_message = I18n.t("activemodel.errors.models.pages/text_settings_form.attributes.input_type.blank")
       text_settings_form.input_type = nil
       expect(text_settings_form).to be_invalid
       expect(text_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
     end
 
     it "is invalid given an empty string input_type" do
-      error_message = I18n.t("activemodel.errors.models.forms/text_settings_form.attributes.input_type.blank")
+      error_message = I18n.t("activemodel.errors.models.pages/text_settings_form.attributes.input_type.blank")
       text_settings_form.input_type = ""
       expect(text_settings_form).to be_invalid
       expect(text_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")
     end
 
     it "is invalid given an input_type which is not in the list" do
-      error_message = I18n.t("activemodel.errors.models.forms/text_settings_form.attributes.input_type.inclusion")
+      error_message = I18n.t("activemodel.errors.models.pages/text_settings_form.attributes.input_type.inclusion")
       text_settings_form.input_type = "some_random_string"
       expect(text_settings_form).to be_invalid
       expect(text_settings_form.errors.full_messages_for(:input_type)).to include("Input type #{error_message}")

--- a/spec/forms/pages/type_of_answer_form_spec.rb
+++ b/spec/forms/pages/type_of_answer_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Forms::TypeOfAnswerForm, type: :model do
+RSpec.describe Pages::TypeOfAnswerForm, type: :model do
   let(:form) { build :form, id: 1 }
   let(:type_of_answer_form) { described_class.new }
 

--- a/spec/forms/selections_settings_form_spec.rb
+++ b/spec/forms/selections_settings_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Forms::SelectionsSettingsForm, type: :model do
     end
 
     it "is invalid if more than 20 selection options are provided" do
-      selections_settings_form.selection_options = (1..21).to_a.map { |i| Forms::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..21).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
       error_message = I18n.t("activemodel.errors.models.forms/selections_settings_form.attributes.selection_options.maximum")
       expect(selections_settings_form).not_to be_valid
 
@@ -26,7 +26,7 @@ RSpec.describe Forms::SelectionsSettingsForm, type: :model do
     end
 
     it "is invalid if selection options are not unique" do
-      selections_settings_form.selection_options = [Forms::SelectionOption.new({ name: "option 1" }), Forms::SelectionOption.new({ name: "option 2" }), Forms::SelectionOption.new({ name: "option 1" })]
+      selections_settings_form.selection_options = [Pages::SelectionOption.new({ name: "option 1" }), Pages::SelectionOption.new({ name: "option 2" }), Pages::SelectionOption.new({ name: "option 1" })]
       error_message = I18n.t("activemodel.errors.models.forms/selections_settings_form.attributes.selection_options.uniqueness")
       expect(selections_settings_form).not_to be_valid
 
@@ -34,12 +34,12 @@ RSpec.describe Forms::SelectionsSettingsForm, type: :model do
     end
 
     it "is valid if there are between 2 and 20 unique selection values" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| Forms::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
 
       expect(selections_settings_form).to be_valid
       expect(selections_settings_form.errors.full_messages_for(:selection_options)).to be_empty
 
-      selections_settings_form.selection_options = (1..20).to_a.map { |i| Forms::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..20).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
 
       expect(selections_settings_form).to be_valid
       expect(selections_settings_form.errors.full_messages_for(:selection_options)).to be_empty
@@ -55,36 +55,36 @@ RSpec.describe Forms::SelectionsSettingsForm, type: :model do
     end
 
     it "sets a session key called 'page' as a hash with the answer type in it" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| Forms::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
       selections_settings_form.only_one_option = true
       selections_settings_form.include_none_of_the_above = true
       selections_settings_form.submit(session_mock)
-      expect(session_mock[:page][:answer_settings].to_json).to eq({ only_one_option: true, selection_options: [Forms::SelectionOption.new(name: "1"), Forms::SelectionOption.new(name: "2")] }.to_json)
+      expect(session_mock[:page][:answer_settings].to_json).to eq({ only_one_option: true, selection_options: [Pages::SelectionOption.new(name: "1"), Pages::SelectionOption.new(name: "2")] }.to_json)
       expect(session_mock[:page][:is_optional]).to eq(true)
     end
   end
 
   describe "add_another" do
     it "adds an empty item to the end of the selection options array" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| Forms::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
       selections_settings_form.add_another
 
-      expect(selections_settings_form.selection_options.to_json).to eq([Forms::SelectionOption.new(name: "1"), Forms::SelectionOption.new(name: "2"), Forms::SelectionOption.new(name: "")].to_json)
+      expect(selections_settings_form.selection_options.to_json).to eq([Pages::SelectionOption.new(name: "1"), Pages::SelectionOption.new(name: "2"), Pages::SelectionOption.new(name: "")].to_json)
     end
   end
 
   describe "remove" do
     it "removes the specified option from the selection options array" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| Forms::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
       selections_settings_form.remove(1)
 
-      expect(selections_settings_form.selection_options.to_json).to eq([Forms::SelectionOption.new(name: "1")].to_json)
+      expect(selections_settings_form.selection_options.to_json).to eq([Pages::SelectionOption.new(name: "1")].to_json)
     end
   end
 
   describe "answer_settings" do
     it "returns the correct answer_settings object" do
-      selection_options = (1..2).to_a.map { |i| Forms::SelectionOption.new({ name: i.to_s }) }
+      selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
       only_one_option = true
       selections_settings_form.selection_options = selection_options
       selections_settings_form.only_one_option = only_one_option
@@ -95,10 +95,10 @@ RSpec.describe Forms::SelectionsSettingsForm, type: :model do
 
   describe "filter_out_blank_options" do
     it "filters out blank inputs" do
-      selections_settings_form.selection_options = [Forms::SelectionOption.new(name: "1"), Forms::SelectionOption.new(name: ""), Forms::SelectionOption.new(name: "2")]
+      selections_settings_form.selection_options = [Pages::SelectionOption.new(name: "1"), Pages::SelectionOption.new(name: ""), Pages::SelectionOption.new(name: "2")]
       selections_settings_form.filter_out_blank_options
 
-      expect(selections_settings_form.selection_options.to_json).to eq([Forms::SelectionOption.new(name: "1"), Forms::SelectionOption.new(name: "2")].to_json)
+      expect(selections_settings_form.selection_options.to_json).to eq([Pages::SelectionOption.new(name: "1"), Pages::SelectionOption.new(name: "2")].to_json)
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:answer_settings) { OpenStruct.new(input_type:) }
 
       context "and 'input_type' set to a valid value" do
-        let(:input_type) { Forms::DateSettingsForm::INPUT_TYPES.sample }
+        let(:input_type) { Pages::DateSettingsForm::INPUT_TYPES.sample }
 
         it "returns the answer subtype" do
           expect(helper.translation_key_for_answer_type(answer_type, answer_settings)).to eq input_type

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:answer_settings) { OpenStruct.new(input_type:) }
 
       context "and 'input_type' set to a valid value" do
-        let(:input_type) { Forms::TextSettingsForm::INPUT_TYPES.sample }
+        let(:input_type) { Pages::TextSettingsForm::INPUT_TYPES.sample }
 
         it "returns the answer subtype" do
           expect(helper.translation_key_for_answer_type(answer_type, answer_settings)).to eq input_type

--- a/spec/requests/pages/address_settings_controller_spec.rb
+++ b/spec/requests/pages/address_settings_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
 
     context "when form is invalid" do
       before do
-        post address_settings_create_path form_id: form.id, params: { forms_address_settings_form: { input_type: nil } }
+        post address_settings_create_path form_id: form.id, params: { pages_address_settings_form: { input_type: nil } }
       end
 
       it "renders the address settings view if there are errors" do
@@ -68,7 +68,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
 
     context "when form is valid and ready to store" do
       before do
-        post address_settings_create_path form_id: form.id, params: { forms_address_settings_form: { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address } }
+        post address_settings_create_path form_id: form.id, params: { pages_address_settings_form: { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address } }
       end
 
       let(:address_settings_form) { build :address_settings_form, form: }
@@ -138,7 +138,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
       let(:international_address) { page.answer_settings.input_type.international_address }
 
       before do
-        post address_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_address_settings_form: { uk_address: "true", international_address: "false" } }
+        post address_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_address_settings_form: { uk_address: "true", international_address: "false" } }
       end
 
       it "loads the updated input type into the session from the page params" do
@@ -157,7 +157,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
       let(:input_type) { nil }
 
       before do
-        post address_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_address_settings_form: { input_type: } }
+        post address_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_address_settings_form: { input_type: } }
       end
 
       it "renders the address settings view if there are errors" do

--- a/spec/requests/pages/date_settings_controller_spec.rb
+++ b/spec/requests/pages/date_settings_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
 
     context "when form is invalid" do
       before do
-        post date_settings_create_path form_id: form.id, params: { forms_date_settings_form: { input_type: nil } }
+        post date_settings_create_path form_id: form.id, params: { pages_date_settings_form: { input_type: nil } }
       end
 
       it "renders the date settings view if there are errors" do
@@ -68,7 +68,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
 
     context "when form is valid and ready to store" do
       before do
-        post date_settings_create_path form_id: form.id, params: { forms_date_settings_form: { input_type: "date_of_birth" } }
+        post date_settings_create_path form_id: form.id, params: { pages_date_settings_form: { input_type: "date_of_birth" } }
       end
 
       let(:date_settings_form) { build :date_settings_form, form: }
@@ -135,7 +135,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
       let(:input_type) { "date_of_birth" }
 
       before do
-        post date_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_date_settings_form: { input_type: "other_date" } }
+        post date_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_date_settings_form: { input_type: "other_date" } }
       end
 
       it "loads the updated input type from the page params" do
@@ -153,7 +153,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
       let(:input_type) { nil }
 
       before do
-        post date_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_date_settings_form: { input_type: } }
+        post date_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_date_settings_form: { input_type: } }
       end
 
       it "renders the date settings view if there are errors" do

--- a/spec/requests/pages/name_settings_controller_spec.rb
+++ b/spec/requests/pages/name_settings_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
 
     context "when form is invalid" do
       before do
-        post name_settings_create_path form_id: form.id, params: { forms_name_settings_form: { input_type: nil } }
+        post name_settings_create_path form_id: form.id, params: { pages_name_settings_form: { input_type: nil } }
       end
 
       it "renders the name settings view if there are errors" do
@@ -68,7 +68,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
 
     context "when form is valid and ready to store" do
       before do
-        post name_settings_create_path form_id: form.id, params: { forms_name_settings_form: { input_type: "first_and_last_name", title_needed: "false" } }
+        post name_settings_create_path form_id: form.id, params: { pages_name_settings_form: { input_type: "first_and_last_name", title_needed: "false" } }
       end
 
       let(:name_settings_form) { build :name_settings_form, form: }
@@ -136,7 +136,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
       let(:title_needed) { "true" }
 
       before do
-        post name_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_name_settings_form: { input_type:, title_needed: } }
+        post name_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_name_settings_form: { input_type:, title_needed: } }
       end
 
       it "loads the updated input type from the page params" do
@@ -156,7 +156,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
       let(:title_needed) { nil }
 
       before do
-        post name_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_name_settings_form: { input_type:, title_needed: } }
+        post name_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_name_settings_form: { input_type:, title_needed: } }
       end
 
       it "renders the name settings view if there are errors" do

--- a/spec/requests/pages/question_text_controller_spec.rb
+++ b/spec/requests/pages/question_text_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pages::QuestionTextController, type: :request do
 
     context "when form is invalid" do
       before do
-        post question_text_create_path form_id: form.id, params: { forms_question_text_form: { question_text: nil } }
+        post question_text_create_path form_id: form.id, params: { pages_question_text_form: { question_text: nil } }
       end
 
       it "renders the date settings view if there are errors" do
@@ -68,7 +68,7 @@ RSpec.describe Pages::QuestionTextController, type: :request do
 
     context "when form is valid and ready to store" do
       before do
-        post question_text_create_path form_id: form.id, params: { forms_question_text_form: { question_text: "Are you a higher rate taxpayer?" } }
+        post question_text_create_path form_id: form.id, params: { pages_question_text_form: { question_text: "Are you a higher rate taxpayer?" } }
       end
 
       let(:question_text_form) { build :question_text_form }

--- a/spec/requests/pages/selections_settings_controller_spec.rb
+++ b/spec/requests/pages/selections_settings_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
 
     context "when form is valid and ready to store" do
       before do
-        post selections_settings_create_path form_id: form.id, params: { forms_selections_settings_form: { selection_options: { "0" => { name: "Option 1" }, "1" => { name: "Option 2" } }, only_one_option: true, include_none_of_the_above: false } }
+        post selections_settings_create_path form_id: form.id, params: { pages_selections_settings_form: { selection_options: { "0" => { name: "Option 1" }, "1" => { name: "Option 2" } }, only_one_option: true, include_none_of_the_above: false } }
       end
 
       it "saves the answer type to session" do
@@ -72,7 +72,7 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
 
     context "when form is invalid" do
       before do
-        post selections_settings_create_path form_id: form.id, params: { forms_selections_settings_form: { answer_settings: nil } }
+        post selections_settings_create_path form_id: form.id, params: { pages_selections_settings_form: { answer_settings: nil } }
       end
 
       it "renders the type of answer view if there are errors" do
@@ -129,7 +129,7 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
 
     context "when form is valid and ready to update in the DB" do
       before do
-        post selections_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_selections_settings_form: { selection_options: { "0" => { name: "Option 1" }, "1" => { name: "New option 2" } }, only_one_option: true, include_none_of_the_above: false } }
+        post selections_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_selections_settings_form: { selection_options: { "0" => { name: "Option 1" }, "1" => { name: "New option 2" } }, only_one_option: true, include_none_of_the_above: false } }
       end
 
       it "saves the updated answer settings to DB" do
@@ -145,7 +145,7 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
 
     context "when form is invalid" do
       before do
-        post selections_settings_create_path form_id: form.id, params: { forms_selections_settings_form: { answer_settings: nil } }
+        post selections_settings_create_path form_id: form.id, params: { pages_selections_settings_form: { answer_settings: nil } }
       end
 
       it "renders the selections settings view if there are errors" do

--- a/spec/requests/pages/selections_settings_controller_spec.rb
+++ b/spec/requests/pages/selections_settings_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
       end
 
       it "saves the updated answer settings to DB" do
-        new_settings = { only_one_option: "true", selection_options: [Forms::SelectionOption.new({ name: "Option 1" }), Forms::SelectionOption.new({ name: "New option 2" })] }
+        new_settings = { only_one_option: "true", selection_options: [Pages::SelectionOption.new({ name: "Option 1" }), Pages::SelectionOption.new({ name: "New option 2" })] }
         form = assigns(:selections_settings_form)
         expect(form.answer_settings.to_json).to eq new_settings.to_json
       end

--- a/spec/requests/pages/text_settings_controller_spec.rb
+++ b/spec/requests/pages/text_settings_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
 
     context "when form is invalid" do
       before do
-        post text_settings_create_path form_id: form.id, params: { forms_text_settings_form: { input_type: nil } }
+        post text_settings_create_path form_id: form.id, params: { pages_text_settings_form: { input_type: nil } }
       end
 
       it "renders the text settings view if there are errors" do
@@ -68,7 +68,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
 
     context "when form is valid and ready to store" do
       before do
-        post text_settings_create_path form_id: form.id, params: { forms_text_settings_form: { input_type: text_settings_form.input_type } }
+        post text_settings_create_path form_id: form.id, params: { pages_text_settings_form: { input_type: text_settings_form.input_type } }
       end
 
       let(:text_settings_form) { build :text_settings_form, form: }
@@ -131,7 +131,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
       let(:input_type) { "single_line" }
 
       before do
-        post text_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_text_settings_form: { input_type: } }
+        post text_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_text_settings_form: { input_type: } }
       end
 
       it "saves the updated input type to DB" do
@@ -149,7 +149,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
       let(:input_type) { nil }
 
       before do
-        post text_settings_update_path(form_id: page.form_id, page_id: page.id), params: { forms_text_settings_form: { input_type: } }
+        post text_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_text_settings_form: { input_type: } }
       end
 
       it "renders the text settings view if there are errors" do

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
     context "when form is valid and ready to store" do
       before do
-        post type_of_answer_create_path form_id: form.id, params: { forms_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
+        post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
       end
 
       context "when answer type is not selection" do
@@ -77,7 +77,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
         let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "selection", form: }
 
         before do
-          post type_of_answer_create_path form_id: form.id, params: { forms_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
+          post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
         end
 
         it "saves the answer type to session" do
@@ -93,7 +93,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
         let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "text", form: }
 
         before do
-          post type_of_answer_create_path form_id: form.id, params: { forms_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
+          post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
         end
 
         it "saves the answer type to session" do
@@ -109,7 +109,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
         let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "date", form: }
 
         before do
-          post type_of_answer_create_path form_id: form.id, params: { forms_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
+          post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
         end
 
         it "saves the answer type to session" do
@@ -125,7 +125,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
         let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "address", form: }
 
         before do
-          post type_of_answer_create_path form_id: form.id, params: { forms_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
+          post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
         end
 
         it "saves the answer type to session" do
@@ -141,7 +141,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
         let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "name", form: }
 
         before do
-          post type_of_answer_create_path form_id: form.id, params: { forms_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
+          post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
         end
 
         it "saves the answer type to session" do
@@ -156,7 +156,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
     context "when form is invalid" do
       before do
-        post type_of_answer_create_path form_id: form.id, params: { forms_type_of_answer_form: { answer_type: nil } }
+        post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: nil } }
       end
 
       it "renders the type of answer view if there are errors" do
@@ -210,10 +210,10 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
     end
 
     context "when form is valid and ready to update in the DB" do
-      let(:forms_type_of_answer_form) { { answer_type: "number" } }
+      let(:pages_type_of_answer_form) { { answer_type: "number" } }
 
       before do
-        post type_of_answer_update_path(form_id: page.form_id, page_id: page.id), params: { forms_type_of_answer_form: }
+        post type_of_answer_update_path(form_id: page.form_id, page_id: page.id), params: { pages_type_of_answer_form: }
       end
 
       it "saves the updated answer type to DB" do
@@ -226,7 +226,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       end
 
       context "when answer type is selection" do
-        let(:forms_type_of_answer_form) { { answer_type: "selection" } }
+        let(:pages_type_of_answer_form) { { answer_type: "selection" } }
 
         it "saves the answer type to session" do
           form = assigns(:type_of_answer_form)
@@ -241,7 +241,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
     context "when form is invalid" do
       before do
-        post type_of_answer_create_path form_id: form.id, params: { forms_type_of_answer_form: { answer_type: nil } }
+        post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: nil } }
       end
 
       it "renders the type of answer view if there are errors" do

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -18,7 +18,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
 
     # mock the path helper
     without_partial_double_verification do
-      allow(view).to receive(:form_forms_type_of_answer_form_path).and_return("/type-of-answer")
+      allow(view).to receive(:form_pages_type_of_answer_form_path).and_return("/type-of-answer")
     end
 
     # setup instance variables
@@ -53,13 +53,13 @@ describe "pages/type_of_answer.html.erb", type: :view do
 
   it "has radio buttons for each answer_type" do
     answer_types.each do |type|
-      expect(rendered).to have_field("forms_type_of_answer_form[answer_type]", with: type)
+      expect(rendered).to have_field("pages_type_of_answer_form[answer_type]", with: type)
     end
   end
 
   it "the answer type from the type_of_answer_form is checked" do
     selected_answer_type = type_of_answer_form.answer_type
-    expect(rendered).to have_checked_field("forms_type_of_answer_form[answer_type]", with: selected_answer_type)
+    expect(rendered).to have_checked_field("pages_type_of_answer_form[answer_type]", with: selected_answer_type)
   end
 
   it "has a submit button with the correct text" do


### PR DESCRIPTION
### What problem does this pull request solve?

I noticed that our FormObjects had a mixture of objects relating to Form model and Page model in the same directory. Sorry about the large number of file changes(mostly just moving files around), I did run lint & rspec before each commit so it should be easier to review looking at each individual commit.

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
