### PR TITLE
Fix markdown ID issue

### DIFF
--- a/app/components/markdown_editor_component/view.html.erb
+++ b/app/components/markdown_editor_component/view.html.erb
@@ -1,16 +1,16 @@
 <div class="app-markdown-editor" data-module="ajax-markdown-preview" data-ajax-markdown-endpoint="<%= render_preview_path %>" data-i18n="<%= translations.to_json() %>">
-  <label class="govuk-label govuk-label--m" for='<%= form_field_id_prefix %>-textarea'>
+  <label class="govuk-label govuk-label--m" for='<%= form_field_id %>'>
     <h2 class="govuk-heading-m"><%= label %></h2>
   </label>
-  <div class="govuk-hint" id="<%= form_field_id_prefix %>-hint"><%= hint %></div>
+  <div class="govuk-hint" id="<%= form_field_id %>-hint"><%= hint %></div>
   <%= govuk_tabs(title: nil) do |component| %>
     <% component.with_tab(label: translations[:write_tab_text]) do %>
       <%= f.govuk_text_area(attribute_name,
                         label: nil,
                         hint: nil,
                         rows: 15,
-                        id: "#{form_field_id_prefix}-textarea",
-                        "aria-describedby": "#{form_field_id_prefix}-hint",
+                        id: "#{form_field_id}",
+                        aria: { describedby: "#{form_field_id}-hint" },
                         "data-module": "markdown-editor-toolbar",
                         "data-ajax-markdown-source": true,
                         "data-i18n": translations[:toolbar].to_json())  %>

--- a/app/components/markdown_editor_component/view.rb
+++ b/app/components/markdown_editor_component/view.rb
@@ -2,6 +2,7 @@
 
 module MarkdownEditorComponent
   class View < ViewComponent::Base
+    include GOVUKDesignSystemFormBuilder::BuilderHelper
     attr_reader :attribute_name, :f, :render_preview_path, :preview_html, :form_model, :label, :hint
 
     def initialize(attribute_name,
@@ -23,8 +24,8 @@ module MarkdownEditorComponent
       @local_translations = local_translations
     end
 
-    def form_field_id_prefix
-      "markdown-editor-#{attribute_name}"
+    def form_field_id
+      govuk_field_id(form_model, attribute_name)
     end
 
     def preview_button_translation

--- a/spec/components/markdown_editor_component/view_spec.rb
+++ b/spec/components/markdown_editor_component/view_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
     expect(page).to have_css("div", text: markdown_editor.hint)
   end
 
+  describe "form_field_id" do
+    it "returns the form field id" do
+      expect(markdown_editor.form_field_id).to eq markdown_editor.govuk_field_id(markdown_editor.form_model, :guidance_markdown)
+    end
+  end
+
   describe "translations" do
     context "when there are no local translations present" do
       it "renders the default translations" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: 

The markdown compenentisation work (#607) introduced a bug, where if the page has a validation error the error summary message does not link to the field correctly.

The reason for this is that we created a custom ID for the guidance field, but the error summary component expects the ID to be in the govuk_form_builder defined format.

Resolved in this PR by using the govuk_form_builder's govuk_field_id helper function to generate the ID in our markdown component, meaning the field's ID will always be in sync with the error summary component's expectations.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
