### PR TITLE
Allow page options service to handle existing pages that dont have guidance

### DIFF
--- a/app/service/page_options_service.rb
+++ b/app/service/page_options_service.rb
@@ -15,8 +15,9 @@ class PageOptionsService
 
   def all_options_for_answer_type
     options = []
-    options.concat(page_heading_options) if @page.page_heading.present?
-    options.concat(guidance_markdown_options) if @page.guidance_markdown.present?
+
+    options.concat(page_heading_options) if @page.respond_to?(:page_heading) && @page.page_heading.present?
+    options.concat(guidance_markdown_options) if @page.respond_to?(:guidance_markdown) && @page.guidance_markdown.present?
 
     options.concat(hint_options) if @page.hint_text?.present?
     options.concat(generic_options) if @read_only && %w[address date text selection name].exclude?(@page.answer_type)

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -13,9 +13,8 @@
 
   <% if FeatureService.enabled? :detailed_guidance_enabled %>
     <h2 class="govuk-heading-m"><%= t("guidance.guidance") %></h2>
-    <% if page_object.page_heading.present? && page_object.guidance_markdown.present? %>
+    <% if (page_object.respond_to?(:page_heading) && page_object.page_heading.present?) && (page_object.respond_to?(:markdown_guidance) && page_object.guidance_markdown.present?) %>
       <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, page: page_object).build_data) %>
-
     <% else %>
       <p><%= t("guidance.instructions") %></p>
 

--- a/spec/service/page_options_service_spec.rb
+++ b/spec/service/page_options_service_spec.rb
@@ -252,6 +252,31 @@ describe PageOptionsService do
             value: { text: "<pre class=\"app-markdown-editor__markdown-example-block\">#{page.guidance_markdown}</pre>" } },
         )
       end
+
+      context "when page doesn't have a page_heading or guidance_markdown method defined" do
+        let(:page) do
+          build(:page).tap do |p|
+            p.attributes.delete(:page_heading)
+            p.attributes.delete(:guidance_markdown)
+          end
+        end
+
+        it "does not raise an error" do
+          expect { page_options_service.all_options_for_answer_type }.not_to raise_error
+        end
+
+        it "does not return a page heading key" do
+          expect(page_options_service.all_options_for_answer_type).not_to include(
+            { key: { text: I18n.t("page_options_service.page_heading") } },
+          )
+        end
+
+        it "does not return a guidance markdown key" do
+          expect(page_options_service.all_options_for_answer_type).not_to include(
+            { key: { text: I18n.t("page_options_service.guidance_markdown") } },
+          )
+        end
+      end
     end
   end
 end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -66,6 +66,19 @@ describe "pages/_form.html.erb", type: :view do
         expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: guidance_edit_path(form_id: form.id, page_id: question.id))
       end
     end
+
+    context "when the page does not have a page_heading or guidance_markdown attributes" do
+      let(:question) do
+        build(:page).tap do |p|
+          p.attributes.delete(:page_heading)
+          p.attributes.delete(:guidance_markdown)
+        end
+      end
+
+      it "contains contents relating to how to add guidance" do
+        expect(rendered).to have_text(I18n.t("guidance.instructions"))
+      end
+    end
   end
 
   context "when it is not a new page" do


### PR DESCRIPTION
### What problem does this pull request solve?

This fixes a problem where there is an existing live form which the user is trying to view the forms pages.

It throws an undefined method error because the snapshot of the live form page did not contain "page_heading" or "guidance_markdown"

fixes
- https://govuk-forms.sentry.io/issues/4458650198/?project=6576190
- https://govuk-forms.sentry.io/issues/4469134101/?project=6576190

Trello card:  https://trello.com/c/mjqZND5D/1019-viewing-an-existing-live-form-pages-in-forms-admin-returns-500-error

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
