### PR TITLE
Suppress IE8 warning

### DIFF
--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -2,6 +2,9 @@ $govuk-images-path: "@govuk/assets/images/";
 $govuk-fonts-path: "@govuk/assets/fonts/";
 $govuk-new-link-styles: true;
 $govuk-global-styles: true;
+$govuk-suppressed-warnings: (
+  ie8
+);
 
 @import "govuk/all";
 @import "dfe-autocomplete/src/dfe-autocomplete";


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: none

This message is appearing because ie8 support is deprecated in govuk-frontend. We don't support Internet Explorer 8 anyway, so we can suppress this warning.

Test this by running `bin/setup` or `bin/vite build` and observing that the FE build no longer gives us the following warning: 
> The govuk-if-ie8 mixin is deprecated and will be removed in v5.0. To silence this warning, update $govuk-suppressed-warnings with key: "ie8"

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
