### PR TITLE
Send input event on paste to markdown field

### DIFF
--- a/app/frontend/javascript/paste-html-to-markdown/index.js
+++ b/app/frontend/javascript/paste-html-to-markdown/index.js
@@ -16,6 +16,8 @@ const insertTextAtCursor = (field, contentToInsert) => {
   } else {
     field.value += contentToInsert
   }
+
+  field.dispatchEvent(new window.InputEvent('input'))
 }
 
 const htmlFromPasteEvent = event => {

--- a/app/frontend/javascript/paste-html-to-markdown/index.test.js
+++ b/app/frontend/javascript/paste-html-to-markdown/index.test.js
@@ -129,3 +129,25 @@ describe('markdown event', () => {
     expect(listener).not.toHaveBeenCalled()
   })
 })
+
+describe('input event', () => {
+  it('is sent when the user pastes HTML', () => {
+    const listener = jest.fn()
+    const html = '<h2>Title</h2>'
+
+    textarea.addEventListener('input', listener)
+    textarea.dispatchEvent(createHtmlPasteEvent(html))
+
+    expect(listener).toHaveBeenCalled()
+  })
+
+  it('is sent when the user pastes text', () => {
+    const listener = jest.fn()
+    const text = 'Title'
+
+    textarea.addEventListener('input', listener)
+    textarea.dispatchEvent(createHtmlPasteEvent(null, text))
+
+    expect(listener).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### What problem does this pull request solve?

Fixes an issue with the paste-to-markdown module that meant the preview wasn't being updated when the user pastes content.  This is because the preview listens for the `input` event on the field, and this wasn't dispatched from the paste module. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
