### PR TITLE
Add Sentry logging to metrics error handler

### DIFF
--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -24,7 +24,9 @@ class Forms::LiveController < Forms::BaseController
       form_is_new:,
     }
   rescue Aws::CloudWatch::Errors::ServiceError,
-         Aws::Errors::MissingCredentialsError
+         Aws::Errors::MissingCredentialsError => e
+
+    Sentry.capture_exception(e)
     nil
   end
 

--- a/spec/controller/forms/live_controller_spec.rb
+++ b/spec/controller/forms/live_controller_spec.rb
@@ -54,11 +54,13 @@ describe Forms::LiveController, type: :controller do
       end
 
       before do
+        allow(Sentry).to receive(:capture_exception)
         allow(CloudWatchService).to receive(:week_starts).and_raise(Aws::Errors::MissingCredentialsError)
       end
 
-      it "returns nil" do
+      it "returns nil and logs the exception in Sentry" do
         expect(live_controller.metrics_data).to eq(nil)
+        expect(Sentry).to have_received(:capture_exception).once
       end
     end
 
@@ -69,10 +71,12 @@ describe Forms::LiveController, type: :controller do
 
       before do
         allow(CloudWatchService).to receive(:week_starts).and_raise(Aws::CloudWatch::Errors::ServiceError)
+        allow(Sentry).to receive(:capture_exception)
       end
 
-      it "returns nil" do
+      it "returns nil and logs the exception in Sentry" do
         expect(live_controller.metrics_data).to eq(nil)
+        expect(Sentry).to have_received(:capture_exception).once
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: None

When turning on the metrics feature in dev, we discovered that the feature was throwing an error. Because we're handling the error in the `live_controller`'s `metrics_data` method, we were unintentionally suppressing errors from being logged in Sentry. This PR restores that behaviour and includes it in the tests, so that we can debug the issue on dev more easily and be alerted if errors happen again in future.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
