### PR TITLE
Update preview area with border

### DIFF
--- a/app/components/markdown_editor_component/_index.scss
+++ b/app/components/markdown_editor_component/_index.scss
@@ -2,6 +2,12 @@
   @include govuk-visually-hidden;
 }
 
+.app-markdown-editor__preview-area {
+  border: 2px solid $govuk-border-colour;
+  padding: 30px;
+  margin: 0 0 1em;
+}
+
 .app-markdown-editor__preview-area :last-child {
   margin-bottom: 0;
 }
@@ -16,9 +22,11 @@
   }
 }
 
-.js-enabled .app-markdown-editor__preview-line-break {
+.js-enabled .app-markdown-editor__preview-area {
   @include govuk-media-query($from: tablet) {
-    display: none;
+    border: 0;
+    padding: 0;
+    margin-bottom: 0;
   }
 }
 

--- a/app/components/markdown_editor_component/view.html.erb
+++ b/app/components/markdown_editor_component/view.html.erb
@@ -60,13 +60,9 @@
           <p><%= translations[:preview_description] %></p>
         </div>
 
-        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-markdown-editor__preview-line-break">
-
-        <div class="app-markdown-editor__preview-area" data-ajax-markdown-target>
+        <div class="app-markdown-editor__preview-area" role="region" aria-label="<%= translations[:preview_area_label] %>" data-ajax-markdown-target>
           <%= preview_html.html_safe %>
         </div>
-
-        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-markdown-editor__preview-line-break">
 
         <%= govuk_link_to translations[:edit_markdown_link], "##{form_field_id}", class: "app-markdown-editor__edit-link" %>
       <% end %>

--- a/app/components/markdown_editor_component/view.rb
+++ b/app/components/markdown_editor_component/view.rb
@@ -43,6 +43,7 @@ module MarkdownEditorComponent
         preview_loading: @local_translations[:preview_loading] || I18n.t("markdown_editor.preview_loading"),
         preview_error: @local_translations[:preview_error] || I18n.t("markdown_editor.preview_error"),
         edit_markdown_link: @local_translations[:edit_markdown_link] || I18n.t("markdown_editor.edit_markdown_link"),
+        preview_area_label: @local_translations[:preview_area_label] || I18n.t("markdown_editor.preview_area_label"),
         toolbar: {
           h2: I18n.t("markdown_editor.toolbar.h2"),
           h3: I18n.t("markdown_editor.toolbar.h3"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,6 +444,7 @@ en:
     preview:
       description: Below is a preview of how your markdown content will be shown to the person completing your form.
       heading: Preview your markdown below
+    preview_area_label: Your preview
     preview_error: Sorry, there is a problem with the service. Try again later.
     preview_loading: Preview loading
     preview_markdown: Preview markdown

--- a/spec/components/markdown_editor_component/view_spec.rb
+++ b/spec/components/markdown_editor_component/view_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
             preview_loading: I18n.t("markdown_editor.preview_loading"),
             preview_error: I18n.t("markdown_editor.preview_error"),
             edit_markdown_link: I18n.t("markdown_editor.edit_markdown_link"),
+            preview_area_label: I18n.t("markdown_editor.preview_area_label"),
             toolbar: {
               h2: I18n.t("markdown_editor.toolbar.h2"),
               h3: I18n.t("markdown_editor.toolbar.h3"),
@@ -88,6 +89,7 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
           preview_loading: "local preview laoding",
           preview_error: "local preview error",
           edit_markdown_link: "local edit markdown link",
+          preview_area_label: "local preview area label",
           toolbar: {
             h2: "local h2",
             h3: "local h3",
@@ -110,6 +112,7 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
             preview_loading: local_translations[:preview_loading],
             preview_error: local_translations[:preview_error],
             edit_markdown_link: local_translations[:edit_markdown_link],
+            preview_area_label: local_translations[:preview_area_label],
             toolbar: {
               h2: I18n.t("markdown_editor.toolbar.h2"),
               h3: I18n.t("markdown_editor.toolbar.h3"),


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ftaYvI4q/1045-change-preview-on-add-guidance-page-when-js-is-disabled

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR contains changes to make it easier to tell which parts of the preview UI are previewed content (i.e the user's content) and which are normal parts of the add guidance page.

We make the distinction visually by adding a 2px border around the preview area. This change will be visible on narrow screens, or when javascript is not enabled. On wider screens, with JS enabled, the tab component will be active, so the visual distinction is already quite clear. 
We've also made the distinction programmatically by giving the preview container the `region` ARIA role. This should make it easier for screen reader users to:
- navigate to their preview 
- realise that they're inside the preview box if they navigate into it from a rotor or other navigation UI.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
