### PR TITLE
Update trial account banner to include new user request url

### DIFF
--- a/app/components/trial_role_warning_component/view.html.erb
+++ b/app/components/trial_role_warning_component/view.html.erb
@@ -1,6 +1,6 @@
 <% if @current_user.trial?  %>
   <%= govuk_notification_banner(title_text: t("trial_role_warning.title")) do |banner| %>
     <% banner.with_heading(text: t("trial_role_warning.heading")) %>
-    <%= t("trial_role_warning.content_html", link_url: '/404') %>
+    <%= t("trial_role_warning.content_html", link_url: user_upgrade_request_path) %>
   <% end %>
 <% end %>

--- a/app/components/trial_role_warning_component/view.html.erb
+++ b/app/components/trial_role_warning_component/view.html.erb
@@ -1,0 +1,6 @@
+<% if @current_user.trial?  %>
+  <%= govuk_notification_banner(title_text: t("trial_role_warning.title")) do |banner| %>
+    <% banner.with_heading(text: t("trial_role_warning.heading")) %>
+    <%= t("trial_role_warning.content_html", link_url: '/404') %>
+  <% end %>
+<% end %>

--- a/app/components/trial_role_warning_component/view.html.erb
+++ b/app/components/trial_role_warning_component/view.html.erb
@@ -1,6 +1,4 @@
-<% if @current_user.trial?  %>
-  <%= govuk_notification_banner(title_text: t("trial_role_warning.title")) do |banner| %>
-    <% banner.with_heading(text: t("trial_role_warning.heading")) %>
-    <%= t("trial_role_warning.content_html", link_url: user_upgrade_request_path) %>
-  <% end %>
+<%= govuk_notification_banner(title_text: t("trial_role_warning.title")) do |banner| %>
+  <% banner.with_heading(text: t("trial_role_warning.heading")) %>
+  <%= t("trial_role_warning.content_html", link_url: link_url) %>
 <% end %>

--- a/app/components/trial_role_warning_component/view.rb
+++ b/app/components/trial_role_warning_component/view.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module TrialRoleWarningComponent
+  class View < ViewComponent::Base
+    def initialize(current_user)
+      super
+      @current_user = current_user
+    end
+  end
+end

--- a/app/components/trial_role_warning_component/view.rb
+++ b/app/components/trial_role_warning_component/view.rb
@@ -2,9 +2,11 @@
 
 module TrialRoleWarningComponent
   class View < ViewComponent::Base
-    def initialize(current_user)
+    attr_reader :link_url
+
+    def initialize(link_url:)
       super
-      @current_user = current_user
+      @link_url = link_url
     end
   end
 end

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render TrialRoleWarningComponent::View.new(@current_user) %>
+    <%= render TrialRoleWarningComponent::View.new(link_url: user_upgrade_request_path) if @current_user.trial? %>
   </div>
 </div>
 

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,17 +1,17 @@
 <% set_page_title(t("page_titles.home")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render TrialRoleWarningComponent::View.new(@current_user) %>
+  </div>
+</div>
+
 <h1 class="govuk-heading-l"><%= t("home.main_heading") %></h1>
 
 <% if flash[:message] %>
   <p>
     <%= flash[:message] %>
   </p>
-<% end %>
-
-<% if @current_user.trial?  %>
-  <%= govuk_notification_banner(title_text: t("trial_role_warning.title")) do |banner| %>
-    <% banner.with_heading(text: t("trial_role_warning.heading")) %>
-    <%= t("trial_role_warning.content") %>
-  <% end %>
 <% end %>
 
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_form_path) %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render TrialRoleWarningComponent::View.new(@current_user) %>
+    <%= render TrialRoleWarningComponent::View.new(link_url: user_upgrade_request_path) if @current_user.trial? %>
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       <span class="govuk-caption-l"><%= @form.name %></span><span class="govuk-visually-hidden"> - </span>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -4,6 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render TrialRoleWarningComponent::View.new(@current_user) %>
+
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       <span class="govuk-caption-l"><%= @form.name %></span><span class="govuk-visually-hidden"> - </span>
       <%= @form.has_live_version ? t("forms.form_overview.title_edit") : t("forms.form_overview.title_create") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -674,7 +674,16 @@ en:
     in_progress: in progress
     not_started: not started
   trial_role_warning:
