### PR TITLE
BUG: Users not seeing pre-filled in forms when they edit an existing questions answer settings

### DIFF
--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -34,7 +34,7 @@ module PageSettingsSummaryComponent
     def answer_settings
       return [] if @draft_question.answer_settings.nil?
 
-      @draft_question.answer_settings.with_indifferent_access
+      @draft_question.answer_settings
     end
 
     def show_selection_options

--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -1,6 +1,6 @@
 class Pages::AddressSettingsController < PagesController
   def new
-    settings = draft_question.answer_settings.with_indifferent_access
+    settings = draft_question.answer_settings
     @address_settings_form = Pages::AddressSettingsForm.new(uk_address: settings.dig(:input_type, :uk_address),
                                                             international_address: settings.dig(:input_type, :international_address))
     @address_settings_path = address_settings_create_path(current_form)
@@ -21,7 +21,7 @@ class Pages::AddressSettingsController < PagesController
   end
 
   def edit
-    settings = draft_question.answer_settings.with_indifferent_access
+    settings = draft_question.answer_settings
     @address_settings_form = Pages::AddressSettingsForm.new(uk_address: settings.dig(:input_type, :uk_address),
                                                             international_address: settings.dig(:input_type, :international_address))
     @address_settings_path = address_settings_update_path(current_form)

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -29,8 +29,8 @@ class Pages::SelectionsSettingsController < PagesController
 
   def edit
     @selections_settings_path = selections_settings_update_path(current_form)
