### PR TITLE
Show notification banner when role is upgraded to editor

### DIFF
--- a/app/components/role_upgrade_component/view.html.erb
+++ b/app/components/role_upgrade_component/view.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_notification_banner(title_text: t("role_upgrade.title"), success: true) do |banner| %>
+  <% banner.with_heading(text: t("role_upgrade.heading")) %>
+  <%= t("role_upgrade.content_html") %>
+<% end %>

--- a/app/components/role_upgrade_component/view.rb
+++ b/app/components/role_upgrade_component/view.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module RoleUpgradeComponent
+  class View < ViewComponent::Base
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,6 +76,15 @@ class User < ApplicationRecord
     mou_signatures.find_by(organisation:)
   end
 
+  def role_changed_to_editor?
+    role_changed_to_editor = editor? && !versions.empty? && versions.last.reify.role != "editor"
+    if role_changed_to_editor
+      self.paper_trail_event = "Role upgrade reported"
+      paper_trail.save_with_version
+    end
+    role_changed_to_editor
+  end
+
 private
 
   def requires_name?

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -2,7 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render TrialRoleWarningComponent::View.new(link_url: user_upgrade_request_path) if @current_user.trial? %>
+    <% if @current_user.trial? %>
+      <%= render TrialRoleWarningComponent::View.new(link_url: user_upgrade_request_path) %>
+    <% elsif @current_user.role_changed_to_editor? %>
+      <%= render RoleUpgradeComponent::View.new() %>
+    <% end %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -664,6 +664,13 @@ en:
       </p>
     heading: Provide a link to privacy information for this form
     submit_button: Save and continue
+  role_upgrade:
+    content_html: |
+      <p>
+        You can create a form and make it live.
+      </p>
+    heading: You now have an editor account
+    title: Your account has been upgraded
   routing_page:
     body_text: "You can send people directly to the question or page you want, based on their previous answer. \nThis means they’ll only see questions that are relevant to them.\n"
     dropdown_default_text: Select a question to start your route from

--- a/spec/components/role_upgrade_component/role_upgrade_component_preview.rb
+++ b/spec/components/role_upgrade_component/role_upgrade_component_preview.rb
@@ -1,0 +1,5 @@
+class RoleUpgradeComponent::RoleUpgradeComponentPreview < ViewComponent::Preview
+  def default
+    render(RoleUpgradeComponent::View.new)
+  end
+end

--- a/spec/components/role_upgrade_component/view_spec.rb
+++ b/spec/components/role_upgrade_component/view_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe RoleUpgradeComponent::View, type: :component do
+  before do
+    render_inline(described_class.new)
+  end
+
+  it "displays a banner with correct locale text" do
+    expect(page).to have_selector(".govuk-notification-banner__content")
+    expect(page).to have_content(I18n.t("role_upgrade.heading"))
+    expect(page).to have_content(Capybara.string(I18n.t("role_upgrade.content_html")).text(normalize_ws: true), normalize_ws: true)
+  end
+end

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -114,5 +114,25 @@ describe "forms/index.html.erb" do
         expect(rendered).not_to have_text(I18n.t("trial_role_warning.heading"))
       end
     end
+
+    context "and a user already has the editor role" do
+      let(:user) { build :user, role: :editor }
+
+      it "does not display a banner" do
+        expect(rendered).not_to have_text(I18n.t("role_upgrade.heading"))
+      end
+    end
+
+    context "and a user gets upgraded to the editor role", versioning: true do
+      let(:user) { create :user, role: :trial }
+
+      it "displays a banner informing the user they have now have the editor role" do
+        user.update!(role: :editor)
+
+        render
+
+        expect(rendered).to have_text(I18n.t("role_upgrade.heading"))
+      end
+    end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?
This commit adds a banner which is shown to users when they first go to the index after their role is upgraded to editor. This uses the PaperTrail version history to establish if the role has changed to editor, and will create a new version the first time the role changes to editor, to prevent the banner being shown subsequently. I'm not sure this is the best way to achieve this, but it does avoid having to persist anything else (or anything feature specific) to determine if the the banner should be shown. It does also sound like this is a [valid use case for PaperTrail.
](https://github.com/paper-trail-gem/paper_trail#saving-a-new-version-manually)

<details><summary>Screenshot</summary>

<img width="978" alt="image" src="https://github.com/alphagov/forms-admin/assets/29330450/f607a0c0-2b9a-4be3-a3c1-48f1f5345516">

</details> 

Trello card: https://trello.com/c/IbfXhuYq

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
