### PR TITLE
improve load_from_session to support different key types for session hash

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -44,8 +44,9 @@ class Page < ActiveResource::Base
   end
 
   def load_from_session(session, keys)
+    session_hash = session.to_h.with_indifferent_access
     keys.each do |key|
-      self.load("#{key}": session.dig(:page, key.to_sym) || send(key.to_sym))
+      self.load("#{key}": session_hash.dig(:page, key.to_sym) || send(key.to_sym))
     end
     self
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -180,6 +180,16 @@ describe Page, type: :model do
         expect(page.answer_type).to eq("address")
       end
     end
+
+    context "when the session being passed in contains a mixture of strings and symbols keys" do
+      let(:session_mock) { { page: { question_text: "Can you fill me in?", "answer_type" => "address" } } }
+
+      it "returns the values from the session" do
+        page.load_from_session(session_mock, %i[question_text answer_type])
+        expect(page.question_text).to eq("Can you fill me in?")
+        expect(page.answer_type).to eq("address")
+      end
+    end
   end
 
   describe "#question_with_number" do


### PR DESCRIPTION
### What problem does this pull request solve?
Continuation from https://github.com/alphagov/forms-admin/pull/644

Currently load_from_session will only work if the session being passed has all its keys as symbols rather than strings. This change will mean that load_from_session should be able to find the attribute value regardless as to whether session is using string or symbols for its keys

Trello card: https://trello.com/c/qRcTZpdS/1053-user-reported-issue-via-zendesk-not-being-able-to-create-edit-guidance

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
