### PR TITLE
Refactor PageSettingsSummaryComponent to not need so many params

### DIFF
--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -2,15 +2,20 @@
 
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
-    def initialize(draft_question, change_answer_type_path: "", change_selections_settings_path: "", change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
+    include Rails.application.routes.url_helpers
+    def initialize(draft_question, change_answer_type_path: "", change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
       super
       @draft_question = draft_question
       @change_answer_type_path = change_answer_type_path
-      @change_selections_settings_path = change_selections_settings_path
       @change_text_settings_path = change_text_settings_path
       @change_date_settings_path = change_date_settings_path
       @change_address_settings_path = change_address_settings_path
       @change_name_settings_path = change_name_settings_path
+    end
+
+    def before_render
+      super
+      @change_selections_settings_path = change_selections_settings_path
     end
 
   private
@@ -34,6 +39,20 @@ module PageSettingsSummaryComponent
 
     def show_selection_options
       answer_settings[:selection_options].map { |option| option[:name] }.join(", ")
+    end
+
+    def change_selections_settings_path
+      return unless @draft_question.answer_type == "selection"
+
+      if is_new_question?
+        selections_settings_new_path(form_id: @draft_question.form_id)
+      else
+        selections_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
+      end
+    end
+
+    def is_new_question?
+      @draft_question.page_id.nil?
     end
   end
 end

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -3,16 +3,16 @@
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
     include Rails.application.routes.url_helpers
-    def initialize(draft_question, change_address_settings_path: "", change_name_settings_path: "")
+    def initialize(draft_question, change_name_settings_path: "")
       super
       @draft_question = draft_question
-      @change_address_settings_path = change_address_settings_path
       @change_name_settings_path = change_name_settings_path
     end
 
     def before_render
       super
       @change_answer_type_path = change_answer_type_path
+      @change_address_settings_path = change_address_settings_path
       @change_date_settings_path = change_date_settings_path
       @change_selections_settings_path = change_selections_settings_path
       @change_text_settings_path = change_text_settings_path
@@ -46,6 +46,16 @@ module PageSettingsSummaryComponent
         type_of_answer_new_path(form_id: @draft_question.form_id)
       else
         type_of_answer_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
+      end
+    end
+
+    def change_address_settings_path
+      return unless @draft_question.answer_type == "address"
+
+      if is_new_question?
+        address_settings_new_path(form_id: @draft_question.form_id)
+      else
+        address_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
       end
     end
 

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -3,10 +3,9 @@
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
     include Rails.application.routes.url_helpers
-    def initialize(draft_question, change_name_settings_path: "")
+    def initialize(draft_question)
       super
       @draft_question = draft_question
-      @change_name_settings_path = change_name_settings_path
     end
 
     def before_render
@@ -14,6 +13,7 @@ module PageSettingsSummaryComponent
       @change_answer_type_path = change_answer_type_path
       @change_address_settings_path = change_address_settings_path
       @change_date_settings_path = change_date_settings_path
+      @change_name_settings_path = change_name_settings_path
       @change_selections_settings_path = change_selections_settings_path
       @change_text_settings_path = change_text_settings_path
     end
@@ -66,6 +66,16 @@ module PageSettingsSummaryComponent
         date_settings_new_path(form_id: @draft_question.form_id)
       else
         date_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
+      end
+    end
+
+    def change_name_settings_path
+      return unless @draft_question.answer_type == "name"
+
+      if is_new_question?
+        name_settings_new_path(form_id: @draft_question.form_id)
+      else
+        name_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
       end
     end
 

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -3,10 +3,9 @@
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
     include Rails.application.routes.url_helpers
-    def initialize(draft_question, change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
+    def initialize(draft_question, change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
       super
       @draft_question = draft_question
-      @change_text_settings_path = change_text_settings_path
       @change_date_settings_path = change_date_settings_path
       @change_address_settings_path = change_address_settings_path
       @change_name_settings_path = change_name_settings_path
@@ -16,6 +15,7 @@ module PageSettingsSummaryComponent
       super
       @change_answer_type_path = change_answer_type_path
       @change_selections_settings_path = change_selections_settings_path
+      @change_text_settings_path = change_text_settings_path
     end
 
   private
@@ -56,6 +56,16 @@ module PageSettingsSummaryComponent
         selections_settings_new_path(form_id: @draft_question.form_id)
       else
         selections_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
+      end
+    end
+
+    def change_text_settings_path
+      return unless @draft_question.answer_type == "text"
+
+      if is_new_question?
+        text_settings_new_path(form_id: @draft_question.form_id)
+      else
+        text_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
       end
     end
 

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -3,10 +3,9 @@
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
     include Rails.application.routes.url_helpers
-    def initialize(draft_question, change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
+    def initialize(draft_question, change_address_settings_path: "", change_name_settings_path: "")
       super
       @draft_question = draft_question
-      @change_date_settings_path = change_date_settings_path
       @change_address_settings_path = change_address_settings_path
       @change_name_settings_path = change_name_settings_path
     end
@@ -14,6 +13,7 @@ module PageSettingsSummaryComponent
     def before_render
       super
       @change_answer_type_path = change_answer_type_path
+      @change_date_settings_path = change_date_settings_path
       @change_selections_settings_path = change_selections_settings_path
       @change_text_settings_path = change_text_settings_path
     end
@@ -46,6 +46,16 @@ module PageSettingsSummaryComponent
         type_of_answer_new_path(form_id: @draft_question.form_id)
       else
         type_of_answer_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
+      end
+    end
+
+    def change_date_settings_path
+      return unless @draft_question.answer_type == "date"
+
+      if is_new_question?
+        date_settings_new_path(form_id: @draft_question.form_id)
+      else
+        date_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
       end
     end
 

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -3,10 +3,9 @@
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
     include Rails.application.routes.url_helpers
-    def initialize(draft_question, change_answer_type_path: "", change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
+    def initialize(draft_question, change_text_settings_path: "", change_date_settings_path: "", change_address_settings_path: "", change_name_settings_path: "")
       super
       @draft_question = draft_question
-      @change_answer_type_path = change_answer_type_path
       @change_text_settings_path = change_text_settings_path
       @change_date_settings_path = change_date_settings_path
       @change_address_settings_path = change_address_settings_path
@@ -15,6 +14,7 @@ module PageSettingsSummaryComponent
 
     def before_render
       super
+      @change_answer_type_path = change_answer_type_path
       @change_selections_settings_path = change_selections_settings_path
     end
 
@@ -39,6 +39,14 @@ module PageSettingsSummaryComponent
 
     def show_selection_options
       answer_settings[:selection_options].map { |option| option[:name] }.join(", ")
+    end
+
+    def change_answer_type_path
+      if is_new_question?
+        type_of_answer_new_path(form_id: @draft_question.form_id)
+      else
+        type_of_answer_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
+      end
     end
 
     def change_selections_settings_path

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -41,7 +41,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -41,7 +41,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_address_settings_path:, change_name_settings_path:) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_name_settings_path:) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -41,7 +41,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_selections_settings_path:, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -41,7 +41,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_name_settings_path:) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -41,7 +41,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_text_settings_path:, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -41,7 +41,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_date_settings_path:, change_address_settings_path:, change_name_settings_path:) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question, change_address_settings_path:, change_name_settings_path:) %>
 
   <%= f.govuk_submit page_object.has_next_page? ? t("pages.submit_edit") : t("pages.submit_add") do %>
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -15,7 +15,6 @@
                                           draft_question:,
                                           question_form: @question_form,
                                           action_path: update_question_path(current_form.id, @page.id) ,
-                                          change_answer_type_path: type_of_answer_edit_path(current_form),
                                           change_text_settings_path: text_settings_edit_path(current_form),
                                           change_date_settings_path: date_settings_edit_path(current_form),
                                           change_address_settings_path: address_settings_edit_path(current_form),

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -15,7 +15,6 @@
                                           draft_question:,
                                           question_form: @question_form,
                                           action_path: update_question_path(current_form.id, @page.id),
-                                          change_name_settings_path: name_settings_edit_path(current_form)
     } %>
 
     <p>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -14,8 +14,7 @@
                                           page_object: @page,
                                           draft_question:,
                                           question_form: @question_form,
