### PR TITLE
Fix create/update question journey when user should be expecting to see validation error messages

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -26,7 +26,7 @@ class Pages::QuestionsController < PagesController
       clear_questions_session_data
       handle_submit_action
     else
-      render :new, locals: { current_form: }, status: :unprocessable_entity
+      render :new, locals: { current_form:, draft_question: }, status: :unprocessable_entity
     end
   end
 
@@ -57,7 +57,7 @@ class Pages::QuestionsController < PagesController
       clear_questions_session_data
       handle_submit_action
     else
-      render :edit, locals: { current_form: }, status: :unprocessable_entity
+      render :edit, locals: { current_form:, draft_question: }, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

When a user was trying to create/update a question if there was a validation error message then the page would fail to load and they would see a 500 error page. I added two new request specs and fixed the issue for both actions

Trello card: https://trello.com/c/THcM9yHL/1212-users-see-500-error-page-when-they-attempt-to-save-invalid-new-question-without-question-text

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