-    @selections_settings_form = Pages::SelectionsSettingsForm.new(only_one_option: draft_question.answer_settings.with_indifferent_access[:only_one_option],
-                                                                  selection_options: draft_question.answer_settings.with_indifferent_access[:selection_options]
+    @selections_settings_form = Pages::SelectionsSettingsForm.new(only_one_option: draft_question.answer_settings[:only_one_option],
+                                                                  selection_options: draft_question.answer_settings[:selection_options]
                                                                                                    .map { |option| { name: option[:name] } },
                                                                   include_none_of_the_above: draft_question.is_optional,
                                                                   draft_question:)

--- a/app/forms/pages/address_settings_form.rb
+++ b/app/forms/pages/address_settings_form.rb
@@ -21,7 +21,7 @@ class Pages::AddressSettingsForm < BaseForm
 
     # Set answer_settings for the draft_question
     draft_question
-      .assign_attributes({ answer_settings: answer_settings.with_indifferent_access })
+      .assign_attributes({ answer_settings: })
 
     draft_question.save!(validate: false)
   end

--- a/app/forms/pages/date_settings_form.rb
+++ b/app/forms/pages/date_settings_form.rb
@@ -16,7 +16,7 @@ class Pages::DateSettingsForm < BaseForm
 
     # Set answer_settings for the draft_question
     draft_question
-      .assign_attributes({ answer_settings: answer_settings.with_indifferent_access })
+      .assign_attributes({ answer_settings: })
 
     draft_question.save!(validate: false)
   end

--- a/app/forms/pages/name_settings_form.rb
+++ b/app/forms/pages/name_settings_form.rb
@@ -19,7 +19,7 @@ class Pages::NameSettingsForm < BaseForm
 
     # Set answer_settings for the draft_question
     draft_question
-      .assign_attributes({ answer_settings: answer_settings.with_indifferent_access })
+      .assign_attributes({ answer_settings: })
 
     draft_question.save!(validate: false)
   end

--- a/app/forms/pages/selections_settings_form.rb
+++ b/app/forms/pages/selections_settings_form.rb
@@ -25,7 +25,7 @@ class Pages::SelectionsSettingsForm < BaseForm
 
     # Set answer_settings for the draft_question
     draft_question
-      .assign_attributes({ answer_settings: answer_settings.with_indifferent_access,
+      .assign_attributes({ answer_settings:,
                            is_optional: include_none_of_the_above })
 
     draft_question.save!(validate: false)

--- a/app/forms/pages/text_settings_form.rb
+++ b/app/forms/pages/text_settings_form.rb
@@ -16,7 +16,7 @@ class Pages::TextSettingsForm < BaseForm
 
     # Set answer_settings for the draft_question
     draft_question
-      .assign_attributes({ answer_settings: answer_settings.with_indifferent_access })
+      .assign_attributes({ answer_settings: })
 
     draft_question.save!(validate: false)
   end

--- a/app/models/draft_question.rb
+++ b/app/models/draft_question.rb
@@ -8,4 +8,11 @@ class DraftQuestion < ApplicationRecord
 
   validates :form_id, presence: true
   validates :hint_text, length: { maximum: 500 }
+
+  def answer_settings
+    raw_settings = read_attribute(:answer_settings)
+    return raw_settings if raw_settings.blank?
+
+    raw_settings.deep_symbolize_keys
+  end
 end

--- a/app/models/draft_question.rb
+++ b/app/models/draft_question.rb
@@ -11,7 +11,7 @@ class DraftQuestion < ApplicationRecord
 
   def answer_settings
     raw_settings = read_attribute(:answer_settings)
-    return raw_settings if raw_settings.blank?
+    return {} if raw_settings.blank?
 
     raw_settings.deep_symbolize_keys
   end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     it "renders the input type" do
       render_inline(described_class.new(draft_question))
       expect(page).to have_text "Length"
-      expect(page).to have_text I18n.t("helpers.label.page.text_settings_options.names.#{draft_question.answer_settings.with_indifferent_access[:input_type]}")
+      expect(page).to have_text I18n.t("helpers.label.page.text_settings_options.names.#{draft_question.answer_settings[:input_type]}")
     end
 
     context "when input_type is long text" do
@@ -138,7 +138,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       it "renders the input type" do
         render_inline(described_class.new(draft_question))
         expect(page).to have_text "Length"
-        expect(page).to have_text I18n.t("helpers.label.page.text_settings_options.names.#{draft_question.answer_settings.with_indifferent_access[:input_type]}")
+        expect(page).to have_text I18n.t("helpers.label.page.text_settings_options.names.#{draft_question.answer_settings[:input_type]}")
       end
     end
 
@@ -173,7 +173,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
     it "renders the input type" do
       render_inline(described_class.new(draft_question))
       expect(page).to have_text "Date of birth"
-      expect(page).to have_text I18n.t("helpers.label.page.date_settings_options.input_types.#{draft_question.answer_settings.with_indifferent_access[:input_type]}")
+      expect(page).to have_text I18n.t("helpers.label.page.date_settings_options.input_types.#{draft_question.answer_settings[:input_type]}")
     end
 
     context "when the date has no answer settings" do

--- a/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
+++ b/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+
+feature "Editing answer_settings for existing question", type: :feature do
+  let(:form) { build :form, :with_active_resource, id: 1, pages: }
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+      mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
+      mock.post "/api/v1/forms/1/pages", post_headers
+      pages.each do |page|
+        mock.get "/api/v1/forms/1/pages/#{page.id}", req_headers, page.to_json, 200
+      end
+    end
+
+    login_as_editor_user
+  end
+
+  context "when a form has existing pages with answer types" do
+    let(:address_question) { build(:page, :with_address_settings, form_id: 1) }
+    let(:date_question) { build(:page, :with_date_settings, form_id: 1, input_type: "date_of_birth") }
+    let(:name_question) { build(:page, :with_name_settings, form_id: 1, input_type: "first_middle_and_last_name", title_needed: "true") }
+    let(:selection_question) { build(:page, :with_selections_settings, form_id: 1, is_optional: true) }
+    let(:text_question) { build(:page, :with_text_settings, form_id: 1, input_type: "long_text") }
+    let(:pages) { [address_question, date_question, name_question, selection_question, text_question] }
+
+    scenario "view answer_settings for each answer type and check the values are set" do
+      when_i_viewing_an_existing_form
+      and_i_view_a_list_of_existing_questions
+
+      pages.each do |question|
+        and_i_want_to_edit(question)
+        then_i_want_change_answer_settings_for(question)
+        and_i_should_see_the_previous_values(question)
+        then_go_back_to_list_of_questions
+      end
+    end
+  end
+
+private
+
+  def when_i_viewing_an_existing_form
+    visit form_path(form.id)
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def and_i_view_a_list_of_existing_questions
+    click_on "Add and edit your questions"
+    expect(page.find("h1")).to have_text "Add and edit your questions"
+    expect(page).to have_selector(".govuk-summary-list__row", count: 5)
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def and_i_want_to_edit(question)
+    click_link "Edit", href: edit_question_path(form.id, question.id)
+    expect(page.find("h1")).to have_text "Edit question"
+    expect(find_field("pages_question_form[question_text]").value).to eq question.question_text
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def then_i_want_change_answer_settings_for(question)
+    href = get_change_link_for(question)
+    # Some "edit question" pages have multiple links to the same url.
+    first(:link, "Change", href:).click
+  end
+
+  def get_change_link_for(question)
+    case question.answer_type.to_sym
+    when :address
+      address_settings_edit_path(form_id: form.id, page_id: question.id)
+    when :date
+      date_settings_edit_path(form_id: form.id, page_id: question.id)
+    when :name
+      name_settings_edit_path(form_id: form.id, page_id: question.id)
+    when :selection
+      selections_settings_edit_path(form_id: form.id, page_id: question.id)
+    when :text
+      text_settings_edit_path(form_id: form.id, page_id: question.id)
+    end
+  end
+
+  def and_i_should_see_the_previous_values(question)
+    case question.answer_type.to_sym
+    when :address
+      check_address_answer_settings
+    when :date
+      check_date_answer_settings
+    when :name
+      check_name_answer_settings
+    when :selection
+      check_selection_answer_settings
+    when :text
+      check_text_answer_settings
+    end
+  end
+
+  def then_go_back_to_list_of_questions
+    click_on "Go to your questions"
+  end
+
+  def check_address_answer_settings
+    expect(page.find("h1")).to have_text "What kind of addresses do you expect to receive?"
+    expect_page_to_have_no_axe_errors(page)
+    expect(page).to have_checked_field("UK addresses", visible: :all)
+    expect(page).to have_checked_field("International addresses", visible: :all)
+    click_button "Continue"
+    expect(page.find(".govuk-summary-list")).to have_text "UK and international addresses"
+  end
+
+  def check_date_answer_settings
+    expect(page.find("h1")).to have_text "Are you asking for someone’s date of birth?"
+    expect_page_to_have_no_axe_errors(page)
+    expect(page).to have_checked_field("pages_date_settings_form[input_type]", with: "date_of_birth", visible: :all)
+    click_button "Continue"
+    expect(page.find_all(".govuk-summary-list__value")[1]).to have_text "Yes"
+  end
+
+  def check_name_answer_settings
+    expect(page.find("h1")).to have_text "Ask for a person’s name"
+    expect_page_to_have_no_axe_errors(page)
+    expect(page).to have_checked_field("pages_name_settings_form[input_type]", with: "first_middle_and_last_name", visible: :all)
+    expect(page).to have_checked_field("pages_name_settings_form[title_needed]", with: "true", visible: :all)
+    click_button "Continue"
+    expect(page.find_all(".govuk-summary-list__value")[1]).to have_text "First, middle and last names in separate boxes"
+    expect(page.find_all(".govuk-summary-list__value")[2]).to have_text "Yes"
+  end
+
+  def check_selection_answer_settings
+    expect(page.find("h1")).to have_text "Create a list of options"
+    expect_page_to_have_no_axe_errors(page)
+    expect(page).to have_checked_field("People can only select one option", visible: :all)
+    expect(page).to have_checked_field("Include an option for ‘None of the above’", visible: :all)
+    expect(find_field("Option 1").value).to eq "Option 1"
+    expect(find_field("Option 2").value).to eq "Option 2"
+    click_button "Continue"
+    expect(page.find_all(".govuk-summary-list__value")[1]).to have_text "Option 1, Option 2"
+    expect(page.find_all(".govuk-summary-list__value")[2]).to have_text "Yes"
+    expect(page.find_all(".govuk-summary-list__value")[3]).to have_text "Yes"
+  end
+
+  def check_text_answer_settings
+    expect(page.find("h1")).to have_text "How much text will people need to provide?"
+    expect_page_to_have_no_axe_errors(page)
+    expect(page).to have_checked_field("pages_text_settings_form[input_type]", with: "long_text", visible: :all)
+    click_button "Continue"
+    expect(page.find_all(".govuk-summary-list__value")[1]).to have_text "More than a single line of text"
+  end
+end

--- a/spec/forms/pages/address_settings_form_spec.rb
+++ b/spec/forms/pages/address_settings_form_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Pages::AddressSettingsForm, type: :model do
           uk_address: "false",
           international_address: "true",
         },
-      }.with_indifferent_access
+      }
 
       expect(address_settings_form.draft_question.answer_settings).to include(expected_settings)
     end

