### PR TITLE
Add view for incomplete week of metrics

### DIFF
--- a/app/components/metrics_summary_component/view.html.erb
+++ b/app/components/metrics_summary_component/view.html.erb
@@ -1,5 +1,5 @@
 <div class="app-metrics">
-  <h2 class="govuk-heading-l"><%= t("metrics_summary.heading", number_of_days:, formatted_date_range:).html_safe %></h2>
+  <h2 class="govuk-heading-l"><%= heading %></h2>
   <% if error_message.present? %>
     <div class="govuk-inset-text">
         <%= error_message.html_safe %>

--- a/app/components/metrics_summary_component/view.html.erb
+++ b/app/components/metrics_summary_component/view.html.erb
@@ -5,7 +5,9 @@
         <%= error_message.html_safe %>
     </div>
   <% else %>
-    <p><%= t("metrics_summary.description") %></p>
+    <p>
+      <%= description %>
+    </p>
     <div class="app-metrics__container">
       <div class="app-metrics__big-number">
         <%= t("metrics_summary.completion_rate") %> <span class="app-metrics__big-number-number"><%= weekly_completion_rate %></span>

--- a/app/components/metrics_summary_component/view.html.erb
+++ b/app/components/metrics_summary_component/view.html.erb
@@ -1,5 +1,5 @@
 <div class="app-metrics">
-  <h2 class="govuk-heading-l"><%= t("metrics_summary.heading", formatted_date_range:).html_safe %></h2>
+  <h2 class="govuk-heading-l"><%= t("metrics_summary.heading", number_of_days:, formatted_date_range:).html_safe %></h2>
   <% if error_message.present? %>
     <div class="govuk-inset-text">
         <%= error_message.html_safe %>

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -4,9 +4,10 @@ module MetricsSummaryComponent
   class View < ViewComponent::Base
     attr_accessor :start_date, :end_date, :weekly_submissions, :weekly_starts, :weekly_started_but_not_completed, :weekly_completion_rate, :form_has_metrics, :error_message
 
-    def initialize(metrics_data)
+    def initialize(form_live_date, metrics_data)
       super
-      set_dates
+      @start_date = [form_live_date, 7.days.ago.to_date].max
+      @end_date = 1.day.ago.to_date
 
       if metrics_data.nil?
         @error_message = I18n.t("metrics_summary.errors.error_loading_data_html")
@@ -54,11 +55,6 @@ module MetricsSummaryComponent
     end
 
   private
-
-    def set_dates
-      @start_date = 1.week.ago.to_date
-      @end_date = 1.day.ago.to_date
-    end
 
     def format_date(date)
       "<span class=\"app-metrics__date\">#{date.strip}</span>"

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -39,10 +39,18 @@ module MetricsSummaryComponent
       (end_date - start_date).to_i + 1
     end
 
+    def complete_week?
+      number_of_days == 7
+    end
+
     def calculate_percentage(number, total)
       return nil if total.zero?
 
       (number.to_f * 100 / total).round
+    end
+
+    def description
+      complete_week? ? I18n.t("metrics_summary.description.complete_week") : I18n.t("metrics_summary.description.incomplete_week")
     end
 
   private

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -33,6 +33,12 @@ module MetricsSummaryComponent
       I18n.t("metrics_summary.date_range", start_date: formatted_start_date, end_date: formatted_end_date)
     end
 
+    def number_of_days
+      # We add 1 because we're calculating the number of days from the start date
+      # to end date inclusive, not the difference between them
+      (end_date - start_date).to_i + 1
+    end
+
     def calculate_percentage(number, total)
       return nil if total.zero?
 

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -2,12 +2,13 @@
 
 module MetricsSummaryComponent
   class View < ViewComponent::Base