-                                          action_path: update_question_path(current_form.id, @page.id) ,
-                                          change_address_settings_path: address_settings_edit_path(current_form),
+                                          action_path: update_question_path(current_form.id, @page.id),
                                           change_name_settings_path: name_settings_edit_path(current_form)
     } %>
 

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -15,7 +15,6 @@
                                           draft_question:,
                                           question_form: @question_form,
                                           action_path: update_question_path(current_form.id, @page.id) ,
-                                          change_date_settings_path: date_settings_edit_path(current_form),
                                           change_address_settings_path: address_settings_edit_path(current_form),
                                           change_name_settings_path: name_settings_edit_path(current_form)
     } %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -15,7 +15,6 @@
                                           draft_question:,
                                           question_form: @question_form,
                                           action_path: update_question_path(current_form.id, @page.id) ,
-                                          change_text_settings_path: text_settings_edit_path(current_form),
                                           change_date_settings_path: date_settings_edit_path(current_form),
                                           change_address_settings_path: address_settings_edit_path(current_form),
                                           change_name_settings_path: name_settings_edit_path(current_form)

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -16,7 +16,6 @@
                                           question_form: @question_form,
                                           action_path: update_question_path(current_form.id, @page.id) ,
                                           change_answer_type_path: type_of_answer_edit_path(current_form),
-                                          change_selections_settings_path: selections_settings_edit_path(current_form),
                                           change_text_settings_path: text_settings_edit_path(current_form),
                                           change_date_settings_path: date_settings_edit_path(current_form),
                                           change_address_settings_path: address_settings_edit_path(current_form),

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -15,7 +15,6 @@
                                           draft_question:,
                                           question_form: @question_form,
                                           action_path: create_question_path(current_form),
-                                          change_answer_type_path: type_of_answer_new_path(current_form),
                                           change_text_settings_path: text_settings_new_path(current_form),
                                           change_date_settings_path: date_settings_new_path(current_form),
                                           change_address_settings_path: address_settings_new_path(current_form),

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -16,7 +16,6 @@
                                           question_form: @question_form,
                                           action_path: create_question_path(current_form),
                                           change_answer_type_path: type_of_answer_new_path(current_form),
-                                          change_selections_settings_path: selections_settings_new_path(current_form),
                                           change_text_settings_path: text_settings_new_path(current_form),
                                           change_date_settings_path: date_settings_new_path(current_form),
                                           change_address_settings_path: address_settings_new_path(current_form),

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -15,7 +15,6 @@
                                           draft_question:,
                                           question_form: @question_form,
                                           action_path: create_question_path(current_form),
-                                          change_text_settings_path: text_settings_new_path(current_form),
                                           change_date_settings_path: date_settings_new_path(current_form),
                                           change_address_settings_path: address_settings_new_path(current_form),
                                           change_name_settings_path: name_settings_new_path(current_form)

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -15,7 +15,6 @@
                                           draft_question:,
                                           question_form: @question_form,
                                           action_path: create_question_path(current_form),