--- a/spec/forms/pages/date_settings_form_spec.rb
+++ b/spec/forms/pages/date_settings_form_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pages::DateSettingsForm, type: :model do
 
       expected_settings = {
         input_type: "date_of_birth",
-      }.with_indifferent_access
+      }
 
       expect(date_settings_form.draft_question.answer_settings).to include(expected_settings)
     end

--- a/spec/forms/pages/name_settings_form_spec.rb
+++ b/spec/forms/pages/name_settings_form_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Pages::NameSettingsForm, type: :model do
       expected_settings = {
         input_type: "full_name",
         title_needed: "true",
-      }.with_indifferent_access
+      }
 
       expect(name_settings_form.draft_question.answer_settings).to include(expected_settings)
     end

--- a/spec/forms/pages/selections_settings_form_spec.rb
+++ b/spec/forms/pages/selections_settings_form_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Pages::SelectionsSettingsForm, type: :model do
       expected_settings = {
         only_one_option: true,
         selection_options: [{ name: "1" }, { name: "2" }],
-      }.with_indifferent_access
+      }
 
       expect(selections_settings_form.draft_question.answer_settings).to include(expected_settings)
       expect(selections_settings_form.draft_question.is_optional).to eq(true)

--- a/spec/forms/pages/text_settings_form_spec.rb
+++ b/spec/forms/pages/text_settings_form_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Pages::TextSettingsForm, type: :model do
 
       expected_settings = {
         input_type: "single_line",
-      }.with_indifferent_access
+      }
 
       expect(text_settings_form.draft_question.answer_settings).to include(expected_settings)
     end