-    attr_accessor :start_date, :end_date, :weekly_submissions, :weekly_starts, :weekly_started_but_not_completed, :weekly_completion_rate, :form_has_metrics, :error_message
+    attr_accessor :start_date, :end_date, :weekly_submissions, :weekly_starts, :weekly_started_but_not_completed, :weekly_completion_rate, :form_has_metrics, :error_message, :heading
 
     def initialize(form_live_date, metrics_data)
       super
       @start_date = [form_live_date, 7.days.ago.to_date].max
       @end_date = 1.day.ago.to_date
+      @heading = heading_text.html_safe
 
       if metrics_data.nil?
         @error_message = I18n.t("metrics_summary.errors.error_loading_data_html")
@@ -52,6 +53,16 @@ module MetricsSummaryComponent
 
     def description
       complete_week? ? I18n.t("metrics_summary.description.complete_week") : I18n.t("metrics_summary.description.incomplete_week")
+    end
+
+    def heading_text
+      if start_date == Time.zone.today
+        I18n.t("metrics_summary.heading_without_dates")
+      elsif start_date == Time.zone.yesterday
+        I18n.t("metrics_summary.heading_with_single_date", date: format_date(start_date.strftime("%e %B %Y")))
+      else
+        I18n.t("metrics_summary.heading_with_dates", number_of_days:, formatted_date_range:)
+      end
     end
 
   private

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -15,7 +15,8 @@ class Forms::LiveController < Forms::BaseController
 
     # If the form went live today, there won't be any metrics to show
     today = Time.zone.today
-    form_is_new = Time.zone.parse(current_live_form.live_at.to_s) >= today.midnight
+
+    form_is_new = current_live_form.made_live_date == today
 
     weekly_submissions = form_is_new ? 0 : CloudWatchService.week_submissions(form_id: current_live_form.id)
     weekly_starts = form_is_new ? 0 : CloudWatchService.week_starts(form_id: current_live_form.id)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -71,6 +71,10 @@ class Form < ActiveResource::Base
     (index.nil? ? pages.length : index) + 1
   end
 
+  def made_live_date
+    Time.zone.parse(live_at.to_s).to_date if defined?(live_at)
+  end
+
 private
 
   def has_routing_conditions

--- a/app/views/live/show_form.html.erb
+++ b/app/views/live/show_form.html.erb
@@ -9,7 +9,7 @@
     </h1>
     <%= render FormStatusTagDescriptionComponent::View.new(status: :live) %>
 
-    <%= render MetricsSummaryComponent::View.new(metrics_data) %>
+    <%= render MetricsSummaryComponent::View.new(form.made_live_date, metrics_data) %>
 
     <h2 class="govuk-heading-l">Your form</h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -497,7 +497,9 @@ en:
         <p>This may be because the form is no longer published on GOV.UK.</p>
     forms_started_but_not_completed: Forms started but not completed
     forms_submitted: Forms submitted
-    heading: 'Form metrics for the past %{number_of_days} days: %{formatted_date_range}'
+    heading_with_dates: 'Form metrics for the past %{number_of_days} days: %{formatted_date_range}'
+    heading_with_single_date: Form metrics for %{date}
+    heading_without_dates: Form metrics
     percentage: "%{number}%"
   new_condition:
     routing_page_text: If the question

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,7 +477,9 @@ en:
   metrics_summary:
     completion_rate: Completion rate
     date_range: "%{start_date} to %{end_date}"
-    description: If you want to track metrics over a longer period you'll need to make a note of these on the same day each week.
+    description:
+      complete_week: If you want to track metrics over a longer period you'll need to make a note of these on the same day each week.
+      incomplete_week: The metrics shown here are for less than a week. To see a full week’s metrics, check again when your form’s been live for 7 days.
     errors:
       error_loading_data_html: |
         <p>Sorry, there's a problem getting your form's metrics.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -495,7 +495,7 @@ en:
         <p>This may be because the form is no longer published on GOV.UK.</p>
     forms_started_but_not_completed: Forms started but not completed
     forms_submitted: Forms submitted
