### PR TITLE
Revert "1184-prevent-forms-runner-and-forms-admin-cloudwatch-requests-when-in-unsuitable-environments"

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -77,7 +77,6 @@ class Form < ActiveResource::Base
 
   def metrics_data
     return nil unless FeatureService.enabled?(:metrics_for_form_creators_enabled)
-    return nil unless has_live_version
 
     # If the form went live today, there won't be any metrics to show
     today = Time.zone.today
@@ -95,8 +94,6 @@ class Form < ActiveResource::Base
          Aws::Errors::MissingCredentialsError => e
 
     Sentry.capture_exception(e)
-    nil
-  rescue CloudWatchService::MetricsDisabledError
     nil
   end
 

--- a/app/service/cloud_watch_service.rb
+++ b/app/service/cloud_watch_service.rb
@@ -2,11 +2,7 @@ class CloudWatchService
   REGION = "eu-west-2".freeze
   A_WEEK = 604_800
 
-  class MetricsDisabledError < StandardError; end
-
   def self.week_submissions(form_id:)
-    raise MetricsDisabledError unless Settings.cloudwatch_metrics_enabled
-
     cloudwatch_client = Aws::CloudWatch::Client.new(region: REGION)
 
     response = cloudwatch_client.get_metric_statistics({
@@ -29,8 +25,6 @@ class CloudWatchService
   end
 
   def self.week_starts(form_id:)
-    raise MetricsDisabledError unless Settings.cloudwatch_metrics_enabled
-
     cloudwatch_client = Aws::CloudWatch::Client.new(region: REGION)
 
     response = cloudwatch_client.get_metric_statistics({

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,6 +63,3 @@ cddo_sso:
   secret:
 
 forms_env: local
-
-# When set to true, the CloudWatch service will attempt to retrieve data from CloudWatch
-cloudwatch_metrics_enabled: false

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -64,12 +64,4 @@ describe "Settings" do
       expect(forms_env).to eq("local")
     end
   end
-
-  describe "cloudwatch_metrics_enabled" do
-    it "has a default value" do
-      cloudwatch_metrics_enabled = settings[:cloudwatch_metrics_enabled]
-
-      expect(cloudwatch_metrics_enabled).to be(false)
-    end
-  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -246,12 +246,12 @@ describe Form, type: :model do
 
   describe "#metrics_data", feature_metrics_for_form_creators_enabled: true do
     let(:form) do
-      described_class.new(id: 2, live_at: Time.zone.now - 1.day, has_live_version: true)
+      described_class.new(id: 2, live_at: Time.zone.now - 1.day)
     end
 
     context "when the form was made today" do
       let(:form) do
-        described_class.new(id: 2, live_at: Time.zone.now, has_live_version: true)
+        described_class.new(id: 2, live_at: Time.zone.now)
       end
 
       before do
@@ -287,20 +287,10 @@ describe Form, type: :model do
       end
     end
 
-    context "when CloudWatch metrics are disabled" do
-      before do
-        allow(CloudWatchService).to receive(:week_submissions).and_raise(CloudWatchService::MetricsDisabledError)
-      end
-
-      it "returns nil" do
-        expect(form.metrics_data).to eq(nil)
-      end
-    end
-
     context "when AWS credentials have not been configured" do
       before do
         allow(Sentry).to receive(:capture_exception)
-        allow(CloudWatchService).to receive(:week_submissions).and_raise(Aws::Errors::MissingCredentialsError)
+        allow(CloudWatchService).to receive(:week_starts).and_raise(Aws::Errors::MissingCredentialsError)
       end
 
       it "returns nil and logs the exception in Sentry" do
@@ -311,8 +301,8 @@ describe Form, type: :model do
 
     context "when CloudWatch returns an error" do
       before do
+        allow(CloudWatchService).to receive(:week_starts).and_raise(Aws::CloudWatch::Errors::ServiceError)
         allow(Sentry).to receive(:capture_exception)
-        allow(CloudWatchService).to receive(:week_submissions).and_raise(Aws::CloudWatch::Errors::ServiceError.new(instance_double(Seahorse::Client::RequestContext), "message"))
       end
 
       it "returns nil and logs the exception in Sentry" do
@@ -323,7 +313,7 @@ describe Form, type: :model do
 
     context "when the form is not live" do
       let(:form) do
-        described_class.new(id: 2, has_live_version: false)
+        described_class.new(id: 2)
       end
 
       it "returns nil" do

--- a/spec/service/cloud_watch_service_spec.rb
+++ b/spec/service/cloud_watch_service_spec.rb
@@ -3,11 +3,9 @@ require "rails_helper"
 describe CloudWatchService do
   let(:forms_env) { "test" }
   let(:form_id) { 3 }
-  let(:cloudwatch_metrics_enabled) { true }
 
   before do
     allow(Settings).to receive(:forms_env).and_return(forms_env)
-    allow(Settings).to receive(:cloudwatch_metrics_enabled).and_return(cloudwatch_metrics_enabled)
   end
 
   around do |example|
@@ -19,14 +17,6 @@ describe CloudWatchService do
   describe "#week_submissions" do
     let(:datapoints) { [{ sum: total_submissions }] }
     let(:total_submissions) { 3.0 }
-
-    context "when CloudWatch metrics are disabled" do
-      let(:cloudwatch_metrics_enabled) { false }
-
-      it "raises a MetricsDisabledError" do
-        expect { described_class.week_submissions(form_id:) }.to raise_error(CloudWatchService::MetricsDisabledError)
-      end
-    end
 
     it "calls the cloudwatch client with get_metric_statistics" do
       cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
@@ -97,14 +87,6 @@ describe CloudWatchService do
   describe "#week_starts" do
     let(:datapoints) { [{ sum: total_starts }] }
     let(:total_starts) { 5.0 }
-
-    context "when CloudWatch metrics are disabled" do
-      let(:cloudwatch_metrics_enabled) { false }
-
-      it "raises a MetricsDisabledError" do
-        expect { described_class.week_starts(form_id:) }.to raise_error(CloudWatchService::MetricsDisabledError)
-      end
-    end
 
     it "calls the cloudwatch client with get_metric_statistics" do
       cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)


### PR DESCRIPTION
Reverts alphagov/forms-admin#765

This PR caused an issue when `has_live_version` is not available.