### PR TITLE
Expire sessions after 24 hours using gds-sso config

### DIFF
--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -33,6 +33,8 @@ Rails.application.config.before_initialize do
     warden.default_strategies(Settings.auth_provider.to_sym, :gds_bearer_token)
     warden.failure_app = AuthenticationController
   end
+
+  GDS::SSO::Config.auth_valid_for = Settings.auth_valid_for
 end
 
 # Monkeypatch omniauth_openid_connect

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,6 +38,8 @@ sentry:
 # How we authenticate users
 auth_provider: # use default auth_provider from environment
 
+auth_valid_for: 86400 # the time after which re-authentication is required, in seconds
+
 auth0:
   client_id: changeme
   client_secret:


### PR DESCRIPTION
For security reasons (See [OWASP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-expiration)), we’d like to ensure forms-admin users log-in at least every 24 hours. To achieve this, we need to make sure that forms-admin re-authenticates with the current auth provider (in this case Auth0) after a given time.

This PR configures auth_valid_for for the gds-sso to require re-authentication after 24 hours. This acts as an absolute session timeout regardless of activity.

### What problem does this pull request solve?

Trello card: https://trello.com/c/yi3v9Mgo


### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
