### PR TITLE
Add metrics section to live form page

### DIFF
--- a/app/components/metrics_summary_component/_index.scss
+++ b/app/components/metrics_summary_component/_index.scss
@@ -1,0 +1,36 @@
+.app-metrics__container {
+  margin-bottom: govuk-spacing(6);
+
+  @include govuk-media-query(tablet) {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(govuk-px-to-rem(100), 1fr));
+    gap: $govuk-gutter;
+  }
+}
+
+.app-metrics__big-number {
+  @include govuk-typography-responsive(19);
+  @include govuk-typography-common;
+
+  padding: govuk-spacing(1) govuk-spacing(0);
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query(tablet) {
+    @supports (display: grid) {
+      display: flex;
+      flex-flow: column nowrap;
+      justify-content: space-between;
+
+      border-top: $govuk-border-width solid $govuk-border-colour;
+      border-bottom: $govuk-border-width solid $govuk-border-colour;
+    }
+  }
+}
+
+.app-metrics__big-number-number {
+  @include govuk-typography-responsive(48);
+  @include govuk-typography-weight-bold;
+
+  display: block;
+  margin-top: govuk-spacing(1);
+}

--- a/app/components/metrics_summary_component/view.html.erb
+++ b/app/components/metrics_summary_component/view.html.erb
@@ -1,0 +1,15 @@
+<div class="app-metrics">
+  <h2 class="govuk-heading-l"><%= t("metrics_summary.heading", formatted_date_range:) %></h2>
+  <% if error_message.present? %>
+    <div class="govuk-inset-text">
+        <%= error_message.html_safe %>
+    </div>
+  <% else %>
+    <p><%= t("metrics_summary.description") %></p>
+    <div class="app-metrics__container">
+      <div class="app-metrics__big-number">
+        <%= t("metrics_summary.forms_submitted") %> <span class="app-metrics__big-number-number"><%= weekly_submissions %></span>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module MetricsSummaryComponent
+  class View < ViewComponent::Base
+    attr_accessor :start_date, :end_date, :weekly_submissions, :weekly_starts, :weekly_started_but_not_completed, :weekly_completion_rate, :form_has_metrics, :error_message
+
+    def initialize(metrics_data)
+      super
+      set_dates
+
+      if metrics_data.nil?
+        @error_message = I18n.t("metrics_summary.errors.error_loading_data_html")
+      elsif metrics_data[:form_is_new]
+        @error_message = I18n.t("metrics_summary.errors.new_form_html")
+      else
+        @weekly_submissions = metrics_data[:weekly_submissions]
+      end
+    end
+
+    def render?
+      FeatureService.enabled?(:metrics_for_form_creators_enabled)
+    end
+
+    def formatted_date_range
+      start_date_format_string = start_date.year == end_date.year ? "%e %B" : "%e %B %Y"
+      I18n.t("metrics_summary.date_range", start_date: start_date.strftime(start_date_format_string).strip, end_date: end_date.strftime("%e %B %Y").strip)
+    end
+
+  private
+
+    def set_dates
+      @start_date = 1.week.ago.to_date
+      @end_date = 1.day.ago.to_date
+    end
+  end
+end

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -2,7 +2,7 @@ class Forms::LiveController < Forms::BaseController
   after_action :verify_authorized
   def show_form
     authorize current_form, :can_view_form?
-    render template: "live/show_form", locals: { form_metadata: current_form, form: current_live_form }
+    render template: "live/show_form", locals: { form_metadata: current_form, form: current_live_form, metrics_data: }
   end
 
   def show_pages
@@ -14,5 +14,17 @@ private
 
   def current_live_form
     Form.find_live(params[:form_id])
+  end
+
+  def metrics_data
+    today = Time.zone.today
+    form_is_new = (today.to_date - Time.zone.parse(current_form.live_at).to_date).to_i < 1
+    # TODO: fetch real data from CloudWatch
+    weekly_submissions = 1025
+
+    {
+      weekly_submissions:,
+      form_is_new:,
+    }
   end
 end

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -10,21 +10,24 @@ class Forms::LiveController < Forms::BaseController
     render template: "live/show_pages", locals: { form: current_live_form }
   end
 
-private
-
-  def current_live_form
-    Form.find_live(params[:form_id])
-  end
-
   def metrics_data
+    # If the form went live today, there won't be any metrics to show
     today = Time.zone.today
