### PR TITLE
Render form starts and completion percentage

### DIFF
--- a/app/components/metrics_summary_component/view.html.erb
+++ b/app/components/metrics_summary_component/view.html.erb
@@ -8,6 +8,9 @@
     <p><%= t("metrics_summary.description") %></p>
     <div class="app-metrics__container">
       <div class="app-metrics__big-number">
+        <%= t("metrics_summary.completion_rate") %> <span class="app-metrics__big-number-number"><%= weekly_completion_rate %></span>
+      </div>
+      <div class="app-metrics__big-number">
         <%= t("metrics_summary.forms_submitted") %> <span class="app-metrics__big-number-number"><%= weekly_submissions %></span>
       </div>
       <div class="app-metrics__big-number">

--- a/app/components/metrics_summary_component/view.html.erb
+++ b/app/components/metrics_summary_component/view.html.erb
@@ -10,6 +10,9 @@
       <div class="app-metrics__big-number">
         <%= t("metrics_summary.forms_submitted") %> <span class="app-metrics__big-number-number"><%= weekly_submissions %></span>
       </div>
+      <div class="app-metrics__big-number">
+        <%= t("metrics_summary.forms_started_but_not_completed") %> <span class="app-metrics__big-number-number"><%= weekly_started_but_not_completed %></span>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -12,10 +12,13 @@ module MetricsSummaryComponent
         @error_message = I18n.t("metrics_summary.errors.error_loading_data_html")
       elsif metrics_data[:form_is_new]
         @error_message = I18n.t("metrics_summary.errors.new_form_html")
+      elsif metrics_data[:weekly_starts].zero?
+        @error_message = I18n.t("metrics_summary.errors.no_submissions_html")
       else
         @weekly_submissions = metrics_data[:weekly_submissions]
         @weekly_starts = metrics_data[:weekly_starts]
         @weekly_started_but_not_completed = @weekly_starts - @weekly_submissions
+        @weekly_completion_rate = I18n.t("metrics_summary.percentage", number: calculate_percentage(@weekly_submissions, @weekly_starts))
       end
     end
 
@@ -26,6 +29,12 @@ module MetricsSummaryComponent
     def formatted_date_range
       start_date_format_string = start_date.year == end_date.year ? "%e %B" : "%e %B %Y"
       I18n.t("metrics_summary.date_range", start_date: start_date.strftime(start_date_format_string).strip, end_date: end_date.strftime("%e %B %Y").strip)
+    end
+
+    def calculate_percentage(number, total)
+      return nil if total.zero?
+
+      (number.to_f * 100 / total).round
     end
 
   private

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -14,6 +14,8 @@ module MetricsSummaryComponent
         @error_message = I18n.t("metrics_summary.errors.new_form_html")
       else
         @weekly_submissions = metrics_data[:weekly_submissions]
+        @weekly_starts = metrics_data[:weekly_starts]
+        @weekly_started_but_not_completed = @weekly_starts - @weekly_submissions
       end
     end
 

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -23,7 +23,8 @@ class Forms::LiveController < Forms::BaseController
       weekly_starts:,
       form_is_new:,
     }
-  rescue Aws::CloudWatch::Errors::ServiceError
+  rescue Aws::CloudWatch::Errors::ServiceError,
+         Aws::Errors::MissingCredentialsError
     nil
   end
 

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -16,9 +16,11 @@ class Forms::LiveController < Forms::BaseController
     form_is_new = Time.zone.parse(current_live_form.live_at.to_s) >= today.midnight
 
     weekly_submissions = form_is_new ? 0 : CloudWatchService.week_submissions(form_id: current_live_form.id)
+    weekly_starts = form_is_new ? 0 : CloudWatchService.week_starts(form_id: current_live_form.id)
 
     {
       weekly_submissions:,
+      weekly_starts:,
       form_is_new:,
     }
   rescue Aws::CloudWatch::Errors::ServiceError

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -475,6 +475,7 @@ en:
     update_preview: Update preview
     write_tab_text: Write
   metrics_summary:
+    completion_rate: Completion rate
     date_range: "%{start_date} to %{end_date}"
     description: If you want to track metrics over a longer period you'll need to make a note of these on the same day each week.
     errors:
@@ -489,9 +490,13 @@ en:
           <li>Number of forms started but not completed</li>
           <li>Completion rate</li>
         </ul>
