### PR TITLE
Update lint task to run sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "lint": "standard | snazzy & stylelint 'app/**/*.scss'",
+    "lint": "standard | snazzy && stylelint 'app/**/*.scss'",
     "format": "standard --fix & stylelint 'app/**/*.scss' --fix",
     "ci": "bin/setup && bin/rails server",
     "dev": "vite dev"


### PR DESCRIPTION
Runs the JS and style linting sequentially instead of in parallel. Running them in parallel meant that the linting tasks wouldn't break the build unless both lints failed, so we saw issues being missed. The equivalent was done in forms-runner[1] .

The time saving from running them in parallel is negligible, so there shouldn't be any noticeable drawbacks to changing this.

[1]: https://github.com/alphagov/forms-runner/pull/412

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
