### PR TITLE
Replace Pages::SelectionOption with a simple Hash

### DIFF
--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -56,12 +56,14 @@ class Pages::SelectionsSettingsController < PagesController
 
 private
 
-  def convert_to_selection_option(hash)
-    if hash.is_a? Pages::SelectionOption
-      # TODO: remove this once we using activerecord models instead of form objects
-      hash
+  def convert_to_selection_option(input)
+    case input
+    when ActionController::Parameters, Hash
+      OpenStruct.new(input)
+    when String
+      OpenStruct.new(name: input)
     else
-      Pages::SelectionOption.new(hash)
+      input
     end
   end
 

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -19,7 +19,7 @@ class Pages::SelectionsSettingsController < PagesController
     elsif params[:remove]
       @selections_settings_form.remove(params[:remove].to_i)
       render selection_settings_view
-    elsif @selections_settings_form.valid? && @selections_settings_form.submit(session)
+    elsif @selections_settings_form.submit(session)
       redirect_to new_question_path(@form)
     else
       render selection_settings_view
@@ -46,8 +46,7 @@ class Pages::SelectionsSettingsController < PagesController
     elsif params[:remove]
       @selections_settings_form.remove(params[:remove].to_i)
       render selection_settings_view
-    elsif @selections_settings_form.valid? && @selections_settings_form.submit(session)
-
+    elsif @selections_settings_form.submit(session)
       redirect_to edit_question_path(@form)
     else
       render selection_settings_view

--- a/app/forms/pages/conditions_form.rb
+++ b/app/forms/pages/conditions_form.rb
@@ -30,7 +30,7 @@ class Pages::ConditionsForm < BaseForm
   end
 
   def routing_answer_options
-    options = page.answer_settings.selection_options.map { |option| OpenStruct.new(value: option.name, label: option.name) }
+    options = page.answer_settings.selection_options.map { |option| OpenStruct.new(value: option.attributes[:name], label: option.attributes[:name]) }
     options << OpenStruct.new(value: :none_of_the_above.to_s, label: I18n.t("page_conditions.none_of_the_above")) if page.is_optional
 
     options

--- a/app/forms/pages/selection_option.rb
+++ b/app/forms/pages/selection_option.rb
@@ -1,7 +1,0 @@
-class Pages::SelectionOption < BaseForm
-  attr_accessor :name
-
-  def init(name)
-    @name = name
-  end
-end

--- a/app/forms/pages/selections_settings_form.rb
+++ b/app/forms/pages/selections_settings_form.rb
@@ -1,13 +1,9 @@
 class Pages::SelectionsSettingsForm < BaseForm
-  include ActiveModel::Validations::Callbacks
-
   DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }],
                       only_one_option: false,
                       include_none_of_the_above: false }.freeze
 
   attr_accessor :selection_options, :only_one_option, :include_none_of_the_above
-
-  before_validation :filter_out_blank_options
 
   validate :selection_options, :validate_selection_options
 
@@ -33,6 +29,8 @@ class Pages::SelectionsSettingsForm < BaseForm
   end
 
   def validate_selection_options
+    filter_out_blank_options
+
     return errors.add(:selection_options, :minimum) if selection_options.length < 2
     return errors.add(:selection_options, :maximum) if selection_options.length > 20
 

--- a/app/forms/pages/selections_settings_form.rb
+++ b/app/forms/pages/selections_settings_form.rb
@@ -1,7 +1,7 @@
 class Pages::SelectionsSettingsForm < BaseForm
   include ActiveModel::Validations::Callbacks
 
-  DEFAULT_OPTIONS = { selection_options: [OpenStruct.new(name: ""), OpenStruct.new(name: "")],
+  DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }],
                       only_one_option: false,
                       include_none_of_the_above: false }.freeze
 
@@ -20,7 +20,7 @@ class Pages::SelectionsSettingsForm < BaseForm
   end
 
   def answer_settings
-    { only_one_option:, selection_options: selection_options.map { |option| { name: option[:name] } } }
+    { only_one_option:, selection_options: }
   end
 
   def submit(session)
@@ -28,7 +28,7 @@ class Pages::SelectionsSettingsForm < BaseForm
 
     session[:page] = {} if session[:page].blank?
 
