### PR TITLE
Users cannot "edit" guidance for an existing question

### DIFF
--- a/app/service/page_summary_data/guidance_service.rb
+++ b/app/service/page_summary_data/guidance_service.rb
@@ -44,8 +44,8 @@ module PageSummaryData
     end
 
     def change_url
-      if page.id.present?
-        guidance_edit_path(form_id: form.id, page_id: page.id)
+      if page.page_id.present?
+        guidance_edit_path(form_id: form.id, page_id: page.page_id)
       else
         guidance_new_path(form_id: form.id)
       end

--- a/app/service/page_summary_data/guidance_service.rb
+++ b/app/service/page_summary_data/guidance_service.rb
@@ -9,15 +9,15 @@ module PageSummaryData
       end
     end
 
-    attr_reader :form, :page
+    attr_reader :form, :draft_question
 
-    def initialize(form:, page:)
+    def initialize(form:, draft_question:)
       @form = form
-      @page = page
+      @draft_question = draft_question
     end
 
     def build_data
-      return nil unless page.page_heading.present? && page.guidance_markdown.present?
+      return nil unless draft_question.page_heading.present? && draft_question.guidance_markdown.present?
 
       { rows: options }
     end
@@ -27,7 +27,7 @@ module PageSummaryData
     def options
       [{
         key: { text: "Page heading" },
-        value: { text: page.page_heading },
+        value: { text: draft_question.page_heading },
         actions: [{ href: change_url, visually_hidden_text: "page heading" }],
       },
        {
@@ -40,12 +40,12 @@ module PageSummaryData
     end
 
     def markdown_content
-      safe_join(['<pre class="app-markdown-editor__markdown-example-block">'.html_safe, page.guidance_markdown, "</pre>".html_safe])
+      safe_join(['<pre class="app-markdown-editor__markdown-example-block">'.html_safe, draft_question.guidance_markdown, "</pre>".html_safe])
     end
 
     def change_url
-      if page.page_id.present?
-        guidance_edit_path(form_id: form.id, page_id: page.page_id)
+      if draft_question.page_id.present?
+        guidance_edit_path(form_id: form.id, page_id: draft_question.page_id)
       else
         guidance_new_path(form_id: form.id)
       end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -11,7 +11,7 @@
 
   <h2 class="govuk-heading-m"><%= t("guidance.guidance") %></h2>
   <% if draft_question.page_heading.present? && draft_question.guidance_markdown.present? %>
-    <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, page: draft_question).build_data) %>
+    <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, draft_question:).build_data) %>
 
   <% else %>
     <p><%= t("guidance.instructions") %></p>

--- a/spec/service/page_summary_data/guidance_service_spec.rb
+++ b/spec/service/page_summary_data/guidance_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe PageSummaryData::GuidanceService do
         let(:page_id) { 1 }
 
         it "has an action to take the user back to change the value" do
-          expect(row[:actions].first[:href]).to eq(guidance_edit_path(form_id: form.id, page_id:))
+          expect(row[:actions].first[:href]).to eq(guidance_edit_path(form_id: form.id, page_id: draft_question.page_id))
         end
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe PageSummaryData::GuidanceService do
         let(:page_id) { 1 }
 
         it "has an action to take the user back to change the value" do
-          expect(row[:actions].first[:href]).to eq(guidance_edit_path(form_id: form.id, page_id:))
+          expect(row[:actions].first[:href]).to eq(guidance_edit_path(form_id: form.id, page_id: draft_question.page_id))
         end
       end
     end

--- a/spec/service/page_summary_data/guidance_service_spec.rb
+++ b/spec/service/page_summary_data/guidance_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe PageSummaryData::GuidanceService do
   include Rails.application.routes.url_helpers
 
-  let(:service) { described_class.call(form:, page: draft_question) }
+  let(:service) { described_class.call(form:, draft_question:) }
   let(:form) { build :form, id: 1 }
   let(:draft_question) { build :draft_question, :with_guidance, page_id:, form_id: form.id }
   let(:page_id) { nil }

--- a/spec/service/page_summary_data/guidance_service_spec.rb
+++ b/spec/service/page_summary_data/guidance_service_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe PageSummaryData::GuidanceService do
   include Rails.application.routes.url_helpers
 
-  let(:service) { described_class.call(form:, page:) }
+  let(:service) { described_class.call(form:, page: draft_question) }
   let(:form) { build :form, id: 1 }
-  let(:page) { build :page, :with_guidance, id: page_id, form: }
+  let(:draft_question) { build :draft_question, :with_guidance, page_id:, form_id: form.id }
   let(:page_id) { nil }
 
   describe "#build_data" do