-    content: You can create a form and test it, but you cannot make a form live.
+    content_html: |
+      <p>
+        You can create a form, preview and test it.
+      </p>
+      <p>
+        You need an editor account to be able to make a form live.
+      </p>
+      <p>
+        <a href="%{link_url}">Find out if you can upgrade to an editor account</a>
+      </p>
     heading: You have a trial account
     title: Important
   type_of_answer:

--- a/spec/components/trial_role_warning_component/trial_role_warning_component_preview.rb
+++ b/spec/components/trial_role_warning_component/trial_role_warning_component_preview.rb
@@ -1,0 +1,5 @@
+class TrialRoleWarningComponent::TrialRoleWarningComponentPreview < ViewComponent::Preview
+  def default
+    render(TrialRoleWarningComponent::View.new(User.new))
+  end
+end

--- a/spec/components/trial_role_warning_component/trial_role_warning_component_preview.rb
+++ b/spec/components/trial_role_warning_component/trial_role_warning_component_preview.rb
@@ -1,5 +1,5 @@
 class TrialRoleWarningComponent::TrialRoleWarningComponentPreview < ViewComponent::Preview
   def default
-    render(TrialRoleWarningComponent::View.new(User.new))
+    render(TrialRoleWarningComponent::View.new(link_url: "#"))
   end
 end

--- a/spec/components/trial_role_warning_component/view_spec.rb
+++ b/spec/components/trial_role_warning_component/view_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe TrialRoleWarningComponent::View, type: :component do
+  before do
+    render_inline(described_class.new(user))
+  end
+
+  context "when a user has the trial role" do
+    let(:user) { build :user, :with_trial_role }
+
+    it "displays a banner informing the user they have a trial account" do
+      expect(page).to have_selector(".govuk-notification-banner__content")
+      expect(page).to have_text("Important")
+      expect(page).to have_text("You have a trial account")
+      expect(page).to have_text("You can create a form, preview and test it.")
+      expect(page).to have_text("You need an editor account to be able to make a form live.")
+      expect(page).to have_link("Find out if you can upgrade to an editor account")
+    end
+  end
+
+  context "when a user does not have the trial role" do
+    let(:user) { build :user, role: :editor }
+
+    it "does not display a banner" do
+      expect(page).not_to have_selector(".govuk-notification-banner__content")
+    end
+  end
+end

--- a/spec/components/trial_role_warning_component/view_spec.rb
+++ b/spec/components/trial_role_warning_component/view_spec.rb
@@ -2,27 +2,13 @@ require "rails_helper"
 
 RSpec.describe TrialRoleWarningComponent::View, type: :component do
   before do
-    render_inline(described_class.new(user))
+    render_inline(described_class.new(link_url: "test-url"))
   end
 
-  context "when a user has the trial role" do
-    let(:user) { build :user, :with_trial_role }
-
-    it "displays a banner informing the user they have a trial account" do
-      expect(page).to have_selector(".govuk-notification-banner__content")
-      expect(page).to have_text("Important")
-      expect(page).to have_text("You have a trial account")
-      expect(page).to have_text("You can create a form, preview and test it.")
-      expect(page).to have_text("You need an editor account to be able to make a form live.")
-      expect(page).to have_link("Find out if you can upgrade to an editor account")
-    end
-  end
-
-  context "when a user does not have the trial role" do
-    let(:user) { build :user, role: :editor }
-
-    it "does not display a banner" do
-      expect(page).not_to have_selector(".govuk-notification-banner__content")
-    end
+  it "displays a banner with correct locale text" do
+    expect(page).to have_selector(".govuk-notification-banner__content")
+    expect(page).to have_content(I18n.t("trial_role_warning.heading"))
+    expect(page).to have_content(Capybara.string(I18n.t("trial_role_warning.content_html", link_url: "test")).text(normalize_ws: true), normalize_ws: true)
+    expect(page).to have_link(href: "test-url")
   end
 end

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -63,6 +63,18 @@ describe "Set or change a user's role", type: :feature do
     then_i_can_see_the_org_forms
   end
 
