### PR TITLE
Correct message about URL staying the same

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -387,7 +387,7 @@ en:
       <p>If you need urgent help with your forms you can %{link}.</p>
     title: Sorry, the service is unavailable
   make_changes_live:
-    url_will_remain_same: The URL for the live form will remain the same.
+    url_will_remain_same: Links to the form will still work, even if you’ve changed the form’s name.
     warning: |
       When you make your changes live, there may be an impact on people who are
       filling in the live form at the same time. They may lose any answers they


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card:https://trello.com/c/fJiGg7G8/708-make-your-changes-live-page-is-inaccurate-on-a-draft-of-a-live-form

When you make the draft of a live form live, you are told: “The URL for the live form will remain the same.“

However, the URL may be different if the form name has changed. Links to the form will still work in this case, as they rely on the first part of the URL which never changes.

So we are changing this line to be more accurate and specific - to make sure people don’t worry unnecessarily about links to their form breaking.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
