### PR TITLE
Save time in docker build by skipping vite:install_dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,4 @@ docker-compose.override.yml
 yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --chown=ruby:ruby . .
 
 # you can't run rails commands like assets:precompile without a secret key set
 # even though the command doesn't use the value itself
-RUN SECRET_KEY_BASE=dummyvalue rails assets:precompile
+RUN SECRET_KEY_BASE=dummyvalue rails vite:build_all
 
 # Remove devDependencies once assets have been built
 RUN npm ci --ignore-scripts --only=production


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The `assets:precompile` Rake task is defined by [vite-ruby] to run `vite:install_dependencies` and then `vite:build_all` [[1]]. This is fine, except that the task `vite:install_dependencies` runs `npm ci` [[2]], which takes a while to do.

Since we've done this already earlier in the Dockerfile, we can skip this step and go straight to `vite:build_all`. If the earlier `npm ci` step has been cached, this can save around 2 minutes off the build time.

This PR also adds the Dockerfile to the `.dockerignore` list, so if you're changing just the Dockerfile you don't need to invalidate the cache from the `COPY . .` step.

[1]: https://github.com/ElMassimo/vite_ruby/blob/vite_ruby%403.3.4/vite_ruby/lib/tasks/vite.rake#L66-L67
[2]: https://github.com/ElMassimo/vite_ruby/blob/vite_ruby%403.3.4/vite_ruby/lib/tasks/vite.rake#L46


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?