### PR TITLE
Add length validations to question text, page heading and hint text

### DIFF
--- a/app/forms/pages/guidance_form.rb
+++ b/app/forms/pages/guidance_form.rb
@@ -1,10 +1,9 @@
 require "govuk_forms_markdown"
 
 class Pages::GuidanceForm < BaseForm
-  attr_accessor :page_heading, :guidance_markdown
+  include GuidanceValidation
 
-  validate :guidance_fields_presence
-  validate :markdown_length_and_tags
+  attr_accessor :page_heading, :guidance_markdown
 
   def submit(session)
     return false if invalid?
@@ -12,31 +11,5 @@ class Pages::GuidanceForm < BaseForm
     session[:page] = {} if session[:page].blank?
     session[:page][:page_heading] = page_heading
     session[:page][:guidance_markdown] = guidance_markdown
-  end
-
-private
-
-  def markdown_length_and_tags
-    return true if guidance_markdown.blank?
-
-    markdown_validation = GovukFormsMarkdown.validate(guidance_markdown)
-
-    return true if markdown_validation[:errors].empty?
-
-    tag_errors = markdown_validation[:errors].excluding(:too_long)
-
-    if tag_errors.any?
-      errors.add(:guidance_markdown, :unsupported_markdown_syntax)
-    elsif markdown_validation[:errors].include?(:too_long)
-      errors.add(:guidance_markdown, :too_long)
-    end
-  end
-
-  def guidance_fields_presence
-    if page_heading.present? && guidance_markdown.blank?
-      errors.add(:guidance_markdown, :blank)
-    elsif guidance_markdown.present? && page_heading.blank?
-      errors.add(:page_heading, :blank)
-    end
   end
 end

--- a/app/forms/pages/question_text_form.rb
+++ b/app/forms/pages/question_text_form.rb
@@ -1,7 +1,7 @@
 class Pages::QuestionTextForm < BaseForm
-  attr_accessor :question_text
+  include QuestionTextValidation
 
-  validates :question_text, presence: true
+  attr_accessor :question_text
 
   def submit(session)
     return false if invalid?

--- a/app/models/concerns/guidance_validation.rb
+++ b/app/models/concerns/guidance_validation.rb
@@ -1,0 +1,35 @@
+module GuidanceValidation
+  extend ActiveSupport::Concern
+
+  included do
+    validate :guidance_fields_presence
+    validates :page_heading, length: { maximum: 250 }
+    validate :markdown_length_and_tags
+  end
+
+private
+
+  def markdown_length_and_tags
+    return true if guidance_markdown.blank?
+
+    markdown_validation = GovukFormsMarkdown.validate(guidance_markdown)
+
+    return true if markdown_validation[:errors].empty?
+
+    tag_errors = markdown_validation[:errors].excluding(:too_long)
+
+    if tag_errors.any?
+      errors.add(:guidance_markdown, :unsupported_markdown_syntax)
+    elsif markdown_validation[:errors].include?(:too_long)
+      errors.add(:guidance_markdown, :too_long)
+    end
+  end
+
+  def guidance_fields_presence
+    if page_heading.present? && guidance_markdown.blank?
+      errors.add(:guidance_markdown, :blank)
+    elsif guidance_markdown.present? && page_heading.blank?
+      errors.add(:page_heading, :blank)
+    end
+  end
+end

--- a/app/models/concerns/question_text_validation.rb
+++ b/app/models/concerns/question_text_validation.rb
@@ -1,0 +1,8 @@
+module QuestionTextValidation
+  extend ActiveSupport::Concern
+
+  included do
+    validates :question_text, presence: true
+    validates :question_text, length: { maximum: 250 }
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -12,6 +12,8 @@ class Page < ActiveResource::Base
 
   belongs_to :form
 
+  validates :hint_text, length: { maximum: 500 }
+
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
   before_validation :convert_is_optional_to_boolean
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,4 +1,6 @@
 class Page < ActiveResource::Base
+  include QuestionTextValidation
+
   self.site = Settings.forms_api.base_url
   self.prefix = "/api/v1/forms/:form_id/"
   self.include_format_in_path = false
@@ -9,7 +11,7 @@ class Page < ActiveResource::Base
   ANSWER_TYPES_WITH_SETTINGS = %w[selection text date address name].freeze
 
   belongs_to :form
-  validates :question_text, presence: true
+
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
   before_validation :convert_is_optional_to_boolean
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
       models:
         page:
           attributes:
+            hint_text:
+              too_long: "Hint text must be %{count} characters or less"
             question_text:
               blank: Enter a question
               too_long: Question text must be %{count} characters or less

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,10 +2,12 @@
 en:
   activemodel:
     errors:
-      page:
-        attributes:
-          question_text:
-            blank: Question text cannot be blank
+      models:
+        page:
+          attributes:
+            question_text:
+              blank: Enter a question
+              too_long: Question text must be %{count} characters or less
   activerecord:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
         page:
           attributes:
             hint_text:
-              too_long: "Hint text must be %{count} characters or less"
+              too_long: Hint text must be %{count} characters or less
             question_text:
               blank: Enter a question
               too_long: Question text must be %{count} characters or less

--- a/config/locales/forms/question_text.yml
+++ b/config/locales/forms/question_text.yml
@@ -10,3 +10,4 @@ en:
           attributes:
             question_text:
               blank: Enter your question
+              too_long: "Your question must be %{count} characters or less"

--- a/config/locales/forms/question_text.yml
+++ b/config/locales/forms/question_text.yml
@@ -9,4 +9,4 @@ en:
         pages/question_text_form:
           attributes:
             question_text:
-              blank: Question text cannot be blank
+              blank: Enter your question