--- a/spec/models/draft_question_spec.rb
+++ b/spec/models/draft_question_spec.rb
@@ -149,4 +149,39 @@ RSpec.describe DraftQuestion, type: :model do
       end
     end
   end
+
+  describe "answer_settings" do
+    let(:draft_question) { create :draft_question, answer_settings: }
+    let(:answer_settings) do
+      {
+        "hello" => "I have a string as a key",
+        "nested_attributes" => {
+          "name" => "Joe Bloggs",
+        },
+      }
+    end
+
+    it "returns a hash with all keys as symbols" do
+      expect(draft_question.answer_settings).to eq(hello: "I have a string as a key",
+                                                   nested_attributes: {
+                                                     name: "Joe Bloggs",
+                                                   })
+    end
+
+    context "when answer_settings is empty JSON" do
+      let(:answer_settings) { {} }
+
+      it "returns empty hash" do
+        expect(draft_question.answer_settings).to be_empty
+      end
+    end
+
+    context "when answer_settings is nil" do
+      let(:answer_settings) { nil }
+
+      it "returns empty hash" do
+        expect(draft_question.answer_settings).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/draft_question_spec.rb
+++ b/spec/models/draft_question_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe DraftQuestion, type: :model do
       let(:answer_settings) { nil }
 
       it "returns empty hash" do
-        expect(draft_question.answer_settings).to be_nil
+        expect(draft_question.answer_settings).to be_empty
       end
     end
   end

--- a/spec/requests/pages/address_settings_controller_spec.rb
+++ b/spec/requests/pages/address_settings_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
 
       it "saves the input type to draft question" do
         form = assigns(:address_settings_form)
-        expect(form.draft_question.answer_settings.with_indifferent_access).to include(input_type: { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address })
+        expect(form.draft_question.answer_settings).to include(input_type: { uk_address: address_settings_form.uk_address, international_address: address_settings_form.international_address })
       end
 
       it "redirects the user to the edit question page" do
@@ -129,8 +129,8 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
 
     it "returns the existing page input type" do
       form = assigns(:address_settings_form)
-      expect(form.uk_address).to eq draft_question.answer_settings.deep_symbolize_keys[:input_type][:uk_address]
-      expect(form.international_address).to eq draft_question.answer_settings.deep_symbolize_keys[:input_type][:international_address]
+      expect(form.uk_address).to eq draft_question.answer_settings[:input_type][:uk_address]
+      expect(form.international_address).to eq draft_question.answer_settings[:input_type][:international_address]
     end
 
     it "sets an instance variable for address_settings_path" do
