### PR TITLE
Add email confirmation feature flag & extra content for form filler

### DIFF
--- a/app/views/forms/contact_details/new.html.erb
+++ b/app/views/forms/contact_details/new.html.erb
@@ -16,6 +16,12 @@
 
       <%= t("contact_details.new.body_html") %>
 
+      <% if FeatureService.enabled?(:email_confirmations_enabled) %>
+        <p class="govuk-!-margin-bottom-6">
+          <%= t("contact_details.new.email_confirmation_hint_html") %>
+        </p>
+      <% end %>
+
       <%= f.govuk_check_boxes_fieldset :contact_details_supplied, legend: { text: t('contact_details.new.title') }, hint: { text: t('contact_details.new.hint') } do %>
         <%= f.govuk_check_box :contact_details_supplied, :supply_email, checked: @contact_details_form.check_email? do %>
           <%= f.govuk_text_field :email %>

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -14,7 +14,7 @@
         <%= t("page_titles.what_happens_next_form") %>
       </h1>
 
-      <p>This page will be shown after someone has completed and submitted the form to let them know that the form has been submitted successfully.</p>
+      <p>This page will be shown after someone has completed and submitted the form to let them know it's been submitted successfully.</p>
 
       <p>Add some content to let people know what will happen next and when, so they know what to expect.</p>
 
@@ -22,6 +22,15 @@
 
       <%= govuk_inset_text do %>
         We'll send you an email to let you know the outcome. You'll usually get a response within 10 working days.
+      <% end %>
+
+      <% if FeatureService.enabled?(:email_confirmations_enabled) %>
+        <p class="govuk-!-margin-bottom-6">
+          This content will also be included in an email confirming that a form's been
+          submitted - if people choose to receive this. The email will include date and
+          time of submission, and contact details for support. It will not contain
+          a copy of someone's answers.
+        </p>
       <% end %>
 
       <%= f.govuk_text_area :what_happens_next_text, max_chars: 2000, label: {size: 'm' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
         <p>
           The contact information will be displayed at the bottom of every page of the form.
         </p>
+      email_confirmation_hint_html: It will also be included in an email confirming that a form's been submitted - if people choose to receive this. The email will include the date and time of submission. It will not contain a copy of someone's answers.
       hint: Select at least one option
       title: How can people get help with filling in this form?
   contact_govuk_forms: contact the GOV.UK Forms team

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
   detailed_guidance_enabled: false
+  email_confirmations_enabled: false
   metrics_for_form_creators_enabled: false
 
 forms_api:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,7 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
   detailed_guidance_enabled: true
+  email_confirmations_enabled: true
 
 forms_api:
   # URL to form-api endpoints

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -23,6 +23,7 @@ describe "Settings" do
 
     include_examples expected_value_test, :detailed_guidance_enabled, features, false
     include_examples expected_value_test, :metrics_for_form_creators_enabled, features, false
+    include_examples expected_value_test, :email_confirmations_enabled, features, false
   end
 
   describe "forms_api" do


### PR DESCRIPTION
### What problem does this pull request solve?

- Add feature flag and enable it in dev 
- Add extra content to "What happens next" explaining that their content will be included in email confirmation sent from form-runner (paragraph just before the form field)
- Add extra content to "Support Contact" explaining that their content will be included in email confirmation sent from form-runner (paragraph just before the form field)

### What happens next
![image](https://github.com/alphagov/forms-admin/assets/3441519/01ec139d-c957-4738-9386-8457f80c043b)

### Support contact details
![image](https://github.com/alphagov/forms-admin/assets/3441519/36f964c6-afc3-4ff9-99fd-7ead20815ca0)

CC: @C-Harry @christophercameron-ixd 

Trello card: https://trello.com/c/4e46lFNU/1134-update-forms-admin-content-help-form-creators-understand-what-form-fillers-will-see-in-confirmation-emails

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
