### PR TITLE
Update en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,7 +188,7 @@ en:
   guidance:
     add_guidance: Add guidance
     guidance: Guidance
-    instructions: Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content. For example, you can use paragraphs, links or lists.
+    instructions: Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content with paragraphs, headings, lists or links.
     markdown_editor:
       preview:
         description: Below is a preview of how your guidance content will be shown to the person completing your form.
@@ -216,21 +216,21 @@ en:
       page:
         answer_type: The answer will be checked to make sure it’s in the selected format.
         hint_text:
-          address: You could use hint text to tell people how you’ll use their address. For example, ‘We’ll send your licence to this address.’
-          checkbox: Use hint text to help people answer the question. For a question where people can select more than one answer you might want to use ‘Select all that apply’.
-          date: Use hint text to help people answer the question. For a date question you could use ‘For example, 27 3 2007’.
-          date_of_birth: Use hint text to help people answer the question. For a date of birth question you could use ‘For example, 27 3 1998’.
-          default: Use hint text to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for.
-          email: You could use hint text to tell people how you’ll use their email address. For example, ‘We’ll only use your email address to contact you about your application.’
-          long_text: Use hint text to help people answer the question. For example, you could give a bit more detail about the information you need.
-          name: Use hint text to help people answer the question. For example, you might need to ask people to enter their name as it’s written on an official document such as a passport or driving licence.
-          national_insurance_number: Use hint text to help people answer the question. For example, ‘It’s on your National Insurance card, benefit letter, payslip or P60. For example, QQ 12 34 56 C.’
-          number: Use hint text to help people answer the question. For example, ‘Do not include bank holidays’.
-          organisation_name: Use hint text to help people answer the question. For example, you might need to ask people to enter the registered name of their company.
-          other_date: Use hint text to help people answer the question. For a date question you could use ‘For example, 27 3 2007’.
-          phone_number: Use hint text to help people answer the question. For example, ‘You can provide either a home or mobile phone number.’
-          radio: Use hint text to help people answer the question. For a question where people can only select one answer you might want to use ‘Select one option’.
-          single_line: Use hint text to help people answer the question. For example, you could say what format the answer should be in or where to find it.
+          address: You can add a short hint to help people answer the question. For example, you could tell people how you'll use their address.
+          checkbox: You can add a short hint to help people answer the question. For a question where people can select more than one answer you might want to use ‘Select all that apply’.
+          date: You can add a short hint to help people answer the question. For a date question you could use ‘For example, 27 3 2007’.
+          date_of_birth: You can add a short hint to help people answer the question. For a date of birth question you could use ‘For example, 27 3 1998’.
+          default: You can add a short hint to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for.
+          email: You could add a short hint to tell people how you’ll use their email address. For example, ‘We’ll only use your email address to contact you about your application.’
+          long_text: You can add a short hint to help people answer the question. For example, you could give a bit more detail about the information you need.
+          name: You can add a short hint to help people answer the question. For example, you might need to ask people to enter their name as it’s written on an official document such as a passport or driving licence.
+          national_insurance_number: You can add a short hint to help people answer the question. For example, ‘It’s on your National Insurance card, benefit letter, payslip or P60. For example, QQ 12 34 56 C.’
+          number: You can add a short hint to help people answer the question. For example, ‘Do not include bank holidays’.
+          organisation_name: You can add a short hint to help people answer the question. For example, you might need to ask people to enter the registered name of their company.
+          other_date: You can add a short hint to help people answer the question. For a date question you could use ‘For example, 27 3 2007’.
+          phone_number: You can add a short hint to help people answer the question. For example, ‘You can provide either a home or mobile phone number.’
+          radio: You can add a short hint to help people answer the question. For a question where people can only select one answer you might want to use ‘Select one option’.
+          single_line: You can add a short hint to help people answer the question. For example, you could say what format the answer should be in or where to find it.
         question_text:
           address: Ask the question the way you would in person. For example, ‘What’s your address?’
           checkbox: Ask the question the way you would in person. For example, ‘Which of these countries have you lived in?’


### PR DESCRIPTION
Updated all the hint text hints that display on 'Edit question' pages. Have specified that 'You can add a short hint to help people answer the question' to help people understand when to use hint text versus longer guidance text.

Also updated the guidance text on 'Edit question' pages to make this one sentence and specify the types of Markdown formatting that are allowed.

### What problem does this pull request solve?

Trello card: [<https://trello.com/c/6X7sxxAg/1011-guidance-add-brief-clarification-to-hint-text-and-guidance-instructions>]

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

- Have I changed all instances of hint text hints?
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Any typos or grammatical errors?