-    session[:page][:answer_settings] = answer_settings
+    session[:page][:answer_settings] = answer_settings.with_indifferent_access
     session[:page][:is_optional] = include_none_of_the_above
   end
 
@@ -36,11 +36,14 @@ class Pages::SelectionsSettingsForm < BaseForm
     return errors.add(:selection_options, :minimum) if selection_options.length < 2
     return errors.add(:selection_options, :maximum) if selection_options.length > 20
 
-    names = selection_options.map { |option| option[:name] }
-    return errors.add(:selection_options, :uniqueness) if names.uniq.length != selection_options.length
+    return errors.add(:selection_options, :uniqueness) if selection_options.uniq.length != selection_options.length
   end
 
   def filter_out_blank_options
     self.selection_options = selection_options.filter { |option| option[:name].present? }
+  end
+
+  def selection_options_form_objects
+    selection_options.map { |option| OpenStruct.new(name: option[:name]) }
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -38,7 +38,7 @@ class Page < ActiveResource::Base
   end
 
   def show_selection_options
-    answer_settings.selection_options.map(&:name).join(", ")
+    answer_settings.selection_options.map { |option| option.attributes[:name] }.join(", ")
   end
 
   def submit

--- a/app/service/page_options_service.rb
+++ b/app/service/page_options_service.rb
@@ -81,9 +81,9 @@ private
   end
 
   def selection_list
-    return @page.show_selection_options unless @page.answer_settings.selection_options.map(&:name).length >= 1
+    return @page.show_selection_options unless @page.answer_settings.selection_options.length >= 1
 
-    options = @page.answer_settings.selection_options.map(&:name)
+    options = @page.answer_settings.selection_options.map { |option| option.attributes[:name] }
     options << "#{I18n.t('page_options_service.selection_type.none_of_the_above')}</li>" if @page.is_optional?
     formatted_list = options.join("</li><li>")
 

--- a/app/views/pages/selections_settings.html.erb
+++ b/app/views/pages/selections_settings.html.erb
@@ -31,10 +31,10 @@
       <%= f.govuk_fieldset legend: { text: t("selections_settings.add_options") } do %>
         <p class="govuk-hint"><%= t("selections_settings.add_options_hint") %></p>
         <ul class="govuk-list app-select-options">
-          <% @selections_settings_form.selection_options.each_with_index do |selection_option, index| %>
+          <% @selections_settings_form.selection_options_form_objects.each_with_index do |selection_option, index| %>
             <%= f.fields_for :selection_options, selection_option, index: index do |selection_options_form| %>
               <li class="app-select-options__list-item">
-                <%= selection_options_form.govuk_text_field :name, id: "forms-selections-settings-form-selection-options-name-field-#{index}", name:"pages_selections_settings_form[selection_options][#{index}][name]", label: { text: t("selections_settings.option", number: index + 1), for: "forms-selections-settings-form-selection-options-name-field-#{index}" }, class: "govuk-input--width-20", form_group: { classes: "app-select-options__form-group" } %>
+                <%= selection_options_form.govuk_text_field :name, id: "forms-selections-settings-form-selection-options-name-field-#{index}", label: { text: t("selections_settings.option", number: index + 1), for: "forms-selections-settings-form-selection-options-name-field-#{index}" }, class: "govuk-input--width-20", form_group: { classes: "app-select-options__form-group" } %>
                 <%= f.govuk_submit t("selections_settings.remove_html", option_number: index + 1), class: "app-select-options__button", name: :remove, value: index, secondary: true %>
               </li>
             <% end %>

--- a/app/views/pages/selections_settings.html.erb
+++ b/app/views/pages/selections_settings.html.erb
@@ -34,7 +34,7 @@
           <% @selections_settings_form.selection_options.each_with_index do |selection_option, index| %>
             <%= f.fields_for :selection_options, selection_option, index: index do |selection_options_form| %>
               <li class="app-select-options__list-item">
