### PR TITLE
Stop using session storage for Text Settings

### DIFF
--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -11,7 +11,7 @@ class Pages::TextSettingsController < PagesController
     @text_settings_path = text_settings_create_path(current_form)
     @back_link_url = type_of_answer_new_path(current_form)
 
-    if @text_settings_form.submit(session)
+    if @text_settings_form.submit
       redirect_to new_question_path(current_form)
     else
       render :text_settings, locals: { current_form: }
@@ -30,7 +30,7 @@ class Pages::TextSettingsController < PagesController
     @text_settings_path = text_settings_update_path(current_form)
     @back_link_url = type_of_answer_edit_path(current_form)
 
-    if @text_settings_form.submit(session)
+    if @text_settings_form.submit
       redirect_to edit_question_path(current_form)
     else
       page

--- a/app/forms/pages/text_settings_form.rb
+++ b/app/forms/pages/text_settings_form.rb
@@ -6,7 +6,7 @@ class Pages::TextSettingsForm < BaseForm
   validates :draft_question, presence: true
   validates :input_type, presence: true, inclusion: { in: INPUT_TYPES }
 
-  def submit(session)
+  def submit
     return false if invalid?
 
     # Set the answer_settings hash
@@ -19,9 +19,5 @@ class Pages::TextSettingsForm < BaseForm
       .assign_attributes({ answer_settings: answer_settings.with_indifferent_access })
 
     draft_question.save!(validate: false)
-
-    # TODO: remove this once we have draft_questions being saved across the whole journey
-    session[:page] = {} if session[:page].blank?
-    session[:page][:answer_settings] = { input_type: }
   end
 end

--- a/spec/forms/pages/text_settings_form_spec.rb
+++ b/spec/forms/pages/text_settings_form_spec.rb
@@ -47,22 +47,14 @@ RSpec.describe Pages::TextSettingsForm, type: :model do
   end
 
   describe "#submit" do
-    let(:session_mock) { {} }
-
     it "returns false if the form is invalid" do
       allow(text_settings_form).to receive(:invalid?).and_return(true)
-      expect(text_settings_form.submit(session_mock)).to be_falsey
-    end
-
-    it "sets a session key called 'page' as a hash with the answer type in it" do
-      text_settings_form.input_type = "single_line"
-      text_settings_form.submit(session_mock)
-      expect(session_mock[:page][:answer_settings]).to include(input_type: "single_line")
+      expect(text_settings_form.submit).to be_falsey
     end
 
     it "sets draft_question answer_settings" do
       text_settings_form.input_type = "single_line"
-      text_settings_form.submit(session_mock)
+      text_settings_form.submit
 
       expected_settings = {
         input_type: "single_line",

--- a/spec/requests/pages/text_settings_controller_spec.rb
+++ b/spec/requests/pages/text_settings_controller_spec.rb
@@ -73,8 +73,9 @@ RSpec.describe Pages::TextSettingsController, type: :request do
 
       let(:text_settings_form) { build :text_settings_form }
 
-      it "saves the input type to session" do
-        expect(session[:page][:answer_settings]).to eq({ input_type: text_settings_form.input_type })
+      it "saves the input type to draft question answers setting" do
+        form = assigns(:text_settings_form)
+        expect(form.draft_question.answer_settings.with_indifferent_access).to include(input_type: text_settings_form.input_type)
       end
 
       it "redirects the user to the edit question page" do
@@ -147,7 +148,8 @@ RSpec.describe Pages::TextSettingsController, type: :request do
       it "saves the updated input type to DB" do
         form_instance_variable = assigns(:text_settings_form)
         expect(form_instance_variable.input_type).to eq input_type
-        expect(session[:page][:answer_settings]).to eq({ input_type: })
+        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access)
+          .to include({ input_type: })
       end
 
       it "redirects the user to the edit question page" do


### PR DESCRIPTION
### What problem does this pull request solve?
This work follow on from:
* https://github.com/alphagov/forms-admin/pull/743
* https://github.com/alphagov/forms-admin/pull/690
* https://github.com/alphagov/forms-admin/pull/669
* https://github.com/alphagov/forms-admin/pull/658
* https://github.com/alphagov/forms-admin/pull/659

https://github.com/alphagov/forms-admin/pull/743 changes meant that we can now stop recording settings information to session and start relying on only using DraftQuestion.

Trello card: https://trello.com/c/RGsOE1bl/1074-switch-all-the-page-form-objects-over-to-use-draftquestion-instead-of-session

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
