### PR TITLE
Remove unnecessary call to set @answer_types

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  before_action :fetch_form, :answer_types, :convert_session_keys_to_symbols
+  before_action :fetch_form, :convert_session_keys_to_symbols
   before_action :check_user_has_permission
   skip_before_action :clear_questions_session_data, except: %i[index move_page]
   after_action :verify_authorized
@@ -51,10 +51,6 @@ private
     direction = p[:up] ? :up : :down
     page_id = p[direction]
     @move_params ||= { form_id:, page_id:, direction: }
-  end
-
-  def answer_types
-    @answer_types = Page::ANSWER_TYPES
   end
 
   def convert_session_keys_to_symbols

--- a/app/views/pages/type-of-answer.html.erb
+++ b/app/views/pages/type-of-answer.html.erb
@@ -15,7 +15,7 @@
 
       <%= f.govuk_collection_radio_buttons(
             :answer_type,
-            @answer_types,
+            Page::ANSWER_TYPES,
             ->(option) { option },
             ->(option) { t('helpers.label.page.answer_type_options.names.' + option) },
             ->(option) { t('helpers.label.page.answer_type_options.descriptions.' + option) },


### PR DESCRIPTION
### What problem does this pull request solve?
We only ever use this instance variable on the "Type of Answer" page. It seems like overkill to call it on every page of the add/edit page journey.

As we don't use it any other place we can just call the constant directly in the view.

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