+  context "when a trial user views the trial account banner" do
+    it "the trial account banner is visible" do
+      login_as trial_user
+      then_i_can_see_trial_account_banner
+    end
+
+    it "the trial account banner link navigates to the upgrade page" do
+      login_as trial_user
+      then_i_can_navigate_to_the_upgrade_page
+    end
+  end
+
 private
 
   def when_i_change_the_trial_users_role_to_editor
@@ -79,6 +91,19 @@ private
   def then_i_can_see_the_trial_user_forms
     visit root_path
     expect(page).to have_text "Trial form"
+  end
+
+  def then_i_can_see_trial_account_banner
+    visit root_path
+    expect(page).to have_text "You have a trial account"
+  end
+
+  def then_i_can_navigate_to_the_upgrade_page
+    visit root_path
+
+    click_link("Find out if you can upgrade to an editor account")
+
+    expect(page).to have_current_path("/404")
   end
 
   def then_i_cannot_see_the_org_forms

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -9,6 +9,7 @@ describe "Set or change a user's role", type: :feature do
     create :organisation, id: 1, slug: "test-org"
     [build(:form, id: 1, creator_id: 1, organisation_id: 1, name: "Org form")]
   end
+
   let(:trial_forms) do
     [build(:form, id: 2, creator_id: 2, organisation_id: nil, name: "Trial form")]
   end
@@ -63,18 +64,6 @@ describe "Set or change a user's role", type: :feature do
     then_i_can_see_the_org_forms
   end
 
-  context "when a trial user views the trial account banner" do
-    it "the trial account banner is visible" do
-      login_as trial_user
-      then_i_can_see_trial_account_banner
-    end
-
-    it "the trial account banner link navigates to the upgrade page" do
-      login_as trial_user
-      then_i_can_navigate_to_the_upgrade_page
-    end
-  end
-
 private
 
   def when_i_change_the_trial_users_role_to_editor
@@ -91,19 +80,6 @@ private
   def then_i_can_see_the_trial_user_forms
     visit root_path
     expect(page).to have_text "Trial form"
-  end
-
-  def then_i_can_see_trial_account_banner
-    visit root_path
-    expect(page).to have_text "You have a trial account"
-  end
-
-  def then_i_can_navigate_to_the_upgrade_page
-    visit root_path
-
-    click_link("Find out if you can upgrade to an editor account")
-
-    expect(page).to have_current_path("/404")
   end
 
   def then_i_cannot_see_the_org_forms

--- a/spec/features/users/user_upgrade_request_spec.rb
+++ b/spec/features/users/user_upgrade_request_spec.rb
@@ -1,13 +1,56 @@
 require "rails_helper"
 
 describe "Request an upgrade from trial user to editor", type: :feature do
-  it "A trial user can request an upgrade when they declare they meet the requirements" do
+  let(:org_forms) do
+    create :organisation, id: 1, slug: "test-org"
+    [build(:form, id: 1, creator_id: 1, organisation_id: 1, name: "Org form")]
+  end
+
+  let(:trial_forms) do
+    [build(:form, id: 2, creator_id: 2, organisation_id: nil, name: "Trial form")]
+  end
+
+  let(:trial_user) do
+    create(:user, :with_trial_role, id: 2)
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?organisation_id=1", req_headers, org_forms.to_json, 200
+      mock.get "/api/v1/forms?creator_id=2", req_headers, trial_forms.to_json, 200
+    end
+  end
+
+  it "the trial account banner is visible" do
     login_as trial_user