-                                          change_address_settings_path: address_settings_new_path(current_form),
                                           change_name_settings_path: name_settings_new_path(current_form)
         } %>
 

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -15,7 +15,6 @@
                                           draft_question:,
                                           question_form: @question_form,
                                           action_path: create_question_path(current_form),
-                                          change_date_settings_path: date_settings_new_path(current_form),
                                           change_address_settings_path: address_settings_new_path(current_form),
                                           change_name_settings_path: name_settings_new_path(current_form)
         } %>

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -15,7 +15,6 @@
                                           draft_question:,
                                           question_form: @question_form,
                                           action_path: create_question_path(current_form),
-                                          change_name_settings_path: name_settings_new_path(current_form)
         } %>
 
     <p>

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -6,14 +6,14 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
   end
 
   def with_selection_answer_type
-    draft_question = DraftQuestion.new(is_optional: "false",
+    draft_question = DraftQuestion.new(form_id: 1,
+                                       is_optional: "false",
                                        answer_type: "selection",
                                        answer_settings: { only_one_option: "true",
                                                           selection_options: [{ name: "Option 1" },
                                                                               { name: "Option 2" }] })
     change_answer_type_path = "https://example.com/change_answer_type"
-    change_selections_settings_path = "https://example.com/change_selections_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:))
   end
 
   def with_text_answer_type

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -43,8 +43,7 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
                                            international_address: "true",
                                          },
                                        })
-    change_address_settings_path = "https://example.com/change_address_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_address_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question))
   end
 
   def with_name_answer_type

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -18,8 +18,7 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     draft_question = DraftQuestion.new(form_id: 1,
                                        answer_type: "text",
                                        answer_settings: { input_type: "long_text" })
-    change_text_settings_path = "https://example.com/change_text_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_text_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question))
   end
 
   def with_date_answer_type

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -53,7 +53,6 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
                                          input_type: "first_middle_and_last_name",
                                          title_needed: "true",
                                        })
-    change_name_settings_path = "https://example.com/change_name_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_name_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question))
   end
 end

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -1,8 +1,7 @@
 class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewComponent::Preview
   def with_non_selection_answer_type
-    draft_question = DraftQuestion.new(answer_type: "email")
-    change_answer_type_path = "https://example.com/change_answer_type"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:))
+    draft_question = DraftQuestion.new(form_id: 1, answer_type: "email")
+    render(PageSettingsSummaryComponent::View.new(draft_question))
   end
 
   def with_selection_answer_type
@@ -12,42 +11,53 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
                                        answer_settings: { only_one_option: "true",
                                                           selection_options: [{ name: "Option 1" },
                                                                               { name: "Option 2" }] })
-    change_answer_type_path = "https://example.com/change_answer_type"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question))
   end
 
   def with_text_answer_type
-    draft_question = DraftQuestion.new(answer_type: "text", answer_settings: { input_type: "long_text" })
-    change_answer_type_path = "https://example.com/change_answer_type"
+    draft_question = DraftQuestion.new(form_id: 1,
+                                       answer_type: "text",
+                                       answer_settings: { input_type: "long_text" })
     change_text_settings_path = "https://example.com/change_text_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_text_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_text_settings_path:))
   end
 
   def with_date_answer_type
-    draft_question = DraftQuestion.new(answer_type: "date", answer_settings: { input_type: "date_of_birth" })
-    change_answer_type_path = "https://example.com/change_answer_type"
+    draft_question = DraftQuestion.new(form_id: 1,
+                                       answer_type: "date",
+                                       answer_settings: { input_type: "date_of_birth" })
     change_date_settings_path = "https://example.com/change_date_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_date_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_date_settings_path:))
   end
 
   def with_legacy_date_answer_type
-    draft_question = DraftQuestion.new(answer_type: "date")
-    change_answer_type_path = "https://example.com/change_answer_type"
+    draft_question = DraftQuestion.new(form_id: 1,
+                                       answer_type: "date")
     change_date_settings_path = "https://example.com/change_date_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_date_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_date_settings_path:))
   end
 
   def with_address_answer_type
-    draft_question = DraftQuestion.new(answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "true" } })
-    change_answer_type_path = "https://example.com/change_answer_type"
+    draft_question = DraftQuestion.new(form_id: 1,
+                                       answer_type: "address",
+                                       answer_settings: {
+                                         input_type: {
+                                           uk_address: "true",
+                                           international_address: "true",
+                                         },
+                                       })
     change_address_settings_path = "https://example.com/change_address_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_address_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_address_settings_path:))
   end
 
   def with_name_answer_type
-    draft_question = DraftQuestion.new(answer_type: "name", answer_settings: { input_type: "first_middle_and_last_name", title_needed: "true" })
-    change_answer_type_path = "https://example.com/change_answer_type"
+    draft_question = DraftQuestion.new(form_id: 1,
+                                       answer_type: "name",
+                                       answer_settings: {
+                                         input_type: "first_middle_and_last_name",
+                                         title_needed: "true",
+                                       })
     change_name_settings_path = "https://example.com/change_name_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_answer_type_path:, change_name_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question, change_name_settings_path:))
   end
 end

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -25,15 +25,13 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     draft_question = DraftQuestion.new(form_id: 1,
                                        answer_type: "date",
                                        answer_settings: { input_type: "date_of_birth" })
-    change_date_settings_path = "https://example.com/change_date_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_date_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question))
   end
 
   def with_legacy_date_answer_type
     draft_question = DraftQuestion.new(form_id: 1,
                                        answer_type: "date")
