### PR TITLE
Prevent metrics summary's start and end dates from breaking across lines

### DIFF
--- a/app/components/metrics_summary_component/_index.scss
+++ b/app/components/metrics_summary_component/_index.scss
@@ -34,3 +34,7 @@
   display: block;
   margin-top: govuk-spacing(1);
 }
+
+.app-metrics__date {
+  white-space: nowrap;
+}

--- a/app/components/metrics_summary_component/view.html.erb
+++ b/app/components/metrics_summary_component/view.html.erb
@@ -1,5 +1,5 @@
 <div class="app-metrics">
-  <h2 class="govuk-heading-l"><%= t("metrics_summary.heading", formatted_date_range:) %></h2>
+  <h2 class="govuk-heading-l"><%= t("metrics_summary.heading", formatted_date_range:).html_safe %></h2>
   <% if error_message.present? %>
     <div class="govuk-inset-text">
         <%= error_message.html_safe %>

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -47,7 +47,7 @@ module MetricsSummaryComponent
     end
 
     def format_date(date)
-      date.strip
+      "<span class=\"app-metrics__date\">#{date.strip}</span>"
     end
   end
 end

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -28,7 +28,9 @@ module MetricsSummaryComponent
 
     def formatted_date_range
       start_date_format_string = start_date.year == end_date.year ? "%e %B" : "%e %B %Y"
-      I18n.t("metrics_summary.date_range", start_date: start_date.strftime(start_date_format_string).strip, end_date: end_date.strftime("%e %B %Y").strip)
+      formatted_start_date = format_date(start_date.strftime(start_date_format_string))
+      formatted_end_date = format_date(end_date.strftime("%e %B %Y"))
+      I18n.t("metrics_summary.date_range", start_date: formatted_start_date, end_date: formatted_end_date)
     end
 
     def calculate_percentage(number, total)
@@ -42,6 +44,10 @@ module MetricsSummaryComponent
     def set_dates
       @start_date = 1.week.ago.to_date
       @end_date = 1.day.ago.to_date
+    end
+
+    def format_date(date)
+      date.strip
     end
   end
 end

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
   end
 
   it "renders the start and end dates" do
-    expect(page).to have_css("h2", text: Nokogiri::HTML(metrics_summary.formatted_date_range).text)
+    expect(render_inline(metrics_summary).to_html).to include(metrics_summary.formatted_date_range)
   end
 
   describe "#formatted_date_range" do
@@ -59,7 +59,7 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
     end
 
     it "renders the error message" do
-      expect(page).to have_css(".govuk-inset-text", text: Nokogiri::HTML(metrics_summary.error_message).text)
+      expect(render_inline(metrics_summary).to_html).to include(metrics_summary.error_message)
     end
   end
 
@@ -71,7 +71,7 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
     end
 
     it "renders the error message" do
-      expect(page).to have_css(".govuk-inset-text", text: Nokogiri::HTML(metrics_summary.error_message).text)
+      expect(render_inline(metrics_summary).to_html).to include(metrics_summary.error_message)
     end
   end
 
@@ -83,7 +83,7 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
     end
 
     it "renders the error message" do
-      expect(page).to have_css(".govuk-inset-text", text: Nokogiri::HTML(metrics_summary.error_message).text)
+      expect(render_inline(metrics_summary).to_html).to include(metrics_summary.error_message)
     end
   end
 

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
   end
 
   it "renders the start and end dates" do
-    expect(page).to have_css("h2", text: metrics_summary.formatted_date_range)
+    expect(page).to have_css("h2", text: Nokogiri::HTML(metrics_summary.formatted_date_range).text)
   end
 
   describe "#formatted_date_range" do
@@ -25,7 +25,7 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
       end
 
       it "returns the full start and end dates" do
-        expect(metrics_summary.formatted_date_range).to eq("25 December 2023 to 2 January 2024")
+        expect(metrics_summary.formatted_date_range).to eq("<span class=\"app-metrics__date\">25 December 2023</span> to <span class=\"app-metrics__date\">2 January 2024</span>")
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
       end
 
       it "returns the start date without the year" do
-        expect(metrics_summary.formatted_date_range).to eq("31 October to 8 November 2023")
+        expect(metrics_summary.formatted_date_range).to eq("<span class=\"app-metrics__date\">31 October</span> to <span class=\"app-metrics__date\">8 November 2023</span>")
       end
     end
   end

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
   end
 
   it "renders the start and end dates" do
-    expect(page).to have_text(metrics_summary.formatted_date_range)
+    expect(page).to have_css("h2", text: metrics_summary.formatted_date_range)
   end
 
   describe "#formatted_date_range" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/eZZKFbZ8/1091-stop-dates-breaking-across-lines-in-metrics-summary-component

Adds a new class to the dates in the `formatted_date_range` method and uses CSS `white-space: nowrap` to stop the dates from breaking across lines.

Also includes:

- a small refactor to make the above easier to implement. 
- an update to the tests to check the HTML rendered by `render_inline` rather than using Nokogiri's `text` method.

See the individual commit messages if you'd like further detail on these.

### Screenshots
#### Before
![Text reading 'Form metrics for the past 7 days: 6 October to 12 October 2023' where the line breaks between the colon after the word the number 6 and the word 'October'.](https://github.com/alphagov/forms-admin/assets/5861235/d26b23f5-e4e5-4780-b533-75d0bcbfe6f3)

#### After 
![Text reading 'Form metrics for the past 7 days: 6 October to 12 October 2023' where the line breaks between the colon after the word 'days' and the number 6.](https://github.com/alphagov/forms-admin/assets/5861235/ff99dac4-a031-4476-9440-aa00adaa4a0c)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
