### PR TITLE
Stop using session storage for Selections Settings

### DIFF
--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -20,7 +20,7 @@ class Pages::SelectionsSettingsController < PagesController
     elsif params[:remove]
       @selections_settings_form.remove(params[:remove].to_i)
       render :selections_settings, locals: { current_form: }
-    elsif @selections_settings_form.submit(session)
+    elsif @selections_settings_form.submit
       redirect_to new_question_path(current_form)
     else
       render :selections_settings, locals: { current_form: }
@@ -52,7 +52,7 @@ class Pages::SelectionsSettingsController < PagesController
     elsif params[:remove]
       @selections_settings_form.remove(params[:remove].to_i)
       render :selections_settings, locals: { current_form: }
-    elsif @selections_settings_form.submit(session)
+    elsif @selections_settings_form.submit
       redirect_to edit_question_path(current_form)
     else
       render :selections_settings, locals: { current_form: }

--- a/app/forms/pages/selections_settings_form.rb
+++ b/app/forms/pages/selections_settings_form.rb
@@ -20,7 +20,7 @@ class Pages::SelectionsSettingsForm < BaseForm
     { only_one_option:, selection_options: }
   end
 
-  def submit(session)
+  def submit
     return false if invalid?
 
     # Set answer_settings for the draft_question
@@ -29,12 +29,6 @@ class Pages::SelectionsSettingsForm < BaseForm
                            is_optional: include_none_of_the_above })
 
     draft_question.save!(validate: false)
-
-    # TODO: remove this once we have draft_questions being saved across the whole journey
-    session[:page] = {} if session[:page].blank?
-
-    session[:page][:answer_settings] = answer_settings.with_indifferent_access
-    session[:page][:is_optional] = include_none_of_the_above
   end
 
   def validate_selection_options

--- a/spec/forms/pages/selections_settings_form_spec.rb
+++ b/spec/forms/pages/selections_settings_form_spec.rb
@@ -55,27 +55,16 @@ RSpec.describe Pages::SelectionsSettingsForm, type: :model do
   end
 
   describe "#submit" do
-    let(:session_mock) { {} }
-
     it "returns false if the form is invalid" do
       selections_settings_form.selection_options = []
-      expect(selections_settings_form.submit(session_mock)).to be_falsey
-    end
-
-    it "sets a session key called 'page' as a hash with the answer type in it" do
-      selections_settings_form.selection_options = (1..2).to_a.map { |i| { name: i.to_s } }
-      selections_settings_form.only_one_option = true
-      selections_settings_form.include_none_of_the_above = true
-      selections_settings_form.submit(session_mock)
-      expect(session_mock[:page][:answer_settings].to_json).to eq({ only_one_option: true, selection_options: [{ name: "1" }, { name: "2" }] }.to_json)
-      expect(session_mock[:page][:is_optional]).to eq(true)
+      expect(selections_settings_form.submit).to be_falsey
     end
 
     it "sets draft_question answer_settings and is_optional" do
       selections_settings_form.selection_options = (1..2).to_a.map { |i| { name: i.to_s } }
       selections_settings_form.only_one_option = true
       selections_settings_form.include_none_of_the_above = true
-      selections_settings_form.submit(session_mock)
+      selections_settings_form.submit
 
       expected_settings = {
         only_one_option: true,

--- a/spec/requests/pages/selections_settings_controller_spec.rb
+++ b/spec/requests/pages/selections_settings_controller_spec.rb
@@ -74,8 +74,13 @@ describe Pages::SelectionsSettingsController, type: :request do
         post selections_settings_create_path form_id: form.id, params: { pages_selections_settings_form: { selection_options: { "0": { name: "Option 1" }, "1": { name: "Option 2" } }, only_one_option: true, include_none_of_the_above: false } }
       end
 
-      it "saves the answer type to session" do
-        expect(session[:page]).to include({ answer_settings: selections_settings_form.answer_settings, is_optional: "false" })
+      it "saves the the info to draft question" do
+        settings_form = assigns(:selections_settings_form)
+        draft_question_settings = settings_form.draft_question.answer_settings.with_indifferent_access
+
+        expect(draft_question_settings).to include(only_one_option: "true",
+                                                   selection_options: [{ name: "Option 1" }, { name: "Option 2" }])
+        expect(settings_form.draft_question.is_optional).to eq false
       end
 
       it "redirects the user to the question details page" do


### PR DESCRIPTION
### What problem does this pull request solve?
This work follow on from:
* https://github.com/alphagov/forms-admin/pull/743
* https://github.com/alphagov/forms-admin/pull/690
* https://github.com/alphagov/forms-admin/pull/669
* https://github.com/alphagov/forms-admin/pull/658
* https://github.com/alphagov/forms-admin/pull/659

https://github.com/alphagov/forms-admin/pull/743 changes meant that we can now stop recording settings information to session and start relying on only using DraftQuestion.

Trello card: https://trello.com/c/RGsOE1bl/1074-switch-all-the-page-form-objects-over-to-use-draftquestion-instead-of-session

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
