### PR TITLE
Reduce length of string being generated by faker

### DIFF
--- a/spec/factories/forms/pages/question_text_form.rb
+++ b/spec/factories/forms/pages/question_text_form.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :question_text_form, class: "Pages::QuestionTextForm" do
-    question_text { Faker::Lorem.question }
+    question_text { Faker::Lorem.question.truncate(250) }
   end
 end

--- a/spec/factories/models/draft_questions.rb
+++ b/spec/factories/models/draft_questions.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     form_id { 1 }
     user { nil }
     sequence(:page_id) { |n| n }
-    question_text { Faker::Lorem.question }
+    question_text { Faker::Lorem.question.truncate(250) }
     hint_text { nil }
     is_optional { false }
     answer_type { Page::ANSWER_TYPES.reject { |item| Page::ANSWER_TYPES_WITH_SETTINGS.include? item }.sample }
@@ -12,11 +12,11 @@ FactoryBot.define do
     answer_settings { {} }
 
     trait :with_hints do
-      hint_text { Faker::Quote.yoda }
+      hint_text { Faker::Quote.yoda.truncate(500) }
     end
 
     trait :with_guidance do
-      page_heading { Faker::Quote.yoda }
+      page_heading { Faker::Quote.yoda.truncate(250) }
       guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
     end
   end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -11,7 +11,7 @@ end
 FactoryBot.define do
   factory :page, class: "Page" do
     sequence(:id) { |n| n }
-    question_text { Faker::Lorem.question }
+    question_text { Faker::Lorem.question.truncate(250) }
     answer_type { Page::ANSWER_TYPES.reject { |item| Page::ANSWER_TYPES_WITH_SETTINGS.include? item }.sample }
     is_optional { nil }
     answer_settings { nil }
@@ -24,11 +24,11 @@ FactoryBot.define do
     guidance_markdown { nil }
 
     trait :with_hints do
-      hint_text { Faker::Quote.yoda }
+      hint_text { Faker::Quote.yoda.truncate(500) }
     end
 
     trait :with_guidance do
-      page_heading { Faker::Quote.yoda }
+      page_heading { Faker::Quote.yoda.truncate(250) }
       guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

if Faker produces longer strings than the attributes support, this can lead to flickering spec failures due to failed validations.

https://github.com/alphagov/forms-admin/actions/runs/6392922742/job/17351148046#step:10:17

https://github.com/alphagov/forms-admin/actions/runs/6396055196/job/17361064124#step:10:17

Trello card: https://trello.com/c/eq6QQK6e/1083-fix-flickering-test

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
