### PR TITLE
Add cancel link to "Add guidance" page

### DIFF
--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -31,8 +31,10 @@
           update_preview: t("guidance.markdown_editor.update_preview"),
           write_tab_text: t("guidance.markdown_editor.write_tab_text"),
         }) %>
-
-      <%= f.govuk_submit t("continue"), name: "route_to", value: "save_and_continue" %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit t("continue"), name: "route_to", value: "save_and_continue" %>
+        <%= govuk_link_to t('cancel'), back_link %>
+      </div>
 
     <% end %>
     <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
       route_deleted: Question %{question_position}’s route has been deleted
       route_updated: Question %{question_position}’s route has been updated
       title: Success
+  cancel: Cancel
   contact_details:
     new:
       body_html: |

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
     it "links back to the previous question page" do
       expect(Capybara.string(response.body)).to have_link("Back", href: new_page_path(form.id))
     end
+
+    it "includes a cancel link" do
+      expect(Capybara.string(response.body)).to have_link(I18n.t("cancel"), href: new_page_path(form.id))
+    end
   end
 
   describe "#create" do
@@ -84,6 +88,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
 
       it "links back to the previous question page" do
         expect(Capybara.string(response.body)).to have_link("Back", href: new_page_path(form.id))
+      end
+
+      it "includes a cancel link" do
+        expect(Capybara.string(response.body)).to have_link(I18n.t("cancel"), href: new_page_path(form.id))
       end
 
       context "when markdown is blank" do
@@ -163,6 +171,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
     it "links back to the previous question page" do
       expect(Capybara.string(response.body)).to have_link("Back", href: edit_page_path(form.id, page.id))
     end
+
+    it "includes a cancel link" do
+      expect(Capybara.string(response.body)).to have_link(I18n.t("cancel"), href: edit_page_path(form.id, page.id))
+    end
   end
 
   describe "#update" do
@@ -199,6 +211,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
 
       it "links back to the previous question page" do
         expect(Capybara.string(response.body)).to have_link("Back", href: edit_page_path(form.id, page.id))
+      end
+
+      it "includes a cancel link" do
+        expect(Capybara.string(response.body)).to have_link(I18n.t("cancel"), href: edit_page_path(form.id, page.id))
       end
 
       context "when markdown is blank" do


### PR DESCRIPTION
### What problem does this pull request solve?

Adding this link to allow users to "leave" the page without saving any changes they have made. It works exactly like the "back link" already on the page

Trello card:  https://trello.com/c/48YVQpfI/1024-add-cancel-link-to-add-guidance-page

### Things to consider when reviewing


- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
