### PR TITLE
Stop using session storage for Name Settings

### DIFF
--- a/app/controllers/pages/name_settings_controller.rb
+++ b/app/controllers/pages/name_settings_controller.rb
@@ -12,7 +12,7 @@ class Pages::NameSettingsController < PagesController
     @name_settings_path = name_settings_create_path(current_form)
     @back_link_url = type_of_answer_new_path(current_form)
 
-    if @name_settings_form.submit(session)
+    if @name_settings_form.submit
       redirect_to new_question_path(current_form)
     else
       render :name_settings, locals: { current_form: }
@@ -32,7 +32,7 @@ class Pages::NameSettingsController < PagesController
     @name_settings_path = name_settings_update_path(current_form)
     @back_link_url = type_of_answer_edit_path(current_form)
 
-    if @name_settings_form.submit(session)
+    if @name_settings_form.submit
       redirect_to edit_question_path(current_form)
     else
       page

--- a/app/forms/pages/name_settings_form.rb
+++ b/app/forms/pages/name_settings_form.rb
@@ -8,7 +8,7 @@ class Pages::NameSettingsForm < BaseForm
   validates :input_type, presence: true, inclusion: { in: INPUT_TYPES }
   validates :title_needed, presence: true, inclusion: { in: TITLE_NEEDED }
 
-  def submit(session)
+  def submit
     return false if invalid?
 
     # Set the answer_settings hash
@@ -22,9 +22,5 @@ class Pages::NameSettingsForm < BaseForm
       .assign_attributes({ answer_settings: answer_settings.with_indifferent_access })
 
     draft_question.save!(validate: false)
-
-    # TODO: remove this once we have draft_questions being saved across the whole journey
-    session[:page] = {} if session[:page].blank?
-    session[:page][:answer_settings] = { input_type:, title_needed: }
   end
 end

--- a/spec/forms/pages/name_settings_form_spec.rb
+++ b/spec/forms/pages/name_settings_form_spec.rb
@@ -65,24 +65,15 @@ RSpec.describe Pages::NameSettingsForm, type: :model do
   end
 
   describe "#submit" do
-    let(:session_mock) { {} }
-
     it "returns false if the form is invalid" do
       allow(name_settings_form).to receive(:invalid?).and_return(true)
-      expect(name_settings_form.submit(session_mock)).to be_falsey
-    end
-
-    it "sets a session key called 'page' as a hash with the answer settings in it" do
-      name_settings_form = build :name_settings_form
-      name_settings_form.submit(session_mock)
-      expect(session_mock[:page][:answer_settings]).to include(input_type: "full_name")
-      expect(session_mock[:page][:answer_settings]).to include(title_needed: "true")
+      expect(name_settings_form.submit).to be_falsey
     end
 
     it "sets draft_question answer_settings" do
       name_settings_form.input_type = "full_name"
       name_settings_form.title_needed = "true"
-      name_settings_form.submit(session_mock)
+      name_settings_form.submit
 
       expected_settings = {
         input_type: "full_name",

--- a/spec/requests/pages/name_settings_controller_spec.rb
+++ b/spec/requests/pages/name_settings_controller_spec.rb
@@ -73,8 +73,9 @@ RSpec.describe Pages::NameSettingsController, type: :request do
 
       let(:name_settings_form) { build :name_settings_form }
 
-      it "saves the input type to session" do
-        expect(session[:page][:answer_settings]).to eq({ input_type: "first_and_last_name", title_needed: "false" })
+      it "saves the input type to draft question" do
+        form = assigns(:name_settings_form)
+        expect(form.draft_question.answer_settings.with_indifferent_access).to include(input_type: "first_and_last_name", title_needed: "false")
       end
 
       it "redirects the user to the edit question page" do
@@ -154,7 +155,8 @@ RSpec.describe Pages::NameSettingsController, type: :request do
         form_instance_variable = assigns(:name_settings_form)
         expect(form_instance_variable.input_type).to eq input_type
         expect(form_instance_variable.title_needed).to eq title_needed
-        expect(session[:page][:answer_settings]).to eq({ input_type:, title_needed: })
+        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access)
+          .to include(input_type: "full_name", title_needed: "true")
       end
 
       it "redirects the user to the edit question page" do


### PR DESCRIPTION
### What problem does this pull request solve?
This work follow on from:
* https://github.com/alphagov/forms-admin/pull/743
* https://github.com/alphagov/forms-admin/pull/690
* https://github.com/alphagov/forms-admin/pull/669
* https://github.com/alphagov/forms-admin/pull/658
* https://github.com/alphagov/forms-admin/pull/659

https://github.com/alphagov/forms-admin/pull/743 changes meant that we can now stop recording settings information to session and start relying on only using DraftQuestion.

Trello card: https://trello.com/c/RGsOE1bl/1074-switch-all-the-page-form-objects-over-to-use-draftquestion-instead-of-session

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
