### PR TITLE
Remove unnecessary live check

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -77,7 +77,6 @@ class Form < ActiveResource::Base
 
   def metrics_data
     return nil unless FeatureService.enabled?(:metrics_for_form_creators_enabled)
-    return nil unless status == :live
 
     # If the form went live today, there won't be any metrics to show
     today = Time.zone.today

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -249,10 +249,6 @@ describe Form, type: :model do
       described_class.new(id: 2, live_at: Time.zone.now - 1.day)
     end
 
-    before do
-      allow(form).to receive(:status).and_return(:live)
-    end
-
     context "when the form was made today" do
       let(:form) do
         described_class.new(id: 2, live_at: Time.zone.now)
@@ -318,10 +314,6 @@ describe Form, type: :model do
     context "when the form is not live" do
       let(:form) do
         described_class.new(id: 2)
-      end
-
-      before do
-        allow(form).to receive(:status).and_return(:live)
       end
 
       it "returns nil" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: None

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
In PR #689 we added a check to see if the form is live, but this is problematic for two reasons. 

Firstly, the has_live_version property it uses isn't present in the live form JSON, so it will cause an error. Secondly, if this method is called on a non-live form, that indicates that the application has gone wrong, so we should allow this to cause an error rather than handle it silently.

This feature branch has been deployed to dev and the smoke tests pass.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
