### PR TITLE
Fix test passing with false positive

### DIFF
--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -53,8 +53,14 @@ describe "users/edit.html.erb" do
       expect(summary_list).to have_text(user.email)
     end
 
-    it "contains organisation slug from GOV.UK Signon" do
-      expect(summary_list).to have_text(user.organisation_slug)
+    context "with user from GOV.UK Signon" do
+      let(:user) do
+        build :user, :with_unknown_org, role: :editor, id: 1, organisation_slug: "department-for-testing"
+      end
+
+      it "contains organisation slug from GOV.UK Signon" do
+        expect(summary_list).to have_text(user.organisation_slug)
+      end
     end
 
     it "contains organisation name" do


### PR DESCRIPTION
### What problem does this pull request solve?


This test was passing but raising the warning

```
Checking for expected text of nil is confusing and/or pointless since it will always match.
```

because `user.organisation_slug` was empty. This commit fixes the test context so there is a non-nil value for the organisation slug.



### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?