### PR TITLE
Revert "Amended question details not displaying on "Edit question" page"

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -8,14 +8,7 @@ class Pages::QuestionsController < PagesController
     guidance_markdown = draft_question.guidance_markdown
     @question_form = Pages::QuestionForm.new(form_id: current_form.id, answer_type:, question_text:, answer_settings:, is_optional:, draft_question:)
 
-    # TODO: Remove this once we have a check your question view. The new view should also pull data directly from draft_question instead of through page model
-    @page = Page.new(form_id: current_form.id,
-                     answer_type:,
-                     answer_settings:,
-                     is_optional:,
-                     page_heading:,
-                     guidance_markdown:)
-
+    @page = Page.new(form_id: current_form.id, question_text:, answer_type:, answer_settings:, is_optional:, page_heading:, guidance_markdown:)
     render :new, locals: { current_form: }
   end
 
@@ -41,18 +34,10 @@ class Pages::QuestionsController < PagesController
   def edit
     @question_form = Pages::QuestionForm.new(form_id: current_form.id,
                                              answer_type: draft_question.answer_type,
-                                             question_text: draft_question.question_text,
+                                             question_text: page.question_text,
                                              hint_text: draft_question.hint_text,
                                              is_optional: draft_question.is_optional,
                                              answer_settings: draft_question.answer_settings)
-
-    # TODO: Remove this once we have a check your question view. The new view should also pull data directly from draft_question instead of through page model
-    page.answer_type = draft_question.answer_type
-    page.answer_settings = draft_question.answer_settings
-    page.is_optional = draft_question.is_optional
-    page.page_heading = draft_question.page_heading
-    page.guidance_markdown = draft_question.guidance_markdown
-
     render :edit, locals: { current_form: }
   end
 

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(title_with_error_prefix(@question_form.question_text, @question_form.errors.any?)) %>
+<% set_page_title(title_with_error_prefix(@page.question_text, @page.errors.any?)) %>
 <% content_for :back_link, govuk_back_link_to(form_pages_path(current_form)) %>
 
 <div class="govuk-grid-row">

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -113,8 +113,6 @@ RSpec.describe Pages::QuestionsController, type: :request do
         }
       end
 
-      let(:draft_question) { create :draft_question, :with_guidance, user: editor_user, form_id: 2, page_id: 1 }
-
       before do
         ActiveResource::HttpMock.respond_to do |mock|
           mock.get "/api/v1/forms/2", req_headers, form_response.to_json, 200
@@ -134,22 +132,6 @@ RSpec.describe Pages::QuestionsController, type: :request do
 
         page_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, req_headers)
         expect(ActiveResource::HttpMock.requests).to include page_request
-      end
-
-      it "renders the detail guidance page_heading and guidance_markdown" do
-        expect(response.body).to include(draft_question.page_heading)
-        expect(response.body).to include(draft_question.guidance_markdown)
-      end
-
-      it "assigns all the draft question attribute values to page object attributes" do
-        page_object = assigns(:page)
-        expect(page_object.attributes).to include(
-          answer_type: draft_question.answer_type,
-          answer_settings: draft_question.answer_settings,
-          is_optional: draft_question.is_optional,
-          page_heading: draft_question.page_heading,
-          guidance_markdown: draft_question.guidance_markdown,
-        )
       end
     end
   end

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe "pages/edit.html.erb" do
 
   before do
     # Initialize models
-    page = Page.new(id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil, page_heading: "Some detailed guidance", guidance_markdown: "This is example of detailed guidance")
+    page = Page.new(id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil, page_heading: nil)
     question_form = Pages::QuestionForm.new(page_id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil)
     form = Form.new(id: 1, name: "Form 1", form_id: 1, pages: [page])
     current_user = OpenStruct.new(uid: "123456")
@@ -35,10 +35,6 @@ describe "pages/edit.html.erb" do
     ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
 
     render template: "pages/edit"
-  end
-
-  it "contains existing detailed Guidance" do
-    expect(rendered).to have_text("Some detailed guidance")
   end
 
   context "when given a title with characters which need escaping" do


### PR DESCRIPTION
Reverts alphagov/forms-admin#763

We need to revert this because in the controller action (https://github.com/alphagov/forms-admin/compare/main...revert-763-fix-missing-edit-details?expand=1#diff-dd2a0dd63c7e87cd1218ed4f218dddc8169b151788bdd8ac55e6a27cdc11a5b2L51) we basically switching from ActiveResource JSON attributes to ActiveRecord JSON attributes and therefore end up losing the methods calls we have when using page.answer_settings. This wouldn't have been too much of an issue if we were using the json keys rather than method calls.

I'll see how much effort it would be to not use page at all and instead use DraftQuestion. This will again help us when we come to adding "Check your question" page

This issue was caught by the e2e tests when the page was failing to load see https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/711966560482/projects/forms-admin-smoke-tests-staging/build/forms-admin-smoke-tests-staging%3Ab4cd2310-1056-4e7f-86d8-08eaa1fffc53?region=eu-west-2#