-    heading: 'Form metrics for the past 7 days: %{formatted_date_range}'
+    heading: 'Form metrics for the past %{number_of_days} days: %{formatted_date_range}'
     percentage: "%{number}%"
   new_condition:
     routing_page_text: If the question

--- a/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
+++ b/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
@@ -1,21 +1,26 @@
 class MetricsSummaryComponent::MetricsSummaryComponentPreview < ViewComponent::Preview
   def with_no_metrics_data
     metrics_data = nil
-    render(MetricsSummaryComponent::View.new(metrics_data))
+    render(MetricsSummaryComponent::View.new(20.days.ago.to_date, metrics_data))
   end
 
   def with_a_new_form
     metrics_data = { weekly_submissions: 0, form_is_new: true, weekly_starts: 0 }
-    render(MetricsSummaryComponent::View.new(metrics_data))
+    render(MetricsSummaryComponent::View.new(20.days.ago.to_date, metrics_data))
   end
 
   def with_no_weekly_starts
     metrics_data = { weekly_submissions: 0, form_is_new: false, weekly_starts: 0 }
-    render(MetricsSummaryComponent::View.new(metrics_data))
+    render(MetricsSummaryComponent::View.new(20.days.ago.to_date, metrics_data))
   end
 
   def with_metrics_available
     metrics_data = { weekly_submissions: 1032, form_is_new: false, weekly_starts: 1568 }
-    render(MetricsSummaryComponent::View.new(metrics_data))
+    render(MetricsSummaryComponent::View.new(20.days.ago.to_date, metrics_data))
+  end
+
+  def with_less_than_a_week_worth_of_metrics
+    metrics_data = { weekly_submissions: 1032, form_is_new: false, weekly_starts: 1568 }
+    render(MetricsSummaryComponent::View.new(3.days.ago.to_date, metrics_data))
   end
 end

--- a/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
+++ b/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
@@ -6,7 +6,12 @@ class MetricsSummaryComponent::MetricsSummaryComponentPreview < ViewComponent::P
 
   def with_a_new_form
     metrics_data = { weekly_submissions: 0, form_is_new: true, weekly_starts: 0 }
-    render(MetricsSummaryComponent::View.new(20.days.ago.to_date, metrics_data))
+    render(MetricsSummaryComponent::View.new(Time.zone.today.to_date, metrics_data))
+  end
+
+  def with_a_form_that_went_live_yesterday
+    metrics_data = { weekly_submissions: 3, form_is_new: false, weekly_starts: 6 }
+    render(MetricsSummaryComponent::View.new(1.day.ago.to_date, metrics_data))
   end
 
   def with_no_weekly_starts

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -66,6 +66,22 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
     end
   end
 
+  describe "#description" do
+    context "when there is a week's worth of metrics" do
+      it "returns the complete week description translation" do
+        expect(metrics_summary.description).to eq(I18n.t("metrics_summary.description.complete_week"))
+      end
+    end
+
+    context "when there is less than a week's worth of metrics" do
+      let(:form_live_date) { 3.days.ago.to_date }
+
+      it "returns the incomplete week description translation" do
+        expect(metrics_summary.description).to eq(I18n.t("metrics_summary.description.incomplete_week"))
+      end
+    end
+  end
+
   context "when metrics_data is null" do
     it "returns the 'error loading data' message" do
       expect(metrics_summary.error_message).to eq(I18n.t("metrics_summary.errors.error_loading_data_html"))
@@ -117,8 +133,39 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
       expect(metrics_summary.weekly_started_but_not_completed).to eq(forms_started_but_not_completed)
     end
 
