### PR TITLE
Make it clearer that a trial user can see what a completed form email looks like

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,9 +174,9 @@ en:
         hint_text_html: Completed forms will be sent to:<br> %{submission_email}
         if_not_permitted:
           body_text: |
-            For a trial account, completed draft forms will be sent to your email address: %{submission_email}
+            When a draft form is completed it will be sent to your email address so you can see how form submissions will look.
 
-            Editor accounts can change the email address for completed forms to be sent to.
+            Editor accounts can change the email address completed forms are sent to.
         title: Set email address for completed forms
       section_3:
         contact_details: Provide contact details for support
@@ -184,7 +184,7 @@ en:
         title: Provide privacy and contact details
       section_4:
         if_not_permitted:
-          body_text: You cannot make a form live with a trial account
+          body_text: You cannot make a form live with a trial account.
         make_live: Make your form live
         title: Make your form live
     task_list_edit:

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -129,10 +129,6 @@ RSpec.describe FormsController, type: :request do
         get form_path(2)
       end
 
-      it "explains where completed forms will be sent to" do
-        expect(response.body).to include(form.submission_email)
-      end
-
       it "does not include setting the submission email address" do
         expect(response.body).not_to include(submission_email_form_path(2))
         expect(response.body).not_to include(submission_email_code_path(2))


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card:https://trello.com/c/7tqM1i53/1112-make-it-clearer-that-you-can-see-what-a-completed-form-email-looks-like-on-the-trial-account-task-list

In research, a couple of people using trial accounts were not clear that they could complete a form and send it to themselves to see what a completed form email would look like.

Also, don't think we need to play the trial account user's own email address back to them.

And added a missing full stop.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
