### PR TITLE
Refactor PageSettingsSummaryComponent to support draft_question instead of page model.

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -22,7 +22,7 @@
                     visually_hidden_text: t("selections_settings.only_one_option")) end %>
         <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.include_none_of_the_above"))
-          row.with_value(text: @draft_question.is_optional == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.with_value(text: @draft_question.is_optional ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -1,13 +1,13 @@
 <%= govuk_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row|
       row.with_key(text: "Answer type")
-      row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@page_object.answer_type}"))
+      row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}"))
       row.with_action(text: "Change",
                  href: @change_answer_type_path,
-                 visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{@page_object.answer_type}")
+                 visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}")
       ) end %>
 
-      <% if @page_object.answer_type == "selection" %>
+      <% if @draft_question.answer_type == "selection" %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Options")
           row.with_value(text: show_selection_options)
@@ -22,12 +22,12 @@
                     visually_hidden_text: t("selections_settings.only_one_option")) end %>
         <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.include_none_of_the_above"))
-          row.with_value(text: @page_object.is_optional == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.with_value(text: @draft_question.is_optional == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
       <% end %>
-      <% if @page_object.answer_type == "text" && answer_settings.present? && answer_settings[:input_type] %>
+      <% if @draft_question.answer_type == "text" && answer_settings.present? && answer_settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Length")
           row.with_value(text: t("helpers.label.page.text_settings_options.names.#{answer_settings[:input_type]}"))
@@ -36,7 +36,7 @@
                     visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if @page_object.answer_type == "date" && answer_settings.present? && answer_settings[:input_type]%>
+      <% if @draft_question.answer_type == "date" && answer_settings.present? && answer_settings[:input_type]%>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Date of birth")
           row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{answer_settings[:input_type]}"))
@@ -45,7 +45,7 @@
                     visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if @page_object.answer_type == "address" && answer_settings.present? && answer_settings[:input_type] %>
+      <% if @draft_question.answer_type == "address" && answer_settings.present? && answer_settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Address type")
           row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
@@ -54,7 +54,7 @@
                      visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if @page_object.answer_type == "name" && answer_settings.present? && answer_settings[:input_type] %>
+      <% if @draft_question.answer_type == "name" && answer_settings.present? && answer_settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Name fields")
           row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:input_type]}"))

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -7,46 +7,45 @@
                  visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{@page_object.answer_type}")
       ) end %>
 
-      <% if (@page_object.answer_type == "selection") %>
+      <% if @page_object.answer_type == "selection" %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Options")
-          row.with_value(text: @page_object.show_selection_options)
+          row.with_value(text: show_selection_options)
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: "Options") end %>
         <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.only_one_option"))
-          row.with_value(text: @page_object.answer_settings.only_one_option == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.with_value(text: answer_settings[:only_one_option] == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.only_one_option")) end %>
         <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.include_none_of_the_above"))
-          row.with_value(text: @page_object.is_optional? ? t("selections_settings.yes") : t("selections_settings.no"))
+          row.with_value(text: @page_object.is_optional == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
       <% end %>
-
-      <% if (@page_object.answer_type == "text") && @page_object&.answer_settings&.input_type%>
+      <% if @page_object.answer_type == "text" && answer_settings.present? && answer_settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Length")
-          row.with_value(text: t("helpers.label.page.text_settings_options.names.#{@page_object.answer_settings.input_type}"))
+          row.with_value(text: t("helpers.label.page.text_settings_options.names.#{answer_settings[:input_type]}"))
           row.with_action(text: "Change",
                     href: @change_text_settings_path,
                     visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if (@page_object.answer_type == "date") && @page_object&.answer_settings&.input_type %>
+      <% if @page_object.answer_type == "date" && answer_settings.present? && answer_settings[:input_type]%>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Date of birth")
-          row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{@page_object.answer_settings.input_type}"))
+          row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{answer_settings[:input_type]}"))
           row.with_action(text: "Change",
                     href: @change_date_settings_path,
                     visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if (@page_object.answer_type == "address") && @page_object&.answer_settings&.input_type %>
+      <% if @page_object.answer_type == "address" && answer_settings.present? && answer_settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Address type")
           row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
@@ -55,17 +54,17 @@
                      visually_hidden_text: "input type") end %>
       <% end %>
 
-      <% if (@page_object.answer_type == "name") && @page_object&.answer_settings&.input_type %>
+      <% if @page_object.answer_type == "name" && answer_settings.present? && answer_settings[:input_type] %>
         <%= summary_list.with_row do |row|
           row.with_key(text: "Name fields")
-          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{@page_object.answer_settings.input_type}"))
+          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:input_type]}"))
           row.with_action(text: "Change",
                      href: @change_name_settings_path,
                      visually_hidden_text: "input type") end %>
 
         <%= summary_list.with_row do |row|
           row.with_key(text: "Title needed")
-          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{@page_object.answer_settings.title_needed}"))
+          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:title_needed]}"))
           row.with_action(text: "Change",
                      href: @change_name_settings_path,
                      visually_hidden_text: "title needed") end %>

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -16,14 +16,24 @@ module PageSettingsSummaryComponent
   private
 
     def address_input_type_to_string
