### PR TITLE
Convert basic auth user to be a trial user by default

### DIFF
--- a/config/initializers/warden/strategies/basic_auth.rb
+++ b/config/initializers/warden/strategies/basic_auth.rb
@@ -22,8 +22,8 @@ Warden::Strategies.add(:basic_auth) do
     if status.nil?
       success! User.find_or_initialize_by(
         name: Settings.basic_auth.username,
-        provider: "basic_auth",
         email: "#{Settings.basic_auth.username}@example.gov.uk",
+        provider: :basic_auth,
         organisation: Organisation.find_or_initialize_by(
           name: Settings.basic_auth.organisation.name,
           slug: Settings.basic_auth.organisation.slug,

--- a/config/initializers/warden/strategies/basic_auth.rb
+++ b/config/initializers/warden/strategies/basic_auth.rb
@@ -22,9 +22,8 @@ Warden::Strategies.add(:basic_auth) do
     if status.nil?
       success! User.find_or_initialize_by(
         name: Settings.basic_auth.username,
-        email: "#{Settings.basic_auth.username}@example.com",
-        role: :editor,
         provider: "basic_auth",
+        email: "#{Settings.basic_auth.username}@example.gov.uk",
         organisation: Organisation.find_or_initialize_by(
           name: Settings.basic_auth.organisation.name,
           slug: Settings.basic_auth.organisation.slug,

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     role { :trial }
     has_access { true }
 
+    factory :basic_auth_user do
+      provider { "basic_auth" }
+    end
+
     trait :with_trial_role do
       role { :trial }
       with_no_org

--- a/spec/integration/basic_auth_spec.rb
+++ b/spec/integration/basic_auth_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe "using basic auth" do
   let(:password) { "password" }
   let(:basic_auth_user) { create :basic_auth_user, name: username, organisation_id: organisation.id }
 
-  let!(:organisation) do
-    create :organisation, id: 1, slug: "test-org", name: "Test Org"
+  let(:organisation) do
+    create :organisation
   end
 
   let(:basic_auth_settings) do
     Config::Options.new(
       organisation: Config::Options.new(
-        slug: "test-org",
-        name: "Test Org",
+        slug: organisation.slug,
+        name: organisation.name,
         govuk_content_id: organisation.govuk_content_id,
       ),
       username:,
@@ -58,11 +58,11 @@ RSpec.describe "using basic auth" do
     end
 
     it "signs in user as defined in settings" do
-      expect(assigns[:current_user].name).to eq username
-      expect(assigns[:current_user].organisation.slug).to eq "test-org"
-      expect(assigns[:current_user].provider).to eq "basic_auth"
+      expect(assigns[:current_user].name).to eq basic_auth_user.name
       expect(assigns[:current_user].email).to eq basic_auth_user.email
       expect(assigns[:current_user].role.to_sym).to eq :trial
+      expect(assigns[:current_user].organisation.slug).to eq basic_auth_user.organisation.slug
+      expect(assigns[:current_user].provider).to eq basic_auth_user.provider
     end
   end
 end

--- a/spec/integration/basic_auth_spec.rb
+++ b/spec/integration/basic_auth_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "using basic auth" do
   let(:username) { "tester" }
   let(:password) { "password" }
+  let(:basic_auth_user) { create :basic_auth_user, name: username, organisation_id: organisation.id }
 
   let!(:organisation) do
     create :organisation, id: 1, slug: "test-org", name: "Test Org"
@@ -27,7 +28,7 @@ RSpec.describe "using basic auth" do
     }
 
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=1", api_headers, [].to_json, 200
+      mock.get "/api/v1/forms?creator_id=#{basic_auth_user.id}", api_headers, [].to_json, 200
     end
 
     allow(Settings).to receive(:auth_provider).and_return("basic_auth")
@@ -58,9 +59,10 @@ RSpec.describe "using basic auth" do
 
     it "signs in user as defined in settings" do
       expect(assigns[:current_user].name).to eq username
-      expect(assigns[:current_user].email).to eq "#{username}@example.com"
       expect(assigns[:current_user].organisation.slug).to eq "test-org"
       expect(assigns[:current_user].provider).to eq "basic_auth"
+      expect(assigns[:current_user].email).to eq basic_auth_user.email
+      expect(assigns[:current_user].role.to_sym).to eq :trial
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Previously the basic auth user was setup as an editor. We would like this user to instead be a trial user and have to go through the who upgrade process to become an editor.

Trello card: https://trello.com/c/KEP6g8NM/1148-make-the-ur-environment-user-a-trial-user

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