@@ -23,7 +23,7 @@ RSpec.describe PageSummaryData::GuidanceService do
       end
 
       it "has a value" do
-        expect(row[:value][:text]).to eq page.page_heading
+        expect(row[:value][:text]).to eq draft_question.page_heading
       end
 
       it "has an action to take the user back to change the value" do
@@ -47,7 +47,7 @@ RSpec.describe PageSummaryData::GuidanceService do
       end
 
       it "has a value" do
-        expect(row[:value][:text]).to eq("<pre class=\"app-markdown-editor__markdown-example-block\">#{page.guidance_markdown}</pre>")
+        expect(row[:value][:text]).to eq("<pre class=\"app-markdown-editor__markdown-example-block\">#{draft_question.guidance_markdown}</pre>")
       end
 
       it "has an action to take the user back to change the value" do
@@ -63,8 +63,8 @@ RSpec.describe PageSummaryData::GuidanceService do
       end
     end
 
-    context "when page doesn't have guidance or page heading" do
-      let(:page) { build :page, form: }
+    context "when draft question doesn't have guidance or page heading" do
+      let(:draft_question) { build :draft_question, form_id: form.id }
 
       it "returns nil" do
         expect(result).to be_nil

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -103,5 +103,13 @@ describe "pages/_form.html.erb", type: :view do
     it "calls the PageSummaryData::GuidanceService with the form and draft_question" do
       expect(PageSummaryData::GuidanceService).to have_received(:call).with(form:, draft_question:)
     end
+
+    it "renders the draft question guidance page heading" do
+      expect(rendered).to have_text(draft_question.page_heading)
+    end
+
+    it "renders the draft question guidance markdown" do
+      expect(rendered).to have_text(draft_question.guidance_markdown)
+    end
   end
 end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -12,20 +12,23 @@ describe "pages/_form.html.erb", type: :view do
   end
   let(:form) { build :form, id: 1 }
   let(:is_new_page) { true }
+  let(:locals) do
+    { is_new_page:,
+      form_object: form,
+      page_object: page,
+      draft_question:,
+      question_form:,
+      action_path: "http://example.com",
+      change_answer_type_path: "http://change-me-please.com",
+      change_selections_settings_path: "http://change-me-please.com",
+      change_text_settings_path: "http://change-me-please.com",
+      change_date_settings_path: "http://change-me-please.com",
+      change_address_settings_path: "http://change-me-please.com",
+      change_name_settings_path: "http://change-me-please.com" }
+  end
 
   before do
-    render partial: "pages/form", locals: { is_new_page:,
-                                            form_object: form,
-                                            page_object: page,
-                                            draft_question:,
-                                            question_form:,
-                                            action_path: "http://example.com",
-                                            change_answer_type_path: "http://change-me-please.com",
-                                            change_selections_settings_path: "http://change-me-please.com",
-                                            change_text_settings_path: "http://change-me-please.com",
-                                            change_date_settings_path: "http://change-me-please.com",
-                                            change_address_settings_path: "http://change-me-please.com",
-                                            change_name_settings_path: "http://change-me-please.com" }
+    render partial: "pages/form", locals:
   end
 
   it "has a form with correct action" do
@@ -73,6 +76,32 @@ describe "pages/_form.html.erb", type: :view do
 
     it "has a delete button" do
       expect(rendered).to have_button("delete")
+    end
+  end
+
+  context "when the page has existing guidance" do
+    let(:draft_question) { build :draft_question, :with_guidance }
+    let(:question_form) do
+      build :question_form,
+            form_id: form.id,
+            draft_question:,
+            answer_type: page.answer_type,
+            question_text: page.question_text,
+            hint_text: page.hint_text
+    end
+
+    let(:guidance_service) { instance_double("PageSummaryData::GuidanceService") }
+    let(:build_data) { {} }
+
+    before do
+      allow(guidance_service).to receive(:build_data).and_return(build_data)
+      allow(PageSummaryData::GuidanceService).to receive(:call).and_return(guidance_service)
+
+      render partial: "pages/form", locals:
+    end
+
+    it "calls the PageSummaryData::GuidanceService with the form and draft_question" do
+      expect(PageSummaryData::GuidanceService).to have_received(:call).with(form:, draft_question:)
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

We discovered that users were getting 404 when they tried to edit their guidance for an existing page. This was because the service that was being used to generate the data and the change links was using the wrong model id. Instead of using page_id it was using draft_question id.

Trello card: https://trello.com/c/peju1SZI/1209-users-unable-to-edit-guidance-for-an-existing-page

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
