### PR TITLE
Replace Timecop with native Rails time helpers for specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,6 @@ group :development, :test do
   gem "rails-controller-testing"
   gem "rspec-rails", ">= 3.9.0"
   gem "rubocop-govuk", require: false
-  gem "timecop"
 
   # For security auditing gem vulnerabilities. RUN IN CI
   gem "bundler-audit", "~> 0.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,7 +505,6 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)
     thread_safe (0.3.6)
-    timecop (0.9.6)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -599,7 +598,6 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   simplecov (~> 0.22.0)
-  timecop
   tzinfo
   tzinfo-data
   validate_url

--- a/spec/forms/make_live_form_spec.rb
+++ b/spec/forms/make_live_form_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
       let(:form) { build(:form, :ready_for_live) }
 
       around do |example|
-        Timecop.freeze(Time.zone.local(2021, 1, 1, 4, 30, 0)) do
+        travel_to(Time.zone.local(2021, 1, 1, 4, 30, 0)) do
           example.run
         end
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,6 +70,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # Add rails own time testing helpers
+  config.include ActiveSupport::Testing::TimeHelpers
+
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
 end

--- a/spec/service/cloud_watch_service_spec.rb
+++ b/spec/service/cloud_watch_service_spec.rb
@@ -9,7 +9,7 @@ describe CloudWatchService do
   end
 
   around do |example|
-    Timecop.freeze(Time.zone.local(2021, 1, 1, 4, 30, 0)) do
+    travel_to(Time.zone.local(2021, 1, 1, 4, 30, 0)) do
       example.run
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?
Theres no need for Timecop, we do not  use it in any of our other apps and we can rely on rails native time helpers to achieve the same result

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
