### PR TITLE
Stop using session storage for Question Text

### DIFF
--- a/app/controllers/pages/question_text_controller.rb
+++ b/app/controllers/pages/question_text_controller.rb
@@ -1,7 +1,6 @@
 class Pages::QuestionTextController < PagesController
   def new
-    question_text = session.dig(:page, :question_text)
-    @question_text_form = Pages::QuestionTextForm.new(question_text:)
+    @question_text_form = Pages::QuestionTextForm.new(question_text: draft_question.question_text)
     @question_text_path = question_text_create_path(current_form)
     @back_link_url = type_of_answer_new_path(current_form)
     render :question_text, locals: { current_form: }
@@ -12,7 +11,7 @@ class Pages::QuestionTextController < PagesController
     @question_text_path = question_text_create_path(current_form)
     @back_link_url = type_of_answer_new_path(current_form)
 
-    if @question_text_form.submit(session)
+    if @question_text_form.submit
       redirect_to selections_settings_new_path(current_form)
     else
       render :question_text, locals: { current_form: }

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -1,7 +1,7 @@
 class Pages::QuestionsController < PagesController
   def new
     answer_type = draft_question.answer_type
-    question_text = session.dig(:page, :question_text)
+    question_text = draft_question.question_text
     answer_settings = draft_question.answer_settings
     is_optional = draft_question.is_optional == "true"
     page_heading = draft_question.page_heading

--- a/app/forms/pages/question_text_form.rb
+++ b/app/forms/pages/question_text_form.rb
@@ -5,17 +5,12 @@ class Pages::QuestionTextForm < BaseForm
 
   validates :draft_question, presence: true
 
-  def submit(session)
+  def submit
     return false if invalid?
 
-    # Set question_text for the draft_question
     draft_question
       .assign_attributes(question_text:)
 
     draft_question.save!(validate: false)
-
-    # TODO: remove this once we have draft_questions being saved across the whole journey
-    session[:page] = {} if session[:page].blank?
-    session[:page][:question_text] = question_text
   end
 end

--- a/spec/forms/pages/question_text_form_spec.rb
+++ b/spec/forms/pages/question_text_form_spec.rb
@@ -42,23 +42,14 @@ RSpec.describe Pages::QuestionTextForm, type: :model do
   end
 
   describe "#submit" do
-    let(:session_mock) { {} }
-
     it "returns false if the form is invalid" do
       allow(question_text_form).to receive(:invalid?).and_return(true)
-      expect(question_text_form.submit(session_mock)).to be_falsey
-    end
-
-    it "sets a session key called 'page' as a hash with the answer type in it" do
-      question_text_form.question_text = "What is your name?"
-      question_text_form.submit(session_mock)
-
-      expect(session_mock[:page][:question_text]).to eq "What is your name?"
+      expect(question_text_form.submit).to be_falsey
     end
 
     it "sets draft_question question_text" do
       question_text_form.question_text = "What is your name?"
-      question_text_form.submit(session_mock)
+      question_text_form.submit
 
       expect(question_text_form.draft_question.question_text).to eq("What is your name?")
     end

--- a/spec/requests/pages/question_text_controller_spec.rb
+++ b/spec/requests/pages/question_text_controller_spec.rb
@@ -73,8 +73,9 @@ RSpec.describe Pages::QuestionTextController, type: :request do
 
       let(:question_text_form) { build :question_text_form }
 
-      it "saves the input type to session" do
-        expect(session[:page][:question_text]).to eq "Are you a higher rate taxpayer?"
+      it "saves the question text to the draft question" do
+        form = assigns(:question_text_form)
+        expect(form.draft_question.question_text).to eq "Are you a higher rate taxpayer?"
       end
 
       it "redirects the user to the edit question page" do


### PR DESCRIPTION
### What problem does this pull request solve?
This work follow on from:
* https://github.com/alphagov/forms-admin/pull/743
* https://github.com/alphagov/forms-admin/pull/690
* https://github.com/alphagov/forms-admin/pull/669
* https://github.com/alphagov/forms-admin/pull/658
* https://github.com/alphagov/forms-admin/pull/659

https://github.com/alphagov/forms-admin/pull/743 changes meant that we can now stop recording settings information to session and start relying on only using DraftQuestion.

Trello card: https://trello.com/c/RGsOE1bl/1074-switch-all-the-page-form-objects-over-to-use-draftquestion-instead-of-session

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