-    visit_upgrade_page
-    check I18n.t("helpers.label.user_upgrade_request.met_requirements_options.1")
+    then_i_can_see_trial_account_banner
+    then_i_can_navigate_to_the_upgrade_page
+    check_met_requirements
     submit_request
     then_i_can_see_request_sent_banner
   end
+
+  # it "A trial user can request an upgrade when they declare they meet the requirements" do
+  #   login_as trial_user
+  #   visit_upgrade_page
+  #   check I18n.t("helpers.label.user_upgrade_request.met_requirements_options.1")
+  #   submit_request
+  #   then_i_can_see_request_sent_banner
+  # end
 
   it "A trial user cannot request an upgrade when they do not declare they meet the requirements" do
     login_as trial_user
@@ -21,6 +64,23 @@ private
   def visit_upgrade_page
     visit new_user_upgrade_request_path
     expect(page).to have_text I18n.t("page_titles.user_upgrade_request_new")
+  end
+
+  def then_i_can_see_trial_account_banner
+    visit root_path
+    expect(page).to have_text "You have a trial account"
+  end
+
+  def check_met_requirements
+    check I18n.t("helpers.label.user_upgrade_request.met_requirements_options.1")
+  end
+
+  def then_i_can_navigate_to_the_upgrade_page
+    visit root_path
+
+    click_link("Find out if you can upgrade to an editor account")
+
+    expect(page).to have_current_path(user_upgrade_request_path)
   end
 
   def submit_request

--- a/spec/features/users/user_upgrade_request_spec.rb
+++ b/spec/features/users/user_upgrade_request_spec.rb
@@ -35,7 +35,7 @@ describe "Request an upgrade from trial user to editor", type: :feature do
     end
   end
 
-  it "the trial account banner is visible" do
+  it "a trial user can request an upgrade when they declare they meet the requirements" do
     login_as trial_user
     then_i_can_see_trial_account_banner
     then_i_can_navigate_to_the_upgrade_page
@@ -44,15 +44,7 @@ describe "Request an upgrade from trial user to editor", type: :feature do
     then_i_can_see_request_sent_banner
   end
 
-  # it "A trial user can request an upgrade when they declare they meet the requirements" do
-  #   login_as trial_user
-  #   visit_upgrade_page
-  #   check I18n.t("helpers.label.user_upgrade_request.met_requirements_options.1")
-  #   submit_request
-  #   then_i_can_see_request_sent_banner
-  # end
-
-  it "A trial user cannot request an upgrade when they do not declare they meet the requirements" do
+  it "a trial user cannot request an upgrade when they do not declare they meet the requirements" do
     login_as trial_user
     visit_upgrade_page
     submit_request

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -103,11 +103,7 @@ describe "forms/index.html.erb" do
       let(:user) { build :user, :with_trial_role }
 
       it "displays a banner informing the user they have a trial account" do
-        banner = Capybara.string(rendered).find(".govuk-notification-banner__content")
-
-        expect(rendered).to have_selector(".govuk-notification-banner__content")
-        expect(banner).to have_text(I18n.t("trial_role_warning.heading"))
-        expect(Capybara.string(banner).text(normalize_ws: true)).to have_text(Capybara.string(I18n.t("trial_role_warning.content_html")).text(normalize_ws: true))
+        expect(rendered).to have_text(I18n.t("trial_role_warning.heading"))
       end
     end
 
@@ -115,7 +111,7 @@ describe "forms/index.html.erb" do
       let(:user) { build :user, role: :editor }
 
       it "does not display a banner" do
