### PR TITLE
Allow super admins to add and change a user's name

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
         user.organisation&.name || "",
         user.has_access ? 0 : 1,
         roles.index(user.role),
-        user.name,
+        user.name || "",
       ]
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,7 +41,7 @@ class UsersController < ApplicationController
 private
 
   def user_params
-    params.require(:user).permit(:has_access, :role, :organisation_id).tap do |p|
+    params.require(:user).permit(:has_access, :name, :role, :organisation_id).tap do |p|
       # We have to take steps to detect when the autocomplete compoenent is
       # empty. We use the value of rawAttribute, which is the text input when JS
       # is enabled. When it's empty, the user has cleared it. This isn't needed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,10 +67,10 @@ class User < ApplicationRecord
 private
 
   def requires_name?
-    name_was.present? || role_changed?(from: :trial)
+    name_was.present? || !trial?
   end
 
   def requires_organisation?
-    organisation_id_was.present? || role_changed?(to: :editor)
+    organisation_id_was.present? || editor?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
     trial: "trial",
   }
 
+  validates :name, presence: true, if: :requires_name?
   validates :role, presence: true
   validates :organisation_id, presence: true, if: :requires_organisation?
   validates :has_access, inclusion: [true, false]
@@ -64,6 +65,10 @@ class User < ApplicationRecord
   end
 
 private
+
+  def requires_name?
+    name_was.present? || role_changed?(from: :trial)
+  end
 
   def requires_organisation?
     organisation_id_was.present? || role_changed?(to: :editor)

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(title_with_error_prefix(@user.name, @user.errors.any?)) %>
+<% set_page_title(title_with_error_prefix(@user.name.present? ? @user.name : @user.email, @user.errors.any?)) %>
 <% content_for :back_link, govuk_back_link_to(users_path) %>
 
 <div class="govuk-grid-row">
@@ -16,7 +16,7 @@
       <%= govuk_summary_list(actions: false) do |summary_list|
         summary_list.with_row do |row|
           row.with_key { t('users.index.table_headings.name') }
-          row.with_value { @user.name }
+          row.with_value { @user.name || t("users.index.name_blank") }
         end
 
         summary_list.with_row do |row|

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -45,6 +45,8 @@
         end
       end %>
 
+      <%= f.govuk_text_field :name, label: { size: 'm', tag: 'h2' }, autocomplete: :name, spellcheck: false %>
+
       <%= render DfE::Autocomplete::View.new(
         f,
         attribute_name: :organisation_id,

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -19,7 +19,7 @@
       users.each do |user|
         body.with_row do |row|
           row.with_cell do
-            govuk_link_to(user.name, edit_user_path(user))
+            govuk_link_to(user.name || t("users.index.name_blank"), edit_user_path(user))
           end
           row.with_cell( text: user.email)
           row.with_cell( text: user.organisation&.name || t("users.index.organisation_blank"))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -756,6 +756,7 @@ en:
         description: Will be able to use GOV.UK Forms
         name: Permitted
     index:
+      name_blank: No name set
       organisation_blank: No organisation set
       table_headings:
         access: Access

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,8 @@ en:
               too_long: Question text must be %{count} characters or less
         user:
           attributes:
+            name:
+              blank: You must enter a name for editor or super admin users
             organisation_id:
               blank: Select the user’s organisation
             role:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,6 +42,6 @@ if HostingEnvironment.local_development? && User.none?
   # create a user who hasn't been assigned to an organisation yet
   FactoryBot.create :user, :with_no_org
 
-  # create a trial user
-  FactoryBot.create :user, :with_trial_role
+  # create some trial users
+  FactoryBot.create_list :user, 3, :with_trial_role
 end

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     trait :with_trial_role do
       role { :trial }
       with_no_org
+      with_no_name
     end
 
     organisation { association :organisation, id: 1, slug: "test-org" }
@@ -32,6 +33,10 @@ FactoryBot.define do
       organisation { nil }
       organisation_slug { nil }
       organisation_content_id { nil }
+    end
+
+    trait :with_no_name do
+      name { nil }
     end
   end
 end

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -70,11 +70,14 @@ private
     visit edit_user_path(trial_user.id)
 
     expect(page).to have_css "h1.govuk-heading-l", text: "Edit user"
-    expect(page).to have_text trial_user.name
+    expect(page).to have_text trial_user.email
 
+    fill_in "Name", with: "Test Name"
     fill_in "Organisation", with: "Test Org\n"
     choose("Editor")
     click_button "Save"
+
+    expect(page).not_to have_css ".govuk-error-summary"
   end
 
   def then_i_can_see_the_trial_user_forms

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -188,4 +188,30 @@ describe User, type: :model do
       end
     end
   end
+
+  context "when updating name" do
+    it "is valid to leave name unset" do
+      user = create :user, :with_no_name
+      user.name = nil
+      expect(user.valid?).to be true
+    end
+
+    it "is not valid to unset name if it is already set" do
+      user = create :user, name: "Test User"
+      user.name = nil
+      expect(user.valid?).to be false
+    end
+
+    it "is not valid to leave name unset if changing role to editor" do
+      user = create :user, :with_no_name, role: :trial
+      user.role = :editor
+      expect(user.valid?).to be false
+    end
+
+    it "is not valid to leave name unset if changing role to super admin" do
+      user = create :user, :with_no_name, role: :trial
+      user.role = :super_admin
+      expect(user.valid?).to be false
+    end
+  end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -152,12 +152,37 @@ RSpec.describe UsersController, type: :request do
         expect(user.reload.role).not_to eq(nil)
       end
 
+      context "when user has a name" do
+        it "does not update user if name is cleared" do
+          put user_path(user), params: { user: { name: nil } }
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.body).to include "You must enter a name for editor or super admin users"
+          expect(user.reload.organisation).not_to eq(nil)
+        end
+      end
+
       context "when user belongs to an organistion" do
         it "does not update user if organisation is not chosen" do
           put user_path(user), params: { user: { organisation_id: nil } }
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.body).to include "Select the user’s organisation"
           expect(user.reload.organisation).not_to eq(nil)
