### PR TITLE
Fix example forms-api auth key

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,8 +4,8 @@ features:
   metrics_for_form_creators_enabled: false
 
 forms_api:
-  # Authentication key to authenticate forms-runner to forms-api
-  auth_key: changeme
+  # Authentication key to authenticate with forms-api
+  auth_key: development_key
   # URL to form-api endpoints
   base_url: http://localhost:9292
 

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -28,7 +28,7 @@ describe "Settings" do
   describe "forms_api" do
     forms_api = settings[:forms_api]
 
-    include_examples expected_value_test, :auth_key, forms_api, "changeme"
+    include_examples expected_value_test, :auth_key, forms_api, "development_key"
 
     include_examples expected_value_test, :base_url, forms_api, "http://localhost:9292"
   end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This comment appears to have been copied from `forms-runner`; let's fix this typo by just removing the reference to the app we're running, it should be obvious in context.

Also update the example value for `auth_key` to match what's currently in our local Docker Compose configuration [[1]].

[1]: https://github.com/alphagov/forms-deploy/blob/4fc8d5060990772e095200e534bdf6a0554f0739/local/docker-compose.yml#L43

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?