### PR TITLE
Update answer setting "input type" label

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -30,7 +30,7 @@
 
       <% if (@page_object.answer_type == "text") && @page_object&.answer_settings&.input_type%>
         <%= summary_list.with_row do |row|
-          row.with_key(text: "Input type")
+          row.with_key(text: "Length")
           row.with_value(text: t("helpers.label.page.text_settings_options.names.#{@page_object.answer_settings.input_type}"))
           row.with_action(text: "Change",
                     href: @change_text_settings_path,
@@ -39,7 +39,7 @@
 
       <% if (@page_object.answer_type == "date") && @page_object&.answer_settings&.input_type %>
         <%= summary_list.with_row do |row|
-          row.with_key(text: "Input type")
+          row.with_key(text: "Date of birth")
           row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{@page_object.answer_settings.input_type}"))
           row.with_action(text: "Change",
                     href: @change_date_settings_path,
@@ -48,7 +48,7 @@
 
       <% if (@page_object.answer_type == "address") && @page_object&.answer_settings&.input_type %>
         <%= summary_list.with_row do |row|
-          row.with_key(text: "Input type")
+          row.with_key(text: "Address type")
           row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
           row.with_action(text: "Change",
                      href: @change_address_settings_path,
@@ -57,7 +57,7 @@
 
       <% if (@page_object.answer_type == "name") && @page_object&.answer_settings&.input_type %>
         <%= summary_list.with_row do |row|
-          row.with_key(text: "Input type")
+          row.with_key(text: "Name fields")
           row.with_value(text: t("helpers.label.page.name_settings_options.names.#{@page_object.answer_settings.input_type}"))
           row.with_action(text: "Change",
                      href: @change_name_settings_path,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,8 +286,8 @@ en:
           title: Answer type
         date_settings_options:
           input_types:
-            date_of_birth: Date of birth
-            other_date: Other date
+            date_of_birth: 'Yes'
+            other_date: 'No'
           names:
             date_of_birth: 'Yes'
             other_date: 'No'

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "renders the input type" do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_text_settings_path:))
-      expect(page).to have_text "Input type"
+      expect(page).to have_text "Length"
       expect(page).to have_text I18n.t("helpers.label.page.text_settings_options.names.#{page_object.answer_settings.input_type}")
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "renders the input type" do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_date_settings_path:))
-      expect(page).to have_text "Input type"
+      expect(page).to have_text "Date of birth"
       expect(page).to have_text I18n.t("helpers.label.page.date_settings_options.input_types.#{page_object.answer_settings.input_type}")
     end
 
@@ -142,7 +142,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "renders the input type" do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_address_settings_path:))
-      expect(page).to have_text "Input type"
+      expect(page).to have_text "Address type"
       expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.uk_and_international_addresses")
     end
 
@@ -192,7 +192,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "renders the input type" do
       render_inline(described_class.new(page_object, change_answer_type_path:, change_name_settings_path:))
-      expect(page).to have_text "Input type"
+      expect(page).to have_text "Name fields"
       expect(page).to have_text I18n.t("helpers.label.page.name_settings_options.names.full_name")
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/AwpPGwM4/1010-production-meaningful-input-type-labels

Update the "input type" label for Persons name, Address, Data and text answer settings

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
