### PR TITLE
Log page ID with requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,7 @@ class ApplicationController < ActionController::Base
     payload[:request_id] = request.request_id
     payload[:user_ip] = user_ip(request.env.fetch("HTTP_X_FORWARDED_FOR", ""))
     payload[:form_id] = params[:form_id] if params[:form_id].present?
+    payload[:page_id] = params[:page_id] if params[:page_id].present?
   end
 
   def clear_questions_session_data

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,7 @@ module FormsAdmin
         h[:request_id] = event.payload[:request_id]
         h[:user_id] = event.payload[:user_id]
         h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
+        h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
         h[:exception] = event.payload[:exception] if event.payload[:exception]
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When searching Splunk for requests related to a particular page of a form it would be nice to be able to construct a query with `page_id=n`.

This PR adds the page ID to the log event JSON payload so that this will be possible in future.

See https://github.com/alphagov/forms-runner/pull/431 for a similar PR for the runner app.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?