-    change_date_settings_path = "https://example.com/change_date_settings"
-    render(PageSettingsSummaryComponent::View.new(draft_question, change_date_settings_path:))
+    render(PageSettingsSummaryComponent::View.new(draft_question))
   end
 
   def with_address_answer_type

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
   let(:new_address_setting_path) { address_settings_new_path(form_id: draft_question.form_id) }
   let(:edit_date_setting_path) { date_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
   let(:new_date_setting_path) { date_settings_new_path(form_id: draft_question.form_id) }
+  let(:edit_name_setting_path) { name_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
+  let(:new_name_setting_path) { name_settings_new_path(form_id: draft_question.form_id) }
   let(:edit_selections_setting_path) { selections_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
   let(:new_selections_setting_path) { selections_settings_new_path(form_id: draft_question.form_id) }
   let(:edit_text_setting_path) { text_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
@@ -260,26 +262,40 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:title_needed) { "true" }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_name_settings_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_link("Change Answer type Person’s name", href: edit_answer_type_path)
     end
 
     it "has links to change the answer settings" do
-      render_inline(described_class.new(draft_question, change_name_settings_path:))
-      expect(page).to have_link("Change input type", href: change_name_settings_path)
-      expect(page).to have_link("Change title needed", href: change_name_settings_path)
+      render_inline(described_class.new(draft_question))
+      expect(page).to have_link("Change input type", href: edit_name_setting_path)
+      expect(page).to have_link("Change title needed", href: edit_name_setting_path)
     end
 
     it "renders the input type" do
-      render_inline(described_class.new(draft_question, change_name_settings_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_text "Name fields"
       expect(page).to have_text I18n.t("helpers.label.page.name_settings_options.names.full_name")
     end
 
     it "renders the title needed" do
-      render_inline(described_class.new(draft_question, change_name_settings_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_text "Title needed"
       expect(page).to have_text I18n.t("helpers.label.page.name_settings_options.names.true")
+    end
+
+    context "when draft_question is setup for new question" do
+      let(:draft_question) { build :name_draft_question, page_id: nil }
+
+      it "has a link to change the answer type" do
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change Answer type Person’s name", href: new_answer_type_path)
+      end
+
+      it "has links to change the text selections" do
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change input type", href: new_name_setting_path)
+      end
     end
   end
 end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -4,29 +4,32 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
   include Rails.application.routes.url_helpers
 
   let(:draft_question) { build :draft_question }
-  let(:change_answer_type_path) { "https://example.com/change_answer_type" }
   let(:change_text_settings_path) { "https://example.com/change_text_settings" }
   let(:change_date_settings_path) { "https://example.com/change_date_settings" }
   let(:change_address_settings_path) { "https://example.com/change_address_settings" }
   let(:change_name_settings_path) { "https://example.com/change_name_settings" }
+
+  let(:edit_answer_type_path) { type_of_answer_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
+  let(:new_answer_type_path) { type_of_answer_new_path(form_id: draft_question.form_id) }
+
   let(:edit_selections_setting_path) { selections_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
   let(:new_selections_setting_path) { selections_settings_new_path(form_id: draft_question.form_id) }
 
   context "when the page is not a selection page" do
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:))
-      expect(page).to have_link("Change Answer type", href: change_answer_type_path)
+      render_inline(described_class.new(draft_question))
+      expect(page).to have_link("Change Answer type", href: edit_answer_type_path)
     end
 
     it "does not have links to change the selection options" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).not_to have_link("Change Options", href: edit_selections_setting_path)
       expect(page).not_to have_link("Change People can only select one option", href: edit_selections_setting_path)
       expect(page).not_to have_link("Change Include an option for ‘None of the above’", href: edit_selections_setting_path)
     end
 
     it "does not render the selection settings" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).not_to have_text "Selection from a list"
       expect(page).not_to have_text "Option 1, Option 2"
     end
@@ -36,19 +39,19 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:draft_question) { build :selection_draft_question }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:))
-      expect(page).to have_link("Change Answer type Selection from a list", href: change_answer_type_path)
+      render_inline(described_class.new(draft_question))
+      expect(page).to have_link("Change Answer type Selection from a list", href: edit_answer_type_path)
     end
 
     it "has links to change the selection options" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_link("Change Options", href: edit_selections_setting_path)
       expect(page).to have_link("Change People can only select one option", href: edit_selections_setting_path)
       expect(page).to have_link("Change Include an option for ‘None of the above’", href: edit_selections_setting_path)
     end
 
     it "renders the selection settings" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:))
+      render_inline(described_class.new(draft_question))
       rows = page.find_all(".govuk-summary-list__row")
 
       expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
@@ -65,7 +68,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:draft_question) { build :selection_draft_question, is_optional: true }
 
       it "renders the selection settings" do
-        render_inline(described_class.new(draft_question, change_answer_type_path:))
+        render_inline(described_class.new(draft_question))
         rows = page.find_all(".govuk-summary-list__row")
 
         expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
@@ -83,12 +86,12 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:draft_question) { build :selection_draft_question, page_id: nil }
 
       it "has a link to change the answer type" do
-        render_inline(described_class.new(draft_question, change_answer_type_path:))
-        expect(page).to have_link("Change Answer type Selection from a list", href: change_answer_type_path)
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change Answer type Selection from a list", href: new_answer_type_path)
       end
 
       it "has links to change the selection options" do
-        render_inline(described_class.new(draft_question, change_answer_type_path:))
+        render_inline(described_class.new(draft_question))
         expect(page).to have_link("Change Options", href: new_selections_setting_path)
         expect(page).to have_link("Change People can only select one option", href: new_selections_setting_path)
         expect(page).to have_link("Change Include an option for ‘None of the above’", href: new_selections_setting_path)
