### PR TITLE
Specify auth0 connection

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -9,7 +9,19 @@ class AuthenticationController < ApplicationController
 
   def redirect_to_omniauth
     store_location(attempted_path) if request.get?
-    redirect_to "/auth/#{default_provider}"
+
+    params = {}
+    if default_provider == "auth0" && e2e_user?
+      # the value passed in connection must match the name given in the auth0 terraform
+      params[:connection] = "Username-Password-Authentication"
+    end
+
+    redirect_to ActionDispatch::Http::URL.path_for(path: "/auth/#{default_provider}", params:)
+  end
+
+  def e2e_user?
+    # this should be appended to the first request in the e2e tests to activate the username/password flow
+    request.params[:auth] == "e2e"
   end
 
   def callback_from_omniauth

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -9,6 +9,7 @@ Rails.application.config.before_initialize do
     callback_path: "/auth/auth0/callback",
     authorize_params: {
       scope: "openid email",
+      connection: "email", # default to using the passwordless flow
     },
   )
 

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -68,6 +68,28 @@ RSpec.describe AuthenticationController, type: :request do
       expect(response).to redirect_to(live_form_pages_path(42))
     end
 
+    context "when the auth provider is auth0" do
+      context "and the user is the end to end test user" do
+        it "uses the Auth0 username/password flow" do
+          allow(Settings).to receive(:auth_provider).and_return("auth0")
+
+          get root_path, params: { auth: "e2e" }
+
+          expect(response).to redirect_to("/auth/auth0?connection=Username-Password-Authentication")
+        end
+      end
+
+      context "and the user is not the end to end test user" do
+        it "uses the Auth0 passwordless flow" do
+          allow(Settings).to receive(:auth_provider).and_return("auth0")
+
+          get root_path
+
+          expect(response).to redirect_to("/auth/auth0")
+        end
+      end
+    end
+
     context "when the user's session expires" do
       before do
         allow(controller_spy).to receive(:redirect_to_omniauth).and_call_original


### PR DESCRIPTION
### What problem does this pull request solve?
The end-to-end tests currently login to the admin service through auth0, which sends an email with a code. The tests then check the email and find the code which is used to login.

This method works, but may be unreliable given the number of deploys we make in production.

This PR defaults forms-admin to using the passwordless "email" authentication flow, but also allows use of the username/password flow by end-to-end tests via specification of the `force_credentials_flow` query parameter.

Trello card: https://trello.com/c/no2hfOty

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
