### PR TITLE
Revert "Refactor predicate methods to simplify"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,10 +67,10 @@ class User < ApplicationRecord
 private
 
   def requires_name?
-    name_was.present? || !trial?
+    name_was.present? || role_changed?(from: :trial)
   end
 
   def requires_organisation?
-    organisation_id_was.present? || editor?
+    organisation_id_was.present? || role_changed?(to: :editor)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,7 +5,7 @@ describe User, type: :model do
   subject(:user) { described_class.new }
 
   it "validates" do
-    expect(user.valid?).to be true
+    expect(user).to be_valid
   end
 
   describe "versioning", versioning: true do
@@ -27,7 +27,7 @@ describe User, type: :model do
     it "is invalid if blank" do
       user.role = nil
 
-      expect(user.valid?).to be false
+      expect(user).to be_invalid
     end
   end
 
@@ -35,27 +35,29 @@ describe User, type: :model do
     it "is allowed to be nil" do
       user.organisation_id = nil
 
-      expect(user.valid?).to be true
+      expect(user).to be_valid
     end
   end
 
   context "when updating organisation" do
+    let(:user) { create :user, :with_no_org, role: :trial }
+
     it "is valid to leave organisation unset" do
-      user = create :user, :with_no_org
       user.organisation_id = nil
-      expect(user.valid?).to be true
+      expect(user).to be_valid
     end
 
     it "is not valid to unset organisation if it is already set" do
-      user = create(:user, organisation: create(:organisation, slug: "test-org"))
+      user.organisation = create(:organisation, slug: "test-org")
+      user.save!
+
       user.organisation_id = nil
-      expect(user.valid?).to be false
+      expect(user).to be_invalid
     end
 
     it "is not valid to leave organisation unset if changing role to editor" do
-      user = create :user, :with_no_org, role: :trial
       user.role = :editor
-      expect(user.valid?).to be false
+      expect(user).to be_invalid
     end
   end
 
@@ -190,28 +192,27 @@ describe User, type: :model do
   end
 
   context "when updating name" do
+    let(:user) { create :user, :with_no_name, role: :trial }
+
     it "is valid to leave name unset" do
-      user = create :user, :with_no_name
       user.name = nil
-      expect(user.valid?).to be true
+      expect(user).to be_valid
     end
 
     it "is not valid to unset name if it is already set" do
-      user = create :user, name: "Test User"
+      user.update!(name: "Test User")
       user.name = nil
-      expect(user.valid?).to be false
+      expect(user).to be_invalid
     end
 
     it "is not valid to leave name unset if changing role to editor" do
-      user = create :user, :with_no_name, role: :trial
       user.role = :editor
-      expect(user.valid?).to be false
+      expect(user).to be_invalid
     end
 
     it "is not valid to leave name unset if changing role to super admin" do
-      user = create :user, :with_no_name, role: :trial
       user.role = :super_admin
-      expect(user.valid?).to be false
+      expect(user).to be_invalid
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,9 +42,26 @@ describe User, type: :model do
   context "when updating organisation" do
     let(:user) { create :user, :with_no_org, role: :trial }
 
-    it "is valid to leave organisation unset" do
-      user.organisation_id = nil
-      expect(user).to be_valid
+    context "when user has been created with a trial account" do
+      it "is valid to leave organisation unset" do
+        user.organisation_id = nil
+        expect(user).to be_valid
+      end
+    end
+
+    described_class.roles.each_key do |role|
+      context "when user somehow has no organisation" do
+        let(:user) do
+          user = build(:user, :with_no_org, role:)
+          user.save!(validate: false)
+          user
+        end
+
+        it "is valid to leave organisation unset" do
+          user.organisation_id = nil
+          expect(user).to be_valid
+        end
+      end
     end
 
     it "is not valid to unset organisation if it is already set" do
@@ -194,9 +211,26 @@ describe User, type: :model do
   context "when updating name" do
     let(:user) { create :user, :with_no_name, role: :trial }
 
-    it "is valid to leave name unset" do
-      user.name = nil
-      expect(user).to be_valid
+    context "when user has been created with a trial account" do
+      it "is valid to leave name unset" do
+        user.name = nil
+        expect(user).to be_valid
+      end
+    end
+
+    described_class.roles.each_key do |role|
+      context "when user somehow has no name" do
+        let(:user) do
+          user = build(:user, :with_no_name, role:)
+          user.save!(validate: false)
+          user
+        end
+
+        it "is valid to leave name unset" do
+          user.name = nil
+          expect(user).to be_valid
+        end
+      end
     end
 
     it "is not valid to unset name if it is already set" do


### PR DESCRIPTION
### What problem does this pull request solve?

The refactor of the validation predicates in commit 2a83c29 caused unexpected side-effects. Although in most cases checking the current role is equivalent to checking whether the role has been changed, the two conditions are not exactly identical. We found that after applying this change we started getting errors from GOV.UK Signon because the Signonotron API user had an editor role and no organisation set.

Although the original logic was more complex, it more precisely describes the behaviour we want and has fewer bugs, so let's revert to that.

This reverts commit 2a83c29dfa3db3bc932a328a70208d6066c5f0c7.


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?