@@ -101,17 +104,17 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:input_type) { "single_line" }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_text_settings_path:))
-      expect(page).to have_link("Change Answer type Text", href: change_answer_type_path)
+      render_inline(described_class.new(draft_question, change_text_settings_path:))
+      expect(page).to have_link("Change Answer type Text", href: edit_answer_type_path)
     end
 
     it "has links to change the selection options" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_text_settings_path:))
+      render_inline(described_class.new(draft_question, change_text_settings_path:))
       expect(page).to have_link("Change input type", href: change_text_settings_path)
     end
 
     it "renders the input type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_text_settings_path:))
+      render_inline(described_class.new(draft_question, change_text_settings_path:))
       expect(page).to have_text "Length"
       expect(page).to have_text I18n.t("helpers.label.page.text_settings_options.names.#{draft_question.answer_settings.with_indifferent_access[:input_type]}")
     end
@@ -120,12 +123,12 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:input_type) { "long_text" }
 
       it "has links to change the selection options" do
-        render_inline(described_class.new(draft_question, change_answer_type_path:, change_text_settings_path:))
+        render_inline(described_class.new(draft_question, change_text_settings_path:))
         expect(page).to have_link("Change input type", href: change_text_settings_path)
       end
 
       it "renders the input type" do
-        render_inline(described_class.new(draft_question, change_answer_type_path:, change_text_settings_path:))
+        render_inline(described_class.new(draft_question, change_text_settings_path:))
         expect(page).to have_text "Length"
         expect(page).to have_text I18n.t("helpers.label.page.text_settings_options.names.#{draft_question.answer_settings.with_indifferent_access[:input_type]}")
       end
@@ -136,17 +139,17 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:draft_question) { build :date_draft_question }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_date_settings_path:))
-      expect(page).to have_link("Change Answer type Date", href: change_answer_type_path)
+      render_inline(described_class.new(draft_question, change_date_settings_path:))
+      expect(page).to have_link("Change Answer type Date", href: edit_answer_type_path)
     end
 
     it "has a link to change the input type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_date_settings_path:))
+      render_inline(described_class.new(draft_question, change_date_settings_path:))
       expect(page).to have_link("Change input type", href: change_date_settings_path)
     end
 
     it "renders the input type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_date_settings_path:))
+      render_inline(described_class.new(draft_question, change_date_settings_path:))
       expect(page).to have_text "Date of birth"
       expect(page).to have_text I18n.t("helpers.label.page.date_settings_options.input_types.#{draft_question.answer_settings.with_indifferent_access[:input_type]}")
     end
@@ -155,7 +158,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:draft_question) { build :date_draft_question, answer_settings: nil }
 
       it "has no link to change the input type" do
-        render_inline(described_class.new(draft_question, change_answer_type_path:, change_date_settings_path:))
+        render_inline(described_class.new(draft_question, change_date_settings_path:))
         expect(page).not_to have_link("Change input type", href: change_date_settings_path)
       end
     end
@@ -167,17 +170,17 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:international_address) { "true" }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_address_settings_path:))
-      expect(page).to have_link("Change Answer type Address", href: change_answer_type_path)
+      render_inline(described_class.new(draft_question, change_address_settings_path:))
+      expect(page).to have_link("Change Answer type Address", href: edit_answer_type_path)
     end
 
     it "has links to change the answer settings" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_address_settings_path:))
+      render_inline(described_class.new(draft_question, change_address_settings_path:))
       expect(page).to have_link("Change input type", href: change_address_settings_path)
     end
 
     it "renders the input type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_address_settings_path:))
+      render_inline(described_class.new(draft_question, change_address_settings_path:))
       expect(page).to have_text "Address type"
       expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.uk_and_international_addresses")
     end
@@ -187,7 +190,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:international_address) { "false" }
 
       it "renders the input type as uk addresses" do
-        render_inline(described_class.new(draft_question, change_answer_type_path:, change_address_settings_path:))
+        render_inline(described_class.new(draft_question, change_address_settings_path:))
         expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.uk_addresses")
       end
     end
@@ -197,7 +200,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:international_address) { "true" }
 
       it "renders the input type as international addresses" do
-        render_inline(described_class.new(draft_question, change_answer_type_path:, change_address_settings_path:))
+        render_inline(described_class.new(draft_question, change_address_settings_path:))
         expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.international_addresses")
       end
     end
@@ -209,24 +212,24 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:title_needed) { "true" }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_name_settings_path:))
-      expect(page).to have_link("Change Answer type Person’s name", href: change_answer_type_path)
+      render_inline(described_class.new(draft_question, change_name_settings_path:))
+      expect(page).to have_link("Change Answer type Person’s name", href: edit_answer_type_path)
     end
 
     it "has links to change the answer settings" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_name_settings_path:))
+      render_inline(described_class.new(draft_question, change_name_settings_path:))
       expect(page).to have_link("Change input type", href: change_name_settings_path)
       expect(page).to have_link("Change title needed", href: change_name_settings_path)
     end
 
     it "renders the input type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_name_settings_path:))
+      render_inline(described_class.new(draft_question, change_name_settings_path:))
       expect(page).to have_text "Name fields"
       expect(page).to have_text I18n.t("helpers.label.page.name_settings_options.names.full_name")
     end
 
     it "renders the title needed" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_name_settings_path:))