-                <%= selection_options_form.govuk_text_field :name, id: "forms-selections-settings-form-selection-options-name-field-#{index}", label: { text: t("selections_settings.option", number: index + 1), for: "forms-selections-settings-form-selection-options-name-field-#{index}" }, class: "govuk-input--width-20", form_group: { classes: "app-select-options__form-group" } %>
+                <%= selection_options_form.govuk_text_field :name, id: "forms-selections-settings-form-selection-options-name-field-#{index}", name:"pages_selections_settings_form[selection_options][#{index}][name]", label: { text: t("selections_settings.option", number: index + 1), for: "forms-selections-settings-form-selection-options-name-field-#{index}" }, class: "govuk-input--width-20", form_group: { classes: "app-select-options__form-group" } %>
                 <%= f.govuk_submit t("selections_settings.remove_html", option_number: index + 1), class: "app-select-options__button", name: :remove, value: index, secondary: true %>
               </li>
             <% end %>

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -6,8 +6,11 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
   end
 
   def with_selection_answer_type
-    page = FactoryBot.build(:page, :with_selections_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
+    page = FactoryBot.build(:page, is_optional: "false",
+                                   answer_type: "selection",
+                                   answer_settings: OpenStruct.new(only_one_option: "true",
+                                                                   selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                                                                                       OpenStruct.new(attributes: { name: "Option 2" })]))
     change_answer_type_path = "https://example.com/change_answer_type"
     change_selections_settings_path = "https://example.com/change_selections_settings"
     render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_selections_settings_path:))

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -31,9 +31,12 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
   context "when the page is a selection page" do
     let(:page_object) do
-      page = FactoryBot.build(:page, :with_selections_settings, id: 1)
-      page.answer_settings = OpenStruct.new(page.answer_settings)
-      page
+      build :page,
+            is_optional: "true",
+            answer_type: "selection",
+            answer_settings: OpenStruct.new(only_one_option: "true",
+                                            selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                                                                OpenStruct.new(attributes: { name: "Option 2" })])
     end
 
     it "has a link to change the answer type" do

--- a/spec/factories/forms/pages/selections_settings_form.rb
+++ b/spec/factories/forms/pages/selections_settings_form.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :selections_settings_form, class: "Pages::SelectionsSettingsForm" do
-    selection_options { [{ "name": "Option 1" }, { "name": "Option 2" }] }
+    selection_options { [{ name: "Option 1" }, { name: "Option 2" }] }
     only_one_option { "true" }
     include_none_of_the_above { true }
   end

--- a/spec/factories/forms/pages/selections_settings_form.rb
+++ b/spec/factories/forms/pages/selections_settings_form.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :selections_settings_form, class: "Pages::SelectionsSettingsForm" do
-    selection_options { [Pages::SelectionOption.new({ name: "Option 1" }), Pages::SelectionOption.new({ name: "Option 2" })] }
+    selection_options { [{ "name": "Option 1" }, { "name": "Option 2" }] }
     only_one_option { "true" }
     include_none_of_the_above { true }
   end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
     trait :with_selections_settings do
       transient do
         only_one_option { "true" }
-        selection_options { [Pages::SelectionOption.new({ name: "Option 1" }), Pages::SelectionOption.new({ name: "Option 2" })] }
+        selection_options { [DataStruct.new({ name: "Option 1" }), DataStruct.new({ name: "Option 2" })] }
       end
 
       question_text { Faker::Lorem.question }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
     trait :with_selections_settings do
       transient do
         only_one_option { "true" }
-        selection_options { [DataStruct.new({ name: "Option 1" }), DataStruct.new({ name: "Option 2" })] }
+        selection_options { [{ name: "Option 1" }, { name: "Option 2" }] }
       end
 
       question_text { Faker::Lorem.question }

--- a/spec/forms/pages/conditions_form_spec.rb
+++ b/spec/forms/pages/conditions_form_spec.rb
@@ -4,7 +4,17 @@ RSpec.describe Pages::ConditionsForm, type: :model do
   let(:conditions_form) { described_class.new(form:, page:, record: condition) }
   let(:form) { build :form, :ready_for_routing, id: 1 }
   let(:pages) { form.pages }
-  let(:page) { pages.second }
+  let(:is_optional) { false }
+  let(:page) do
+    pages.second.tap do |second_page|
+      second_page.is_optional = is_optional
+      second_page.answer_type = "selection"
+      second_page.answer_settings = DataStruct.new(
+        only_one_option: true,
+        selection_options: [OpenStruct.new(attributes: { name: "Option 1" }), OpenStruct.new(attributes: { name: "Option 2" })],
+      )
+    end
+  end
   let(:condition) { nil }
 
   let(:post_headers) do
