### PR TITLE
Add mailer and logging for upgrade requests

### DIFF
--- a/app/mailers/user_upgrade_request_mailer.rb
+++ b/app/mailers/user_upgrade_request_mailer.rb
@@ -1,0 +1,9 @@
+class UserUpgradeRequestMailer < GovukNotifyRails::Mailer
+  def upgrade_request_email(user_email:)
+    set_template(Settings.govuk_notify.user_upgrade_template_id)
+
+    set_email_reply_to(Settings.govuk_notify.zendesk_reply_to_id)
+
+    mail(to: user_email)
+  end
+end

--- a/app/service/user_upgrade_request_service.rb
+++ b/app/service/user_upgrade_request_service.rb
@@ -1,10 +1,15 @@
 class UserUpgradeRequestService
+  attr_accessor :user
+
   def initialize(user)
     @user = user
   end
 
   def request_upgrade
-    # send email
-    # log event
+    UserUpgradeRequestMailer.upgrade_request_email(user_email: user.email).deliver_now
+    EventLogger.log({
+      event: "upgrade_request",
+      user_id: user.id,
+    })
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  GovukNotifyRails::Mailer.default(delivery_method: :test, from: "forms@example.com")
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,8 @@ forms_runner:
 govuk_notify:
   api_key: changeme
   submission_email_confirmation_code_email_template_id: ce2638ab-754c-416d-8df6-c0ccb5e1a688
+  user_upgrade_template_id: 5ec25494-c045-4cf6-9009-2f122e3339f4
+  zendesk_reply_to_id: 0acefa17-04b5-4614-a2ad-6c7f17dd26ab
 
 # When set to true, any capybara tests will run chrome normally rather than in headless mode.
 show_browser_during_tests: false

--- a/spec/features/users/user_upgrade_request_spec.rb
+++ b/spec/features/users/user_upgrade_request_spec.rb
@@ -1,16 +1,6 @@
 require "rails_helper"
 
 describe "Request an upgrade from trial user to editor", type: :feature do
-  before do
-    # prevent notify being called
-    mailer = instance_double(ActionMailer::MessageDelivery)
-    allow(mailer).to receive(:deliver_now)
-
-    allow(UserUpgradeRequestMailer).to receive(:upgrade_request_email).with(
-      user_email: trial_user.email,
-    ).and_return(mailer)
-  end
-
   it "A trial user can request an upgrade when they declare they meet the requirements" do
     login_as trial_user
     visit_upgrade_page

--- a/spec/features/users/user_upgrade_request_spec.rb
+++ b/spec/features/users/user_upgrade_request_spec.rb
@@ -1,6 +1,16 @@
 require "rails_helper"
 
 describe "Request an upgrade from trial user to editor", type: :feature do
+  before do
+    # prevent notify being called
+    mailer = instance_double(ActionMailer::MessageDelivery)
+    allow(mailer).to receive(:deliver_now)
+
+    allow(UserUpgradeRequestMailer).to receive(:upgrade_request_email).with(
+      user_email: trial_user.email,
+    ).and_return(mailer)
+  end
+
   it "A trial user can request an upgrade when they declare they meet the requirements" do
     login_as trial_user
     visit_upgrade_page

--- a/spec/mailers/user_upgrade_request_mailer_spec.rb
+++ b/spec/mailers/user_upgrade_request_mailer_spec.rb
@@ -4,8 +4,6 @@ describe UserUpgradeRequestMailer do
   describe "sending an email to a user" do
     let(:mail) { described_class.upgrade_request_email(user_email: "test@example.gov.uk") }
 
-    before { mail }
-
     it "sends an email with the correct template" do
       expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.user_upgrade_template_id)
     end

--- a/spec/mailers/user_upgrade_request_mailer_spec.rb
+++ b/spec/mailers/user_upgrade_request_mailer_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe UserUpgradeRequestMailer do
+  describe "sending an email to a user" do
+    let(:mail) { described_class.upgrade_request_email(user_email: "test@example.gov.uk") }
+
+    before { mail }
+
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.user_upgrade_template_id)
+    end
+
+    it "sends an email with the correct reply-to value" do
+      expect(mail.govuk_notify_email_reply_to).to eq(Settings.govuk_notify.zendesk_reply_to_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq(["test@example.gov.uk"])
+    end
+  end
+end

--- a/spec/service/user_upgrade_request_service_spec.rb
+++ b/spec/service/user_upgrade_request_service_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe UserUpgradeRequestService do
+  subject(:user_upgrade_request_service) do
+    described_class.new(user)
+  end
+
+  let(:user) { build :user, :with_trial_role, id: 1 }
+
+  describe "#request_upgrade" do
+    before do
+      # prevent notify being called
+      mailer = instance_double(ActionMailer::MessageDelivery)
+      allow(mailer).to receive(:deliver_now)
+
+      allow(UserUpgradeRequestMailer).to receive(:upgrade_request_email).and_return(mailer)
+
+      allow(EventLogger).to receive(:log)
+
+      user_upgrade_request_service.request_upgrade
+    end
+
+    it "calls mailer with user email" do
+      expect(UserUpgradeRequestMailer).to have_received(:upgrade_request_email).with(user_email: user.email)
+    end
+
+    it "logs event" do
+      expect(EventLogger).to have_received(:log).with(
+        {
+          "event": "upgrade_request",
+          "user_id": user.id,
+        },
+      )
+    end
+  end
+end

--- a/spec/service/user_upgrade_request_service_spec.rb
+++ b/spec/service/user_upgrade_request_service_spec.rb
@@ -9,19 +9,15 @@ describe UserUpgradeRequestService do
 
   describe "#request_upgrade" do
     before do
-      # prevent notify being called
-      mailer = instance_double(ActionMailer::MessageDelivery)
-      allow(mailer).to receive(:deliver_now)
-
-      allow(UserUpgradeRequestMailer).to receive(:upgrade_request_email).and_return(mailer)
-
       allow(EventLogger).to receive(:log)
 
       user_upgrade_request_service.request_upgrade
     end
 
     it "calls mailer with user email" do
-      expect(UserUpgradeRequestMailer).to have_received(:upgrade_request_email).with(user_email: user.email)
+      expect(ActionMailer::Base.deliveries.length).to eq 1
+      mail = ActionMailer::Base.deliveries[0]
+      expect(mail.to).to eq [user.email]
     end
 
     it "logs event" do


### PR DESCRIPTION
Add sending of email for user_upgrade_request and logging

When a user requests to upgrade from a trail user to an editor, they should receive an email with more instructions.

The email should have a reply-to of our teams zendesk account so that when the user replies, the answer is passed on to the engagement team.

An event is also logged.

a screenshot of the email:
![image](https://github.com/alphagov/forms-admin/assets/11035856/7ba17077-af87-43df-9649-965d9d55e015)


### What problem does this pull request solve?

Trello card: https://trello.com/c/c4WHxHZi/1039-send-an-email-to-the-account-upgrade-requestor-to-ask-for-more-information-and-create-account-upgrade-requested-confirmation-pag

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