+      no_submissions_html: |
+        <p>No metrics are available as no-one has started or submitted a form in the past 7 days.</p>
+        <p>This may be because the form is no longer published on GOV.UK.</p>
     forms_started_but_not_completed: Forms started but not completed
     forms_submitted: Forms submitted
     heading: 'Form metrics for the past 7 days: %{formatted_date_range}'
+    percentage: "%{number}%"
   new_condition:
     routing_page_text: If the question
   not_found:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -489,6 +489,7 @@ en:
           <li>Number of forms started but not completed</li>
           <li>Completion rate</li>
         </ul>
+    forms_started_but_not_completed: Forms started but not completed
     forms_submitted: Forms submitted
     heading: 'Form metrics for the past 7 days: %{formatted_date_range}'
   new_condition:

--- a/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
+++ b/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
@@ -5,12 +5,12 @@ class MetricsSummaryComponent::MetricsSummaryComponentPreview < ViewComponent::P
   end
 
   def with_a_new_form
-    metrics_data = { weekly_submissions: 0, form_is_new: true }
+    metrics_data = { weekly_submissions: 0, form_is_new: true, weekly_starts: 0 }
     render(MetricsSummaryComponent::View.new(metrics_data))
   end
 
   def with_metrics_available
-    metrics_data = { weekly_submissions: 1032, form_is_new: false }
+    metrics_data = { weekly_submissions: 1032, form_is_new: false, weekly_starts: 1568 }
     render(MetricsSummaryComponent::View.new(metrics_data))
   end
 end

--- a/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
+++ b/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
@@ -9,6 +9,11 @@ class MetricsSummaryComponent::MetricsSummaryComponentPreview < ViewComponent::P
     render(MetricsSummaryComponent::View.new(metrics_data))
   end
 
+  def with_no_weekly_starts
+    metrics_data = { weekly_submissions: 0, form_is_new: false, weekly_starts: 0 }
+    render(MetricsSummaryComponent::View.new(metrics_data))
+  end
+
   def with_metrics_available
     metrics_data = { weekly_submissions: 1032, form_is_new: false, weekly_starts: 1568 }
     render(MetricsSummaryComponent::View.new(metrics_data))

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -63,11 +63,16 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
     end
   end
 
-  context "when metrics_data has a value for weekly submissions" do
-    let(:metrics_data) { { weekly_submissions: 1235, form_is_new: false } }
+  context "when metrics_data has data for weekly submissions and starts" do
+    let(:metrics_data) { { weekly_submissions: 1235, form_is_new: false, weekly_starts: 1991 } }
+    let(:forms_started_but_not_completed) { metrics_data[:weekly_starts] - metrics_data[:weekly_submissions] }
 
     it "returns the metrics component with the number of submissions" do
       expect(metrics_summary.weekly_submissions).to eq(metrics_data[:weekly_submissions])
+    end
+
+    it "returns the metrics component with the number of forms started but not completed" do
+      expect(metrics_summary.weekly_started_but_not_completed).to eq(forms_started_but_not_completed)
     end
 
     it "renders the description text" do
@@ -76,6 +81,10 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
 
     it "renders the weekly submissions figure" do
       expect(page).to have_text("#{I18n.t('metrics_summary.forms_submitted')} #{metrics_data[:weekly_submissions]}")
+    end
+
+    it "renders the forms started but not completed figure" do
+      expect(page).to have_text("#{I18n.t('metrics_summary.forms_started_but_not_completed')} #{forms_started_but_not_completed}")
     end
   end
 end

--- a/spec/controller/forms/live_controller_spec.rb
+++ b/spec/controller/forms/live_controller_spec.rb
@@ -47,5 +47,33 @@ describe Forms::LiveController, type: :controller do
         expect(live_controller.metrics_data).to eq({ weekly_submissions: 1255, form_is_new: false, weekly_starts: 1991 })
       end
     end
+
+    context "when AWS credentials have not been configured" do
+      let(:form) do
+        build(:form, :live, id: 2, live_at: Time.zone.now - 1.day)
+      end
+
+      before do
+        allow(CloudWatchService).to receive(:week_starts).and_raise(Aws::Errors::MissingCredentialsError)
+      end
+
+      it "returns nil" do
+        expect(live_controller.metrics_data).to eq(nil)
+      end
+    end
+
+    context "when CloudWatch returns an error" do
+      let(:form) do
+        build(:form, :live, id: 2, live_at: Time.zone.now - 1.day)
+      end
+
+      before do
+        allow(CloudWatchService).to receive(:week_starts).and_raise(Aws::CloudWatch::Errors::ServiceError)
+      end
+
+      it "returns nil" do
+        expect(live_controller.metrics_data).to eq(nil)
+      end
+    end
   end
 end

