### PR TITLE
Amended question details not displaying on the "Edit question" page

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -7,46 +7,46 @@
                  visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{@page_object.answer_type}")
       ) end %>
 
-      <% if (@page_object.answer_type == "selection") %>
+      <% if @page_object.answer_type == "selection" %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Options")
-          row.with_value(text: @page_object.show_selection_options)
+          row.with_value(text: show_selection_options)
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: "Options") end %>
         <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.only_one_option"))
-          row.with_value(text: @page_object.answer_settings.only_one_option == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.with_value(text: settings[:only_one_option] == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.only_one_option")) end %>
         <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.include_none_of_the_above"))
-          row.with_value(text: @page_object.is_optional? ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.with_value(text: @page_object.is_optional == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
       <% end %>
 
-      <% if (@page_object.answer_type == "text") && @page_object&.answer_settings&.input_type%>
+      <% if @page_object.answer_type == "text" && settings[:input_type]%>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Length")
-          row.with_value(text: t("helpers.label.page.text_settings_options.names.#{@page_object.answer_settings.input_type}"))
+          row.with_value(text: t("helpers.label.page.text_settings_options.names.#{settings[:input_type]}"))
           row.with_action(text: "Change",
                     href: @change_text_settings_path,
                     visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if (@page_object.answer_type == "date") && @page_object&.answer_settings&.input_type %>
+      <% if @page_object.answer_type == "date" && settings.present? && settings[:input_type]%>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Date of birth")
-          row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{@page_object.answer_settings.input_type}"))
+          row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{settings[:input_type]}"))
           row.with_action(text: "Change",
                     href: @change_date_settings_path,
                     visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if (@page_object.answer_type == "address") && @page_object&.answer_settings&.input_type %>
+      <% if @page_object.answer_type == "address" && settings.present? && settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Address type")
           row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
@@ -55,17 +55,17 @@
                      visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if (@page_object.answer_type == "name") && @page_object&.answer_settings&.input_type %>
+      <% if @page_object.answer_type == "name" && settings.present? && settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Name fields")
-          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{@page_object.answer_settings.input_type}"))
+          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{settings[:input_type]}"))
           row.with_action(text: "Change",
                      href: @change_name_settings_path,
                      visually_hidden_text: "input type") end %>
 
         <%= summary_list.with_row do |row|
           row.with_key(text: "Title needed")
-          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{@page_object.answer_settings.title_needed}"))
+          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{settings[:title_needed]}"))
           row.with_action(text: "Change",
                      href: @change_name_settings_path,
                      visually_hidden_text: "title needed") end %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -22,7 +22,7 @@
                     visually_hidden_text: t("selections_settings.only_one_option")) end %>
         <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.include_none_of_the_above"))
-          row.with_value(text: @draft_question.is_optional == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.with_value(text: @draft_question.is_optional ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -1,13 +1,13 @@
 <%= govuk_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row|
       row.with_key(text: "Answer type")
-      row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@page_object.answer_type}"))
+      row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}"))
       row.with_action(text: "Change",
                  href: @change_answer_type_path,
-                 visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{@page_object.answer_type}")
+                 visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}")
       ) end %>
 
-      <% if @page_object.answer_type == "selection" %>
+      <% if @draft_question.answer_type == "selection" %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Options")
           row.with_value(text: show_selection_options)
@@ -22,13 +22,13 @@
                     visually_hidden_text: t("selections_settings.only_one_option")) end %>
         <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.include_none_of_the_above"))
-          row.with_value(text: @page_object.is_optional == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.with_value(text: @draft_question.is_optional == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
       <% end %>
 
-      <% if @page_object.answer_type == "text" && settings[:input_type]%>
+      <% if @draft_question.answer_type == "text" && settings[:input_type]%>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Length")
           row.with_value(text: t("helpers.label.page.text_settings_options.names.#{settings[:input_type]}"))
@@ -37,7 +37,7 @@
                     visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if @page_object.answer_type == "date" && settings.present? && settings[:input_type]%>
+      <% if @draft_question.answer_type == "date" && settings.present? && settings[:input_type]%>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Date of birth")
           row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{settings[:input_type]}"))
@@ -46,7 +46,7 @@
                     visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if @page_object.answer_type == "address" && settings.present? && settings[:input_type] %>
+      <% if @draft_question.answer_type == "address" && settings.present? && settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Address type")
           row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
@@ -55,7 +55,7 @@
                      visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if @page_object.answer_type == "name" && settings.present? && settings[:input_type] %>
+      <% if @draft_question.answer_type == "name" && settings.present? && settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Name fields")
           row.with_value(text: t("helpers.label.page.name_settings_options.names.#{settings[:input_type]}"))

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -2,9 +2,9 @@
 
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
-    def initialize(page_object, change_answer_type_path: "", change_selections_settings_path: "", change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
+    def initialize(draft_question, change_answer_type_path: "", change_selections_settings_path: "", change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
       super
-      @page_object = page_object
+      @draft_question = draft_question
       @change_answer_type_path = change_answer_type_path
       @change_selections_settings_path = change_selections_settings_path
       @change_text_settings_path = change_text_settings_path
@@ -27,9 +27,9 @@ module PageSettingsSummaryComponent
     end
 
     def settings
-      return [] if @page_object.answer_settings.nil?
+      return [] if @draft_question.answer_settings.nil?
 
-      @page_object.answer_settings.with_indifferent_access
+      @draft_question.answer_settings.with_indifferent_access
     end
 
     def show_selection_options

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -16,14 +16,24 @@ module PageSettingsSummaryComponent
   private
 
     def address_input_type_to_string
-      input_type = @page_object.answer_settings.input_type
-      if input_type.uk_address == "true" && input_type.international_address == "true"
+      input_type = settings[:input_type]
+      if input_type[:uk_address] == "true" && input_type[:international_address] == "true"
         "uk_and_international_addresses"
-      elsif input_type.uk_address == "true"
+      elsif input_type[:uk_address] == "true"
         "uk_addresses"
       else
         "international_addresses"
       end
+    end
+
+    def settings
+      return [] if @page_object.answer_settings.nil?
+
+      @page_object.answer_settings.with_indifferent_access
+    end
+
+    def show_selection_options
+      settings[:selection_options].map { |option| option[:name] }.join(", ")
     end
   end
 end

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -6,7 +6,7 @@ class Pages::QuestionsController < PagesController
     is_optional = draft_question.is_optional == "true"
     @question_form = Pages::QuestionForm.new(form_id: current_form.id, answer_type:, question_text:, answer_settings:, is_optional:, draft_question:)
 
-    @page = Page.new(form_id: current_form.id, answer_type:, answer_settings:, is_optional:)
+    @page = Page.new(form_id: current_form.id)
     render :new, locals: { current_form:, draft_question: }
   end
 

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -4,12 +4,10 @@ class Pages::QuestionsController < PagesController
     question_text = draft_question.question_text
     answer_settings = draft_question.answer_settings
     is_optional = draft_question.is_optional == "true"
-    page_heading = draft_question.page_heading
-    guidance_markdown = draft_question.guidance_markdown
     @question_form = Pages::QuestionForm.new(form_id: current_form.id, answer_type:, question_text:, answer_settings:, is_optional:, draft_question:)
 
-    @page = Page.new(form_id: current_form.id, question_text:, answer_type:, answer_settings:, is_optional:, page_heading:, guidance_markdown:)
-    render :new, locals: { current_form: }
+    @page = Page.new(form_id: current_form.id, answer_type:, answer_settings:, is_optional:)
+    render :new, locals: { current_form:, draft_question: }
   end
 
   def create
@@ -38,7 +36,7 @@ class Pages::QuestionsController < PagesController
                                              hint_text: draft_question.hint_text,
                                              is_optional: draft_question.is_optional,
                                              answer_settings: draft_question.answer_settings)
-    render :edit, locals: { current_form: }
+    render :edit, locals: { current_form:, draft_question: }
   end
 
   def update

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -1,10 +1,11 @@
 class Pages::QuestionsController < PagesController
   def new
-    answer_type = draft_question.answer_type
-    question_text = draft_question.question_text
-    answer_settings = draft_question.answer_settings
-    is_optional = draft_question.is_optional == "true"
-    @question_form = Pages::QuestionForm.new(form_id: current_form.id, answer_type:, question_text:, answer_settings:, is_optional:, draft_question:)
+    @question_form = Pages::QuestionForm.new(form_id: current_form.id,
+                                             answer_type: draft_question.answer_type,
+                                             question_text: draft_question.question_text,
+                                             answer_settings: draft_question.answer_settings,
+                                             is_optional: draft_question.is_optional,
+                                             draft_question:)
 
     @page = Page.new(form_id: current_form.id)
     render :new, locals: { current_form:, draft_question: }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,9 +47,9 @@ module ApplicationHelper
   def translation_key_for_answer_type(answer_type, answer_settings)
     case answer_type
     when "selection"
-      answer_settings.only_one_option == "true" ? "radio" : "checkbox"
+      answer_settings[:only_one_option] == "true" ? "radio" : "checkbox"
     when "text", "date"
-      answer_settings.input_type
+      answer_settings[:input_type]
     else
       answer_type
     end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -1,17 +1,17 @@
 <%= form_with model: [form_object, question_form], url: action_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_text_field :question_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("question_text", page_object.answer_type, page_object.answer_settings) } %>
+  <%= f.govuk_text_field :question_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("question_text", draft_question.answer_type, draft_question.answer_settings) } %>
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
-  <%= f.govuk_text_area :hint_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("hint_text", page_object.answer_type, page_object.answer_settings) } %>
+  <%= f.govuk_text_area :hint_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("hint_text", draft_question.answer_type, draft_question.answer_settings) } %>
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
   <h2 class="govuk-heading-m"><%= t("guidance.guidance") %></h2>
-  <% if page_object.page_heading.present? && page_object.guidance_markdown.present? %>
-    <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, page: page_object).build_data) %>
+  <% if draft_question.page_heading.present? && draft_question.guidance_markdown.present? %>
+    <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, page: draft_question).build_data) %>
 
   <% else %>
     <p><%= t("guidance.instructions") %></p>

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -41,7 +41,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(page_object, change_answer_type_path:, change_selections_settings_path:, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_selections_settings_path:, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -12,6 +12,7 @@
     <%= render partial: 'form', locals: { is_new_page: false,
                                           form_object: current_form,
                                           page_object: @page,
+                                          draft_question:,
                                           question_form: @question_form,
                                           action_path: update_question_path(current_form.id, @page.id) ,
                                           change_answer_type_path: type_of_answer_edit_path(current_form),

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -10,16 +10,17 @@
     </h1>
 
     <%= render partial: 'form', locals: { is_new_page: true,
-                                             form_object: current_form,
-                                             page_object: @page,
-                                             question_form: @question_form,
-                                             action_path: create_question_path(current_form),
-                                             change_answer_type_path: type_of_answer_new_path(current_form),
-                                             change_selections_settings_path: selections_settings_new_path(current_form),
-                                             change_text_settings_path: text_settings_new_path(current_form),
-                                             change_date_settings_path: date_settings_new_path(current_form),
-                                             change_address_settings_path: address_settings_new_path(current_form),
-                                             change_name_settings_path: name_settings_new_path(current_form)
+                                          form_object: current_form,
+                                          page_object: @page,
+                                          draft_question:,
+                                          question_form: @question_form,
+                                          action_path: create_question_path(current_form),
+                                          change_answer_type_path: type_of_answer_new_path(current_form),
+                                          change_selections_settings_path: selections_settings_new_path(current_form),
+                                          change_text_settings_path: text_settings_new_path(current_form),
+                                          change_date_settings_path: date_settings_new_path(current_form),
+                                          change_address_settings_path: address_settings_new_path(current_form),
+                                          change_name_settings_path: name_settings_new_path(current_form)
         } %>
 
     <p>

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -1,39 +1,37 @@
 class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewComponent::Preview
   def with_non_selection_answer_type
-    page = FactoryBot.build(:page, :with_simple_answer_type, id: 1)
+    draft_question = DraftQuestion.new(answer_type: "email")
     change_answer_type_path = "https://example.com/change_answer_type"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:))
   end
 
   def with_selection_answer_type