-    form_is_new = (today.to_date - Time.zone.parse(current_form.live_at).to_date).to_i < 1
-    # TODO: fetch real data from CloudWatch
-    weekly_submissions = 1025
+    form_is_new = Time.zone.parse(current_live_form.live_at.to_s) >= today.midnight
+
+    weekly_submissions = form_is_new ? 0 : CloudWatchService.week_submissions(form_id: current_live_form.id)
 
     {
       weekly_submissions:,
       form_is_new:,
     }
+  rescue Aws::CloudWatch::Errors::ServiceError
+    nil
+  end
+
+private
+
+  def current_live_form
+    Form.find_live(params[:form_id])
   end
 end

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -11,3 +11,4 @@ $govuk-global-styles: true;
 @import "../../components/page_list_component/";
 @import "../../components/header_component/";
 @import "../../components/markdown_editor_component";
+@import "../../components/metrics_summary_component";

--- a/app/views/live/show_form.html.erb
+++ b/app/views/live/show_form.html.erb
@@ -4,51 +4,53 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
       <%= form.name %>
     </h1>
-
     <%= render FormStatusTagDescriptionComponent::View.new(status: :live) %>
+
+    <%= render MetricsSummaryComponent::View.new(metrics_data) %>
+
+    <h2 class="govuk-heading-l">Your form</h2>
 
     <p>
       <%= render PreviewLinkComponent::View.new(form.pages, link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: :preview_live)) %>
     </p>
 
     <%= render FormUrlComponent::View.new(link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: :live ))%>
-
-    <h2 class="govuk-heading-m"><%= t('show_live_form.questions') %></h2>
+    <h3 class="govuk-heading-m"><%= t('show_live_form.questions') %></h3>
     <p><%= govuk_link_to t('show_live_form.questions_link', count: form.pages.count), live_form_pages_path(form.id) %></p>
 
     <% if form.declaration_text.present? %>
-      <h2 class="govuk-heading-m"><%= t('show_live_form.declaration') %></h2>
+      <h3 class="govuk-heading-m"><%= t('show_live_form.declaration') %></h3>
       <p><%= form.declaration_text %></p>
       <%= govuk_details(summary_text: t('show_live_form.what_is_declaration'), text: t('show_live_form.declaration_description')) %>
     <% end %>
 
-    <h2 class="govuk-heading-m"><%= t('show_live_form.what_happens_next') %></h2>
+    <h3 class="govuk-heading-m"><%= t('show_live_form.what_happens_next') %></h3>
     <p><%= form.what_happens_next_text %></p>
     <%= govuk_details(summary_text: t('show_live_form.what_is_what_happens_next'), text: t('show_live_form.what_happens_next_description')) %>
 
-    <h2 class="govuk-heading-m"><%= t('show_live_form.submission_email') %></h2>
+    <h3 class="govuk-heading-m"><%= t('show_live_form.submission_email') %></h3>
     <p><%= form.submission_email %></p>
 
-    <h2 class="govuk-heading-m"><%= t('show_live_form.privacy_policy_link') %></h2>
+    <h3 class="govuk-heading-m"><%= t('show_live_form.privacy_policy_link') %></h3>
     <p><%= govuk_link_to(form.privacy_policy_url, form.privacy_policy_url) %></p>
 
-    <h2 class="govuk-heading-m"><%= t('show_live_form.contact_details') %></h2>
+    <h3 class="govuk-heading-m"><%= t('show_live_form.contact_details') %></h3>
 
     <% if form.support_email %>
-      <h3 class="govuk-heading-s"><%= t('show_live_form.support_email') %></h3>
+      <h4 class="govuk-heading-s"><%= t('show_live_form.support_email') %></h4>
       <p><%= form.support_email %></p>
     <% end %>
 
     <% if form.support_phone %>
-      <h3 class="govuk-heading-s"><%= t('show_live_form.support_phone') %></h3>
+      <h4 class="govuk-heading-s"><%= t('show_live_form.support_phone') %></h4>
       <p><%= form.support_phone %></p>
     <% end %>
 
     <% if form.support_url %>
-      <h3 class="govuk-heading-s"><%= t('show_live_form.support_url') %></h3>
+      <h4 class="govuk-heading-s"><%= t('show_live_form.support_url') %></h4>
       <p><%= govuk_link_to form.support_url_text, form.support_url %></p>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -474,6 +474,23 @@ en:
       numbered_list: Add a numbered list
     update_preview: Update preview
     write_tab_text: Write
