### PR TITLE
Pages::QuestionForm does not require form or page id

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -1,25 +1,20 @@
 class Pages::QuestionsController < PagesController
   def new
-    @question_form = Pages::QuestionForm.new(form_id: current_form.id,
-                                             answer_type: draft_question.answer_type,
+    @question_form = Pages::QuestionForm.new(answer_type: draft_question.answer_type,
                                              question_text: draft_question.question_text,
                                              answer_settings: draft_question.answer_settings,
                                              is_optional: draft_question.is_optional,
                                              draft_question:)
 
+    # TODO: Remove this once we have a check your question view. The new view should also pull data directly from draft_question instead of through page model
     @page = Page.new(form_id: current_form.id)
     render :new, locals: { current_form:, draft_question: }
   end
 
   def create
-    @question_form = Pages::QuestionForm.new(page_params.merge(answer_settings: draft_question.answer_settings,
-                                                               page_heading: draft_question.page_heading,
-                                                               guidance_markdown: draft_question.guidance_markdown,
-                                                               draft_question:))
-    @page = Page.new(page_params.merge(answer_settings: draft_question.answer_settings,
-                                       page_heading: draft_question.page_heading,
-                                       guidance_markdown: draft_question.guidance_markdown,
-                                       answer_type: draft_question.answer_type))
+    @question_form = Pages::QuestionForm.new(page_params_for_form_object)
+
+    @page = Page.new(page_params_for_forms_api)
 
     # TODO: Move Page creation to be part of the form submit method
     if @question_form.submit && @page.save
@@ -31,8 +26,7 @@ class Pages::QuestionsController < PagesController
   end
 
   def edit
-    @question_form = Pages::QuestionForm.new(form_id: current_form.id,
-                                             answer_type: draft_question.answer_type,
+    @question_form = Pages::QuestionForm.new(answer_type: draft_question.answer_type,
                                              question_text: draft_question.question_text,
                                              hint_text: draft_question.hint_text,
                                              is_optional: draft_question.is_optional,
@@ -41,16 +35,9 @@ class Pages::QuestionsController < PagesController
   end
 
   def update
-    page.load(page_params)
-    page.page_heading = draft_question.page_heading
-    page.guidance_markdown = draft_question.guidance_markdown
-    page.answer_type = draft_question.answer_type
-    page.answer_settings = draft_question.answer_settings
+    page.load(page_params_for_forms_api)
 
-    @question_form = Pages::QuestionForm.new(page_params.merge(answer_settings: draft_question.answer_settings,
-                                                               page_heading: draft_question.page_heading,
-                                                               guidance_markdown: draft_question.guidance_markdown,
-                                                               draft_question:))
+    @question_form = Pages::QuestionForm.new(page_params_for_form_object)
 
     # TODO: Move Page creation to be part of the form submit method
     if @question_form.submit && page.save
@@ -64,8 +51,23 @@ class Pages::QuestionsController < PagesController
 private
 
   def page_params
-    # TODO: Remove current_form from merge once we using draft question properly. the question form shouldn't need to know about form id
-    params.require(:pages_question_form).permit(:question_text, :hint_text, :is_optional).merge(form_id: current_form.id)
+    params.require(:pages_question_form).permit(:question_text, :hint_text, :is_optional)
+  end
+
+  def page_params_for_form_object
+    page_params.merge(draft_question:,
+                      answer_type: draft_question.answer_type,
+                      answer_settings: draft_question.answer_settings,
+                      page_heading: draft_question.page_heading,
+                      guidance_markdown: draft_question.guidance_markdown)
+  end
+
+  def page_params_for_forms_api
+    page_params.merge(form_id: current_form.id,
+                      answer_settings: draft_question.answer_settings,
+                      page_heading: draft_question.page_heading,
+                      guidance_markdown: draft_question.guidance_markdown,
+                      answer_type: draft_question.answer_type)
   end
 
   def handle_submit_action

--- a/app/forms/pages/question_form.rb
+++ b/app/forms/pages/question_form.rb
@@ -6,9 +6,6 @@ class Pages::QuestionForm < BaseForm
   # TODO: We could lose these attributes once we have an Check your answers page
   attr_accessor :answer_settings, :page_heading, :guidance_markdown
 
-  # TODO: Remove once we get rid of session storage
-  attr_accessor :form_id, :page_id
-
   validates :draft_question, presence: true
   validates :hint_text, length: { maximum: 500 }
 

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -72,7 +72,7 @@ describe ApplicationController, type: :controller do
       expect(user.draft_questions.count).to eq(0)
     end
 
-    it "does not raise an error when session and user are not present" do
+    it "does not raise an error when draft question and user are not present" do
       expect { controller.send(:clear_draft_questions_data) }.not_to raise_exception
     end
   end

--- a/spec/factories/forms/pages/question_form.rb
+++ b/spec/factories/forms/pages/question_form.rb
@@ -7,8 +7,6 @@ FactoryBot.define do
     answer_settings { nil }
     page_heading { nil }
     guidance_markdown { nil }
-    page_id { nil }
-    form_id { nil }
     draft_question { build :draft_question, question_text: }
 
     trait :with_hints do

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -5,7 +5,6 @@ describe "pages/_form.html.erb", type: :view do
   let(:draft_question) { question_form.draft_question }
   let(:question_form) do
     build :question_form,
-          form_id: form.id,
           answer_type: page.answer_type,
           question_text: page.question_text,
           hint_text: page.hint_text
@@ -73,7 +72,6 @@ describe "pages/_form.html.erb", type: :view do
     let(:draft_question) { build :draft_question, :with_guidance }
     let(:question_form) do
       build :question_form,
-            form_id: form.id,
             draft_question:,
             answer_type: page.answer_type,
             question_text: page.question_text,

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -9,7 +9,6 @@ describe "pages/edit.html.erb" do
   let(:draft_question) { question_form.draft_question }
   let(:question_form) do
     build :question_form,
-          form_id: form.id,
           answer_type: page.answer_type,
           question_text: page.question_text,
           hint_text: page.hint_text
@@ -29,7 +28,6 @@ describe "pages/edit.html.erb" do
     assign(:page, page)
     assign(:question_form, question_form)
     assign(:current_user, current_user)
-    assign(:answer_types, [])
 
     # This is normally done in the ApplicationController, but we aren't using
     # that in this test


### PR DESCRIPTION
### What problem does this pull request solve?
This work follow on from:
* https://github.com/alphagov/forms-admin/pull/743
* https://github.com/alphagov/forms-admin/pull/690
* https://github.com/alphagov/forms-admin/pull/669
* https://github.com/alphagov/forms-admin/pull/658
* https://github.com/alphagov/forms-admin/pull/659

Theres no need for the form object to know about form id or page id. Its primary forcus is on display a question text, hint text and is optional field. Behind the scenes it still needs answer type because in the view answer type is used as part of the locales key lookup to customise the hint text for the hint text field.


Trello card: https://trello.com/c/RGsOE1bl/1074-switch-all-the-page-form-objects-over-to-use-draftquestion-instead-of-session


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
