### PR TITLE
Fix issue with pages not being able to read/update from sessions

### DIFF
--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -21,7 +21,7 @@ class Pages::AddressSettingsController < PagesController
   end
 
   def edit
-    page.load_from_session(session, %w[answer_type answer_settings])
+    page.load_from_session(session, %i[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
     uk_address = input_type&.uk_address
     international_address = input_type&.international_address

--- a/app/controllers/pages/date_settings_controller.rb
+++ b/app/controllers/pages/date_settings_controller.rb
@@ -20,7 +20,7 @@ class Pages::DateSettingsController < PagesController
   end
 
   def edit
-    page.load_from_session(session, %w[answer_type answer_settings])
+    page.load_from_session(session, %i[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
     @date_settings_form = Pages::DateSettingsForm.new(input_type:, page: @page)
     @date_settings_path = date_settings_update_path(@form)

--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -27,7 +27,7 @@ class Pages::GuidanceController < PagesController
   end
 
   def edit
-    page.load_from_session(session, %w[answer_type page_heading guidance_markdown])
+    page.load_from_session(session, %i[answer_type page_heading guidance_markdown])
 
     guidance_form = Pages::GuidanceForm.new(page_heading: page.page_heading,
                                             guidance_markdown: page.guidance_markdown)

--- a/app/controllers/pages/name_settings_controller.rb
+++ b/app/controllers/pages/name_settings_controller.rb
@@ -21,7 +21,7 @@ class Pages::NameSettingsController < PagesController
   end
 
   def edit
-    page.load_from_session(session, %w[answer_type answer_settings])
+    page.load_from_session(session, %i[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
     title_needed = @page&.answer_settings&.title_needed
     @name_settings_form = Pages::NameSettingsForm.new(input_type:, title_needed:, page: @page)

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -27,7 +27,7 @@ class Pages::SelectionsSettingsController < PagesController
   end
 
   def edit
-    page.load_from_session(session, %w[answer_type answer_settings is_optional])
+    page.load_from_session(session, %i[answer_type answer_settings is_optional])
     @selections_settings_path = selections_settings_update_path(@form)
     @selections_settings_form = Pages::SelectionsSettingsForm.new(load_answer_settings_from_page_object(page))
     @back_link_url = edit_page_path(@form, page)

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -20,7 +20,7 @@ class Pages::TextSettingsController < PagesController
   end
 
   def edit
-    page.load_from_session(session, %w[answer_type answer_settings])
+    page.load_from_session(session, %i[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
     @text_settings_form = Pages::TextSettingsForm.new(input_type:, page: @page)
     @text_settings_path = text_settings_update_path(@form)

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -18,7 +18,7 @@ class Pages::TypeOfAnswerController < PagesController
   end
 
   def edit
-    page.load_from_session(session, %w[answer_type])
+    page.load_from_session(session, %i[answer_type])
 
     @type_of_answer_form = Pages::TypeOfAnswerForm.new(answer_type: @page.answer_type, page: @page)
     @type_of_answer_path = type_of_answer_update_path(@form)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -36,11 +36,11 @@ class PagesController < ApplicationController
 
   def edit
     reset_session_if_answer_settings_not_present
-    page.load_from_session(session, %w[answer_settings answer_type is_optional page_heading guidance_markdown])
+    page.load_from_session(session, %i[answer_settings answer_type is_optional page_heading guidance_markdown])
   end
 
   def update
-    page.load_from_session(session, %w[answer_type answer_settings page_heading guidance_markdown]).load(page_params)
+    page.load_from_session(session, %i[answer_type answer_settings page_heading guidance_markdown]).load(page_params)
 
     if page.save
       clear_questions_session_data

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -45,7 +45,7 @@ class Page < ActiveResource::Base
 
   def load_from_session(session, keys)
     keys.each do |key|
-      self.load("#{key}": session.dig(:page, key) || send(key.to_sym))
+      self.load("#{key}": session.dig(:page, key.to_sym) || send(key.to_sym))
     end
     self
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -149,7 +149,7 @@ describe Page, type: :model do
 
     context "when the key is not present in the session" do
       it "returns the value from the page" do
-        page.load_from_session(session_mock, %w[answer_type])
+        page.load_from_session(session_mock, %i[answer_type])
         expect(page.answer_type).to eq("date")
       end
     end
@@ -158,13 +158,22 @@ describe Page, type: :model do
       let(:session_mock) { { page: { answer_type: nil } } }
 
       it "returns the value from the page" do
-        page.load_from_session(session_mock, %w[answer_type])
+        page.load_from_session(session_mock, %i[answer_type])
         expect(page.answer_type).to eq("date")
       end
     end
 
     context "when the key is present in the session" do
-      let(:session_mock) { { page: { "answer_type" => "address" } } }
+      let(:session_mock) { { page: { answer_type: "address" } } }
+
+      it "returns the value from the session" do
+        page.load_from_session(session_mock, %i[answer_type])
+        expect(page.answer_type).to eq("address")
+      end
+    end
+
+    context "when the key is a string rather than a symbol" do
+      let(:session_mock) { { page: { answer_type: "address" } } }
 
       it "returns the value from the session" do
         page.load_from_session(session_mock, %w[answer_type])


### PR DESCRIPTION
### What problem does this pull request solve?
Recently, we did a refactor to convert all our session hash strings to symbols for consistency reasons and for better performance. https://github.com/alphagov/forms-admin/pull/637

A user reported issues with adding/editing guidance. On closer inspection, this was because the session keys were symbols but the main `load_from session` method was being passed in keys as strings rather than symbols.

` self.load("#{key}": session.dig(:page, key) || send(key.to_sym))` This meant that session.dig was returning nil and therefore it was falling back to whatever was last saved in forms-api.

The problem was not identify for a couple of reasons.

- The specs matched the calls being made in the controller so were all passing in strings.
- There was an issue with the spec that was written to check `load_from_session` returns the value from the session, had mocked out a session that was using strings as its hash key and so it was returning a false positive.
- There was also a missing spec to test what would happen if `load_from_session` was passed an array of strings

Trello card: <!-- link -->

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
