### PR TITLE
Fix back link on the "add guidance" page

### DIFF
--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -5,21 +5,23 @@ class Pages::GuidanceController < PagesController
     page_heading = session.dig(:page, "page_heading")
     guidance_markdown = session.dig(:page, "guidance_markdown")
     guidance_form = Pages::GuidanceForm.new(page_heading:, guidance_markdown:)
-    render "pages/guidance", locals: view_locals(nil, guidance_form)
+    back_link = new_page_path(@form)
+    render "pages/guidance", locals: view_locals(nil, guidance_form, back_link)
   end
 
   def create
     guidance_form = Pages::GuidanceForm.new(guidance_form_params)
+    back_link = new_page_path(@form)
 
     case route_to
     when :preview
       guidance_form.valid?
-      render "pages/guidance", locals: view_locals(nil, guidance_form)
+      render "pages/guidance", locals: view_locals(nil, guidance_form, back_link)
     when :save_and_continue
       if guidance_form.submit(session)
         redirect_to new_page_path(@form)
       else
-        render "pages/guidance", locals: view_locals(nil, guidance_form), status: :unprocessable_entity
+        render "pages/guidance", locals: view_locals(nil, guidance_form, back_link), status: :unprocessable_entity
       end
     end
   end
@@ -29,22 +31,24 @@ class Pages::GuidanceController < PagesController
 
     guidance_form = Pages::GuidanceForm.new(page_heading: page.page_heading,
                                             guidance_markdown: page.guidance_markdown)
+    back_link = edit_page_path(@form, page)
 
-    render "pages/guidance", locals: view_locals(page, guidance_form)
+    render "pages/guidance", locals: view_locals(page, guidance_form, back_link)
   end
 
   def update
     guidance_form = Pages::GuidanceForm.new(guidance_form_params)
+    back_link = edit_page_path(@form, page.id)
 
     case route_to
     when :preview
       guidance_form.valid?
-      render "pages/guidance", locals: view_locals(page, guidance_form)
+      render "pages/guidance", locals: view_locals(page, guidance_form, back_link)
     when :save_and_continue
       if guidance_form.submit(session)
         redirect_to edit_page_path(@form.id, page.id)
       else
-        render "pages/guidance", locals: view_locals(page, guidance_form), status: :unprocessable_entity
+        render "pages/guidance", locals: view_locals(page, guidance_form, back_link), status: :unprocessable_entity
       end
     end
   end
@@ -71,8 +75,8 @@ private
     GovukFormsMarkdown.render(guidance_form.guidance_markdown)
   end
 
-  def view_locals(current_page, guidance_form)
+  def view_locals(current_page, guidance_form, back_link)
     post_url = current_page.present? && current_page.id.present? ? guidance_edit_path : guidance_new_path
-    { form: @form, page: @page, guidance_form:, preview_html: preview_html(guidance_form), post_url: }
+    { form: @form, page: @page, guidance_form:, preview_html: preview_html(guidance_form), post_url:, back_link: }
   end
 end

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,5 +1,5 @@
 <% set_page_title(title_with_error_prefix(t("page_titles.add_guidance"), guidance_form.errors&.any?)) %>
-<% content_for :back_link, govuk_back_link_to(form_pages_path(form)) %>
+<% content_for :back_link, govuk_back_link_to(back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
     it "returns 200" do
       expect(response).to have_http_status(:ok)
     end
+
+    it "links back to the previous question page" do
+      expect(Capybara.string(response.body)).to have_link("Back", href: new_page_path(form.id))
+    end
   end
 
   describe "#create" do
@@ -76,6 +80,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
 
       it "renders the guidance markdown as html" do
         expect(response.body).to include('<h2 class="govuk-heading-m">Heading level 2</h2>')
+      end
+
+      it "links back to the previous question page" do
+        expect(Capybara.string(response.body)).to have_link("Back", href: new_page_path(form.id))
       end
 
       context "when markdown is blank" do
@@ -151,6 +159,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
     it "returns 200" do
       expect(response).to have_http_status(:ok)
     end
+
+    it "links back to the previous question page" do
+      expect(Capybara.string(response.body)).to have_link("Back", href: edit_page_path(form.id, page.id))
+    end
   end
 
   describe "#update" do
@@ -183,6 +195,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
 
       it "renders the guidance markdown as html" do
         expect(response.body).to include('<h2 class="govuk-heading-m">Heading level 2</h2>')
+      end
+
+      it "links back to the previous question page" do
+        expect(Capybara.string(response.body)).to have_link("Back", href: edit_page_path(form.id, page.id))
       end
 
       context "when markdown is blank" do


### PR DESCRIPTION
### What problem does this pull request solve?

The back link on the "Add guidance" page was taking users back to the list of questions page rather than back to the previous "Add/Edit Question" page

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
