### PR TITLE
Use setup-node action to install Node.js and cache npm downloads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@
 # run tests and linters.
 
 name: "Tests"
+
 on:
   push:
     branches: [main]
@@ -24,21 +25,21 @@ jobs:
         ports:
           - "5432:5432"
         env:
-          POSTGRES_DB: rails_test
-          POSTGRES_USER: rails
-          POSTGRES_PASSWORD: password
+          POSTGRES_DB: forms_admin_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
     env:
-      RAILS_ENV: test
-      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+      RAILS_ENV: "test"
+      DATABASE_URL: "postgres://postgres:postgres@localhost:5432/forms_admin_test"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       # Add or replace dependency steps here
-      # The ruby version is taken from the .ruby-version file, no need to specify here.
       - name: Install Ruby and gems
+        # The ruby version is taken from the .ruby-version file, no need to specify here.
         uses: ruby/setup-ruby@5311f05890856149502132d25c4a24985a00d426
         with:
-          bundler-cache: true
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
@@ -60,10 +61,10 @@ jobs:
         run: npm test
       # Add or replace any other lints here
       - name: Security audit dependencies
-        run: bundler exec bundle audit check
+        run: bundle exec bundle-audit check --update
       - name: Security audit application code
-        run: bundler exec brakeman -q -w2
+        run: bundle exec brakeman -q -w2
       - name: Lint Ruby files
-        run: bundler exec rubocop --parallel
+        run: bundle exec rubocop --parallel
       - name: Lint Javascript and Sass files
         run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
         uses: ruby/setup-ruby@5311f05890856149502132d25c4a24985a00d426
         with:
           bundler-cache: true
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - name: Install frontend dependencies
         run: npm ci
       - name: Run Frontend build


### PR DESCRIPTION
### What problem does this pull request solve?

Currently `npm ci` can take over 2 minutes in GitHub Actions, this commit uses the actions/setup-node action to cache the npm downloads to try and speed things up.

We also use the action to install the same version of Node as in the `.nvmrc` file, because we might as well.

This PR also makes the `.test.yaml` workflow file more consistent with the same workflow file in our other app repos.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?