+      render_inline(described_class.new(draft_question, change_name_settings_path:))
       expect(page).to have_text "Title needed"
       expect(page).to have_text I18n.t("helpers.label.page.name_settings_options.names.true")
     end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
   let(:edit_selections_setting_path) { selections_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
   let(:new_selections_setting_path) { selections_settings_new_path(form_id: draft_question.form_id) }
+  let(:edit_text_setting_path) { text_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
+  let(:new_text_setting_path) { text_settings_new_path(form_id: draft_question.form_id) }
 
   context "when the page is not a selection page" do
     it "has a link to change the answer type" do
@@ -104,17 +106,17 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:input_type) { "single_line" }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_text_settings_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_link("Change Answer type Text", href: edit_answer_type_path)
     end
 
-    it "has links to change the selection options" do
-      render_inline(described_class.new(draft_question, change_text_settings_path:))
-      expect(page).to have_link("Change input type", href: change_text_settings_path)
+    it "has links to change the text selections" do
+      render_inline(described_class.new(draft_question))
+      expect(page).to have_link("Change input type", href: edit_text_setting_path)
     end
 
     it "renders the input type" do
-      render_inline(described_class.new(draft_question, change_text_settings_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_text "Length"
       expect(page).to have_text I18n.t("helpers.label.page.text_settings_options.names.#{draft_question.answer_settings.with_indifferent_access[:input_type]}")
     end
@@ -122,15 +124,29 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     context "when input_type is long text" do
       let(:input_type) { "long_text" }
 
-      it "has links to change the selection options" do
-        render_inline(described_class.new(draft_question, change_text_settings_path:))
-        expect(page).to have_link("Change input type", href: change_text_settings_path)
+      it "has links to change the text settings" do
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change input type", href: edit_text_setting_path)
       end
 
       it "renders the input type" do
-        render_inline(described_class.new(draft_question, change_text_settings_path:))
+        render_inline(described_class.new(draft_question))
         expect(page).to have_text "Length"
         expect(page).to have_text I18n.t("helpers.label.page.text_settings_options.names.#{draft_question.answer_settings.with_indifferent_access[:input_type]}")
+      end
+    end
+
+    context "when draft_question is setup for new question" do
+      let(:draft_question) { build :text_draft_question, page_id: nil }
+
+      it "has a link to change the answer type" do
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change Answer type Text", href: new_answer_type_path)
+      end
+
+      it "has links to change the text selections" do
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change input type", href: new_text_setting_path)
       end
     end
   end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
   let(:edit_answer_type_path) { type_of_answer_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
   let(:new_answer_type_path) { type_of_answer_new_path(form_id: draft_question.form_id) }
 
+  let(:edit_date_setting_path) { date_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
+  let(:new_date_setting_path) { date_settings_new_path(form_id: draft_question.form_id) }
   let(:edit_selections_setting_path) { selections_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
   let(:new_selections_setting_path) { selections_settings_new_path(form_id: draft_question.form_id) }
   let(:edit_text_setting_path) { text_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
@@ -155,17 +157,17 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:draft_question) { build :date_draft_question }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_date_settings_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_link("Change Answer type Date", href: edit_answer_type_path)
     end
 
     it "has a link to change the input type" do
-      render_inline(described_class.new(draft_question, change_date_settings_path:))
-      expect(page).to have_link("Change input type", href: change_date_settings_path)
+      render_inline(described_class.new(draft_question))
+      expect(page).to have_link("Change input type", href: edit_date_setting_path)
     end
 
     it "renders the input type" do
-      render_inline(described_class.new(draft_question, change_date_settings_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_text "Date of birth"
       expect(page).to have_text I18n.t("helpers.label.page.date_settings_options.input_types.#{draft_question.answer_settings.with_indifferent_access[:input_type]}")
     end
@@ -174,8 +176,22 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:draft_question) { build :date_draft_question, answer_settings: nil }
 
       it "has no link to change the input type" do
-        render_inline(described_class.new(draft_question, change_date_settings_path:))
-        expect(page).not_to have_link("Change input type", href: change_date_settings_path)
+        render_inline(described_class.new(draft_question))
+        expect(page).not_to have_link("Change input type", href: edit_date_setting_path)
+      end
+    end
+
+    context "when draft_question is setup for new question" do
+      let(:draft_question) { build :date_draft_question, page_id: nil }
+
+      it "has a link to change the answer type" do
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change Answer type Date", href: new_answer_type_path)
+      end
+
+      it "has links to change the text selections" do
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change input type", href: new_date_setting_path)
       end
     end
   end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
   let(:edit_answer_type_path) { type_of_answer_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
   let(:new_answer_type_path) { type_of_answer_new_path(form_id: draft_question.form_id) }
 
+  let(:edit_address_setting_path) { address_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
+  let(:new_address_setting_path) { address_settings_new_path(form_id: draft_question.form_id) }
   let(:edit_date_setting_path) { date_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
   let(:new_date_setting_path) { date_settings_new_path(form_id: draft_question.form_id) }
   let(:edit_selections_setting_path) { selections_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
@@ -202,17 +204,17 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:international_address) { "true" }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_address_settings_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_link("Change Answer type Address", href: edit_answer_type_path)
     end
 
     it "has links to change the answer settings" do
-      render_inline(described_class.new(draft_question, change_address_settings_path:))
-      expect(page).to have_link("Change input type", href: change_address_settings_path)
+      render_inline(described_class.new(draft_question))
+      expect(page).to have_link("Change input type", href: edit_address_setting_path)
     end
 
     it "renders the input type" do
-      render_inline(described_class.new(draft_question, change_address_settings_path:))
+      render_inline(described_class.new(draft_question))
       expect(page).to have_text "Address type"
       expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.uk_and_international_addresses")
     end
@@ -222,7 +224,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:international_address) { "false" }
 
       it "renders the input type as uk addresses" do
-        render_inline(described_class.new(draft_question, change_address_settings_path:))
+        render_inline(described_class.new(draft_question))
         expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.uk_addresses")
       end
     end
@@ -232,8 +234,22 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:international_address) { "true" }
 
       it "renders the input type as international addresses" do
-        render_inline(described_class.new(draft_question, change_address_settings_path:))
+        render_inline(described_class.new(draft_question))
         expect(page).to have_text I18n.t("helpers.label.page.address_settings_options.names.international_addresses")
+      end
+    end
+
+    context "when draft_question is setup for new question" do
+      let(:draft_question) { build :address_draft_question, page_id: nil }
+
+      it "has a link to change the answer type" do
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change Answer type Address", href: new_answer_type_path)
+      end
+
+      it "has links to change the text selections" do
+        render_inline(described_class.new(draft_question))
+        expect(page).to have_link("Change input type", href: new_address_setting_path)
       end
     end
   end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -1,13 +1,16 @@
 require "rails_helper"
 
 RSpec.describe PageSettingsSummaryComponent::View, type: :component do
+  include Rails.application.routes.url_helpers
+
   let(:draft_question) { build :draft_question }
   let(:change_answer_type_path) { "https://example.com/change_answer_type" }
-  let(:change_selections_settings_path) { "https://example.com/change_selections_settings" }
   let(:change_text_settings_path) { "https://example.com/change_text_settings" }
   let(:change_date_settings_path) { "https://example.com/change_date_settings" }
   let(:change_address_settings_path) { "https://example.com/change_address_settings" }
   let(:change_name_settings_path) { "https://example.com/change_name_settings" }
+  let(:edit_selections_setting_path) { selections_settings_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id) }
+  let(:new_selections_setting_path) { selections_settings_new_path(form_id: draft_question.form_id) }
 
   context "when the page is not a selection page" do
     it "has a link to change the answer type" do
@@ -16,14 +19,14 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     end
 
     it "does not have links to change the selection options" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
-      expect(page).not_to have_link("Change Options", href: change_selections_settings_path)
-      expect(page).not_to have_link("Change People can only select one option", href: change_selections_settings_path)
-      expect(page).not_to have_link("Change Include an option for ‘None of the above’", href: change_selections_settings_path)
+      render_inline(described_class.new(draft_question, change_answer_type_path:))
+      expect(page).not_to have_link("Change Options", href: edit_selections_setting_path)
+      expect(page).not_to have_link("Change People can only select one option", href: edit_selections_setting_path)
+      expect(page).not_to have_link("Change Include an option for ‘None of the above’", href: edit_selections_setting_path)
     end
 
     it "does not render the selection settings" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
+      render_inline(described_class.new(draft_question, change_answer_type_path:))
       expect(page).not_to have_text "Selection from a list"
       expect(page).not_to have_text "Option 1, Option 2"
     end
@@ -33,19 +36,19 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     let(:draft_question) { build :selection_draft_question }
 
     it "has a link to change the answer type" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
+      render_inline(described_class.new(draft_question, change_answer_type_path:))
       expect(page).to have_link("Change Answer type Selection from a list", href: change_answer_type_path)
     end
 
     it "has links to change the selection options" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
-      expect(page).to have_link("Change Options", href: change_selections_settings_path)
-      expect(page).to have_link("Change People can only select one option", href: change_selections_settings_path)
-      expect(page).to have_link("Change Include an option for ‘None of the above’", href: change_selections_settings_path)
+      render_inline(described_class.new(draft_question, change_answer_type_path:))
+      expect(page).to have_link("Change Options", href: edit_selections_setting_path)
+      expect(page).to have_link("Change People can only select one option", href: edit_selections_setting_path)
+      expect(page).to have_link("Change Include an option for ‘None of the above’", href: edit_selections_setting_path)
     end
 
     it "renders the selection settings" do
-      render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
+      render_inline(described_class.new(draft_question, change_answer_type_path:))
       rows = page.find_all(".govuk-summary-list__row")
 
       expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
@@ -62,7 +65,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       let(:draft_question) { build :selection_draft_question, is_optional: true }
 
       it "renders the selection settings" do
-        render_inline(described_class.new(draft_question, change_answer_type_path:, change_selections_settings_path:))
+        render_inline(described_class.new(draft_question, change_answer_type_path:))
         rows = page.find_all(".govuk-summary-list__row")
 
         expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
@@ -73,6 +76,22 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         expect(rows[2].find(".govuk-summary-list__value")).to have_text "Yes"
         expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
         expect(rows[3].find(".govuk-summary-list__value")).to have_text "Yes"
+      end
+    end
+
+    context "when draft_question is setup for new question" do
+      let(:draft_question) { build :selection_draft_question, page_id: nil }
+
+      it "has a link to change the answer type" do
+        render_inline(described_class.new(draft_question, change_answer_type_path:))
+        expect(page).to have_link("Change Answer type Selection from a list", href: change_answer_type_path)
+      end
+
+      it "has links to change the selection options" do
+        render_inline(described_class.new(draft_question, change_answer_type_path:))
+        expect(page).to have_link("Change Options", href: new_selections_setting_path)
+        expect(page).to have_link("Change People can only select one option", href: new_selections_setting_path)
+        expect(page).to have_link("Change Include an option for ‘None of the above’", href: new_selections_setting_path)
       end
     end
   end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -18,8 +18,7 @@ describe "pages/_form.html.erb", type: :view do
       page_object: page,
       draft_question:,
       question_form:,
-      action_path: "http://example.com",
-      change_name_settings_path: "http://change-me-please.com" }
+      action_path: "http://example.com" }
   end
 
   before do

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -20,7 +20,6 @@ describe "pages/_form.html.erb", type: :view do
       question_form:,
       action_path: "http://example.com",
       change_answer_type_path: "http://change-me-please.com",
-      change_selections_settings_path: "http://change-me-please.com",
       change_text_settings_path: "http://change-me-please.com",
       change_date_settings_path: "http://change-me-please.com",
       change_address_settings_path: "http://change-me-please.com",

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -19,7 +19,6 @@ describe "pages/_form.html.erb", type: :view do
       draft_question:,
       question_form:,
       action_path: "http://example.com",
-      change_address_settings_path: "http://change-me-please.com",
       change_name_settings_path: "http://change-me-please.com" }
   end
 

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -19,7 +19,6 @@ describe "pages/_form.html.erb", type: :view do
       draft_question:,
       question_form:,
       action_path: "http://example.com",
-      change_answer_type_path: "http://change-me-please.com",
       change_text_settings_path: "http://change-me-please.com",
       change_date_settings_path: "http://change-me-please.com",
       change_address_settings_path: "http://change-me-please.com",
@@ -44,10 +43,6 @@ describe "pages/_form.html.erb", type: :view do
 
   it "has an unchecked optional checkbox" do
     expect(rendered).to have_unchecked_field("pages_question_form[is_optional]")
-  end
-
-  it "has a link to change the answer type" do
-    expect(rendered).to have_link(text: "Change", href: "http://change-me-please.com")
   end
 
   it "has a submit button with the correct text" do

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -19,7 +19,6 @@ describe "pages/_form.html.erb", type: :view do
       draft_question:,
       question_form:,
       action_path: "http://example.com",
-      change_date_settings_path: "http://change-me-please.com",
       change_address_settings_path: "http://change-me-please.com",
       change_name_settings_path: "http://change-me-please.com" }
   end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -19,7 +19,6 @@ describe "pages/_form.html.erb", type: :view do
       draft_question:,
       question_form:,
       action_path: "http://example.com",
-      change_text_settings_path: "http://change-me-please.com",
       change_date_settings_path: "http://change-me-please.com",
       change_address_settings_path: "http://change-me-please.com",
       change_name_settings_path: "http://change-me-please.com" }

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -21,8 +21,6 @@ describe "pages/edit.html.erb" do
     # If models aren't persisted, they won't work with form builders correctly
     without_partial_double_verification do
       allow(form).to receive(:persisted?).and_return(true)
-      allow(view).to receive(:type_of_answer_edit_path).and_return("/type-of-answer")
-      allow(view).to receive(:selections_settings_edit_path).and_return("/selections_settings")
       allow(view).to receive(:text_settings_edit_path).and_return("/text-settings")
       allow(view).to receive(:date_settings_edit_path).and_return("/date-settings")
       allow(view).to receive(:address_settings_edit_path).and_return("/address-settings")

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -21,7 +21,6 @@ describe "pages/edit.html.erb" do
     # If models aren't persisted, they won't work with form builders correctly
     without_partial_double_verification do
       allow(form).to receive(:persisted?).and_return(true)
-      allow(view).to receive(:address_settings_edit_path).and_return("/address-settings")
       allow(view).to receive(:name_settings_edit_path).and_return("/name-settings")
       allow(view).to receive(:current_form).and_return(form)
       allow(view).to receive(:draft_question).and_return(draft_question)

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -21,7 +21,6 @@ describe "pages/edit.html.erb" do
     # If models aren't persisted, they won't work with form builders correctly
     without_partial_double_verification do
       allow(form).to receive(:persisted?).and_return(true)
-      allow(view).to receive(:date_settings_edit_path).and_return("/date-settings")
       allow(view).to receive(:address_settings_edit_path).and_return("/address-settings")
       allow(view).to receive(:name_settings_edit_path).and_return("/name-settings")
       allow(view).to receive(:current_form).and_return(form)

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -21,7 +21,6 @@ describe "pages/edit.html.erb" do
     # If models aren't persisted, they won't work with form builders correctly
     without_partial_double_verification do
       allow(form).to receive(:persisted?).and_return(true)
-      allow(view).to receive(:name_settings_edit_path).and_return("/name-settings")
       allow(view).to receive(:current_form).and_return(form)
       allow(view).to receive(:draft_question).and_return(draft_question)
     end

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -21,7 +21,6 @@ describe "pages/edit.html.erb" do
     # If models aren't persisted, they won't work with form builders correctly
     without_partial_double_verification do
       allow(form).to receive(:persisted?).and_return(true)
-      allow(view).to receive(:text_settings_edit_path).and_return("/text-settings")
       allow(view).to receive(:date_settings_edit_path).and_return("/date-settings")
       allow(view).to receive(:address_settings_edit_path).and_return("/address-settings")
       allow(view).to receive(:name_settings_edit_path).and_return("/name-settings")


### PR DESCRIPTION
### What problem does this pull request solve?
PageSettingsSummaryComponent required a lot of params when it was being called. This on its own is a bit of a code smell. Along with all these params we were also setting them up in the relevent new/edit views and passing them along to the `forms` partial before passing them on to the view component. This is a lot of processing for the views but also we are defining those values in the view instead of controller action. It feels like a lot of unnecessary noise when we could get the component to workout which link it needs to display from the data we already provide it. 

These changes will help us when we come to implement https://trello.com/c/Z46xTPB5/1085-spike-add-check-your-question-page because we dont have to lift/shift all these params to the new page and we dont have to work out if the user is creating/editing questions.

This refactor is still not 100% because ideally working out the what rows/data/links etc should be done in a service and once that is done theres no real need for this component at all because we can use generic govuk_components summary list component.


Trello card: https://trello.com/c/emgcDnRB/1210-refactor-pagesettingssummarycomponent-to-not-need-so-many-params

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