+        end
+      end
+
+      context "with a trial user with no name set" do
+        let(:user) { create(:user, :with_trial_role) }
+
+        it "does not return error if name is not chosen and role is not changed" do
+          put user_path(user), params: { user: { role: "trial", name: nil } }
+          expect(response).to redirect_to(users_path)
+          expect(user.reload.name).to eq(nil)
+        end
+
+        it "returns an error if name is not chosen and role is changed to editor" do
+          put user_path(user), params: { user: { role: "editor", name: nil } }
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(user.reload.role).to eq("trial")
         end
       end
 
@@ -174,6 +199,16 @@ RSpec.describe UsersController, type: :request do
           put user_path(user), params: { user: { role: "editor", organisation_id: nil } }
           expect(response).to have_http_status(:unprocessable_entity)
           expect(user.reload.role).to eq("trial")
+        end
+      end
+
+      context "with a user with no name set" do
+        let(:user) { create(:user, :with_no_name) }
+
+        it "does not return error if name is not chosen" do
+          put user_path(user), params: { user: { name: nil } }
+          expect(response).to redirect_to(users_path)
+          expect(user.reload.name).to eq(nil)
         end
       end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -130,6 +130,11 @@ RSpec.describe UsersController, type: :request do
         expect(user.reload.super_admin?).to be true
       end
 
+      it "can update the user's name" do
+        patch user_path(user), params: { user: { name: "Fakey McFakeName" } }
+        expect(user.reload.name).to eq "Fakey McFakeName"
+      end
+
       it "can update whether user has access" do
         patch user_path(user), params: { user: { has_access: false } }
         expect(user.reload.has_access).to be false

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -77,6 +77,13 @@ describe "users/edit.html.erb" do
       expect(rendered).to have_unchecked_field("Trial")
     end
 
+    it "has a name field" do
+      expect(rendered).to have_field("Name") do |field|
+        expect(field[:autocomplete]).to eq "name"
+        expect(field[:spellcheck]).to eq "false"
+      end
+    end
+
     it "has organisation fields" do
       expect(rendered).to have_select(
         "Organisation", selected: "Test Org", with_options: ["Department For Tests", "Ministry Of Testing", "Test Org"]

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -14,6 +14,28 @@ describe "users/edit.html.erb" do
     render template: "users/edit"
   end
 
+  describe "page title" do
+    it "is the user's name" do
+      expect(view.content_for(:title)).to eq user.name
+    end
+
+    context "with a user with no name set" do
+      let(:user) { build(:user, :with_no_name, role: :editor, id: 1) }
+
+      it "is the users's email address" do
+        expect(view.content_for(:title)).to eq user.email
+      end
+    end
+
+    context "with a user with a blank name" do
+      let(:user) { build(:user, name: "", role: :editor, id: 1) }
+
+      it "is the users's email address" do
+        expect(view.content_for(:title)).to eq user.email
+      end
+    end
+  end
+
   it "contains page heading" do
     expect(rendered).to have_css("h1.govuk-heading-l", text: /Edit user/)
   end
@@ -64,6 +86,14 @@ describe "users/edit.html.erb" do
     it "has access fields" do
       expect(rendered).to have_checked_field("Permitted")
       expect(rendered).to have_unchecked_field("Denied")
+    end
+  end
+
+  context "with a user with no name set" do
+    let(:user) { build(:user, :with_no_name, role: :editor, id: 1) }
+
+    it "shows no name set" do
+      expect(rendered).to have_text("No name set")
     end
   end
 

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -36,6 +36,14 @@ describe "users/index.html.erb" do
     expect(rendered).to have_text("Permitted")
   end
 
+  context "with a user with no name set" do
+    let(:users) { [build(:user, :with_no_name, id: 1)] }
+
+    it "shows no name set" do
+      expect(rendered).to have_text("No name set")
+    end
+  end
+
   context "with a user with an unknown organisation" do
     let(:users) { [build(:user, :with_unknown_org, id: 1)] }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/tUxg95jK/1068-allow-super-admins-to-add-and-change-a-users-name <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When we switch to the Auth0 passwordless email flow we won't get a name for a user when they first sign up. We've agreed for now that super admins will be able to set a user's name, and will do so when upgrading their account from the trial role. This PR adds a name field to the edit user form.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?

<details><summary>

### Screenshots

</summary>

#### Users list

![Screenshot of users list page `/users`](https://github.com/alphagov/forms-admin/assets/503614/a668c822-7841-4410-bf85-d45337665fc0)

#### Edit a user with no name set

![Screenshot of edit user page `/users/:id/edit` when user has no name set](https://github.com/alphagov/forms-admin/assets/503614/968669b0-4520-42eb-b11f-7e0943e4e2ba)

#### Error if trying to give user with no name or organisation set an editor role

![Screenshot of edit user page in error state](https://github.com/alphagov/forms-admin/assets/503614/0ac737f4-0c07-4274-ba75-b2d0ad932772)


</details>