-      input_type = @page_object.answer_settings.input_type
-      if input_type.uk_address == "true" && input_type.international_address == "true"
+      input_type = answer_settings[:input_type]
+      if input_type[:uk_address] == "true" && input_type[:international_address] == "true"
         "uk_and_international_addresses"
-      elsif input_type.uk_address == "true"
+      elsif input_type[:uk_address] == "true"
         "uk_addresses"
       else
         "international_addresses"
       end
+    end
+
+    def answer_settings
+      return [] if @page_object.answer_settings.nil?
+
+      @page_object.answer_settings.with_indifferent_access
+    end
+
+    def show_selection_options
+      answer_settings[:selection_options].map { |option| option[:name] }.join(", ")
     end
   end
 end

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -2,9 +2,9 @@
 
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
-    def initialize(page_object, change_answer_type_path: "", change_selections_settings_path: "", change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
+    def initialize(draft_question, change_answer_type_path: "", change_selections_settings_path: "", change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
       super
-      @page_object = page_object
+      @draft_question = draft_question
       @change_answer_type_path = change_answer_type_path
       @change_selections_settings_path = change_selections_settings_path
       @change_text_settings_path = change_text_settings_path
@@ -27,9 +27,9 @@ module PageSettingsSummaryComponent
     end
 
     def answer_settings
-      return [] if @page_object.answer_settings.nil?
+      return [] if @draft_question.answer_settings.nil?
 
-      @page_object.answer_settings.with_indifferent_access
+      @draft_question.answer_settings.with_indifferent_access
     end
 
     def show_selection_options

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -41,7 +41,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(page_object, change_answer_type_path:, change_selections_settings_path:, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_selections_settings_path:, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -1,58 +1,53 @@
 class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewComponent::Preview
   def with_non_selection_answer_type
-    page = FactoryBot.build(:page, :with_simple_answer_type, id: 1)
+    draft_question = DraftQuestion.new(answer_type: "email")
     change_answer_type_path = "https://example.com/change_answer_type"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:))
   end
 
   def with_selection_answer_type
-    page = FactoryBot.build(:page, is_optional: "false",
-                                   answer_type: "selection",
-                                   answer_settings: OpenStruct.new(only_one_option: "true",
-                                                                   selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
-                                                                                       OpenStruct.new(attributes: { name: "Option 2" })]))
+    draft_question = DraftQuestion.new(is_optional: "false",
+                                       answer_type: "selection",
+                                       answer_settings: { only_one_option: "true",
+                                                          selection_options: [{ name: "Option 1" },
+                                                                              { name: "Option 2" }] })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_selections_settings_path = "https://example.com/change_selections_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_selections_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
   end
 
   def with_text_answer_type