-    it "renders the description text" do
-      expect(page).to have_text(I18n.t("metrics_summary.description"))
+    it "renders the complete week description text" do
+      expect(page).to have_text(I18n.t("metrics_summary.description.complete_week"))
+    end
+
+    it "renders the weekly submissions figure" do
+      expect(page).to have_text("#{I18n.t('metrics_summary.forms_submitted')} #{metrics_data[:weekly_submissions]}")
+    end
+
+    it "renders the forms started but not completed figure" do
+      expect(page).to have_text("#{I18n.t('metrics_summary.forms_started_but_not_completed')} #{forms_started_but_not_completed}")
+    end
+  end
+
+  context "when there are fewer than 7 days worth of data" do
+    let(:metrics_data) { { weekly_submissions: 269, form_is_new: false, weekly_starts: 1000 } }
+    let(:forms_started_but_not_completed) { metrics_data[:weekly_starts] - metrics_data[:weekly_submissions] }
+    let(:percentage) { metrics_summary.calculate_percentage(metrics_data[:weekly_submissions], metrics_data[:weekly_starts]) }
+    let(:start_date) { 3.days.ago.to_date }
+
+    it "renders the completion rate percentage" do
+      expect(page).to have_text("#{I18n.t('metrics_summary.completion_rate')} #{percentage}%")
+    end
+
+    it "returns the metrics component with the number of submissions" do
+      expect(metrics_summary.weekly_submissions).to eq(metrics_data[:weekly_submissions])
+    end
+
+    it "returns the metrics component with the number of forms started but not completed" do
+      expect(metrics_summary.weekly_started_but_not_completed).to eq(forms_started_but_not_completed)
+    end
+
+    it "renders the incomplete week description text" do
+      expect(page).to have_text(I18n.t("metrics_summary.description.incomplete_week"))
     end
 
     it "renders the weekly submissions figure" do

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_for_form_creators_enabled: true do
   let(:metrics_data) { nil }
-  let(:metrics_summary) { described_class.new(metrics_data) }
+  let(:form_live_date) { 7.days.ago.to_date }
+  let(:metrics_summary) { described_class.new(form_live_date, metrics_data) }
 
   before do
     render_inline(metrics_summary)
@@ -59,7 +60,6 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
 
   describe "#number_of_days" do
     it "returns the number of days between the start date and today's date, inclusive" do
-      metrics_summary.start_date = 1.week.ago.to_date
       metrics_summary.end_date = 1.day.ago.to_date
 
       expect(metrics_summary.number_of_days).to eq(7)
@@ -150,7 +150,7 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
     let(:metrics_data) { { weekly_submissions: 269, form_is_new: false, weekly_starts: 1000 } }
     let(:forms_started_but_not_completed) { metrics_data[:weekly_starts] - metrics_data[:weekly_submissions] }
     let(:percentage) { metrics_summary.calculate_percentage(metrics_data[:weekly_submissions], metrics_data[:weekly_starts]) }
-    let(:start_date) { 3.days.ago.to_date }
+    let(:form_live_date) { 3.days.ago.to_date }
 
     it "renders the completion rate percentage" do
       expect(page).to have_text("#{I18n.t('metrics_summary.completion_rate')} #{percentage}%")

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
     expect(render_inline(metrics_summary).to_html).to include(metrics_summary.formatted_date_range)
   end
 
+  it "renders the number of days spanned" do
+    expect(page).to have_css("h2", text: metrics_summary.number_of_days)
+  end
+
   describe "#formatted_date_range" do
     context "when the start and end dates are in different years" do
       before do
@@ -50,6 +54,15 @@ RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_
       expect(metrics_summary.calculate_percentage(168, 1000)).to eq(17)
       expect(metrics_summary.calculate_percentage(253, 1000)).to eq(25)
       expect(metrics_summary.calculate_percentage(965, 1000)).to eq(97)
+    end
+  end
+
+  describe "#number_of_days" do
+    it "returns the number of days between the start date and today's date, inclusive" do
+      metrics_summary.start_date = 1.week.ago.to_date
+      metrics_summary.end_date = 1.day.ago.to_date
+
+      expect(metrics_summary.number_of_days).to eq(7)
     end
   end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -229,4 +229,18 @@ describe Form, type: :model do
       end
     end
   end