@@ -172,7 +172,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
         form_instance_variable = assigns(:address_settings_form)
         expect(form_instance_variable.uk_address).to eq "true"
         expect(form_instance_variable.international_address).to eq "false"
-        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access).to include(input_type: { uk_address: "true", international_address: "false" })
+        expect(form_instance_variable.draft_question.answer_settings).to include(input_type: { uk_address: "true", international_address: "false" })
       end
 
       it "redirects the user to the edit question page" do

--- a/spec/requests/pages/date_settings_controller_spec.rb
+++ b/spec/requests/pages/date_settings_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
 
       it "saves the input type to Draft Question" do
         form_instance_variable = assigns(:date_settings_form)
-        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access).to include(input_type: "date_of_birth")
+        expect(form_instance_variable.draft_question.answer_settings).to include(input_type: "date_of_birth")
       end
 
       it "redirects the user to the edit question page" do
@@ -152,7 +152,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
       it "loads the updated input type from the page params" do
         form_instance_variable = assigns(:date_settings_form)
         expect(form_instance_variable.input_type).to eq "other_date"
-        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access).to include(input_type: "other_date")
+        expect(form_instance_variable.draft_question.answer_settings).to include(input_type: "other_date")
       end
 
       it "redirects the user to the edit question page" do

--- a/spec/requests/pages/name_settings_controller_spec.rb
+++ b/spec/requests/pages/name_settings_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
 
       it "saves the input type to draft question" do
         form = assigns(:name_settings_form)
-        expect(form.draft_question.answer_settings.with_indifferent_access).to include(input_type: "first_and_last_name", title_needed: "false")
+        expect(form.draft_question.answer_settings).to include(input_type: "first_and_last_name", title_needed: "false")
       end
 
       it "redirects the user to the edit question page" do
@@ -155,7 +155,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
         form_instance_variable = assigns(:name_settings_form)
         expect(form_instance_variable.input_type).to eq input_type
         expect(form_instance_variable.title_needed).to eq title_needed
-        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access)
+        expect(form_instance_variable.draft_question.answer_settings)
           .to include(input_type: "full_name", title_needed: "true")
       end
 

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
           question_text: "What is your home address?",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
-          answer_settings: nil,
+          answer_settings: {},
           is_optional: nil,
           page_heading: "New page heading",
           guidance_markdown: "## Heading level 2",

--- a/spec/requests/pages/selections_settings_controller_spec.rb
+++ b/spec/requests/pages/selections_settings_controller_spec.rb
@@ -76,7 +76,7 @@ describe Pages::SelectionsSettingsController, type: :request do
 
       it "saves the the info to draft question" do
         settings_form = assigns(:selections_settings_form)
-        draft_question_settings = settings_form.draft_question.answer_settings.with_indifferent_access
+        draft_question_settings = settings_form.draft_question.answer_settings
 
         expect(draft_question_settings).to include(only_one_option: "true",
                                                    selection_options: [{ name: "Option 1" }, { name: "Option 2" }])
@@ -119,7 +119,7 @@ describe Pages::SelectionsSettingsController, type: :request do
 
     it "returns the existing draft question answer settings" do
       settings_form = assigns(:selections_settings_form)
-      draft_question_settings = settings_form.draft_question.answer_settings.with_indifferent_access
+      draft_question_settings = settings_form.draft_question.answer_settings
       expect(settings_form.only_one_option).to eq draft_question_settings[:only_one_option]
       expect(settings_form.selection_options.map { |option| { name: option[:name] } }).to eq(draft_question_settings[:selection_options].map { |option| { name: option[:name] } })
       expect(settings_form.include_none_of_the_above).to eq settings_form.draft_question.is_optional

--- a/spec/requests/pages/text_settings_controller_spec.rb
+++ b/spec/requests/pages/text_settings_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
 
       it "saves the input type to draft question answers setting" do
         form = assigns(:text_settings_form)
-        expect(form.draft_question.answer_settings.with_indifferent_access).to include(input_type: text_settings_form.input_type)
+        expect(form.draft_question.answer_settings).to include(input_type: text_settings_form.input_type)
       end
 
       it "redirects the user to the edit question page" do
