### PR TITLE
Stop using session storage for add/edit questions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
-  before_action :clear_questions_session_data
+  before_action :clear_draft_questions_data
 
   add_flash_types :success
 
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
     payload[:page_id] = params[:page_id] if params[:page_id].present?
   end
 
-  def clear_questions_session_data
+  def clear_draft_questions_data
     session.delete(:page) if session[:page].present?
 
     current_user.draft_questions.destroy_all if current_user.present?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,8 +50,6 @@ class ApplicationController < ActionController::Base
   end
 
   def clear_draft_questions_data
-    session.delete(:page) if session[:page].present?
-
     current_user.draft_questions.destroy_all if current_user.present?
   end
 

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,5 +1,5 @@
 class HeartbeatController < ApplicationController
-  skip_before_action :authenticate_and_check_access, :check_maintenance_mode_is_enabled, :clear_questions_session_data
+  skip_before_action :authenticate_and_check_access, :check_maintenance_mode_is_enabled, :clear_draft_questions_data
 
   def ping
     render(body: "PONG")

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -23,7 +23,7 @@ class Pages::QuestionsController < PagesController
 
     # TODO: Move Page creation to be part of the form submit method
     if @question_form.submit && @page.save
-      clear_questions_session_data
+      clear_draft_questions_data
       handle_submit_action
     else
       render :new, locals: { current_form:, draft_question: }, status: :unprocessable_entity
@@ -54,7 +54,7 @@ class Pages::QuestionsController < PagesController
 
     # TODO: Move Page creation to be part of the form submit method
     if @question_form.submit && page.save
-      clear_questions_session_data
+      clear_draft_questions_data
       handle_submit_action
     else
       render :edit, locals: { current_form:, draft_question: }, status: :unprocessable_entity

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
   before_action :convert_session_keys_to_symbols
   before_action :check_user_has_permission
-  skip_before_action :clear_questions_session_data, except: %i[index move_page]
+  skip_before_action :clear_draft_questions_data, except: %i[index move_page]
   after_action :verify_authorized
 
   def index

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,4 @@
 class PagesController < ApplicationController
-  before_action :convert_session_keys_to_symbols
   before_action :check_user_has_permission
   skip_before_action :clear_draft_questions_data, except: %i[index move_page]
   after_action :verify_authorized
@@ -48,10 +47,6 @@ private
     direction = p[:up] ? :up : :down
     page_id = p[direction]
     @move_params ||= { form_id:, page_id:, direction: }
-  end
-
-  def convert_session_keys_to_symbols
-    session[:page].deep_symbolize_keys! if session[:page].present?
   end
 
   def setup_draft_question_for_existing_page

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -60,14 +60,14 @@ describe ApplicationController, type: :controller do
     end
   end
 
-  describe "#clear_questions_session_data" do
+  describe "#clear_draft_questions_data" do
     let(:user) { create(:user) }
 
     it "clears session data when session is present" do
       # Simulate a session with some data
       session[:page] = { question: "What is your name?" }
 
-      controller.send(:clear_questions_session_data)
+      controller.send(:clear_draft_questions_data)
 
       expect(session[:page]).to be_nil
     end
@@ -76,13 +76,13 @@ describe ApplicationController, type: :controller do
       allow(controller).to receive(:current_user).and_return(user)
       create_list(:draft_question, 3, user:)
 
-      controller.send(:clear_questions_session_data)
+      controller.send(:clear_draft_questions_data)
 
       expect(user.draft_questions.count).to eq(0)
     end
 
     it "does not raise an error when session and user are not present" do
-      expect { controller.send(:clear_questions_session_data) }.not_to raise_exception
+      expect { controller.send(:clear_draft_questions_data) }.not_to raise_exception
     end
   end
 

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -63,15 +63,6 @@ describe ApplicationController, type: :controller do
   describe "#clear_draft_questions_data" do
     let(:user) { create(:user) }
 
-    it "clears session data when session is present" do
-      # Simulate a session with some data
-      session[:page] = { question: "What is your name?" }
-
-      controller.send(:clear_draft_questions_data)
-
-      expect(session[:page]).to be_nil
-    end
-
     it "destroys draft questions when user is present" do
       allow(controller).to receive(:current_user).and_return(user)
       create_list(:draft_question, 3, user:)


### PR DESCRIPTION
### What problem does this pull request solve?

Originally part of https://github.com/alphagov/forms-admin/pull/755 but I decided it might be best to split these out seeing as these commits relate to session storage and means that we no longer using session storage for anything other than authentication purposes.

Trello card: https://trello.com/c/RGsOE1bl/1074-switch-all-the-page-form-objects-over-to-use-draftquestion-instead-of-session

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