@@ -107,7 +117,7 @@ RSpec.describe Pages::ConditionsForm, type: :model do
     end
 
     context "when selection setting includes 'none of the above'" do
-      let(:page) { build :page, :with_selections_settings, is_optional: "true" }
+      let(:is_optional) { true }
 
       it "adds extra 'None of above' options to the end" do
         result = conditions_form.routing_answer_options

--- a/spec/forms/pages/selections_settings_form_spec.rb
+++ b/spec/forms/pages/selections_settings_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Pages::SelectionsSettingsForm, type: :model do
     end
 
     it "is invalid if more than 20 selection options are provided" do
-      selections_settings_form.selection_options = (1..21).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..21).to_a.map { |i| OpenStruct.new(name: i.to_s) }
       error_message = I18n.t("activemodel.errors.models.pages/selections_settings_form.attributes.selection_options.maximum")
       expect(selections_settings_form).not_to be_valid
 
@@ -26,7 +26,7 @@ RSpec.describe Pages::SelectionsSettingsForm, type: :model do
     end
 
     it "is invalid if selection options are not unique" do
-      selections_settings_form.selection_options = [Pages::SelectionOption.new({ name: "option 1" }), Pages::SelectionOption.new({ name: "option 2" }), Pages::SelectionOption.new({ name: "option 1" })]
+      selections_settings_form.selection_options = [{ name: "option 1" }, { name: "option 2" }, { name: "option 1" }]
       error_message = I18n.t("activemodel.errors.models.pages/selections_settings_form.attributes.selection_options.uniqueness")
       expect(selections_settings_form).not_to be_valid
 
@@ -34,12 +34,12 @@ RSpec.describe Pages::SelectionsSettingsForm, type: :model do
     end
 
     it "is valid if there are between 2 and 20 unique selection values" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..2).to_a.map { |i| { name: i.to_s } }
 
       expect(selections_settings_form).to be_valid
       expect(selections_settings_form.errors.full_messages_for(:selection_options)).to be_empty
 
-      selections_settings_form.selection_options = (1..20).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..20).to_a.map { |i| { name: i.to_s } }
 
       expect(selections_settings_form).to be_valid
       expect(selections_settings_form.errors.full_messages_for(:selection_options)).to be_empty
@@ -55,36 +55,36 @@ RSpec.describe Pages::SelectionsSettingsForm, type: :model do
     end
 
     it "sets a session key called 'page' as a hash with the answer type in it" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..2).to_a.map { |i| { name: i.to_s } }
       selections_settings_form.only_one_option = true
       selections_settings_form.include_none_of_the_above = true
       selections_settings_form.submit(session_mock)
-      expect(session_mock[:page][:answer_settings].to_json).to eq({ only_one_option: true, selection_options: [Pages::SelectionOption.new(name: "1"), Pages::SelectionOption.new(name: "2")] }.to_json)
+      expect(session_mock[:page][:answer_settings].to_json).to eq({ only_one_option: true, selection_options: [{ name: "1" }, { name: "2" }] }.to_json)
       expect(session_mock[:page][:is_optional]).to eq(true)
     end
   end
 
   describe "add_another" do
     it "adds an empty item to the end of the selection options array" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..2).to_a.map { |i| { name: i.to_s } }
       selections_settings_form.add_another
 
-      expect(selections_settings_form.selection_options.to_json).to eq([Pages::SelectionOption.new(name: "1"), Pages::SelectionOption.new(name: "2"), Pages::SelectionOption.new(name: "")].to_json)
+      expect(selections_settings_form.selection_options).to eq([{ name: "1" }, { name: "2" }, { name: "" }])
     end
   end
 
   describe "remove" do
     it "removes the specified option from the selection options array" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
+      selections_settings_form.selection_options = (1..2).to_a.map { |i| { name: i.to_s } }
       selections_settings_form.remove(1)
 
