### PR TITLE
Content updates to 'Add guidance' page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,9 +209,11 @@ en:
       </p>
       <ul class="govuk-list govuk-list--bullet">
         <li>explain how to answer the question in more detail</li>
-        <li>provide more context</li>
-        <li>format your content - for example, with links, sub-headings or lists</li>
+        <li>format your content with paragraphs, headings, lists or links</li>
       </ul>
+      <p>
+        Guidance will be displayed at the top of the page, above your question.
+      </p>
   header:
     product_name: Forms
     sign_out: Sign out

--- a/config/locales/pages/guidance.yml
+++ b/config/locales/pages/guidance.yml
@@ -2,7 +2,7 @@ en:
   helpers:
     hint:
       pages_guidance_form:
-        page_heading: Use a heading that’s a statement rather than a question - for example, ‘Interview needs’. This will be your main page heading.
+        page_heading: When you add guidance your question text will no longer be the main page heading, so you need to use a different one. Use a heading that’s a statement rather than a question - for example, ‘Interview needs’.
         guidance_markdown: Use Markdown if you need to format your guidance content. Formatting help can be found below.
     label:
       pages_guidance_form:


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/gVtM7i1U/1046-guidance-clarify-why-a-page-heading-is-needed-for-guidance

I've made minor content updates in a couple of files to help users understand why they need to add a page heading when using guidance. 

Both updates will appear on the 'Add guidance' page in a form - this is the page users will see when they click the 'Add guidance' button on an 'Edit question' page.

### Things to consider when reviewing

- Any typos or mishaps with the html?!
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?

