### PR TITLE
Revert "allow add/edit page to handle existing pages that dont have guidance"

### DIFF
--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -13,8 +13,9 @@
 
   <% if FeatureService.enabled? :detailed_guidance_enabled %>
     <h2 class="govuk-heading-m"><%= t("guidance.guidance") %></h2>
-    <% if (page_object.respond_to?(:page_heading) && page_object.page_heading.present?) && (page_object.respond_to?(:markdown_guidance) && page_object.guidance_markdown.present?) %>
+    <% if page_object.page_heading.present? && page_object.guidance_markdown.present? %>
       <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, page: page_object).build_data) %>
+
     <% else %>
       <p><%= t("guidance.instructions") %></p>
 

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -66,19 +66,6 @@ describe "pages/_form.html.erb", type: :view do
         expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: guidance_edit_path(form_id: form.id, page_id: question.id))
       end
     end
-
-    context "when the page does not have a page_heading or guidance_markdown attributes" do
-      let(:question) do
-        build(:page).tap do |p|
-          p.attributes.delete(:page_heading)
-          p.attributes.delete(:guidance_markdown)
-        end
-      end
-
-      it "contains contents relating to how to add guidance" do
-        expect(rendered).to have_text(I18n.t("guidance.instructions"))
-      end
-    end
   end
 
   context "when it is not a new page" do


### PR DESCRIPTION
### What problem does this pull request solve?

This reverts commit c6fe07544716e6ff15625b9228be70bdf849ab73.

This should never have been implemented as the c6fe075 commit itself said its unlikely to happen. The Page model resource itself will always have guidance attributes unless the columns were dropped by then more things would break and need to refactor.

Trello card: https://trello.com/c/mjqZND5D/1019-viewing-an-existing-live-form-pages-in-forms-admin-returns-500-error

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
