### PR TITLE
Switch guidance markdown from storing data in session to activerecord

### DIFF
--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -2,9 +2,8 @@ require "govuk_forms_markdown"
 
 class Pages::GuidanceController < PagesController
   def new
-    page_heading = session.dig(:page, :page_heading)
-    guidance_markdown = session.dig(:page, :guidance_markdown)
-    guidance_form = Pages::GuidanceForm.new(page_heading:, guidance_markdown:)
+    guidance_form = Pages::GuidanceForm.new(page_heading: draft_question.page_heading,
+                                            guidance_markdown: draft_question.guidance_markdown)
     back_link = new_question_path(@form)
     render "pages/guidance", locals: view_locals(nil, guidance_form, back_link)
   end
@@ -18,7 +17,7 @@ class Pages::GuidanceController < PagesController
       guidance_form.valid?
       render "pages/guidance", locals: view_locals(nil, guidance_form, back_link)
     when :save_and_continue
-      if guidance_form.submit(session)
+      if guidance_form.submit
         redirect_to new_question_path(@form)
       else
         render "pages/guidance", locals: view_locals(nil, guidance_form, back_link), status: :unprocessable_entity
@@ -27,10 +26,8 @@ class Pages::GuidanceController < PagesController
   end
 
   def edit
-    page.load_from_session(session, %i[answer_type page_heading guidance_markdown])
-
-    guidance_form = Pages::GuidanceForm.new(page_heading: page.page_heading,
-                                            guidance_markdown: page.guidance_markdown)
+    guidance_form = Pages::GuidanceForm.new(page_heading: draft_question.page_heading,
+                                            guidance_markdown: draft_question.guidance_markdown)
     back_link = edit_question_path(@form, page)
 
     render "pages/guidance", locals: view_locals(page, guidance_form, back_link)
@@ -45,7 +42,7 @@ class Pages::GuidanceController < PagesController
       guidance_form.valid?
       render "pages/guidance", locals: view_locals(page, guidance_form, back_link)
     when :save_and_continue
-      if guidance_form.submit(session)
+      if guidance_form.submit
         redirect_to edit_question_path(@form.id, page.id)
       else
         render "pages/guidance", locals: view_locals(page, guidance_form, back_link), status: :unprocessable_entity

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -4,16 +4,17 @@ class Pages::QuestionsController < PagesController
     question_text = session.dig(:page, :question_text)
     answer_settings = session.dig(:page, :answer_settings)
     is_optional = session.dig(:page, :is_optional) == "true"
-    page_heading = session.dig(:page, :page_heading)
-    guidance_markdown = session.dig(:page, :guidance_markdown)
+    page_heading = draft_question.page_heading
+    guidance_markdown = draft_question.guidance_markdown
     @question_form = Pages::QuestionForm.new(form_id: @form.id, answer_type:, question_text:, answer_settings:, is_optional:, draft_question:)
+
     @page = Page.new(form_id: @form.id, question_text:, answer_type:, answer_settings:, is_optional:, page_heading:, guidance_markdown:)
   end
 
   def create
     answer_settings = session.dig(:page, :answer_settings)
-    page_heading = session.dig(:page, :page_heading)
-    guidance_markdown = session.dig(:page, :guidance_markdown)
+    page_heading = draft_question.page_heading
+    guidance_markdown = draft_question.guidance_markdown
 
     @page = Page.new(page_params.merge(answer_settings:, page_heading:, guidance_markdown:))
     @question_form = Pages::QuestionForm.new(page_params.merge(answer_settings:, page_heading:, guidance_markdown:, draft_question:))
@@ -29,9 +30,11 @@ class Pages::QuestionsController < PagesController
 
   def edit
     reset_session_if_answer_settings_not_present
-    page.load_from_session(session, %i[answer_settings answer_type is_optional page_heading guidance_markdown])
+    page.load_from_session(session, %i[answer_settings answer_type is_optional])
 
