### PR TITLE
Add failure page with correct retry link

### DIFF
--- a/app/views/authentications/failure.html.erb
+++ b/app/views/authentications/failure.html.erb
@@ -1,0 +1,3 @@
+<h1>Error</h1>
+
+<p>There was a problem logging you into the application. Please <%= link_to "try again", "/auth/#{params[:strategy]}" %>.</p>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require "validate_url/rspec_matcher"
 require "selenium/webdriver"
 require "axe-rspec"
 
+ENV["RACK_ENV"] ||= "test"
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/eHzFLLjJ/1155-fix-auth0-failure-page

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Currently we're using the failure page from gds-sso gem [[1]] if there is an issue when authenticating with OmniAuth. However, the redirect link in that failure page is hardcoded to send users to GOV.UK Signon, which isn't always what we want.

This commit copies the failure page into our own app so we can edit it, and makes the link dependant on the `strategy` parameter from OmniAuth (which should match the provider, at least in the scenarios we care about).

[1]: https://github.com/alphagov/gds-sso/blob/3aa846de2d71c1f90c120546ade3595e0883c60c/app/views/authentications/failure.html.erb


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?

<details><summary><h4>Screenshots</h4></summary>

##### Before

<img width="1193" alt="Screenshot of https://admin.staging.forms.service.gov.uk/auth/failure?message=invalid_credentials&strategy=auth0, the link 'try again' points to /auth/gds" src="https://github.com/alphagov/forms-admin/assets/503614/97c3d5e0-156e-415e-acd8-5aa1132d2a54">

##### After


<img width="1193" alt="Screenshot of http://localhost:3000/auth/failure?message=invalid_credentials&strategy=auth0, the link 'try again' points to /auth/auth0" src="https://github.com/alphagov/forms-admin/assets/503614/6b5735aa-1966-4aa5-8200-72140b081c81">

</details>