+
+  describe "#made_live_date" do
+    it "returns nil" do
+      expect(form.made_live_date).to eq(nil)
+    end
+
+    context "when the form is live" do
+      let(:form) { described_class.new(id: 1, name: "Form 1", organisation:, submission_email: "", live_at: Time.zone.now.to_s) }
+
+      it "returns the date the form went live" do
+        expect(form.made_live_date).to eq(form.live_at.to_date)
+      end
+    end
+  end
 end

--- a/spec/views/live/show_form.html.erb_spec.rb
+++ b/spec/views/live/show_form.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe "live/show_form.html.erb", feature_metrics_for_form_creators_enabled: f
   let(:declaration) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:what_happens_next) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:form_metadata) { OpenStruct.new(has_draft_version: false) }
-  let(:form) { build(:form, :live, id: 2, declaration_text: declaration, what_happens_next_text: what_happens_next) }
+  let(:form) { build(:form, :live, id: 2, declaration_text: declaration, what_happens_next_text: what_happens_next, live_at: 1.week.ago) }
   let(:metrics_data) { nil }
 
   before do
@@ -130,7 +130,7 @@ describe "live/show_form.html.erb", feature_metrics_for_form_creators_enabled: f
     let(:metrics_data) { { weekly_submissions: 125, form_is_new: false, weekly_starts: 256 } }
 
     it "renders the metrics summary component" do
-      expect(rendered).to have_text(I18n.t("metrics_summary.description"))
+      expect(rendered).to have_text(I18n.t("metrics_summary.description.complete_week"))
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/JSIJWVBM/1095-add-a-variation-of-the-metrics-component-for-when-the-form-has-less-than-a-weeks-worth-of-data

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
This PR adds logic to vary the heading and description text in the metrics component if the form went live less than a week ago. Specifically this PR:
 - Makes the number of days in the heading text ("Form metrics for the past 7 days: 9 October to 15 October 2023") vary (e.g. "Form metrics for the past 3 days: 13 October to 15 October 2023")
 - Adds a new translation for the description (`t("metrics_summary.description.incomplete_week")`)
 - Adds some logic to vary the heading depending on when the form went live. This is necessary to prevent the following bug cases:
   - a form that went live today showing the heading "Form metrics for the past 0 days: 17 October to 16 October 2023."
   - a form that went live yesterday showing the heading "Form metrics for the past 1 days: 16 October to 16 October 2023."

To make this work we have to pass the form's `live_at` date into the component, so this PR includes that too.

### Screenshots

Previously we'd see this view, even if the form went live after the start date the heading is claiming: 
![A heading with text "Form metrics for the past 7 days: 10 October to 16 October 2023." and a description with the text "If you want to track metrics over a longer period you'll need to make a note of these on the same day each week."](https://github.com/alphagov/forms-admin/assets/5861235/a4c209b3-5352-48d3-bcf3-e1644643cf26)

#### For a form that went live less than a week ago, but not today or yesterday
![A heading with text "Form metrics for the past 3 days: 14 October to 16 October 2023." and a description with the text "The metrics shown here are for less than a week. To see a full week’s metrics, check again when your form’s been live for 7 days."](https://github.com/alphagov/forms-admin/assets/5861235/3fdc6604-1a12-4ef4-bd9e-d02430de6230)

#### For a form that went live yesterday
![A heading with text "Form metrics for 16 October 2023." and a description with the text "The metrics shown here are for less than a week. To see a full week’s metrics, check again when your form’s been live for 7 days."](https://github.com/alphagov/forms-admin/assets/5861235/b56f6e15-03f5-4121-8f6b-b122cda0c6c2)

#### For a form that went live today
![A heading with text "Form metrics" and inset text with the text "No metrics are available yet as no-one has started or submitted a form since it went live."](https://github.com/alphagov/forms-admin/assets/5861235/c96b5821-80bd-432e-adc5-4cee20283cde)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