-      expect(selections_settings_form.selection_options.to_json).to eq([Pages::SelectionOption.new(name: "1")].to_json)
+      expect(selections_settings_form.selection_options.to_json).to eq([{ name: "1" }].to_json)
     end
   end
 
   describe "answer_settings" do
     it "returns the correct answer_settings object" do
-      selection_options = (1..2).to_a.map { |i| Pages::SelectionOption.new({ name: i.to_s }) }
+      selection_options = (1..2).to_a.map { |i| { name: i.to_s } }
       only_one_option = true
       selections_settings_form.selection_options = selection_options
       selections_settings_form.only_one_option = only_one_option
@@ -95,10 +95,10 @@ RSpec.describe Pages::SelectionsSettingsForm, type: :model do
 
   describe "filter_out_blank_options" do
     it "filters out blank inputs" do
-      selections_settings_form.selection_options = [Pages::SelectionOption.new(name: "1"), Pages::SelectionOption.new(name: ""), Pages::SelectionOption.new(name: "2")]
+      selections_settings_form.selection_options = [{ name: "1" }, { name: "" }, { name: "2" }]
       selections_settings_form.filter_out_blank_options
 
-      expect(selections_settings_form.selection_options.to_json).to eq([Pages::SelectionOption.new(name: "1"), Pages::SelectionOption.new(name: "2")].to_json)
+      expect(selections_settings_form.selection_options.to_json).to eq([{ name: "1" }, { name: "2" }].to_json)
     end
   end
 end

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -3,7 +3,17 @@ require "rails_helper"
 RSpec.describe Pages::ConditionsController, type: :request do
   let(:form) { build :form, :ready_for_routing, id: 1 }
   let(:pages) { form.pages }
-  let(:page) { pages.first }
+  let(:page) do
+    pages.first.tap do |first_page|
+      first_page.is_optional = false
+      first_page.answer_type = "selection"
+      first_page.answer_settings = DataStruct.new(
+        only_one_option: true,
+        selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                            OpenStruct.new(attributes: { name: "Option 2" })],
+      )
+    end
+  end
   let(:selected_page) { page }
 
   let(:submit_result) { true }

--- a/spec/requests/pages/selections_settings_controller_spec.rb
+++ b/spec/requests/pages/selections_settings_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
       end
 
       it "saves the answer type to session" do
-        expect(session[:page].to_json).to eq({ answer_settings: selections_settings_form.answer_settings, is_optional: "false" }.to_json)
+        expect(session[:page]).to include({ answer_settings: selections_settings_form.answer_settings, is_optional: "false" })
       end
 
       it "redirects the user to the question details page" do
@@ -101,7 +101,7 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
     it "returns the existing page answer settings" do
       settings_form = assigns(:selections_settings_form)
       expect(settings_form.only_one_option).to eq page.answer_settings[:only_one_option]
-      expect(settings_form.selection_options.map(&:name)).to eq page.answer_settings[:selection_options].map(&:name)
+      expect(settings_form.selection_options.map { |option| { name: option[:name] } }).to eq(page.answer_settings[:selection_options].map { |option| { name: option[:name] } })
       expect(settings_form.include_none_of_the_above).to eq page.is_optional
     end
 

--- a/spec/requests/pages/selections_settings_controller_spec.rb
+++ b/spec/requests/pages/selections_settings_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
       end
 
       it "saves the answer type to session" do
-        expect(session[:page].to_json).to eq({ "answer_settings": selections_settings_form.answer_settings, is_optional: "false" }.to_json)
+        expect(session[:page].to_json).to eq({ answer_settings: selections_settings_form.answer_settings, is_optional: "false" }.to_json)
       end
 
       it "redirects the user to the question details page" do
@@ -99,10 +99,10 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
     end
 
     it "returns the existing page answer settings" do
-      form = assigns(:selections_settings_form)
-      expect(form.answer_settings[:only_one_option]).to eq page.answer_settings[:only_one_option]
-      expect(form.answer_settings[:selection_options].map(&:name)).to eq page.answer_settings[:selection_options].map(&:name)
-      expect(form.answer_settings[:include_none_of_the_above]).to eq page.is_optional
+      settings_form = assigns(:selections_settings_form)
+      expect(settings_form.only_one_option).to eq page.answer_settings[:only_one_option]
+      expect(settings_form.selection_options.map(&:name)).to eq page.answer_settings[:selection_options].map(&:name)
+      expect(settings_form.include_none_of_the_above).to eq page.is_optional
     end
 
     it "sets an instance variable for selections_settings_path" do
