### PR TITLE
Stop using session storage for Address Settings

### DIFF
--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -1,8 +1,8 @@
 class Pages::AddressSettingsController < PagesController
   def new
-    uk_address = draft_question.answer_settings.dig(:input_type, :uk_address)
-    international_address = draft_question.answer_settings.dig(:input_type, :international_address)
-    @address_settings_form = Pages::AddressSettingsForm.new(uk_address:, international_address:)
+    settings = draft_question.answer_settings.with_indifferent_access
+    @address_settings_form = Pages::AddressSettingsForm.new(uk_address: settings.dig(:input_type, :uk_address),
+                                                            international_address: settings.dig(:input_type, :international_address))
     @address_settings_path = address_settings_create_path(current_form)
     @back_link_url = type_of_answer_new_path(current_form)
     render :address_settings, locals: { current_form: }
@@ -21,9 +21,9 @@ class Pages::AddressSettingsController < PagesController
   end
 
   def edit
-    uk_address = draft_question.answer_settings.with_indifferent_access.dig(:input_type, :uk_address)
-    international_address = draft_question.answer_settings.with_indifferent_access.dig(:input_type, :international_address)
-    @address_settings_form = Pages::AddressSettingsForm.new(uk_address:, international_address:)
+    settings = draft_question.answer_settings.with_indifferent_access
+    @address_settings_form = Pages::AddressSettingsForm.new(uk_address: settings.dig(:input_type, :uk_address),
+                                                            international_address: settings.dig(:input_type, :international_address))
     @address_settings_path = address_settings_update_path(current_form)
     @back_link_url = type_of_answer_edit_path(current_form)
     render :address_settings, locals: { current_form: }

--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -13,7 +13,7 @@ class Pages::AddressSettingsController < PagesController
     @address_settings_path = address_settings_create_path(current_form)
     @back_link_url = type_of_answer_new_path(current_form)
 
-    if @address_settings_form.submit(session)
+    if @address_settings_form.submit
       redirect_to new_question_path(current_form)
     else
       render :address_settings, locals: { current_form: }
@@ -34,7 +34,7 @@ class Pages::AddressSettingsController < PagesController
     @address_settings_path = address_settings_update_path(current_form)
     @back_link_url = type_of_answer_edit_path(current_form)
 
-    if @address_settings_form.submit(session)
+    if @address_settings_form.submit
       redirect_to edit_question_path(current_form)
     else
       page

--- a/app/forms/pages/address_settings_form.rb
+++ b/app/forms/pages/address_settings_form.rb
@@ -8,7 +8,7 @@ class Pages::AddressSettingsForm < BaseForm
   validates :uk_address, inclusion: { in: %w[true false] }
   validates :international_address, inclusion: { in: %w[true false] }
 
-  def submit(session)
+  def submit
     return false if invalid?
 
     # Set the answer_settings hash
@@ -24,10 +24,6 @@ class Pages::AddressSettingsForm < BaseForm
       .assign_attributes({ answer_settings: answer_settings.with_indifferent_access })
 
     draft_question.save!(validate: false)
-
-    # TODO: remove this once we have draft_questions being saved across the whole journey
-    session[:page] = {} if session[:page].blank?
-    session[:page][:answer_settings] = answer_settings
   end
 
   def at_least_one_selected?

--- a/spec/forms/pages/address_settings_form_spec.rb
+++ b/spec/forms/pages/address_settings_form_spec.rb
@@ -50,22 +50,15 @@ RSpec.describe Pages::AddressSettingsForm, type: :model do
   end
 
   describe "#submit" do
-    let(:session_mock) { {} }
-
     it "returns false if the form is invalid" do
       allow(address_settings_form).to receive(:invalid?).and_return(true)
-      expect(address_settings_form.submit(session_mock)).to be_falsey
-    end
-
-    it "sets a session key called 'page' as a hash with the answer type in it" do
-      address_settings_form.submit(session_mock)
-      expect(session_mock[:page][:answer_settings]).to include(input_type: { international_address: "true", uk_address: "true" })
+      expect(address_settings_form.submit).to be_falsey
     end
 
     it "sets draft_question answer_settings" do
       address_settings_form.uk_address = "false"
       address_settings_form.international_address = "true"
-      address_settings_form.submit(session_mock)
+      address_settings_form.submit
 
       expected_settings = {
         input_type: {

--- a/spec/requests/pages/address_settings_controller_spec.rb
+++ b/spec/requests/pages/address_settings_controller_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
         form_instance_variable = assigns(:address_settings_form)
         expect(form_instance_variable.uk_address).to eq "true"
         expect(form_instance_variable.international_address).to eq "false"
-        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access).to include( input_type: { uk_address: "true", international_address: "false" })
+        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access).to include(input_type: { uk_address: "true", international_address: "false" })
       end
 
       it "redirects the user to the edit question page" do

--- a/spec/requests/pages/address_settings_controller_spec.rb
+++ b/spec/requests/pages/address_settings_controller_spec.rb
@@ -86,8 +86,9 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
 
       let(:address_settings_form) { build :address_settings_form }
 
-      it "saves the input type to session" do
-        expect(session[:page][:answer_settings]).to eq({ input_type: { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address } })
+      it "saves the input type to draft question" do
+        form = assigns(:address_settings_form)
+        expect(form.draft_question.answer_settings.with_indifferent_access).to include(input_type: { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address })
       end
 
       it "redirects the user to the edit question page" do
@@ -167,11 +168,11 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
         post address_settings_update_path(form_id: page.form_id, page_id: page.id), params: { pages_address_settings_form: { uk_address: "true", international_address: "false" } }
       end
 
-      it "loads the updated input type into the session from the page params" do
+      it "saves the params to draft question" do
         form_instance_variable = assigns(:address_settings_form)
         expect(form_instance_variable.uk_address).to eq "true"
         expect(form_instance_variable.international_address).to eq "false"
-        expect(session[:page][:answer_settings]).to eq({ input_type: { uk_address: "true", international_address: "false" } })
+        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access).to include( input_type: { uk_address: "true", international_address: "false" })
       end
 
       it "redirects the user to the edit question page" do


### PR DESCRIPTION
### What problem does this pull request solve?
This work follow on from:
* https://github.com/alphagov/forms-admin/pull/743
* https://github.com/alphagov/forms-admin/pull/690
* https://github.com/alphagov/forms-admin/pull/669
* https://github.com/alphagov/forms-admin/pull/658
* https://github.com/alphagov/forms-admin/pull/659

https://github.com/alphagov/forms-admin/pull/743 changes meant that we can now stop recording settings information to session and start relying on only using DraftQuestion.

Trello card: https://trello.com/c/RGsOE1bl/1074-switch-all-the-page-form-objects-over-to-use-draftquestion-instead-of-session

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
