### PR TITLE
Remove db:migrate From Start Command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ COPY --chown=ruby:ruby --from=build /app /app
 
 EXPOSE 3000
 
-CMD ["/bin/sh", "-o", "xtrace", "-c", "rake db:migrate && rails s -b 0.0.0.0"]
+CMD ["/bin/sh", "-o", "xtrace", "-c", "rails s -b 0.0.0.0"]


### PR DESCRIPTION
The database migrations are now handled by a separate ECS task managed by Terraform. We no longer need to run db:migrate when starting the containers which was causing issues with new containers exiting because multiple containers were trying to run db:migrate.

### What problem does this pull request solve?

Trello card: https://trello.com/c/x8XeIzQN/283-remove-dbmigrate-from-docker-start-command



### Things to consider when reviewing
Related PR to manage this in Terraform: https://github.com/alphagov/forms-deploy/pull/398/files
<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
