### PR TITLE
[DO NOT MERGE] Update trial account banner

### DIFF
--- a/app/components/trial_role_warning_component/view.html.erb
+++ b/app/components/trial_role_warning_component/view.html.erb
@@ -1,0 +1,6 @@
+<% if @current_user.trial?  %>
+  <%= govuk_notification_banner(title_text: t("trial_role_warning.title")) do |banner| %>
+    <% banner.with_heading(text: t("trial_role_warning.heading")) %>
+    <%= t("trial_role_warning.content_html", link_url: '/404') %>
+  <% end %>
+<% end %>

--- a/app/components/trial_role_warning_component/view.rb
+++ b/app/components/trial_role_warning_component/view.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module TrialRoleWarningComponent
+  class View < ViewComponent::Base
+    def initialize(current_user)
+      super
+      @current_user = current_user
+    end
+  end
+end

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,17 +1,17 @@
 <% set_page_title(t("page_titles.home")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render TrialRoleWarningComponent::View.new(@current_user) %>
+  </div>
+</div>
+
 <h1 class="govuk-heading-l"><%= t("home.main_heading") %></h1>
 
 <% if flash[:message] %>
   <p>
     <%= flash[:message] %>
   </p>
-<% end %>
-
-<% if @current_user.trial?  %>
-  <%= govuk_notification_banner(title_text: t("trial_role_warning.title")) do |banner| %>
-    <% banner.with_heading(text: t("trial_role_warning.heading")) %>
-    <%= t("trial_role_warning.content") %>
-  <% end %>
 <% end %>
 
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_form_path) %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -4,6 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render TrialRoleWarningComponent::View.new(@current_user) %>
+
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       <span class="govuk-caption-l"><%= @form.name %></span><span class="govuk-visually-hidden"> - </span>
       <%= @form.has_live_version ? t("forms.form_overview.title_edit") : t("forms.form_overview.title_create") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -657,7 +657,16 @@ en:
     in_progress: in progress
     not_started: not started
   trial_role_warning:
-    content: You can create a form and test it, but you cannot make a form live.
+    content_html: |
+      <p>
+        You can create a form, preview and test it.
+      </p>
+      <p>
+        You need an editor account to be able to make a form live.
+      </p>
+      <p>
+        <a href="%{link_url}">Find out if you can upgrade to an editor account</a>
+      </p>
     heading: You have a trial account
     title: Important
   type_of_answer:

--- a/spec/components/trial_role_warning_component/trial_role_warning_component_preview.rb
+++ b/spec/components/trial_role_warning_component/trial_role_warning_component_preview.rb
@@ -1,0 +1,5 @@
+class TrialRoleWarningComponent::TrialRoleWarningComponentPreview < ViewComponent::Preview
+  def default
+    render(TrialRoleWarningComponent::View.new(User.new))
+  end
+end

--- a/spec/components/trial_role_warning_component/view_spec.rb
+++ b/spec/components/trial_role_warning_component/view_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe TrialRoleWarningComponent::View, type: :component do
+  before do
+    render_inline(described_class.new(user))
+  end
+
+  context "when a user has the trial role" do
+    let(:user) { build :user, :with_trial_role }
+
+    it "displays a banner informing the user they have a trial account" do
+      expect(page).to have_selector(".govuk-notification-banner__content")
+      expect(page).to have_text("Important")
+      expect(page).to have_text("You have a trial account")
+      expect(page).to have_text("You can create a form, preview and test it.")
+      expect(page).to have_text("You need an editor account to be able to make a form live.")
+      expect(page).to have_link("Find out if you can upgrade to an editor account")
+    end
+  end
+
+  context "when a user does not have the trial role" do
+    let(:user) { build :user, role: :editor }
+
+    it "does not display a banner" do
+      expect(page).not_to have_selector(".govuk-notification-banner__content")
+    end
+  end
+end

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -63,6 +63,18 @@ describe "Set or change a user's role", type: :feature do
     then_i_can_see_the_org_forms
   end
 
