### PR TITLE
Remove detailed_guidance feature flag

### DIFF
--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -11,24 +11,22 @@
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
-  <% if FeatureService.enabled? :detailed_guidance_enabled %>
-    <h2 class="govuk-heading-m"><%= t("guidance.guidance") %></h2>
-    <% if page_object.page_heading.present? && page_object.guidance_markdown.present? %>
-      <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, page: page_object).build_data) %>
+  <h2 class="govuk-heading-m"><%= t("guidance.guidance") %></h2>
+  <% if page_object.page_heading.present? && page_object.guidance_markdown.present? %>
+    <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, page: page_object).build_data) %>
 
-    <% else %>
-      <p><%= t("guidance.instructions") %></p>
+  <% else %>
+    <p><%= t("guidance.instructions") %></p>
 
-      <p>
-        <% guidance_link = unless is_new_page
-                             guidance_edit_path(form_id: form_object.id, page_id: page_object.id)
-                           else
-                             guidance_new_path(form_id: form_object.id)
-                           end%>
-        <%= govuk_button_link_to t("guidance.add_guidance"), guidance_link, {secondary: true} %>
-      </p>
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-    <% end %>
+    <p>
+      <% guidance_link = unless is_new_page
+                            guidance_edit_path(form_id: form_object.id, page_id: page_object.id)
+                          else
+                            guidance_new_path(form_id: form_object.id)
+                          end%>
+      <%= govuk_button_link_to t("guidance.add_guidance"), guidance_link, {secondary: true} %>
+    </p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
   <% end %>
 
   <% if question_form.answer_type == 'selection' %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,5 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
-  detailed_guidance_enabled: false
   email_confirmations_enabled: false
   metrics_for_form_creators_enabled: false
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,5 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
-  detailed_guidance_enabled: true
   email_confirmations_enabled: true
 
 forms_api:

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -21,7 +21,6 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    include_examples expected_value_test, :detailed_guidance_enabled, features, false
     include_examples expected_value_test, :metrics_for_form_creators_enabled, features, false
     include_examples expected_value_test, :email_confirmations_enabled, features, false
   end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -58,26 +58,16 @@ describe "pages/_form.html.erb", type: :view do
     expect(rendered).not_to have_button("delete")
   end
 
-  it "does not contain a link to add guidance" do
-    expect(rendered).to have_no_link(text: I18n.t("guidance.add_guidance"), href: guidance_new_path(form_id: form.id))
-  end
-
-  context "when detailed_guidance feature flag enabled", feature_detailed_guidance_enabled: true do
-    it "contains a link to add guidance" do
-      expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: guidance_new_path(form_id: form.id))
-    end
-
-    context "when it is not a new page" do
-      let(:is_new_page) { false }
-
-      it "contains a link to add guidance" do
-        expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: guidance_edit_path(form_id: form.id, page_id: page.id))
-      end
-    end
+  it "contains a link to add guidance" do
+    expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: guidance_new_path(form_id: form.id))
   end
 
   context "when it is not a new page" do
     let(:is_new_page) { false }
+
+    it "contains a link to add guidance" do
+      expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: guidance_edit_path(form_id: form.id, page_id: page.id))
+    end
 
     it "has no hidden field for the answer type" do
       expect(rendered).not_to have_field("question_form[answer_type]", type: :hidden)

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe "pages/edit.html.erb" do
 
   before do
     # Initialize models
-    page = Page.new(id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil)
+    page = Page.new(id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil, page_heading: nil)
     question_form = Pages::QuestionForm.new(page_id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil)
     form = Form.new(id: 1, name: "Form 1", form_id: 1, pages: [page])
     current_user = OpenStruct.new(uid: "123456")


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/syLfXSVT/1158-remove-feature-flags-for-detailed-guidance

Removes the feature flag `detailed_guidance_enabled` and refactors tests to reflect the feature being permanently enabled. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
