### PR TITLE
1070 fetch from cloudwatch the total submissions of a form for the last 7 days in forms admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,9 @@ gem "validate_url"
 # For auditing tables
 gem "paper_trail"
 
+# For obtaining CloudWatch metrics
+gem "aws-sdk-cloudwatch", "~> 1.81"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,18 @@ GEM
     aes_key_wrap (1.1.0)
     ast (2.4.2)
     attr_required (1.0.1)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.834.0)
+    aws-sdk-cloudwatch (1.81.0)
+      aws-sdk-core (~> 3, >= 3.184.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-core (3.185.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sigv4 (1.6.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     axe-core-api (4.7.0)
       dumb_delegator
       virtus
@@ -245,6 +257,7 @@ GEM
     io-console (0.6.0)
     irb (1.6.4)
       reline (>= 0.3.0)
+    jmespath (1.6.2)
     json (2.6.3)
     json-jwt (1.16.3)
       activesupport (>= 4.2)
@@ -543,6 +556,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeresource (~> 6.0)
+  aws-sdk-cloudwatch (~> 1.81)
   axe-core-rspec
   bootsnap
   brakeman (~> 6.0.1)

--- a/app/service/cloud_watch_service.rb
+++ b/app/service/cloud_watch_service.rb
@@ -1,0 +1,33 @@
+class CloudWatchService
+  def self.week_submissions(form_id:)
+    region = "eu-west-2"
+    a_week = 604_800
+    cloudwatch_client = Aws::CloudWatch::Client.new(region:)
+
+    response = cloudwatch_client.get_metric_statistics({
+      metric_name: "submitted",
+      namespace: metric_namespace.to_s,
+      dimensions: [
+        {
+          name: "form_id",
+          value: form_id.to_s,
+        },
+      ],
+      start_time: start_of_today - 7.days,
+      end_time: start_of_today,
+      period: a_week,
+      statistics: %w[Sum],
+      unit: "Count",
+    })
+
+    response.datapoints[0]&.sum.to_i || 0
+  end
+
+  def self.metric_namespace
+    "forms/#{Settings.forms_env}".downcase
+  end
+
+  def self.start_of_today
+    Time.zone.now.midnight
+  end
+end

--- a/spec/service/cloud_watch_service_spec.rb
+++ b/spec/service/cloud_watch_service_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe CloudWatchService do
+  describe "#week_submissions" do
+    let(:forms_env) { "test" }
+    let(:form_id) { 3 }
+    let(:datapoints) { [{ sum: total_submissions }] }
+    let(:total_submissions) { 3.0 }
+
+    around do |example|
+      Timecop.freeze(Time.zone.local(2021, 1, 1, 4, 30, 0)) do
+        example.run
+      end
+    end
+
+    before do
+      allow(Settings).to receive(:forms_env).and_return(forms_env)
+    end
+
+    it "calls the cloudwatch client with get_metric_statistics" do
+      cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+      metric_response = cloudwatch_client.stub_data(:get_metric_statistics, datapoints:)
+
+      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+      allow(cloudwatch_client).to receive(:get_metric_statistics).with({
+        metric_name: "submitted",
+        namespace: "forms/#{forms_env}",
+        dimensions: [
+          {
+            name: "form_id",
+            value: form_id.to_s,
+          },
+        ],
+        start_time: Time.zone.now.midnight - 7.days,
+        end_time: Time.zone.now.midnight,
+        period: 604_800,
+        statistics: %w[Sum],
+        unit: "Count",
+      }).and_return(metric_response)
+
+      described_class.week_submissions(form_id:)
+    end
+
+    it "returns the sum for the datapoint in the response" do
+      cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+      metric_response = cloudwatch_client.stub_data(:get_metric_statistics, datapoints:)
+      cloudwatch_client.stub_responses(:get_metric_statistics, metric_response)
+
+      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+      expect(described_class.week_submissions(form_id:)).to eq(total_submissions)
+    end
+
+    context "when there is no submission data for the form" do
+      let(:datapoints) { [] }
+
+      it "returns 0 if there is no data for the form" do
+        cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+        metric_response = cloudwatch_client.stub_data(:get_metric_statistics, datapoints:)
+        cloudwatch_client.stub_responses(:get_metric_statistics, metric_response)
+
+        allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+        expect(described_class.week_submissions(form_id:)).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/73R1GLQV/1070-fetch-from-cloudwatch-the-total-submissions-of-a-form-for-the-last-7-days-in-forms-admin

This adds a service for obtaining submission stats for a given form. If there are stats available in the appropriate namespace in cloudwatch (based on the environment the request is coming from), then it should end up giving a number. 

Bit of a pain to test, but I can go through it with you. It will involve running things through the gds-cli as an aws role, which will enable submissions being logged with cloudwatch. This in turn will mean you can get data back from cloudwatch that isn't just the default 0. 

I'm not sure if the default response should be 0 if there's no data for a form - if haven't been any metrics sent to cloudwatch within the 1 week timeframe, it just doesn't send anything back. It's not possible to do the SUM of no data, so defaulting to 0 is assuming that no data == no submissions.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