+  context "when a trial user views the trial account banner" do
+    it "the trial account banner is visible" do
+      login_as trial_user
+      then_i_can_see_trial_account_banner
+    end
+
+    it "the trial account banner link navigates to the upgrade page" do
+      login_as trial_user
+      then_i_can_navigate_to_the_upgrade_page
+    end
+  end
+
 private
 
   def when_i_change_the_trial_users_role_to_editor
@@ -79,6 +91,19 @@ private
   def then_i_can_see_the_trial_user_forms
     visit root_path
     expect(page).to have_text "Trial form"
+  end
+
+  def then_i_can_see_trial_account_banner
+    visit root_path
+    expect(page).to have_text "You have a trial account"
+  end
+
+  def then_i_can_navigate_to_the_upgrade_page
+    visit root_path
+
+    click_link("Find out if you can upgrade to an editor account")
+
+    expect(page).to have_current_path("/404")
   end
 
   def then_i_cannot_see_the_org_forms

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -107,7 +107,7 @@ describe "forms/index.html.erb" do
 
         expect(rendered).to have_selector(".govuk-notification-banner__content")
         expect(banner).to have_text(I18n.t("trial_role_warning.heading"))
-        expect(banner).to have_text(I18n.t("trial_role_warning.content"))
+        expect(Capybara.string(banner).text(normalize_ws: true)).to have_text(Capybara.string(I18n.t("trial_role_warning.content_html")).text(normalize_ws: true))
       end
     end
 

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 describe "forms/show.html.erb" do
+  let(:user) { build :user, role: :editor }
   let(:form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", pages:) }
   let(:pages) { [{ id: 183, question_text: "What is your address?", hint_text: "", answer_type: "address", next_page: nil }] }
 
   before do
+    assign(:current_user, user)
     assign(:form, form)
     assign(:task_status_counts, { completed: 12, total: 20 })
     render template: "forms/show"
@@ -52,6 +54,26 @@ describe "forms/show.html.erb" do
 
     it "does not contain a link to delete the form" do
       expect(rendered).not_to have_link("Delete draft form", href: delete_form_path(2))
+    end
+  end
+
+  context "and a user has the trial role" do
+    let(:user) { build :user, :with_trial_role }
+
+    it "displays a banner informing the user they have a trial account" do
+      banner = Capybara.string(rendered).find(".govuk-notification-banner__content")
+
+      expect(rendered).to have_selector(".govuk-notification-banner__content")
+      expect(banner).to have_text(I18n.t("trial_role_warning.heading"))
+      expect(Capybara.string(banner).text(normalize_ws: true)).to have_text(Capybara.string(I18n.t("trial_role_warning.content_html")).text(normalize_ws: true))
+    end
+  end
+
+  context "and a user does not have the trial role" do
+    let(:user) { build :user, role: :editor }
+
+    it "does not display a banner" do
+      expect(rendered).not_to have_selector(".govuk-notification-banner__content")
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?
- We need to update the content on the trial account banner - primarily to add a link for people to request to upgrade to editor

- We also need to add the trial banner to the task list page for creating a form (it’s currently only on the main landing page)

This PR does both of the above, but just links to `/404` for now, since the upgrade page doesn't yet exist. This might mean we'd like to block merging this PR until after the upgrade page exists.

Trello card: https://trello.com/c/ZDIdgJCJ

<details><summary>Screenshots</summary>
<p>

![Screenshot 2023-09-19 at 15 37 09](https://github.com/alphagov/forms-admin/assets/29330450/019c06bd-5128-4889-b928-f3d500aaa364)

![Screenshot 2023-09-19 at 15 37 22](https://github.com/alphagov/forms-admin/assets/29330450/3886c6cc-70c1-4101-b6bb-38acf10664ee)
</p>
</details> 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->


- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
