### PR TITLE
Add edit guidance link

### DIFF
--- a/app/components/markdown_editor_component/_index.scss
+++ b/app/components/markdown_editor_component/_index.scss
@@ -22,6 +22,12 @@
   }
 }
 
+.js-enabled .app-markdown-editor__edit-link {
+  @include govuk-media-query($from: tablet) {
+    display: none;
+  }
+}
+
 .app-markdown-editor__toolbar {
   display: flex;
   gap: 5px;

--- a/app/components/markdown_editor_component/view.html.erb
+++ b/app/components/markdown_editor_component/view.html.erb
@@ -67,6 +67,8 @@
         </div>
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-markdown-editor__preview-line-break">
+
+        <%= govuk_link_to translations[:edit_markdown_link], "##{form_field_id}", class: "app-markdown-editor__edit-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/markdown_editor_component/view.rb
+++ b/app/components/markdown_editor_component/view.rb
@@ -42,6 +42,7 @@ module MarkdownEditorComponent
         write_tab_text: @local_translations[:write_tab_text] || I18n.t("markdown_editor.write_tab_text"),
         preview_loading: @local_translations[:preview_loading] || I18n.t("markdown_editor.preview_loading"),
         preview_error: @local_translations[:preview_error] || I18n.t("markdown_editor.preview_error"),
+        edit_markdown_link: @local_translations[:edit_markdown_link] || I18n.t("markdown_editor.edit_markdown_link"),
         toolbar: {
           h2: I18n.t("markdown_editor.toolbar.h2"),
           h3: I18n.t("markdown_editor.toolbar.h3"),

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -30,6 +30,7 @@
           preview_tab_text: t("guidance.markdown_editor.preview_tab_text"),
           update_preview: t("guidance.markdown_editor.update_preview"),
           write_tab_text: t("guidance.markdown_editor.write_tab_text"),
+          edit_markdown_link: t("guidance.markdown_editor.edit_markdown_link"),
         }) %>
       <div class="govuk-button-group">
         <%= f.govuk_submit t("continue"), name: "route_to", value: "save_and_continue" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,6 +190,7 @@ en:
     guidance: Guidance
     instructions: Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content with paragraphs, headings, lists or links.
     markdown_editor:
+      edit_markdown_link: Edit guidance text
       preview:
         description: Below is a preview of how your guidance content will be shown to the person completing your form.
         heading: Preview your guidance below
@@ -387,6 +388,7 @@ en:
     legend: Do you want to mark this task as complete?
     'true': 'Yes'
   markdown_editor:
+    edit_markdown_link: Edit markdown
     formatting_help:
       bulleted_lists:
         example: |

--- a/spec/components/markdown_editor_component/view_spec.rb
+++ b/spec/components/markdown_editor_component/view_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
     expect(page).to have_css("div", text: markdown_editor.hint)
   end
 
+  it "renders the edit markdown link" do
+    expect(page).to have_link(I18n.t("markdown_editor.edit_markdown_link"), href: "##{markdown_editor.form_field_id}")
+  end
+
   describe "form_field_id" do
     it "returns the form field id" do
       expect(markdown_editor.form_field_id).to eq markdown_editor.govuk_field_id(markdown_editor.form_model, :guidance_markdown)
@@ -59,6 +63,7 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
             write_tab_text: I18n.t("markdown_editor.write_tab_text"),
             preview_loading: I18n.t("markdown_editor.preview_loading"),
             preview_error: I18n.t("markdown_editor.preview_error"),
+            edit_markdown_link: I18n.t("markdown_editor.edit_markdown_link"),
             toolbar: {
               h2: I18n.t("markdown_editor.toolbar.h2"),
               h3: I18n.t("markdown_editor.toolbar.h3"),
@@ -82,6 +87,7 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
           write_tab_text: "local write tab text",
           preview_loading: "local preview laoding",
           preview_error: "local preview error",
+          edit_markdown_link: "local edit markdown link",
           toolbar: {
             h2: "local h2",
             h3: "local h3",
@@ -103,6 +109,7 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
             write_tab_text: local_translations[:write_tab_text],
             preview_loading: local_translations[:preview_loading],
             preview_error: local_translations[:preview_error],
+            edit_markdown_link: local_translations[:edit_markdown_link],
             toolbar: {
               h2: I18n.t("markdown_editor.toolbar.h2"),
               h3: I18n.t("markdown_editor.toolbar.h3"),

--- a/spec/views/pages/guidance.html.erb_spec.rb
+++ b/spec/views/pages/guidance.html.erb_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+describe "pages/guidance.html.erb", type: :view do
+  let(:form) { build :form, id: 1 }
+  let(:page) { OpenStruct.new(conditions: [], answer_type: "number") }
+  let(:guidance_form) { Pages::GuidanceForm.new }
+  let(:preview_html) { I18n.t("guidance.no_guidance_added_html") }
+  let(:back_link) { "/forms/1/pages/new" }
+  let(:question_number) { 1 }
+  let(:is_new_page) { true }
+  let(:guidance_form_path) { "/forms/1/pages/new/guidance" }
+
+  before do
+    # allow objects to use ids in form helper
+    allow(form).to receive(:persisted?).and_return(true)
+    allow(guidance_form).to receive(:persisted?).and_return(true)
+
+    # mock the form.page_number method
+    allow(form).to receive(:page_number).and_return(question_number)
+
+    # mock the path helper
+    without_partial_double_verification do
+      allow(view).to receive(:form_pages_guidance_form_path).and_return(guidance_form_path)
+    end
+
+    # setup instance variables
+    assign(:form, form)
+    assign(:page, page)
+    assign(:guidance_form, guidance_form)
+
+    render(template: "pages/guidance", locals: { guidance_form:, back_link:, post_url: guidance_form_path, form:, page:, preview_html: })
+  end
+
+  it "has the correct title" do
+    expect(view.content_for(:title)).to have_content(I18n.t("page_titles.add_guidance"))
+  end
+
+  it "has a back link to the live form page" do
+    expect(view.content_for(:back_link)).to have_link("Back", href: back_link)
+  end
+
+  it "contains the question number" do
+    expect(rendered).to have_content("Question #{question_number}")
+  end
+
+  it "has the correct heading and caption" do
+    expect(rendered).to have_selector("h1", text: "Question #{question_number}")
+    expect(rendered).to have_selector("h1", text: I18n.t("guidance.add_guidance"))
+  end
+
+  it "contains a form which submits to @guidance_form_path" do
+    expect(rendered).to have_selector("form[action=\"#{guidance_form_path}\"]")
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/70ocEwDu/1044-add-edit-guidance-text-link-to-add-guidance-page-when-js-is-disabled

Adds a anchor link to the guidance page which will take the user back to the guidance field. This is useful if there's no JS or if the user's on a narrow screen, as in those cases the preview and the edit field are further apart than on wider screens with JS enabled. The link won't display if the tabs component is active.

Also adds a few view tests for the guidance view as there weren't any.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