--- a/config/locales/pages/guidance.yml
+++ b/config/locales/pages/guidance.yml
@@ -15,6 +15,7 @@ en:
           attributes:
             page_heading:
               blank: Enter a page heading
+              too_long: "Page heading must be %{count} characters or less"
             guidance_markdown:
               blank: Enter guidance text
               unsupported_markdown_syntax: Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)

--- a/spec/forms/pages/guidance_form_spec.rb
+++ b/spec/forms/pages/guidance_form_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe Pages::GuidanceForm, type: :model do
       expect(guidance_form).to be_invalid
       expect(guidance_form.errors.full_messages_for(:guidance_markdown)).to include("Guidance markdown #{error_message}")
     end
+
+    ["A" * 10, "A" * 250].each do |question_text|
+      it "is valid if page_heading is less than or equal to 250 characters" do
+        guidance_form.page_heading = question_text
+        expect(guidance_form).to be_valid
+      end
+    end
+
+    it "is invalid if page heading is more than 250 characters" do
+      guidance_form.page_heading = "A" * 251
+      expect(guidance_form).not_to be_valid
+      error_message = I18n.t("activemodel.errors.models.pages/guidance_form.attributes.page_heading.too_long", count: 250)
+      expect(guidance_form.errors.full_messages_for(:page_heading)).to include("Page heading #{error_message}")
+    end
   end
 
   describe "#submit" do

--- a/spec/forms/pages/question_text_form_spec.rb
+++ b/spec/forms/pages/question_text_form_spec.rb
@@ -19,9 +19,18 @@ RSpec.describe Pages::QuestionTextForm, type: :model do
       end
     end
 
-    it "is valid if input type is a valid input type" do
-      question_text_form.question_text = "Do you want to be contacted?"
-      expect(question_text_form).to be_valid
+    ["A" * 10, "A" * 250].each do |question_text|
+      it "is valid if question text is less than or equal to 250 characters" do
+        question_text_form.question_text = question_text
+        expect(question_text_form).to be_valid
+      end
+    end
+
+    it "is invalid if question text is more than 250 characters" do
+      question_text_form.question_text = "A" * 251
+      expect(question_text_form).not_to be_valid
+      error_message = I18n.t("activemodel.errors.models.pages/question_text_form.attributes.question_text.too_long", count: 250)
+      expect(question_text_form.errors.full_messages_for(:question_text)).to include("Question text #{error_message}")
     end
   end
 

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Condition do
+describe Condition, type: :model do
   let(:validation_errors) { [] }
   let(:condition) { described_class.new(id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3, validation_errors:) }
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Form do
+describe Form, type: :model do
   let(:organisation) { build :organisation, id: 1 }
   let(:form) { described_class.new(id: 1, name: "Form 1", organisation:, submission_email: "") }
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -40,6 +40,41 @@ describe Page, type: :model do
         end
       end
     end
+
+    describe "#hint_text" do
+      let(:page) { build :page, hint_text: }
+      let(:hint_text) { "Enter your full name as it appears in your passport" }
+
+      it "is valid if hint text is empty" do
+        page.hint_text = nil
+        expect(page).to be_valid
+      end
+
+      it "is valid if hint text below 500 characters" do
+        expect(page).to be_valid
+      end
+
+      context "when hint text 500 characters" do
+        let(:hint_text) { "A" * 500 }
+
+        it "is valid" do
+          expect(page).to be_valid
+        end
+      end
+
+      context "when hint text more than 500 characters" do
+        let(:hint_text) { "A" * 501 }
+
+        it "is invalid" do
+          expect(page).not_to be_valid
+        end
+
+        it "has an error message" do
+          page.valid?
+          expect(page.errors[:hint_text]).to include(I18n.t("activemodel.errors.models.page.attributes.hint_text.too_long", count: 500))
+        end
+      end
+    end
   end
 
   describe "#convert_is_optional_to_boolean" do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Page do
+describe Page, type: :model do
   describe "#convert_is_optional_to_boolean" do
     context "when a question is optional" do
       it "set the model attribute to true" do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,6 +1,47 @@
 require "rails_helper"
 
 describe Page, type: :model do
+  describe "validations" do
+    let(:page) { build :page, question_text: }
+    let(:question_text) { "What is your address?" }
+
+    describe "#question_text" do
+      [nil, ""].each do |question_text|
+        it "is invalid given {question_text} question text" do
+          error_message = I18n.t("activemodel.errors.models.page.attributes.question_text.blank")
+          page.question_text = question_text
+          expect(page).not_to be_valid
+          expect(page.errors[:question_text]).to include(error_message)
+        end
+      end
+
+      it "is valid if question text below 200 characters" do
+        expect(page).to be_valid
+      end
+
+      context "when question text 250 characters" do
+        let(:question_text) { "A" * 250 }
+
+        it "is valid" do
+          expect(page).to be_valid
+        end
+      end
+
+      context "when question text more 250 characters" do
+        let(:question_text) { "A" * 251 }
+
+        it "is invalid" do
+          expect(page).not_to be_valid
+        end
+
+        it "has an error message" do
+          page.valid?
+          expect(page.errors[:question_text]).to include(I18n.t("activemodel.errors.models.page.attributes.question_text.too_long", count: 250))
+        end
+      end
+    end
+  end
+
   describe "#convert_is_optional_to_boolean" do
     context "when a question is optional" do
       it "set the model attribute to true" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require "gds-sso/lint/user_spec"
 require "rails_helper"
 
-describe User do
+describe User, type: :model do
   subject(:user) { described_class.new }
 
   it "validates" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/MAokcg4Y/1001-add-size-limit-to-question-text-pageheading-hint-text

This should match the validations that we have in forms-api and as a result the validations in forms-api should only be a safety net for us should any validations form forms-admin fail to catch invalid data

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
