### PR TITLE
Fix build_title optional text check

### DIFF
--- a/app/service/page_summary_card_data_service.rb
+++ b/app/service/page_summary_card_data_service.rb
@@ -24,7 +24,7 @@ class PageSummaryCardDataService
 private
 
   def build_title
-    return @page.question_text unless @page.is_optional? || @page.answer_type == "selection"
+    return @page.question_text unless @page.is_optional? && @page.answer_type != "selection"
 
     "#{@page.question_text} (optional)"
   end

--- a/spec/service/page_summary_card_data_service_spec.rb
+++ b/spec/service/page_summary_card_data_service_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe PageSummaryCardDataService do
-  let(:page) { build :page, is_optional: optional }
-  let(:optional) { false }
+  let(:page) { build :page, is_optional: }
+  let(:is_optional) { false }
   let(:pages) do
     form = build :form, :with_pages
     form.pages
@@ -22,19 +22,43 @@ describe PageSummaryCardDataService do
       expect(service.build_data[:rows]).to eq [1, 2]
     end
 
+    context "when the page is a selection question" do
+      let(:page) { build :page, :with_selections_settings, is_optional: }
+
+      it "includes a title without (optional) added to it" do
+        expect(service.build_data[:card][:title]).to eq page.question_text.to_s
+      end
+    end
+
     context "when question is optional" do
-      let(:optional) { "true" }
+      let(:is_optional) { "true" }
 
       it "includes a title with (optional) added to it" do
         expect(service.build_data[:card][:title]).to eq "#{page.question_text} (optional)"
       end
+
+      context "when the page is a selection question" do
+        let(:page) { build :page, :with_selections_settings, is_optional: }
+
+        it "includes a title without (optional) added to it" do
+          expect(service.build_data[:card][:title]).to eq page.question_text.to_s
+        end
+      end
     end
 
     context "when question is optional is nil" do
-      let(:optional) { nil }
+      let(:is_optional) { nil }
 
       it "includes a title" do
         expect(service.build_data[:card][:title]).to eq page.question_text
+      end
+
+      context "when the page is a selection question" do
+        let(:page) { build :page, :with_selections_settings, is_optional: }
+
+        it "includes a title without (optional) added to it" do
+          expect(service.build_data[:card][:title]).to eq page.question_text.to_s
+        end
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->None

The logic in this method was wrong - we never want selection questions displaying as optional, *even if* they've got 'None of the above' enabled. But the current logic will always show the '(optional)' text for selection questions, _whether or not_ they've got 'None of the above' enabled.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
