### PR TITLE
Revise error message for edit user page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
         user:
           attributes:
             name:
-              blank: You must enter a name for editor or super admin users
+              blank: Enter the user’s name
             organisation_id:
               blank: Select the user’s organisation
             role:

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe UsersController, type: :request do
         it "does not update user if name is cleared" do
           put user_path(user), params: { user: { name: nil } }
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(response.body).to include "You must enter a name for editor or super admin users"
+          expect(response.body).to include "Enter the user’s name"
           expect(user.reload.organisation).not_to eq(nil)
         end
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/tUxg95jK/1068-allow-super-admins-to-add-and-change-a-users-name <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Change the name blank error message to be more consistent with the organisation blank error message.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?

<details>
<summary><h3>Screenshots</h3></summary>


![Screenshot of edit user page; two errors are shown as a save was attempted with the role as editor but no name or organisation is set.](https://github.com/alphagov/forms-admin/assets/503614/a2dba9b9-fab1-4e0f-87f3-4bcc1529aed9)


</details>