@@ -148,7 +148,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
       it "saves the updated input type to DB" do
         form_instance_variable = assigns(:text_settings_form)
         expect(form_instance_variable.input_type).to eq input_type
-        expect(form_instance_variable.draft_question.answer_settings.with_indifferent_access)
+        expect(form_instance_variable.draft_question.answer_settings)
           .to include({ input_type: })
       end
 

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -64,8 +64,9 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       context "when answer type is not selection" do
         let(:type_of_answer_form) { build :type_of_answer_form, :with_simple_answer_type }
 
-        it "saves the answer type to draft question" do
-          expect(type_of_answer_form.draft_question.attributes.with_indifferent_access).to include({ answer_type: type_of_answer_form.answer_type, answer_settings: {} })
+        it "saves the answer type & answer settings to draft question" do
+          expect(type_of_answer_form.draft_question.answer_type).to eq(type_of_answer_form.answer_type)
+          expect(type_of_answer_form.draft_question.answer_settings).to be_empty
         end
 
         it "redirects the user to the question details page" do
@@ -78,7 +79,11 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
         it "saves the answer type & answer settings to draft question" do
           form = assigns(:type_of_answer_form)
-          expect(form.draft_question.attributes.with_indifferent_access).to include(answer_type: type_of_answer_form.answer_type, answer_settings: { include_none_of_the_above: false, only_one_option: false, selection_options: [{ name: "" }, { name: "" }] })
+          expect(form.draft_question.answer_type).to eq(type_of_answer_form.answer_type)
+          expect(form.draft_question.answer_settings).to eq(include_none_of_the_above: false,
+                                                            only_one_option: false,
+                                                            selection_options: [{ name: "" },
+                                                                                { name: "" }])
         end
 
         it "redirects the user to the question text page" do
@@ -91,7 +96,8 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
         it "saves the answer type to draft question" do
           form = assigns(:type_of_answer_form)
-          expect(form.draft_question.attributes.with_indifferent_access).to include(answer_type: type_of_answer_form.answer_type, answer_settings: { input_type: nil })
+          expect(form.draft_question.answer_type).to eq(type_of_answer_form.answer_type)
+          expect(form.draft_question.answer_settings).to eq(input_type: nil)
         end
 
         it "redirects the user to the text settings page" do
@@ -104,7 +110,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
         it "saves the answer type to draft question" do
           form = assigns(:type_of_answer_form)
-          expect(form.draft_question.attributes.with_indifferent_access).to include(answer_settings: { input_type: nil })
+          expect(form.draft_question.answer_settings).to include(input_type: nil)
         end
 
         it "redirects the user to the date settings page" do
@@ -117,7 +123,8 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
         it "saves the answer type to draft question" do
           form = assigns(:type_of_answer_form)
-          expect(form.draft_question.attributes.with_indifferent_access).to include(answer_type: type_of_answer_form.answer_type, answer_settings: { input_type: nil })
+          expect(form.draft_question.answer_type).to eq(type_of_answer_form.answer_type)
+          expect(form.draft_question.answer_settings).to eq(input_type: nil)
         end
 
         it "redirects the user to the address settings page" do
@@ -130,7 +137,8 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
         it "saves the answer type to draft question" do
           form = assigns(:type_of_answer_form)
-          expect(form.draft_question.attributes.with_indifferent_access).to include(answer_type: type_of_answer_form.answer_type, answer_settings: { input_type: nil, title_needed: nil })
+          expect(form.draft_question.answer_type).to eq(type_of_answer_form.answer_type)
+          expect(form.draft_question.answer_settings).to eq(input_type: nil, title_needed: nil)
         end
 
         it "redirects the user to the name settings page" do


### PR DESCRIPTION
### What problem does this pull request solve?

**ISSUE:**  When a user tried to edit an existing questions answer setting, the settings page was not populating the form fields with the last saved values.

**CAUSE**: We weren't consistently switching the hash keys to symbols using either `with_indifferent_access` or `deep_symbolize_keys`. 

**FIX**:  see commit message for 3acec0922a61868bbd62dbd2159c38840bcace7b

### Going forward...
You should always use symbols when trying to access any values within answer_settings.

Trello card: https://trello.com/c/KnK13cLX/1213-when-a-user-tries-to-change-an-existing-answer-setting-the-page-is-not-populating-the-form-fields-with-their-previous-saved-valu

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
