### PR TITLE
Prevent unnecessary CloudWatch request

### DIFF
--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -11,6 +11,8 @@ class Forms::LiveController < Forms::BaseController
   end
 
   def metrics_data
+    return nil unless FeatureService.enabled?(:metrics_for_form_creators_enabled)
+
     # If the form went live today, there won't be any metrics to show
     today = Time.zone.today
     form_is_new = Time.zone.parse(current_live_form.live_at.to_s) >= today.midnight

--- a/spec/controller/forms/live_controller_spec.rb
+++ b/spec/controller/forms/live_controller_spec.rb
@@ -14,7 +14,7 @@ describe Forms::LiveController, type: :controller do
     }
   end
 
-  describe "#metrics_data" do
+  describe "#metrics_data", feature_metrics_for_form_creators_enabled: true do
     before do
       allow(live_controller).to receive(:current_live_form).and_return(form)
       ActiveResource::HttpMock.respond_to(false) do |mock|
@@ -77,6 +77,12 @@ describe Forms::LiveController, type: :controller do
       it "returns nil and logs the exception in Sentry" do
         expect(live_controller.metrics_data).to eq(nil)
         expect(Sentry).to have_received(:capture_exception).once
+      end
+    end
+
+    context "when the metrics feature flag is off", feature_metrics_for_form_creators_enabled: false do
+      it "returns nil" do
+        expect(live_controller.metrics_data).to eq(nil)
       end
     end
   end

--- a/spec/requests/forms/live_controller_spec.rb
+++ b/spec/requests/forms/live_controller_spec.rb
@@ -53,9 +53,29 @@ RSpec.describe Forms::LiveController, type: :request do
           build(:form, :live, id: 2, live_at: Time.zone.now - 1.day)
         end
 
-        it "does not read the Cloudwatch API" do
+        it "reads the Cloudwatch API" do
           expect(CloudWatchService).to have_received(:week_submissions).once
           expect(CloudWatchService).to have_received(:week_starts).once
+        end
+      end
+    end
+
+    context "when the metrics feature flag is off", feature_metrics_for_form_creators_enabled: false do
+      context "when the form went live today" do
+        it "does not read the Cloudwatch API" do
+          expect(CloudWatchService).not_to have_received(:week_submissions)
+          expect(CloudWatchService).not_to have_received(:week_starts)
+        end
+      end
+
+      context "when the form went live before today" do
+        let(:form) do
+          build(:form, :live, id: 2, live_at: Time.zone.now - 1.day)
+        end
+
+        it "does not read the Cloudwatch API" do
+          expect(CloudWatchService).not_to have_received(:week_submissions)
+          expect(CloudWatchService).not_to have_received(:week_starts)
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: None

We have a feature flag (:metrics_for_form_creators_enabled) to determine whether the metric component should be displayed on the live form page.

Currently we only use this flag in the component view file, to detemine whether the component should be rendered, but we don't use the flag in the controller. This means that we still send the get_metric_statistics request to CloudWatch, even if we're not going to render the metrics component.

This PR adds a guard clause to the controller's metrics_data method, so that the CloudWatch requests will not be sent if the flag is off.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
