### PR TITLE
Remove obsolete table called schema_info & session

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,15 +65,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_03_140934) do
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
-  create_table "sessions", force: :cascade do |t|
-    t.string "session_id", null: false
-    t.text "data"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
-    t.index ["updated_at"], name: "index_sessions_on_updated_at"
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,10 +65,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_03_140934) do
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
-  create_table "schema_info", id: false, force: :cascade do |t|
-    t.integer "version", default: 0, null: false
-  end
-
   create_table "sessions", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"


### PR DESCRIPTION
### What problem does this pull request solve?

Remove obsolete db tables from db/schema

@DavidBiddle could you check your local instance to see if you have `schema_info`, because it was added over 4 months ago but it could be that it has been removed since.

@thomasiles could you check your local instance and make sure it does not include `sessions` table. 

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
