### PR TITLE
Add client side validation for guidance

### DIFF
--- a/app/components/markdown_editor_component/_index.scss
+++ b/app/components/markdown_editor_component/_index.scss
@@ -93,3 +93,7 @@
     font-family: inherit;
   }
 }
+
+.app-markdown-editor__error-message {
+  margin: 0;
+}

--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -55,8 +55,9 @@ class Pages::GuidanceController < PagesController
 
   def render_preview
     guidance_form = Pages::GuidanceForm.new(guidance_markdown: params[:guidance_markdown])
+    guidance_form.validate
 
-    render json: { preview_html: preview_html(guidance_form) }.to_json
+    render json: { preview_html: preview_html(guidance_form), errors: guidance_form.errors[:guidance_markdown] }.to_json
   end
 
 private

--- a/app/frontend/javascript/ajax-markdown-preview/index.test.js
+++ b/app/frontend/javascript/ajax-markdown-preview/index.test.js
@@ -14,7 +14,8 @@ import {
 let source, target
 
 const jsonResponse = {
-  preview_html: '<h2 class="govuk-heading-m">This is a heading</h2>'
+  preview_html: '<h2 class="govuk-heading-m">This is a heading</h2>',
+  errors: []
 }
 const setupDocument = () => {
   const i18n = JSON.stringify({

--- a/app/frontend/javascript/ajax-markdown-preview/index.test.js
+++ b/app/frontend/javascript/ajax-markdown-preview/index.test.js
@@ -17,14 +17,40 @@ const jsonResponse = {
   preview_html: '<h2 class="govuk-heading-m">This is a heading</h2>',
   errors: []
 }
-const setupDocument = () => {
+
+const jsonResponseWithError = {
+  preview_html: '<p>This is a level one heading</p>',
+  errors: [
+    'Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)'
+  ]
+}
+
+const updateMarkdown = markdownContent => {
+  source.value = markdownContent
+  const event = new window.Event('input')
+  source.dispatchEvent(event)
+}
+
+const generateSourceHTML = (markdownContent, includeServerSideError) => {
+  if (includeServerSideError) {
+    return `<div class="govuk-form-group govuk-form-group--error">
+        <p class="govuk-error-message" id="markdown-field-error">
+          <span class="govuk-visually-hidden">Error: </span>Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
+        </p>
+        <textarea aria-describedby="markdown-field-error" data-ajax-markdown-source="true">${markdownContent}</textarea>
+      </div>`
+  } else {
+    return `<div class="govuk-form-group"><textarea data-ajax-markdown-source="true">${markdownContent}</textarea></div>`
+  }
+}
+
+const setupDocument = (markdownContent, includeServerSideError = false) => {
   const i18n = JSON.stringify({
     preview_loading: 'Loading...',
     preview_error: 'There was an error'
   })
 
-  const sourceHTML =
-    '<textarea data-ajax-markdown-source="true">## This is a markdown heading</textarea>'
+  const sourceHTML = generateSourceHTML(markdownContent, includeServerSideError)
   const targetHTML =
     '<div data-ajax-markdown-target><p>Some old preview content</p></div>'
   document.body.innerHTML = `<div data-module="ajax-markdown-preview" data-ajax-markdown-endpoint="/endpoint" data-i18n='${i18n}'>
@@ -58,10 +84,10 @@ describe('AJAX Markdown preview', () => {
     jest.useRealTimers()
   })
 
-  describe('when the request returns the JSON response', () => {
+  describe('when the request returns the JSON response with no errors', () => {
     beforeEach(() => {
       global.fetch = mockFetch(jsonResponse)
-      setupDocument()
+      setupDocument('## This is a markdown heading')
     })
 
     test('preview is called on page load', async () => {
@@ -73,8 +99,7 @@ describe('AJAX Markdown preview', () => {
     test('preview event fires if the user makes a change', () => {
       expect(global.fetch).toHaveBeenCalledTimes(1)
 
-      const event = new window.Event('input')
-      source.dispatchEvent(event)
+      updateMarkdown()
 
       jest.runAllTimers()
 
@@ -105,12 +130,108 @@ describe('AJAX Markdown preview', () => {
     })
   })
 
+  describe('when the request returns the JSON response with errors', () => {
+    describe('when there is no server-side error message present', () => {
+      beforeEach(() => {
+        global.fetch = mockFetch(jsonResponseWithError)
+        setupDocument('# This is a level one heading')
+      })
+
+      test('an error message is displayed', () => {
+        expect(document.querySelector('.govuk-error-message').textContent).toBe(
+          `Error: ${jsonResponseWithError.errors[0]}`
+        )
+      })
+
+      test('the error message is associated with the textarea using aria-described', () => {
+        expect(source.getAttribute('aria-describedby')).toContain(
+          document.querySelector('.govuk-error-message').getAttribute('id')
+        )
+      })
+
+      test('the form group has the error class', () => {
+        expect(
+          document.querySelectorAll('.govuk-form-group--error')
+        ).toHaveLength(1)
+      })
+
+      describe('when the user fixes the error', () => {
+        beforeEach(async () => {
+          global.fetch = mockFetch(jsonResponse)
+          updateMarkdown('## This is a level two heading')
+
+          jest.runAllTimers()
+          await flushPromises()
+        })
+
+        test('the error message is removed', () => {
+          expect(
+            document.querySelector('.govuk-error-message').textContent
+          ).toBe('')
+        })
+
+        test('the form group does not have the error class', () => {
+          expect(
+            document.querySelectorAll('.govuk-form-group--error')
+          ).toHaveLength(0)
+        })
+      })
+    })
+
+    describe('when a server-side error is already present', () => {
+      beforeEach(() => {
+        global.fetch = mockFetch(jsonResponseWithError)
+        setupDocument('# This is a level one heading', true)
+      })
+
+      test('an error message is displayed', () => {
+        expect(document.querySelector('.govuk-error-message').textContent).toBe(
+          `Error: ${jsonResponseWithError.errors[0]}`
+        )
+      })
+
+      test('the error message is associated with the textarea using aria-described', () => {
+        expect(source.getAttribute('aria-describedby')).toContain(
+          document.querySelector('.govuk-error-message').getAttribute('id')
+        )
+      })
+
+      test('the form group has the error class', () => {
+        expect(
+          document.querySelectorAll('.govuk-form-group--error')
+        ).toHaveLength(1)
+      })
+
+      describe('when the user fixes the error', () => {
+        beforeEach(async () => {
+          global.fetch = mockFetch(jsonResponse)
+          updateMarkdown('## This is a level two heading')
+
+          jest.runAllTimers()
+          await flushPromises()
+        })
+
+        test('the error message is removed', () => {
+          expect(
+            document.querySelector('.govuk-error-message').textContent
+          ).toBe('')
+        })
+
+        test('the form group does not have the error class', () => {
+          expect(
+            document.querySelectorAll('.govuk-form-group--error')
+          ).toHaveLength(0)
+        })
+      })
+    })
+  })
+
   describe('when the AJAX request fails', () => {
     beforeEach(() => {
       global.fetch = jest.fn(async () => {
         return Promise.reject(new Error('API is down'))
       })
-      setupDocument()
+      setupDocument('## This is a markdown heading')
     })
 
     test('the error message is displayed', () => {
@@ -137,7 +258,7 @@ describe('AJAX Markdown preview', () => {
     beforeEach(() => {
       global.fetch = mockFetchWithDelay(jsonResponse, 500)
 
-      setupDocument()
+      setupDocument('## This is a markdown heading')
     })
 
     test('Loading text is displayed before the response arrives', async () => {

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe Pages::GuidanceController, type: :request do
     end
 
     it "returns a JSON object containing the converted HTML" do
-      expect(response.body).to eq({ preview_html: "<h3 class=\"govuk-heading-s\">Markdown</h3>" }.to_json)
+      expect(response.body).to eq({ preview_html: "<h3 class=\"govuk-heading-s\">Markdown</h3>", errors: [] }.to_json)
     end
 
     it "returns 200" do
@@ -287,7 +287,19 @@ RSpec.describe Pages::GuidanceController, type: :request do
       let(:guidance_markdown) { "" }
 
       it "returns a JSON object containing the converted HTML" do
-        expect(response.body).to eq({ preview_html: I18n.t("guidance.no_guidance_added_html") }.to_json)
+        expect(response.body).to eq({ preview_html: I18n.t("guidance.no_guidance_added_html"), errors: [] }.to_json)
+      end
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when markdown contains forbidden syntax" do
+      let(:guidance_markdown) { "# A level one heading" }
+
+      it "returns a JSON object containing the converted HTML" do
+        expect(response.body).to eq({ preview_html: "<p class=\"govuk-body\">A level one heading</p>", errors: [I18n.t("activemodel.errors.models.pages/guidance_form.attributes.guidance_markdown.unsupported_markdown_syntax")] }.to_json)
       end
 
       it "returns 200" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/aQ09lXJw/1041-guidance-build-solution-to-add-client-side-validation-to-markdown-editor

For the guidance editor, we have distinct non-JS and JS-enhanced experiences. In the non-JS experience, when the user presses the 'Preview' button their input is validated on the server side. In the JS-enhanced journey, the preview currently happens on the client-side without a page refresh, so the input is not validated.

In this PR, we add an `errors` key to the response from the render_preview endpoint, which can have 0 or more errors as its value:
```jsonc
// input: '# A second-level heading'
{
  "preview_html": "\u003ch2 class=\"govuk-heading-m\"\u003e# A second-level heading\u003c/h2\u003e", 
  "errors": []
}
```

```jsonc
// input: '# A top-level heading'
{
  "preview_html": "\u003cp class=\"govuk-body\"\u003eA top-level heading\u003c/p\u003e", 
  "errors": ["Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)"]
}
```

We then handle this in the UI by:
- checking if there's a server-side error message present already, and creating a client-side one if not
- adding the `.govuk-form-group--error` class to the form group element if there is an error
- removing the error message and the `.govuk-form-group--error` class if the user updates the content and fixes the error

As devloped here the validation script won't do anything with the error summary at the top of the page - it's only concerned with the inline error message and the error class on the markdown field. This means that:

- if the page has a server-side error, the error summary will remain present even if the user fixes the error.
- if the page doesn't have a server-side error, but the user introduces an error and the error message appears on the client-side, the error summary won't be displayed.

This may not be ideal behaviour (but if we did make the error summary appear and disappear, this would likely cause annoying and confusing vertical layout shifts for the user).

This will stay in Draft for now because it's speculative work - the design hasn't been completed yet (that's covered in this card: https://trello.com/c/Gk4wELR5/1040-guidance-design-add-client-side-validation-to-markdown-editor ). I will review with @christophercameron-ixd when he's back and we can decide what to do with it.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
