### PR TITLE
Remove unnecessary Form Object attributes.

### DIFF
--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -25,7 +25,7 @@ class Pages::AddressSettingsController < PagesController
     input_type = @page&.answer_settings&.input_type
     uk_address = input_type&.uk_address
     international_address = input_type&.international_address
-    @address_settings_form = Pages::AddressSettingsForm.new(uk_address:, international_address:, page: @page)
+    @address_settings_form = Pages::AddressSettingsForm.new(uk_address:, international_address:)
     @address_settings_path = address_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render address_settings_view
@@ -47,8 +47,7 @@ class Pages::AddressSettingsController < PagesController
 private
 
   def address_settings_form_params
-    form = Form.find(params[:form_id])
-    params.require(:pages_address_settings_form).permit(:uk_address, :international_address).merge(form:)
+    params.require(:pages_address_settings_form).permit(:uk_address, :international_address)
   end
 
   def address_settings_view

--- a/app/controllers/pages/date_settings_controller.rb
+++ b/app/controllers/pages/date_settings_controller.rb
@@ -22,7 +22,7 @@ class Pages::DateSettingsController < PagesController
   def edit
     page.load_from_session(session, %i[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
-    @date_settings_form = Pages::DateSettingsForm.new(input_type:, page: @page)
+    @date_settings_form = Pages::DateSettingsForm.new(input_type:)
     @date_settings_path = date_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render "pages/date_settings"
@@ -44,7 +44,6 @@ class Pages::DateSettingsController < PagesController
 private
 
   def date_settings_form_params
-    form = Form.find(params[:form_id])
-    params.require(:pages_date_settings_form).permit(:input_type).merge(form:)
+    params.require(:pages_date_settings_form).permit(:input_type)
   end
 end

--- a/app/controllers/pages/name_settings_controller.rb
+++ b/app/controllers/pages/name_settings_controller.rb
@@ -24,7 +24,7 @@ class Pages::NameSettingsController < PagesController
     page.load_from_session(session, %i[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
     title_needed = @page&.answer_settings&.title_needed
-    @name_settings_form = Pages::NameSettingsForm.new(input_type:, title_needed:, page: @page)
+    @name_settings_form = Pages::NameSettingsForm.new(input_type:, title_needed:)
     @name_settings_path = name_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render name_settings_view
@@ -46,8 +46,7 @@ class Pages::NameSettingsController < PagesController
 private
 
   def name_settings_form_params
-    form = Form.find(params[:form_id])
-    params.require(:pages_name_settings_form).permit(:input_type, :title_needed).merge(form:)
+    params.require(:pages_name_settings_form).permit(:input_type, :title_needed)
   end
 
   def name_settings_view

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -22,7 +22,7 @@ class Pages::TextSettingsController < PagesController
   def edit
     page.load_from_session(session, %i[answer_type answer_settings])
     input_type = @page&.answer_settings&.input_type
-    @text_settings_form = Pages::TextSettingsForm.new(input_type:, page: @page)
+    @text_settings_form = Pages::TextSettingsForm.new(input_type:)
     @text_settings_path = text_settings_update_path(@form)
     @back_link_url = type_of_answer_edit_path(@form)
     render "pages/text_settings"
@@ -44,7 +44,6 @@ class Pages::TextSettingsController < PagesController
 private
 
   def text_settings_form_params
-    form = Form.find(params[:form_id])
-    params.require(:pages_text_settings_form).permit(:input_type).merge(form:)
+    params.require(:pages_text_settings_form).permit(:input_type)
   end
 end

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -20,7 +20,7 @@ class Pages::TypeOfAnswerController < PagesController
   def edit
     page.load_from_session(session, %i[answer_type])
 
-    @type_of_answer_form = Pages::TypeOfAnswerForm.new(answer_type: @page.answer_type, page: @page)
+    @type_of_answer_form = Pages::TypeOfAnswerForm.new(answer_type: @page.answer_type)
     @type_of_answer_path = type_of_answer_update_path(@form)
     render "pages/type-of-answer"
   end
@@ -80,8 +80,7 @@ private
   end
 
   def answer_type_form_params
-    form = Form.find(params[:form_id])
-    params.require(:pages_type_of_answer_form).permit(:answer_type).merge(form:)
+    params.require(:pages_type_of_answer_form).permit(:answer_type)
   end
 
   def answer_type_changed?

--- a/app/forms/pages/address_settings_form.rb
+++ b/app/forms/pages/address_settings_form.rb
@@ -1,5 +1,5 @@
 class Pages::AddressSettingsForm < BaseForm
-  attr_accessor :uk_address, :international_address, :form, :page
+  attr_accessor :uk_address, :international_address
 
   INPUT_TYPES = %w[uk_address international_address].freeze
 

--- a/app/forms/pages/date_settings_form.rb
+++ b/app/forms/pages/date_settings_form.rb
@@ -1,5 +1,5 @@
 class Pages::DateSettingsForm < BaseForm
-  attr_accessor :input_type, :form, :page
+  attr_accessor :input_type
 
   INPUT_TYPES = %w[date_of_birth other_date].freeze
 

--- a/app/forms/pages/name_settings_form.rb
+++ b/app/forms/pages/name_settings_form.rb
@@ -1,5 +1,5 @@
 class Pages::NameSettingsForm < BaseForm
-  attr_accessor :input_type, :title_needed, :form, :page
+  attr_accessor :input_type, :title_needed
 
   INPUT_TYPES = %w[full_name first_and_last_name first_middle_and_last_name].freeze
   TITLE_NEEDED = %w[true false].freeze

--- a/app/forms/pages/text_settings_form.rb
+++ b/app/forms/pages/text_settings_form.rb
@@ -1,5 +1,5 @@
 class Pages::TextSettingsForm < BaseForm
-  attr_accessor :input_type, :form, :page
+  attr_accessor :input_type
 
   INPUT_TYPES = %w[single_line long_text].freeze
 

--- a/app/forms/pages/type_of_answer_form.rb
+++ b/app/forms/pages/type_of_answer_form.rb
@@ -1,5 +1,5 @@
 class Pages::TypeOfAnswerForm < BaseForm
-  attr_accessor :answer_type, :form, :page
+  attr_accessor :answer_type
 
   validates :answer_type, presence: true, inclusion: { in: Page::ANSWER_TYPES }
 

--- a/spec/factories/forms/pages/type_of_answer_form.rb
+++ b/spec/factories/forms/pages/type_of_answer_form.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :type_of_answer_form, class: "Pages::TypeOfAnswerForm" do
     answer_type { Page::ANSWER_TYPES.sample }
-    form { build :form }
 
     trait :with_simple_answer_type do
       answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }

--- a/spec/requests/pages/address_settings_controller_spec.rb
+++ b/spec/requests/pages/address_settings_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
 
-  let(:address_settings_form) { build :address_settings_form, form: }
+  let(:address_settings_form) { build :address_settings_form }
 
   let(:req_headers) do
     {
@@ -31,7 +31,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       end
 
-      get address_settings_new_path(form_id: address_settings_form.form.id)
+      get address_settings_new_path(form_id: form.id)
     end
 
     it "reads the existing form" do
@@ -40,7 +40,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
 
     it "sets an instance variable for address_settings_path" do
       path = assigns(:address_settings_path)
-      expect(path).to eq address_settings_new_path(address_settings_form.form.id)
+      expect(path).to eq address_settings_new_path(form.id)
     end
 
     it "renders the template" do
@@ -71,7 +71,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
         post address_settings_create_path form_id: form.id, params: { pages_address_settings_form: { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address } }
       end
 
-      let(:address_settings_form) { build :address_settings_form, form: }
+      let(:address_settings_form) { build :address_settings_form }
 
       it "saves the input type to session" do
         expect(session[:page][:answer_settings]).to eq({ input_type: { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address } })
@@ -108,7 +108,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
 
     it "sets an instance variable for address_settings_path" do
       path = assigns(:address_settings_path)
-      expect(path).to eq address_settings_edit_path(address_settings_form.form.id)
+      expect(path).to eq address_settings_edit_path(form.id)
     end
 
     it "renders the template" do

--- a/spec/requests/pages/date_settings_controller_spec.rb
+++ b/spec/requests/pages/date_settings_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
 
-  let(:date_settings_form) { build :date_settings_form, form: }
+  let(:date_settings_form) { build :date_settings_form }
 
   let(:req_headers) do
     {
@@ -31,7 +31,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       end
 
-      get date_settings_new_path(form_id: date_settings_form.form.id)
+      get date_settings_new_path(form_id: form.id)
     end
 
     it "reads the existing form" do
@@ -40,7 +40,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
 
     it "sets an instance variable for date_settings_path" do
       path = assigns(:date_settings_path)
-      expect(path).to eq date_settings_new_path(date_settings_form.form.id)
+      expect(path).to eq date_settings_new_path(form.id)
     end
 
     it "renders the template" do
@@ -71,7 +71,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
         post date_settings_create_path form_id: form.id, params: { pages_date_settings_form: { input_type: "date_of_birth" } }
       end
 
-      let(:date_settings_form) { build :date_settings_form, form: }
+      let(:date_settings_form) { build :date_settings_form }
 
       it "saves the input type to session" do
         expect(session[:page][:answer_settings]).to eq({ input_type: "date_of_birth" })
@@ -107,7 +107,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
 
     it "sets an instance variable for date_settings_path" do
       path = assigns(:date_settings_path)
-      expect(path).to eq date_settings_edit_path(date_settings_form.form.id)
+      expect(path).to eq date_settings_edit_path(form.id)
     end
 
     it "renders the template" do

--- a/spec/requests/pages/name_settings_controller_spec.rb
+++ b/spec/requests/pages/name_settings_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
 
-  let(:name_settings_form) { build :name_settings_form, form: }
+  let(:name_settings_form) { build :name_settings_form }
 
   let(:req_headers) do
     {
@@ -31,7 +31,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       end
 
-      get name_settings_new_path(form_id: name_settings_form.form.id)
+      get name_settings_new_path(form_id: form.id)
     end
 
     it "reads the existing form" do
@@ -40,7 +40,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
 
     it "sets an instance variable for name_settings_path" do
       path = assigns(:name_settings_path)
-      expect(path).to eq name_settings_new_path(name_settings_form.form.id)
+      expect(path).to eq name_settings_new_path(form.id)
     end
 
     it "renders the template" do
@@ -71,7 +71,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
         post name_settings_create_path form_id: form.id, params: { pages_name_settings_form: { input_type: "first_and_last_name", title_needed: "false" } }
       end
 
-      let(:name_settings_form) { build :name_settings_form, form: }
+      let(:name_settings_form) { build :name_settings_form }
 
       it "saves the input type to session" do
         expect(session[:page][:answer_settings]).to eq({ input_type: "first_and_last_name", title_needed: "false" })
@@ -107,7 +107,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
 
     it "sets an instance variable for name_settings_path" do
       path = assigns(:name_settings_path)
-      expect(path).to eq name_settings_edit_path(name_settings_form.form.id)
+      expect(path).to eq name_settings_edit_path(form.id)
     end
 
     it "renders the template" do

--- a/spec/requests/pages/text_settings_controller_spec.rb
+++ b/spec/requests/pages/text_settings_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
 
-  let(:text_settings_form) { build :text_settings_form, form: }
+  let(:text_settings_form) { build :text_settings_form }
 
   let(:req_headers) do
     {
@@ -31,7 +31,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       end
 
-      get text_settings_new_path(form_id: text_settings_form.form.id)
+      get text_settings_new_path(form_id: form.id)
     end
 
     it "reads the existing form" do
@@ -40,7 +40,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
 
     it "sets an instance variable for text_settings_path" do
       path = assigns(:text_settings_path)
-      expect(path).to eq text_settings_new_path(text_settings_form.form.id)
+      expect(path).to eq text_settings_new_path(form.id)
     end
 
     it "renders the template" do
@@ -71,7 +71,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
         post text_settings_create_path form_id: form.id, params: { pages_text_settings_form: { input_type: text_settings_form.input_type } }
       end
 
-      let(:text_settings_form) { build :text_settings_form, form: }
+      let(:text_settings_form) { build :text_settings_form }
 
       it "saves the input type to session" do
         expect(session[:page][:answer_settings]).to eq({ input_type: text_settings_form.input_type })
@@ -107,7 +107,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
 
     it "sets an instance variable for text_settings_path" do
       path = assigns(:text_settings_path)
-      expect(path).to eq text_settings_edit_path(text_settings_form.form.id)
+      expect(path).to eq text_settings_edit_path(form.id)
     end
 
     it "renders the template" do

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
 
-  let(:type_of_answer_form) { build :type_of_answer_form, form: }
+  let(:type_of_answer_form) { build :type_of_answer_form }
 
   let(:req_headers) do
     {
@@ -31,7 +31,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       end
 
-      get type_of_answer_new_path(form_id: type_of_answer_form.form.id)
+      get type_of_answer_new_path(form_id: form.id)
     end
 
     it "reads the existing form" do
@@ -40,7 +40,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
     it "sets an instance variable for type_of_answer_path" do
       path = assigns(:type_of_answer_path)
-      expect(path).to eq type_of_answer_new_path(type_of_answer_form.form.id)
+      expect(path).to eq type_of_answer_new_path(form.id)
     end
 
     it "renders the template" do
@@ -62,7 +62,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       end
 
       context "when answer type is not selection" do
-        let(:type_of_answer_form) { build :type_of_answer_form, :with_simple_answer_type, form: }
+        let(:type_of_answer_form) { build :type_of_answer_form, :with_simple_answer_type }
 
         it "saves the answer type to session" do
           expect(session[:page]).to eq({ answer_type: type_of_answer_form.answer_type, answer_settings: nil })
@@ -74,7 +74,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       end
 
       context "when answer type is selection" do
-        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "selection", form: }
+        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "selection" }
 
         before do
           post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
@@ -90,7 +90,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       end
 
       context "when answer type is text" do
-        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "text", form: }
+        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "text" }
 
         before do
           post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
@@ -106,7 +106,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       end
 
       context "when answer type is date" do
-        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "date", form: }
+        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "date" }
 
         before do
           post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
@@ -122,7 +122,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       end
 
       context "when answer type is address" do
-        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "address", form: }
+        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "address" }
 
         before do
           post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
@@ -138,7 +138,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       end
 
       context "when answer type is name" do
-        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "name", form: }
+        let(:type_of_answer_form) { build :type_of_answer_form, answer_type: "name" }
 
         before do
           post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_form: { answer_type: type_of_answer_form.answer_type } }
@@ -189,7 +189,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
     it "sets an instance variable for type_of_answer_path" do
       path = assigns(:type_of_answer_path)
-      expect(path).to eq type_of_answer_edit_path(type_of_answer_form.form.id)
+      expect(path).to eq type_of_answer_edit_path(form.id)
     end
 
     it "renders the template" do

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "pages/type_of_answer.html.erb", type: :view do
   let(:form) { build :form, id: 1 }
-  let(:type_of_answer_form) { build :type_of_answer_form, form: }
+  let(:type_of_answer_form) { build :type_of_answer_form }
   let(:answer_types) { Page::ANSWER_TYPES }
   let(:page) { OpenStruct.new(conditions: [], answer_type: "number") }
   let(:question_number) { 1 }


### PR DESCRIPTION
### What problem does this pull request solve?

We seem to be setting/passing in the current form and current page in most of the page form objects. They were not
being used in the form object and adding no value.

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
