### PR TITLE
1184-prevent-forms-runner-and-forms-admin-cloudwatch-requests-when-in-unsuitable-environments

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -77,6 +77,7 @@ class Form < ActiveResource::Base
 
   def metrics_data
     return nil unless FeatureService.enabled?(:metrics_for_form_creators_enabled)
+    return nil unless has_live_version
 
     # If the form went live today, there won't be any metrics to show
     today = Time.zone.today

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -95,6 +95,8 @@ class Form < ActiveResource::Base
 
     Sentry.capture_exception(e)
     nil
+  rescue CloudWatchService::MetricsDisabledError
+    nil
   end
 
 private

--- a/app/service/cloud_watch_service.rb
+++ b/app/service/cloud_watch_service.rb
@@ -2,7 +2,11 @@ class CloudWatchService
   REGION = "eu-west-2".freeze
   A_WEEK = 604_800
 
+  class MetricsDisabledError < StandardError; end
+
   def self.week_submissions(form_id:)
+    raise MetricsDisabledError unless Settings.cloudwatch_metrics_enabled
+
     cloudwatch_client = Aws::CloudWatch::Client.new(region: REGION)
 
     response = cloudwatch_client.get_metric_statistics({
@@ -25,6 +29,8 @@ class CloudWatchService
   end
 
   def self.week_starts(form_id:)
+    raise MetricsDisabledError unless Settings.cloudwatch_metrics_enabled
+
     cloudwatch_client = Aws::CloudWatch::Client.new(region: REGION)
 
     response = cloudwatch_client.get_metric_statistics({

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,3 +63,6 @@ cddo_sso:
   secret:
 
 forms_env: local
+
+# When set to true, the CloudWatch service will attempt to retrieve data from CloudWatch
+cloudwatch_metrics_enabled: false

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -64,4 +64,12 @@ describe "Settings" do
       expect(forms_env).to eq("local")
     end
   end
+
+  describe "cloudwatch_metrics_enabled" do
+    it "has a default value" do
+      cloudwatch_metrics_enabled = settings[:cloudwatch_metrics_enabled]
+
+      expect(cloudwatch_metrics_enabled).to be(false)
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -246,12 +246,12 @@ describe Form, type: :model do
 
   describe "#metrics_data", feature_metrics_for_form_creators_enabled: true do
     let(:form) do
-      described_class.new(id: 2, live_at: Time.zone.now - 1.day)
+      described_class.new(id: 2, live_at: Time.zone.now - 1.day, has_live_version: true)
     end
 
     context "when the form was made today" do
       let(:form) do
-        described_class.new(id: 2, live_at: Time.zone.now)
+        described_class.new(id: 2, live_at: Time.zone.now, has_live_version: true)
       end
 
       before do
@@ -323,7 +323,7 @@ describe Form, type: :model do
 
     context "when the form is not live" do
       let(:form) do
-        described_class.new(id: 2)
+        described_class.new(id: 2, has_live_version: false)
       end
 
       it "returns nil" do

--- a/spec/service/cloud_watch_service_spec.rb
+++ b/spec/service/cloud_watch_service_spec.rb
@@ -3,9 +3,11 @@ require "rails_helper"
 describe CloudWatchService do
   let(:forms_env) { "test" }
   let(:form_id) { 3 }
+  let(:cloudwatch_metrics_enabled) { true }
 
   before do
     allow(Settings).to receive(:forms_env).and_return(forms_env)
+    allow(Settings).to receive(:cloudwatch_metrics_enabled).and_return(cloudwatch_metrics_enabled)
   end
 
   around do |example|
@@ -17,6 +19,14 @@ describe CloudWatchService do
   describe "#week_submissions" do
     let(:datapoints) { [{ sum: total_submissions }] }
     let(:total_submissions) { 3.0 }
+
+    context "when CloudWatch metrics are disabled" do
+      let(:cloudwatch_metrics_enabled) { false }
+
+      it "raises a MetricsDisabledError" do
+        expect { described_class.week_submissions(form_id:) }.to raise_error(CloudWatchService::MetricsDisabledError)
+      end
+    end
 
     it "calls the cloudwatch client with get_metric_statistics" do
       cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
@@ -87,6 +97,14 @@ describe CloudWatchService do
   describe "#week_starts" do
     let(:datapoints) { [{ sum: total_starts }] }
     let(:total_starts) { 5.0 }
+
+    context "when CloudWatch metrics are disabled" do
+      let(:cloudwatch_metrics_enabled) { false }
+
+      it "raises a MetricsDisabledError" do
+        expect { described_class.week_starts(form_id:) }.to raise_error(CloudWatchService::MetricsDisabledError)
+      end
+    end
 
     it "calls the cloudwatch client with get_metric_statistics" do
       cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/eGLh3RTp/1184-prevent-forms-runner-and-forms-admin-cloudwatch-requests-when-in-unsuitable-environments

Now that https://github.com/alphagov/forms-deploy/pull/435 is in, we can make use of the environment variable that it's set to turn off metrics in dev and user research. 

This PR makes the CloudWatchService check the environment variable `cloudwatch_metrics_enabled` before it continues making CloudWatch requests, and breaks early if they're disabled. 