### PR TITLE
Sort users page by organisation, access, role, and name

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,12 @@ class UsersController < ApplicationController
 
     roles = User.roles.keys
     @users = policy_scope(User).sort_by do |user|
-      [user.organisation&.name || "", roles.index(user.role), user.name]
+      [
+        user.organisation&.name || "",
+        user.has_access ? 0 : 1,
+        roles.index(user.role),
+        user.name,
+      ]
     end
 
     render template: "users/index", locals: { users: @users }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,13 @@ class UsersController < ApplicationController
 
   def index
     authorize current_user, :can_manage_user?
-    render template: "users/index", locals: { users: policy_scope(User) }
+
+    roles = User.roles.keys
+    @users = policy_scope(User).sort_by do |user|
+      [user.organisation&.name || "", roles.index(user.role), user.name]
+    end
+
+    render template: "users/index", locals: { users: @users }
   end
 
   def edit

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -47,25 +47,33 @@ RSpec.describe UsersController, type: :request do
 
         organisations.each_with_index.flat_map do |organisation|
           roles.each_with_index.flat_map do |role|
-            create_list(:user, 5, organisation:, role:)
+            create_list(:user, 5, organisation:, role:) do |user, i|
+              user.has_access = i < 4
+              user.save!
+            end
           end
         end
 
         get users_path
       end
 
-      it "sorts users by organisation, role, and name" do
+      it "sorts users by organisation, access, role, and name " do
+        assigns[:users].each do |user|
+          puts "#{user.organisation.name}:#{user.has_access}:#{user.role}:#{user.name}"
+        end
         assigns[:users].each_cons(2) do |user, next_user|
           if user.organisation.name == next_user.organisation.name
-            if user.role == next_user.role
-              expect(user.name).to be <= next_user.name
-            else
-              case user.role
-              when "super_admin"
-                expect(next_user.role).to eq "editor"
-              when "editor"
-                expect(next_user.role).to eq "trial"
+            if user.has_access == next_user.has_access
+              if user.role == next_user.role
+                expect(user.name).to be <= next_user.name
+              else
+                case user.role
+                when "super_admin" then expect(next_user.role).to eq "editor"
+                when "editor" then expect(next_user.role).to eq "trial"
+                end
               end
+            else
+              expect(next_user.has_access).to be false
             end
           else
             expect(user.organisation.name < next_user.organisation.name)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -33,6 +33,46 @@ RSpec.describe UsersController, type: :request do
         expect(response).to have_http_status(:forbidden)
       end
     end
+
+    context "with many users" do
+      before do
+        login_as_super_admin_user
+
+        organisations = [
+          create(:organisation, slug: "test-org"),
+          create(:organisation, slug: "ministry-of-tests"),
+          create(:organisation, slug: "department-for-testing"),
+        ]
+        roles = User.roles.keys
+
+        organisations.each_with_index.flat_map do |organisation|
+          roles.each_with_index.flat_map do |role|
+            create_list(:user, 5, organisation:, role:)
+          end
+        end
+
+        get users_path
+      end
+
+      it "sorts users by organisation, role, and name" do
+        assigns[:users].each_cons(2) do |user, next_user|
+          if user.organisation.name == next_user.organisation.name
+            if user.role == next_user.role
+              expect(user.name).to be <= next_user.name
+            else
+              case user.role
+              when "super_admin"
+                expect(next_user.role).to eq "editor"
+              when "editor"
+                expect(next_user.role).to eq "trial"
+              end
+            end
+          else
+            expect(user.organisation.name < next_user.organisation.name)
+          end
+        end
+      end
+    end
   end
 
   describe "#edit" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/3tyyHhoK

Currently the users table that lists all users is not ordered. That’s ok when there aren’t many users but it would probably make sense to order them by organisation, name, user type or a combination of these - so that it’s easier to find a specific user or get a view of a number of users in a group.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

<details><summary>Screenshot</summary>

![Screenshot of table of users at locahost:3000/users](https://github.com/alphagov/forms-admin/assets/503614/38b50dc0-c48e-4929-bb38-5c8e14229d1e)

</details>

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?