### PR TITLE
Add forms started CloudWatch metrics

### DIFF
--- a/app/service/cloud_watch_service.rb
+++ b/app/service/cloud_watch_service.rb
@@ -1,8 +1,9 @@
 class CloudWatchService
+  REGION = "eu-west-2".freeze
+  A_WEEK = 604_800
+
   def self.week_submissions(form_id:)
-    region = "eu-west-2"
-    a_week = 604_800
-    cloudwatch_client = Aws::CloudWatch::Client.new(region:)
+    cloudwatch_client = Aws::CloudWatch::Client.new(region: REGION)
 
     response = cloudwatch_client.get_metric_statistics({
       metric_name: "submitted",
@@ -15,7 +16,29 @@ class CloudWatchService
       ],
       start_time: start_of_today - 7.days,
       end_time: start_of_today,
-      period: a_week,
+      period: A_WEEK,
+      statistics: %w[Sum],
+      unit: "Count",
+    })
+
+    response.datapoints[0]&.sum.to_i || 0
+  end
+
+  def self.week_starts(form_id:)
+    cloudwatch_client = Aws::CloudWatch::Client.new(region: REGION)
+
+    response = cloudwatch_client.get_metric_statistics({
+      metric_name: "started",
+      namespace: metric_namespace.to_s,
+      dimensions: [
+        {
+          name: "form_id",
+          value: form_id.to_s,
+        },
+      ],
+      start_time: start_of_today - 7.days,
+      end_time: start_of_today,
+      period: A_WEEK,
       statistics: %w[Sum],
       unit: "Count",
     })

--- a/spec/service/cloud_watch_service_spec.rb
+++ b/spec/service/cloud_watch_service_spec.rb
@@ -1,21 +1,22 @@
 require "rails_helper"
 
 describe CloudWatchService do
+  let(:forms_env) { "test" }
+  let(:form_id) { 3 }
+
+  before do
+    allow(Settings).to receive(:forms_env).and_return(forms_env)
+  end
+
+  around do |example|
+    Timecop.freeze(Time.zone.local(2021, 1, 1, 4, 30, 0)) do
+      example.run
+    end
+  end
+
   describe "#week_submissions" do
-    let(:forms_env) { "test" }
-    let(:form_id) { 3 }
     let(:datapoints) { [{ sum: total_submissions }] }
     let(:total_submissions) { 3.0 }
-
-    around do |example|
-      Timecop.freeze(Time.zone.local(2021, 1, 1, 4, 30, 0)) do
-        example.run
-      end
-    end
-
-    before do
-      allow(Settings).to receive(:forms_env).and_return(forms_env)
-    end
 
     it "calls the cloudwatch client with get_metric_statistics" do
       cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
@@ -38,6 +39,22 @@ describe CloudWatchService do
         statistics: %w[Sum],
         unit: "Count",
       }).and_return(metric_response)
+
+      expect(cloudwatch_client).to receive(:get_metric_statistics).with({
+        metric_name: "submitted",
+        namespace: "forms/#{forms_env}",
+        dimensions: [
+          {
+            name: "form_id",
+            value: form_id.to_s,
+          },
+        ],
+        start_time: Time.zone.now.midnight - 7.days,
+        end_time: Time.zone.now.midnight,
+        period: 604_800,
+        statistics: %w[Sum],
+        unit: "Count",
+      }).once
 
       described_class.week_submissions(form_id:)
     end
@@ -63,6 +80,76 @@ describe CloudWatchService do
         allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
 
         expect(described_class.week_submissions(form_id:)).to eq(0)
+      end
+    end
+  end
+
+  describe "#week_starts" do
+    let(:datapoints) { [{ sum: total_starts }] }
+    let(:total_starts) { 5.0 }
+
+    it "calls the cloudwatch client with get_metric_statistics" do
+      cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+      metric_response = cloudwatch_client.stub_data(:get_metric_statistics, datapoints:)
+
+      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+      allow(cloudwatch_client).to receive(:get_metric_statistics).with({
+        metric_name: "started",
+        namespace: "forms/#{forms_env}",
+        dimensions: [
+          {
+            name: "form_id",
+            value: form_id.to_s,
+          },
+        ],
+        start_time: Time.zone.now.midnight - 7.days,
+        end_time: Time.zone.now.midnight,
+        period: 604_800,
+        statistics: %w[Sum],
+        unit: "Count",
+      }).and_return(metric_response)
+
+      expect(cloudwatch_client).to receive(:get_metric_statistics).with({
+        metric_name: "started",
+        namespace: "forms/#{forms_env}",
+        dimensions: [
+          {
+            name: "form_id",
+            value: form_id.to_s,
+          },
+        ],
+        start_time: Time.zone.now.midnight - 7.days,
+        end_time: Time.zone.now.midnight,
+        period: 604_800,
+        statistics: %w[Sum],
+        unit: "Count",
+      }).once
+
+      described_class.week_starts(form_id:)
+    end
+
+    it "returns the sum for the datapoint in the response" do
+      cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+      metric_response = cloudwatch_client.stub_data(:get_metric_statistics, datapoints:)
+      cloudwatch_client.stub_responses(:get_metric_statistics, metric_response)
+
+      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+      expect(described_class.week_starts(form_id:)).to eq(total_starts)
+    end
+
+    context "when there is no submission data for the form" do
+      let(:datapoints) { [] }
+
+      it "returns 0 if there is no data for the form" do
+        cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+        metric_response = cloudwatch_client.stub_data(:get_metric_statistics, datapoints:)
+        cloudwatch_client.stub_responses(:get_metric_statistics, metric_response)
+
+        allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+        expect(described_class.week_starts(form_id:)).to eq(0)
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: [1076-fetch-from-cloudwatch-the-total-started-forms-for-the-last-7-days-in-forms-admin
](https://trello.com/c/pwgdk1Tm/1076-fetch-from-cloudwatch-the-total-started-forms-for-the-last-7-days-in-forms-admin)
Continuing on from https://github.com/alphagov/forms-runner/pull/443, this change creates a new class method for obtaining the number of times the form has been started in the last week. There's a little bit of refactoring to remove some duplication. There is still a lot of duplication, but removing it seemed a bit unclean, and it's nice to have each method be in control of its own API call. 

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
