### PR TITLE
Revert "Bump selenium-webdriver from 4.14.0 to 4.15.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,7 +476,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.15.0)
+    selenium-webdriver (4.14.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)


### PR DESCRIPTION
Reverts alphagov/forms-admin#728

The selenium-webdriver update broke our deployments, so reverting to unblock the pipeline.