-        expect(rendered).not_to have_selector(".govuk-notification-banner__content")
+        expect(rendered).not_to have_text(I18n.t("trial_role_warning.heading"))
       end
     end
   end

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -107,7 +107,7 @@ describe "forms/index.html.erb" do
 
         expect(rendered).to have_selector(".govuk-notification-banner__content")
         expect(banner).to have_text(I18n.t("trial_role_warning.heading"))
-        expect(banner).to have_text(I18n.t("trial_role_warning.content"))
+        expect(Capybara.string(banner).text(normalize_ws: true)).to have_text(Capybara.string(I18n.t("trial_role_warning.content_html")).text(normalize_ws: true))
       end
     end
 

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 describe "forms/show.html.erb" do
+  let(:user) { build :user, role: :editor }
   let(:form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", pages:) }
   let(:pages) { [{ id: 183, question_text: "What is your address?", hint_text: "", answer_type: "address", next_page: nil }] }
 
   before do
+    assign(:current_user, user)
     assign(:form, form)
     assign(:task_status_counts, { completed: 12, total: 20 })
     render template: "forms/show"
@@ -52,6 +54,26 @@ describe "forms/show.html.erb" do
 
     it "does not contain a link to delete the form" do
       expect(rendered).not_to have_link("Delete draft form", href: delete_form_path(2))
+    end
+  end
+
+  context "and a user has the trial role" do
+    let(:user) { build :user, :with_trial_role }
+
+    it "displays a banner informing the user they have a trial account" do
+      banner = Capybara.string(rendered).find(".govuk-notification-banner__content")
+
+      expect(rendered).to have_selector(".govuk-notification-banner__content")
+      expect(banner).to have_text(I18n.t("trial_role_warning.heading"))
+      expect(Capybara.string(banner).text(normalize_ws: true)).to have_text(Capybara.string(I18n.t("trial_role_warning.content_html")).text(normalize_ws: true))
+    end
+  end
+
+  context "and a user does not have the trial role" do
+    let(:user) { build :user, role: :editor }
+
+    it "does not display a banner" do
+      expect(rendered).not_to have_selector(".govuk-notification-banner__content")
     end
   end
 end

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -61,11 +61,7 @@ describe "forms/show.html.erb" do
     let(:user) { build :user, :with_trial_role }
 
     it "displays a banner informing the user they have a trial account" do
-      banner = Capybara.string(rendered).find(".govuk-notification-banner__content")
-
-      expect(rendered).to have_selector(".govuk-notification-banner__content")
-      expect(banner).to have_text(I18n.t("trial_role_warning.heading"))
-      expect(Capybara.string(banner).text(normalize_ws: true)).to have_text(Capybara.string(I18n.t("trial_role_warning.content_html")).text(normalize_ws: true))
+      expect(rendered).to have_text(I18n.t("trial_role_warning.heading"))
     end
   end
 
@@ -73,7 +69,7 @@ describe "forms/show.html.erb" do
     let(:user) { build :user, role: :editor }
 
     it "does not display a banner" do
-      expect(rendered).not_to have_selector(".govuk-notification-banner__content")
+      expect(rendered).not_to have_text(I18n.t("trial_role_warning.heading"))
     end
   end
 end


### PR DESCRIPTION
# Add trial user banner

This is the work to add the trial user banner - it's the work from this [PR](https://github.com/alphagov/forms-admin/pull/638) but with a few changes, which is why it's a new PR. If we are happy with them, I'll merge this one and close the other.

Now that the user_upgrade_request path is known, we can use it in the trial role warning banner.
    
I've also changed the banner component to keep it as simple as possible by:
    - moving the conditional for showing the banner to the views
    - not passing in the whole user object, just the link_url
    
This allows the tests for the component to be simpler and makes the    component a bit more reusable, and reduces the number of tests we need [inspired by this commit](   https://github.com/alphagov/formsadmin/commit/cfac2629711ad237c2fb2299253535fdbf065cb9)


Trello card: https://trello.com/c/ZDIdgJCJ/1043-update-trial-account-banner-content-and-add-to-task-list-page

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