-    draft_question
+    page.page_heading = draft_question.page_heading
+    page.guidance_markdown = draft_question.guidance_markdown
+
     @question_form = Pages::QuestionForm.new(form_id: @form.id,
                                              answer_type: page.answer_type,
                                              question_text: page.question_text,
@@ -41,7 +44,9 @@ class Pages::QuestionsController < PagesController
   end
 
   def update
-    page.load_from_session(session, %i[answer_type answer_settings page_heading guidance_markdown]).load(page_params)
+    page.load_from_session(session, %i[answer_type answer_settings]).load(page_params)
+    page.page_heading = draft_question.page_heading
+    page.guidance_markdown = draft_question.guidance_markdown
 
     @question_form = Pages::QuestionForm.new(page_params.merge(answer_settings: page.answer_settings,
                                                                page_heading: page.page_heading,

--- a/app/forms/pages/guidance_form.rb
+++ b/app/forms/pages/guidance_form.rb
@@ -7,17 +7,12 @@ class Pages::GuidanceForm < BaseForm
 
   validates :draft_question, presence: true
 
-  def submit(session)
+  def submit
     return false if invalid?
 
     draft_question
       .assign_attributes({ page_heading:, guidance_markdown: })
 
     draft_question.save!(validate: false)
-
-    # TODO: remove this once we have draft_questions being saved across the whole journey
-    session[:page] = {} if session[:page].blank?
-    session[:page][:page_heading] = page_heading
-    session[:page][:guidance_markdown] = guidance_markdown
   end
 end

--- a/spec/forms/pages/guidance_form_spec.rb
+++ b/spec/forms/pages/guidance_form_spec.rb
@@ -72,31 +72,19 @@ RSpec.describe Pages::GuidanceForm, type: :model do
   end
 
   describe "#submit" do
-    let(:session_mock) { {} }
-
     it "returns false if the form is invalid" do
       allow(guidance_form).to receive(:invalid?).and_return(true)
-      expect(guidance_form.submit(session_mock)).to eq false
+      expect(guidance_form.submit).to eq false
     end
 
     context "when page_heading and guidance_markdown are valid" do
       let(:page_heading) { "My new page heading" }
       let(:guidance_markdown) { "Extra guidance needed to answer this question" }
 
-      it "sets a session key called 'page' as a hash with the page heading in it" do
-        guidance_form.submit(session_mock)
-        expect(session_mock[:page][:page_heading]).to eq page_heading
-      end
-
-      it "sets a session key called 'page' as a hash with the guidance_markdown in it" do
-        guidance_form.submit(session_mock)
-        expect(session_mock[:page][:guidance_markdown]).to eq guidance_markdown
-      end
-
       it "sets draft_question page_heading and guidance_markdown" do
         guidance_form.page_heading = "This is my heading"
         guidance_form.guidance_markdown = "This is markdown guidance"
-        guidance_form.submit(session_mock)
+        guidance_form.submit
 
         expect(guidance_form.draft_question.page_heading).to eq("This is my heading")
         expect(guidance_form.draft_question.guidance_markdown).to eq("This is markdown guidance")

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -4,8 +4,15 @@ RSpec.describe Pages::GuidanceController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
   let(:page) { pages.first }
+  let(:draft_question) { build :draft_question }
   let(:page_heading) { "Page heading" }
   let(:guidance_markdown) { "## Heading level 2" }
+
+  let(:controller_spy) do
+    controller_spy = described_class.new
+    allow(described_class).to receive(:new).and_return(controller_spy)
+    controller_spy
+  end
 
   let(:req_headers) do
     {
@@ -64,6 +71,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
         mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
       end
+
+      allow(controller_spy).to receive(:draft_question).and_return(draft_question)
       post guidance_new_path(form_id: form.id), params: { pages_guidance_form: { page_heading:, guidance_markdown: }, route_to: }
     end
 
@@ -123,8 +132,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
       end
 
       it "saves the page_heading and guidance_markdown to session" do
-        expect(session[:page][:page_heading]).to eq("Page heading")
-        expect(session[:page][:guidance_markdown]).to eq("## Heading level 2")
+        expect(draft_question.page_heading).to eq("Page heading")
+        expect(draft_question.guidance_markdown).to eq("## Heading level 2")
       end
 
       it "redirects the user to the new question page" do
@@ -187,6 +196,7 @@ RSpec.describe Pages::GuidanceController, type: :request do
         mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{page.id}", req_headers, page.to_json, 200
       end
+      allow(controller_spy).to receive(:draft_question).and_return(draft_question)
       post guidance_update_path(form_id: form.id, page_id: page.id), params: { pages_guidance_form: { page_heading:, guidance_markdown: }, route_to: }
     end
 
@@ -246,8 +256,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
       end
 
       it "saves the page_heading and guidance_markdown to session" do
-        expect(session[:page][:page_heading]).to eq("Page heading")
-        expect(session[:page][:guidance_markdown]).to eq("## Heading level 2")
+        expect(draft_question.page_heading).to eq("Page heading")
+        expect(draft_question.guidance_markdown).to eq("## Heading level 2")
       end
 
       it "redirects the user to the edit question page" do


### PR DESCRIPTION
### What problem does this pull request solve?
We are in the process of switching from session to activerecord for storage. We had an issue logged by a user trying to use the guidance feature but because they had markdown syntax it meant that their guidance was reaching the 4kb cookie limit before the 5k character limit.

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