--- a/spec/controller/forms/live_controller_spec.rb
+++ b/spec/controller/forms/live_controller_spec.rb
@@ -23,8 +23,13 @@ describe Forms::LiveController, type: :controller do
     end
 
     context "when the form was made today" do
+      before do
+        allow(CloudWatchService).to receive(:week_submissions).and_return(0)
+        allow(CloudWatchService).to receive(:week_starts).and_return(0)
+      end
+
       it "returns form_is_new: true and 0 weekly submissions" do
-        expect(live_controller.metrics_data).to eq({ weekly_submissions: 0, form_is_new: true })
+        expect(live_controller.metrics_data).to eq({ weekly_submissions: 0, form_is_new: true, weekly_starts: 0 })
       end
     end
 
@@ -35,10 +40,11 @@ describe Forms::LiveController, type: :controller do
 
       before do
         allow(CloudWatchService).to receive(:week_submissions).and_return(1255)
+        allow(CloudWatchService).to receive(:week_starts).and_return(1991)
       end
 
-      it "returns form_is_new: true and the correct number of weekly submissions" do
-        expect(live_controller.metrics_data).to eq({ weekly_submissions: 1255, form_is_new: false })
+      it "returns form_is_new: true and the correct number of weekly starts and submissions" do
+        expect(live_controller.metrics_data).to eq({ weekly_submissions: 1255, form_is_new: false, weekly_starts: 1991 })
       end
     end
   end

--- a/spec/views/live/show_form.html.erb_spec.rb
+++ b/spec/views/live/show_form.html.erb_spec.rb
@@ -127,7 +127,7 @@ describe "live/show_form.html.erb", feature_metrics_for_form_creators_enabled: f
   end
 
   context "when the metrics feature is enabled", feature_metrics_for_form_creators_enabled: true do
-    let(:metrics_data) { { weekly_submissions: 125, form_is_new: false } }
+    let(:metrics_data) { { weekly_submissions: 125, form_is_new: false, weekly_starts: 256 } }
 
     it "renders the metrics summary component" do
       expect(rendered).to have_text(I18n.t("metrics_summary.description"))


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/sXIsnAqj/1075-render-total-started-forms-for-the-last-7-days-and-forms-completion-rate-for-last-7-days-in-forms-admin

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
This PR adds two new metrics to the metrics summary component:
- the number of times a form has been started but not completed (calculated as the number of starts that week - the number of submissions)
- the percentage of form journeys that are completed (calculated as the number of submissions as a percentage of the total number of starts, rounded to the nearest whoile percentage point)

It also includes:
- a new error message to be displayed if the form hasn't had any starts that week
- a fix for an unhandled error when the AWS credentials have not been set (this is
most likely to happen on a developer's local machine)

See the individual commit messages for more detail.

If running locally you'll need to:
- have `metrics_for_form_creators_enabled` set to `true`
- run it with `aws vault` to be able to read from CloudWatch
  - i.e. run `bin/setup` then `aws-vault exec gds-forms-dev-admin -- bin/rails s`
- have a live form set up locally whose `live_at` date is before today (you may need to fake this in the database)

### Screenshots
#### Message shown for a form with no starts in the last week
![A large heading that says 'A live form with metrics, followed by a smaller heading that says 'Form metrics for the past 7 days: 5 October to 11 October 2023'. Under the headings there is inset text that says 'No metrics are available as no-one has started or submitted a form in the past 7 days.This may be because the form is no longer published on GOV.UK.'](https://github.com/alphagov/forms-admin/assets/5861235/2f534efe-5e4a-45c7-acb3-ae87a1840010)

#### Form with available stats in the last week
![A large heading that says 'A live form with metrics, followed by a smaller heading that says 'Form metrics for the past 7 days: 5 October to 11 October 2023'.  Under the headings there is inset text that says 'If you want to track metrics over a longer period you'll need to make a note of these on the same day each week', and under that are three boxes containing form metrics. The metrics are 'Completion rate 66%', 'Forms submitted 1032' and 'Forms started but not completed 536' where in each acase the number in the box is in a large font size.](https://github.com/alphagov/forms-admin/assets/5861235/154081ce-f1bf-44d3-9d2c-e379fae4e045)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?