### PR TITLE
Remove attributes params when initialising a new Page and new spec

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -6,7 +6,7 @@ class Pages::QuestionsController < PagesController
     is_optional = draft_question.is_optional == "true"
     @question_form = Pages::QuestionForm.new(form_id: current_form.id, answer_type:, question_text:, answer_settings:, is_optional:, draft_question:)
 
-    @page = Page.new(form_id: current_form.id, answer_type:, answer_settings:, is_optional:)
+    @page = Page.new(form_id: current_form.id)
     render :new, locals: { current_form:, draft_question: }
   end
 

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -1,10 +1,11 @@
 class Pages::QuestionsController < PagesController
   def new
-    answer_type = draft_question.answer_type
-    question_text = draft_question.question_text
-    answer_settings = draft_question.answer_settings
-    is_optional = draft_question.is_optional == "true"
-    @question_form = Pages::QuestionForm.new(form_id: current_form.id, answer_type:, question_text:, answer_settings:, is_optional:, draft_question:)
+    @question_form = Pages::QuestionForm.new(form_id: current_form.id,
+                                             answer_type: draft_question.answer_type,
+                                             question_text: draft_question.question_text,
+                                             answer_settings: draft_question.answer_settings,
+                                             is_optional: draft_question.is_optional,
+                                             draft_question:)
 
     @page = Page.new(form_id: current_form.id)
     render :new, locals: { current_form:, draft_question: }


### PR DESCRIPTION
This work should fix the issues raised and reverted in the below PR:
* https://github.com/alphagov/forms-admin/pull/763
* https://github.com/alphagov/forms-admin/pull/764
* https://github.com/alphagov/forms-admin/pull/768
* https://github.com/alphagov/forms-admin/pull/772
* https://github.com/alphagov/forms-admin/pull/773

Remove attributes params when when setting up a new instance of Page mode in the QuestionController new action.
Also added a new missing request spec for this action

Trello card: https://trello.com/c/HeXLnq1m/1201-form-creators-cannot-view-all-details-for-a-particular-page-when-they-edit-the-question

Trello card: https://trello.com/c/l7OUqJEN/1202-tech-debt-add-missing-request-spec-for-questioncontroller-new-action

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
