### PR TITLE
Use ActiveRecord Session Store instead of cookies or Redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,3 +118,5 @@ group :test do
   # axe-core for running automated accessibility checks
   gem "axe-core-rspec"
 end
+
+gem "activerecord-session_store", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,13 @@ GEM
     activerecord (7.0.8)
       activemodel (= 7.0.8)
       activesupport (= 7.0.8)
+    activerecord-session_store (2.1.0)
+      actionpack (>= 6.1)
+      activerecord (>= 6.1)
+      cgi (>= 0.3.6)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 4)
+      railties (>= 6.1)
     activeresource (6.0.0)
       activemodel (>= 6.0)
       activemodel-serializers-xml (~> 1.0)
@@ -135,6 +142,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.3.6)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.2)
@@ -272,6 +280,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.6.0)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     net-imap (0.3.7)
       date
@@ -542,6 +551,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-session_store (~> 2.1)
   activeresource (~> 6.0)
   axe-core-rspec
   bootsnap

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, key: "_forms_admin_session"

--- a/db/migrate/20230913134033_add_sessions_table.rb
+++ b/db/migrate/20230913134033_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_02_102230) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_13_134033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_02_102230) do
 
   create_table "schema_info", id: false, force: :cascade do |t|
     t.integer "version", default: 0, null: false
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## What problem does this pull request solve?

We will switch out from using Rails default cookie based session storage, which has 4k data limit and use ActiveRecord db storage instead where we would no longer have this restriction.

As this would affect existing users, I plan on deploying this first thing tomorrow morning.

Trello card: https://trello.com/c/o1oPv62S/1052-switch-cookie-storage-to-activerecord-session-store-gem


### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