-    page = FactoryBot.build(:page, is_optional: "false",
-                                   answer_type: "selection",
-                                   answer_settings: OpenStruct.new(only_one_option: "true",
-                                                                   selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
-                                                                                       OpenStruct.new(attributes: { name: "Option 2" })]))
+    draft_question = DraftQuestion.new(is_optional: "false",
+                                       answer_type: "selection",
+                                       answer_settings: { only_one_option: "true",
+                                                          selection_options: [{ name: "Option 1" },
+                                                                              { name: "Option 2" }] })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_selections_settings_path = "https://example.com/change_selections_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_selections_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
   end
 
   def with_text_answer_type
-    page = FactoryBot.build(:page, :with_text_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
+    draft_question = DraftQuestion.new(answer_type: "text", answer_settings: { input_type: "long_text" })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_text_settings_path = "https://example.com/change_text_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_text_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_text_settings_path:))
   end
 
   def with_date_answer_type
-    page = FactoryBot.build(:page, :with_date_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
+    draft_question = DraftQuestion.new(answer_type: "date", answer_settings: { input_type: "date_of_birth" })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_date_settings_path = "https://example.com/change_date_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_date_settings_path:))
   end
 
   def with_legacy_date_answer_type
-    page = FactoryBot.build(:page, :with_date_settings, id: 1)
+    page = DraftQuestion.new(answer_type: "date")
     page.answer_settings = nil
     change_answer_type_path = "https://example.com/change_answer_type"
     change_date_settings_path = "https://example.com/change_date_settings"
@@ -41,18 +39,16 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
   end
 
   def with_address_answer_type
-    page = FactoryBot.build(:page, :with_address_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
+    draft_question = DraftQuestion.new(answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "true" } })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_address_settings_path = "https://example.com/change_address_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_address_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_address_settings_path:))
   end
 
   def with_name_answer_type
-    page = FactoryBot.build(:page, :with_name_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
+    draft_question = DraftQuestion.new(answer_type: "name", answer_settings: { input_type: "first_middle_and_last_name", title_needed: "true" })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_name_settings_path = "https://example.com/change_name_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_name_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_name_settings_path:))
   end
 end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -46,10 +46,34 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "renders the selection settings" do
       render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
-      expect(page).to have_text "Selection from a list"
-      expect(page).to have_text "Option 1, Option 2"
-      expect(page).to have_text "Yes"
-      expect(page).to have_text "No"
+      rows = page.find_all(".govuk-summary-list__row")
+
+      expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
+      expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
+      expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
+      expect(rows[1].find(".govuk-summary-list__value")).to have_text "Option 1, Option 2"
+      expect(rows[2].find(".govuk-summary-list__key")).to have_text "People can only select one option"
+      expect(rows[2].find(".govuk-summary-list__value")).to have_text "Yes"
+      expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
+      expect(rows[3].find(".govuk-summary-list__value")).to have_text "No"
+    end
+
+    context "when 'None of the above' is a setting" do
+      let(:draft_question) { build :selection_draft_question, is_optional: true }
+
+      it "renders the selection settings" do
+        render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
+        rows = page.find_all(".govuk-summary-list__row")
+
+        expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
+        expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
+        expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
+        expect(rows[1].find(".govuk-summary-list__value")).to have_text "Option 1, Option 2"
+        expect(rows[2].find(".govuk-summary-list__key")).to have_text "People can only select one option"
+        expect(rows[2].find(".govuk-summary-list__value")).to have_text "Yes"
+        expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
+        expect(rows[3].find(".govuk-summary-list__value")).to have_text "Yes"
+      end
     end
   end
 

--- a/spec/factories/models/draft_questions.rb
+++ b/spec/factories/models/draft_questions.rb
@@ -11,10 +11,6 @@ FactoryBot.define do
     guidance_markdown { nil }
     answer_settings { {} }
 
-    factory :draft_question_for_new_page do
-      page_id { nil }
-    end
-
     trait :with_hints do
       hint_text { Faker::Quote.yoda.truncate(500) }
     end
@@ -22,6 +18,54 @@ FactoryBot.define do
     trait :with_guidance do
       page_heading { Faker::Quote.yoda.truncate(250) }
       guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
+    end
+
+    factory :draft_question_for_new_page do
+      page_id { nil }
+    end
+
+    factory :address_draft_question do
+      transient do
+        uk_address { "true" }
+        international_address { "true" }
+      end
+
+      answer_type { "address" }
+      answer_settings { { input_type: { uk_address:, international_address: } } }
+    end
+
+    factory :date_draft_question do
+      transient do
+        input_type { Pages::DateSettingsForm::INPUT_TYPES.sample }
+      end
+
+      answer_type { "date" }
+      answer_settings { { input_type: } }
+    end
+
+    factory :name_draft_question do
+      transient do
+        input_type { Pages::NameSettingsForm::INPUT_TYPES.sample }
+        title_needed { Pages::NameSettingsForm::TITLE_NEEDED.sample }
+      end
+
+      answer_type { "name" }
+      answer_settings { { input_type:, title_needed: } }
+    end
+
+    factory :selection_draft_question do
+      question_text { Faker::Lorem.question }
+      answer_type { "selection" }
+      answer_settings { { only_one_option: "true", selection_options: [{ name: "Option 1" }, { name: "Option 2" }] } }
+    end
+
+    factory :text_draft_question do
+      transient do
+        input_type { Pages::TextSettingsForm::INPUT_TYPES.sample }
+      end
+
+      answer_type { "text" }
+      answer_settings { { input_type: } }
     end
   end
 end

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -14,13 +14,66 @@ RSpec.describe Pages::QuestionsController, type: :request do
     }
   end
 
-  let(:form_response) do
-    (build :form, id: 2)
-  end
+  let(:form_response) { build :form, id: 2 }
+
   let(:draft_question) { create :draft_question_for_new_page, user: editor_user, form_id: 2 }
 
   before do
     login_as_editor_user
+  end
+
+
+  describe "#new" do
+    let(:draft_question) do
+      record = create :draft_question_for_new_page, user: editor_user, form_id: 2
+      record.question_text = nil
+      record.save!(validate: false)
+      record.reload
+    end
+
+    let(:form_pages_response) do
+      [{
+         id: 1,
+         form_id: 2,
+         question_text: draft_question.question_text,
+         hint_text: draft_question.hint_text,
+         answer_type: draft_question.answer_type,
+         answer_settings: nil,
+         page_heading: nil,
+         guidance_markdown: nil,
+       }].to_json
+    end
+
+    let(:req_headers) do
+      {
+        "X-API-Token" => Settings.forms_api.auth_key,
+        "Accept" => "application/json",
+      }
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2", req_headers, form_response.to_json, 200
+        mock.get "/api/v1/forms/2/pages", req_headers, form_pages_response, 200
+      end
+
+      draft_question
+
+      get new_question_path(form_id: 2)
+    end
+
+    it "Reads the form from the API" do
+      expect(form_response).to have_been_read
+    end
+
+    it "Reads the pages from the API" do
+      form_pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, req_headers)
+      expect(ActiveResource::HttpMock.requests).to include form_pages_request
+    end
+
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe "#create" do

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
           mock.post "/api/v1/forms/2/pages", post_headers
         end
 