+  metrics_summary:
+    date_range: "%{start_date} to %{end_date}"
+    description: If you want to track metrics over a longer period you'll need to make a note of these on the same day each week.
+    errors:
+      error_loading_data_html: |
+        <p>Sorry, there's a problem getting your form's metrics.</p>
+        <p>Try again later.</p>
+      new_form_html: |
+        <p>No metrics are available yet as no-one has started or submitted a form since it went live.</p>
+        <p>Once they have, you'll be able to see the following metrics for the past 7 days:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Number of forms completed</li>
+          <li>Number of forms started but not completed</li>
+          <li>Completion rate</li>
+        </ul>
+    forms_submitted: Forms submitted
+    heading: 'Form metrics for the past 7 days: %{formatted_date_range}'
   new_condition:
     routing_page_text: If the question
   not_found:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "private": "true",
   "browserslist": [
-    ">0.1%",
+    ">0.1% and not dead",
     "last 2 Chrome versions",
     "last 2 Firefox versions",
     "last 2 Edge versions",

--- a/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
+++ b/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
@@ -1,0 +1,16 @@
+class MetricsSummaryComponent::MetricsSummaryComponentPreview < ViewComponent::Preview
+  def with_no_metrics_data
+    metrics_data = nil
+    render(MetricsSummaryComponent::View.new(metrics_data))
+  end
+
+  def with_a_new_form
+    metrics_data = { weekly_submissions: 0, form_is_new: true }
+    render(MetricsSummaryComponent::View.new(metrics_data))
+  end
+
+  def with_metrics_available
+    metrics_data = { weekly_submissions: 1032, form_is_new: false }
+    render(MetricsSummaryComponent::View.new(metrics_data))
+  end
+end

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_for_form_creators_enabled: true do
+  let(:metrics_data) { nil }
+  let(:metrics_summary) { described_class.new(metrics_data) }
+
+  before do
+    render_inline(metrics_summary)
+  end
+
+  it "has the correct start and end dates" do
+    expect(metrics_summary.start_date).to eq(1.week.ago.to_date)
+    expect(metrics_summary.end_date).to eq(1.day.ago.to_date)
+  end
+
+  it "renders the start and end dates" do
+    expect(page).to have_text(metrics_summary.formatted_date_range)
+  end
+
+  describe "#formatted_date_range" do
+    context "when the start and end dates are in different years" do
+      before do
+        metrics_summary.start_date = Time.zone.local(2023, 12, 25)
+        metrics_summary.end_date = Time.zone.local(2024, 0o1, 0o2)
+      end
+
+      it "returns the full start and end dates" do
+        expect(metrics_summary.formatted_date_range).to eq("25 December 2023 to 2 January 2024")
+      end
+    end
+
+    context "when the start and end dates are in the same year" do
+      before do
+        metrics_summary.start_date = Time.zone.local(2023, 10, 31)
+        metrics_summary.end_date = Time.zone.local(2023, 11, 8)
+      end
+
+      it "returns the start date without the year" do
+        expect(metrics_summary.formatted_date_range).to eq("31 October to 8 November 2023")
+      end
+    end
+  end
+
+  context "when metrics_data is null" do
+    it "returns the 'error loading data' message" do
+      expect(metrics_summary.error_message).to eq(I18n.t("metrics_summary.errors.error_loading_data_html"))
+    end
+
+    it "renders the error message" do
+      expect(page).to have_text(Nokogiri::HTML(metrics_summary.error_message).text)
+    end
+  end
+
+  context "when form is too new" do
+    let(:metrics_data) { { weekly_submissions: 0, form_is_new: true } }
+
+    it "returns the 'new form' message" do
+      expect(metrics_summary.error_message).to eq(I18n.t("metrics_summary.errors.new_form_html"))
+    end
+
+    it "renders the error message" do
+      expect(page).to have_text(Nokogiri::HTML(metrics_summary.error_message).text)
+    end
+  end
+
+  context "when metrics_data has a value for weekly submissions" do
+    let(:metrics_data) { { weekly_submissions: 1235, form_is_new: false } }
+
+    it "returns the metrics component with the number of submissions" do
+      expect(metrics_summary.weekly_submissions).to eq(metrics_data[:weekly_submissions])
+    end
+
+    it "renders the description text" do
+      expect(page).to have_text(I18n.t("metrics_summary.description"))
+    end
+
+    it "renders the weekly submissions figure" do
+      expect(page).to have_text("#{I18n.t('metrics_summary.forms_submitted')} #{metrics_data[:weekly_submissions]}")
+    end
+  end
+end

--- a/spec/controller/forms/live_controller_spec.rb
+++ b/spec/controller/forms/live_controller_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe Forms::LiveController, type: :controller do
+  let(:live_controller) { described_class.new }
+
+  let(:form) do
+    build(:form, :live, id: 2)
+  end
+
+  let(:headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  describe "#metrics_data" do
+    before do
+      allow(live_controller).to receive(:current_live_form).and_return(form)
+      ActiveResource::HttpMock.respond_to(false) do |mock|
+        mock.get "/api/v1/forms/2", headers, form.to_json, 200
+      end
+    end
+
+    context "when the form was made today" do
+      it "returns form_is_new: true and 0 weekly submissions" do
+        expect(live_controller.metrics_data).to eq({ weekly_submissions: 0, form_is_new: true })
+      end
+    end
+
+    context "when the form was made before today" do
+      let(:form) do
+        build(:form, :live, id: 2, live_at: Time.zone.now - 1.day)
+      end
+
+      before do
+        allow(CloudWatchService).to receive(:week_submissions).and_return(1255)
+      end
+
+      it "returns form_is_new: true and the correct number of weekly submissions" do
+        expect(live_controller.metrics_data).to eq({ weekly_submissions: 1255, form_is_new: false })
+      end
+    end
+  end
+end

--- a/spec/requests/forms/live_controller_spec.rb
+++ b/spec/requests/forms/live_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Forms::LiveController, type: :request do
 
   describe "#show_form" do
     before do
+      allow(CloudWatchService).to receive(:week_submissions).and_return(nil)
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/2", headers, form.to_json, 200
         mock.get "/api/v1/forms/2/live", headers, form.to_json, 200


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/n9Xq0v5L/1071-render-on-a-forms-info-page-the-metric-for-total-submissions-for-the-last-7-days

This PR creates a new 'Metrics summary' component that displays the number of submissions in the last week. The component also handles rendering the error states for metrics when a form is too new to have any metrics, or when the metrics data cannot be fetched from CloudWatch. This component will be rendered on the live form page if the `metrics_for_form_creators_enabled` feature flag is set to `true`.

This PR also includes [a commit updating the browserslist in package.json](https://github.com/alphagov/forms-admin/pull/663/commits/c5d1536e9a80a0f4cdae77429eb1b797f653c21d) to fix a layout issue spotted in this work. See the inidividual commit message for more information about what this change means and why it's necessary.

If running locally you'll need to:
- have `metrics_for_form_creators_enabled` set to `true`
- run it with `aws vault` to be able to read from CloudWatch
  - i.e. run `bin/setup` then `aws-vault exec gds-forms-dev-admin -- bin/rails s`
- have a live form set up locally whose `live_at` date is before today (you may need to fake this in the database)

### Screenshots
#### When metrics are available
![A large heading that says 'A live form with metrics, followed by a smaller heading that says 'Form metrics for the past 7 days: 4 October to 10 October 2023'.  Under the headings there is inset text that says 'If you want to track metrics over a longer period you'll need to make a note of these on the same day each week', and under that is the text 'Forms submitted' follwed by the number 1032 in large font.](https://github.com/alphagov/forms-admin/assets/5861235/8147027d-aa33-4757-941f-b6f8d8b8829f)

#### When the form was made today
![A large heading that says 'A live form with metrics, followed by a smaller heading that says 'Form metrics for the past 7 days: 4 October to 10 October 2023'. Under the headings there is inset text that says 'No metrics are available yet as no-one has started or submitted a form since it went live. Once they have, you'll be able to see the following metrics for the past 7 days: Number of forms completed, Number of forms started but not completed, Completion rate'](https://github.com/alphagov/forms-admin/assets/5861235/54aa2b72-e9f0-4ca4-b1e7-bbbaf8f5327d)

#### When Cloudwatch returns an Aws::CloudWatch::Errors::ServiceError
![A large heading that says 'A live form with metrics, followed by a smaller heading that says 'Form metrics for the past 7 days: 4 October to 10 October 2023'. Under the headings there is inset text that says 'Sorry, there's a problem getting your form's metrics. Try again later.'](https://github.com/alphagov/forms-admin/assets/5861235/bbd2c8a6-7182-46c1-94a7-a0ed4595e7fe)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
