### PR TITLE
Bump govuk-forms-markdown gem from 0.3.0 to 0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "govuk_design_system_formbuilder", "~> 4.1.1"
 gem "dfe-autocomplete", require: "dfe/autocomplete", github: "DFE-Digital/dfe-autocomplete", ref: "36d80e6b5bba67c92cd9ec6982a4e536d1889aed"
 
 # Our own custom markdown renderer
-gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.3.0"
+gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.3.1"
 
 # For structured logging
 gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GIT
 
 GIT
   remote: https://github.com/alphagov/govuk-forms-markdown.git
-  revision: 673d4f1aea5328af7ed855dac75c156ebce92182
-  tag: 0.3.0
+  revision: 87504748c303bf8bbd6383f3cbb06844fb38da73
+  tag: 0.3.1
   specs:
-    govuk-forms-markdown (0.3.0)
+    govuk-forms-markdown (0.3.1)
       redcarpet (~> 3.6)
 
 GEM


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: none

Gives us the latest version of the markdown renderer, which prevents rendering code blocks.

See the gem release notes: https://github.com/alphagov/govuk-forms-markdown/releases/tag/0.3.1

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