+        # Setup a draft_question so that create question action doesn't need to create a completely new records
         draft_question
 
         post create_question_path(2), params: { pages_question_form: {
@@ -119,6 +120,9 @@ RSpec.describe Pages::QuestionsController, type: :request do
           mock.get "/api/v1/forms/2/pages", req_headers, form_pages_response, 200
           mock.get "/api/v1/forms/2/pages/1", req_headers, page_response, 200
         end
+
+        # Setup a draft_question so that edit question action doesn't need to create a completely new records
+        draft_question
 
         get edit_question_path(form_id: 2, page_id: 1)
       end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "pages/_form.html.erb", type: :view do
   let(:page) { build :page, :with_hints, :with_simple_answer_type, id: 2, form_id: form.id }
+  let(:draft_question) { question_form.draft_question }
   let(:question_form) do
     build :question_form,
           form_id: form.id,
@@ -16,6 +17,7 @@ describe "pages/_form.html.erb", type: :view do
     render partial: "pages/form", locals: { is_new_page:,
                                             form_object: form,
                                             page_object: page,
+                                            draft_question:,
                                             question_form:,
                                             action_path: "http://example.com",
                                             change_answer_type_path: "http://change-me-please.com",

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -3,17 +3,23 @@ require "rails_helper"
 describe "pages/edit.html.erb" do
   let(:question_text) { nil }
 
+  let(:form) { build :form, id: 1, pages: [page] }
+  let(:page) { build :page, id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil, page_heading: nil }
+
+  let(:draft_question) { question_form.draft_question }
+  let(:question_form) do
+    build :question_form,
+          form_id: form.id,
+          answer_type: page.answer_type,
+          question_text: page.question_text,
+          hint_text: page.hint_text
+  end
+
+  let(:current_user) { OpenStruct.new(uid: "123456") }
+
   before do
-    # Initialize models
-    page = Page.new(id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil, page_heading: nil)
-    question_form = Pages::QuestionForm.new(page_id: 1, question_text:, form_id: 1, answer_type: "email", answer_settings: nil)
-    form = Form.new(id: 1, name: "Form 1", form_id: 1, pages: [page])
-    current_user = OpenStruct.new(uid: "123456")
-
     # If models aren't persisted, they won't work with form builders correctly
-
     without_partial_double_verification do
-      allow(question_form).to receive(:persisted?).and_return(true)
       allow(form).to receive(:persisted?).and_return(true)
       allow(view).to receive(:type_of_answer_edit_path).and_return("/type-of-answer")
       allow(view).to receive(:selections_settings_edit_path).and_return("/selections_settings")
@@ -22,6 +28,7 @@ describe "pages/edit.html.erb" do
       allow(view).to receive(:address_settings_edit_path).and_return("/address-settings")
       allow(view).to receive(:name_settings_edit_path).and_return("/name-settings")
       allow(view).to receive(:current_form).and_return(form)
+      allow(view).to receive(:draft_question).and_return(draft_question)
     end
 
     # Assign instance variables so they can be accessed from views


### PR DESCRIPTION
### What problem does this pull request solve?

This work should fix the issues raised and reverted in the below PR:
* https://github.com/alphagov/forms-admin/pull/763
* https://github.com/alphagov/forms-admin/pull/764

"Edit question" page was not using draft_question page to display the answer_settings to the user. As part of the changes
there was a bit of refactoring to the PageSettingsSummaryComponent to better support draft_question instead of Page model. We should refactor this further so it doesn't require so many params when its called but that will be done as a separate PR. 

Best to view individual commits.

Trello card: 
- https://trello.com/c/HeXLnq1m/1201-form-creators-cannot-view-all-details-for-a-particular-page-when-they-edit-the-question
- https://trello.com/c/JhfQQNIb/1205-error-when-saving-a-selection-question-with-none-of-the-above-option
<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