@@ -133,9 +133,9 @@ RSpec.describe Pages::SelectionsSettingsController, type: :request do
       end
 
       it "saves the updated answer settings to DB" do
-        new_settings = { only_one_option: "true", selection_options: [Pages::SelectionOption.new({ name: "Option 1" }), Pages::SelectionOption.new({ name: "New option 2" })] }
+        new_settings = { only_one_option: "true", selection_options: [{ name: "Option 1" }, { name: "New option 2" }] }
         form = assigns(:selections_settings_form)
-        expect(form.answer_settings.to_json).to eq new_settings.to_json
+        expect(form.answer_settings).to eq new_settings
       end
 
       it "redirects the user to the question details page " do

--- a/spec/service/page_options_service_spec.rb
+++ b/spec/service/page_options_service_spec.rb
@@ -99,7 +99,14 @@ describe PageOptionsService do
     end
 
     context "with selection" do
-      let(:page) { build :page, :with_selections_settings }
+      let(:page) do
+        build :page,
+              is_optional: "false",
+              answer_type: "selection",
+              answer_settings: OpenStruct.new(only_one_option: "true",
+                                              selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                                                                  OpenStruct.new(attributes: { name: "Option 2" })])
+      end
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
@@ -110,7 +117,14 @@ describe PageOptionsService do
     end
 
     context "with selection not only_one_option " do
-      let(:page) { build :page, :with_selections_settings, only_one_option: "false" }
+      let(:page) do
+        build :page,
+              is_optional: "false",
+              answer_type: "selection",
+              answer_settings: OpenStruct.new(only_one_option: "false",
+                                              selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                                                                  OpenStruct.new(attributes: { name: "Option 2" })])
+      end
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([

--- a/spec/views/pages/conditions/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/edit.html.erb_spec.rb
@@ -4,8 +4,16 @@ describe "pages/conditions/edit.html.erb" do
   let(:condition_form) { Pages::ConditionsForm.new(form:, page:, record: condition) }
   let(:form) { build :form, :ready_for_routing, id: 1 }
   let(:condition) { build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
-  let(:pages) { form.pages }
-  let(:page) { pages.first }
+  let(:pages) { form.pages << page }
+  let(:page) do
+    build :page,
+          form_id: form.id,
+          is_optional: "false",
+          answer_type: "selection",
+          answer_settings: OpenStruct.new(only_one_option: "true",
+                                          selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                                                              OpenStruct.new(attributes: { name: "Option 2" })])
+  end
 
   before do
     page.position = 1

--- a/spec/views/pages/conditions/new.html.erb_spec.rb
+++ b/spec/views/pages/conditions/new.html.erb_spec.rb
@@ -2,7 +2,11 @@ require "rails_helper"
 
 describe "pages/conditions/new.html.erb" do
   let(:form) { build :form, id: 1 }
-  let(:pages) { build_list :page, 3, :with_selections_settings, form_id: 1 }
+  let(:pages) do
+    build_list :page, 3, answer_settings: OpenStruct.new(only_one_option: "true",
+                                                         selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                                                                             OpenStruct.new(attributes: { name: "Option 2" })]), form_id: 1
+  end
   let(:condition_form) { Pages::ConditionsForm.new(form:, page: pages.first) }
 
   before do


### PR DESCRIPTION
### What problem does this pull request solve?
`Pages::SelectionOption`inherits from `BaseForm` form object class which makes it an ActiveModel and includes ActiveModel validations. Validations are not needed to be included and we cannot stop this class from inherit BaseForm without breaking a lot of things.

Instead we should replace the answer_settings selection_options to just be a simple hash but for us to use it in the GOV.UK Design System form builder we need to make that hash into an OpenStruct. Theres no need at this time to abstract and complicate how we build up these select list options.

I deployed this to Dev and manually tested a bunch of existing pages. No errors reported.

Trello card: https://trello.com/c/ly8wbae5/1085-refactor-how-we-build-up-select-from-a-list-options

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