-    page = FactoryBot.build(:page, :with_text_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
+    draft_question = DraftQuestion.new(answer_type: "text", answer_settings: { input_type: "long_text" })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_text_settings_path = "https://example.com/change_text_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_text_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_text_settings_path:))
   end
 
   def with_date_answer_type
-    page = FactoryBot.build(:page, :with_date_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
+    draft_question = DraftQuestion.new(answer_type: "date", answer_settings: { input_type: "date_of_birth" })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_date_settings_path = "https://example.com/change_date_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_date_settings_path:))
   end
 
   def with_legacy_date_answer_type
-    page = FactoryBot.build(:page, :with_date_settings, id: 1)
-    page.answer_settings = nil
+    draft_question = DraftQuestion.new(answer_type: "date")
     change_answer_type_path = "https://example.com/change_answer_type"
     change_date_settings_path = "https://example.com/change_date_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_date_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_date_settings_path:))
   end
 
   def with_address_answer_type
-    page = FactoryBot.build(:page, :with_address_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
+    draft_question = DraftQuestion.new(answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "true" } })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_address_settings_path = "https://example.com/change_address_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_address_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_address_settings_path:))
   end
 
   def with_name_answer_type
-    page = FactoryBot.build(:page, :with_name_settings, id: 1)
-    page.answer_settings = OpenStruct.new(page.answer_settings)
+    draft_question = DraftQuestion.new(answer_type: "name", answer_settings: { input_type: "first_middle_and_last_name", title_needed: "true" })
     change_answer_type_path = "https://example.com/change_answer_type"
     change_name_settings_path = "https://example.com/change_name_settings"
-    render(PageSettingsSummaryComponent::View.new(page, change_answer_type_path:, change_name_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_name_settings_path:))
   end
 end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -46,10 +46,34 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "renders the selection settings" do
       render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
-      expect(page).to have_text "Selection from a list"
-      expect(page).to have_text "Option 1, Option 2"
-      expect(page).to have_text "Yes"
-      expect(page).to have_text "No"
+      rows = page.find_all(".govuk-summary-list__row")
+
+      expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
+      expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
+      expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
+      expect(rows[1].find(".govuk-summary-list__value")).to have_text "Option 1, Option 2"
+      expect(rows[2].find(".govuk-summary-list__key")).to have_text "People can only select one option"
+      expect(rows[2].find(".govuk-summary-list__value")).to have_text "Yes"
+      expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
+      expect(rows[3].find(".govuk-summary-list__value")).to have_text "No"
+    end
+
+    context "when 'None of the above' is a setting" do
+      let(:draft_question) { build :selection_draft_question, is_optional: true }
+
+      it "renders the selection settings" do
+        render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
+        rows = page.find_all(".govuk-summary-list__row")
+
+        expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
+        expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
+        expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
+        expect(rows[1].find(".govuk-summary-list__value")).to have_text "Option 1, Option 2"
+        expect(rows[2].find(".govuk-summary-list__key")).to have_text "People can only select one option"
+        expect(rows[2].find(".govuk-summary-list__value")).to have_text "Yes"
+        expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
+        expect(rows[3].find(".govuk-summary-list__value")).to have_text "Yes"
+      end
     end
   end
 

--- a/spec/factories/models/draft_questions.rb
+++ b/spec/factories/models/draft_questions.rb
@@ -11,10 +11,6 @@ FactoryBot.define do
     guidance_markdown { nil }
     answer_settings { {} }
 
-    factory :draft_question_for_new_page do
-      page_id { nil }
-    end
-
     trait :with_hints do
       hint_text { Faker::Quote.yoda.truncate(500) }
     end
@@ -22,6 +18,54 @@ FactoryBot.define do
     trait :with_guidance do
       page_heading { Faker::Quote.yoda.truncate(250) }
       guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
+    end
+
+    factory :draft_question_for_new_page do
+      page_id { nil }
+    end
+
+    factory :address_draft_question do
+      transient do
+        uk_address { "true" }
+        international_address { "true" }
+      end
+
+      answer_type { "address" }
+      answer_settings { { input_type: { uk_address:, international_address: } } }
+    end
+
+    factory :date_draft_question do
+      transient do
+        input_type { Pages::DateSettingsForm::INPUT_TYPES.sample }
+      end
+
+      answer_type { "date" }
+      answer_settings { { input_type: } }
+    end
+
+    factory :name_draft_question do
+      transient do
+        input_type { Pages::NameSettingsForm::INPUT_TYPES.sample }
+        title_needed { Pages::NameSettingsForm::TITLE_NEEDED.sample }
+      end
+
+      answer_type { "name" }
+      answer_settings { { input_type:, title_needed: } }
+    end
+
+    factory :selection_draft_question do
+      question_text { Faker::Lorem.question }
+      answer_type { "selection" }
+      answer_settings { { only_one_option: "true", selection_options: [{ name: "Option 1" }, { name: "Option 2" }] } }
+    end
+
+    factory :text_draft_question do
+      transient do
+        input_type { Pages::TextSettingsForm::INPUT_TYPES.sample }
+      end
+
+      answer_type { "text" }
+      answer_settings { { input_type: } }
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

This work should fix the issues raised and reverted in the below PR:
* https://github.com/alphagov/forms-admin/pull/763
* https://github.com/alphagov/forms-admin/pull/764
* https://github.com/alphagov/forms-admin/pull/768
* https://github.com/alphagov/forms-admin/pull/772

Refactor PageSettingsSummaryComponent to support draft_question instead of page model. 

Trello card: https://trello.com/c/HeXLnq1m/1201-form-creators-cannot-view-all-details-for-a-particular-page-when-they-edit-the-question

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
