### PR TITLE
Change the OmniAuth redirect into a POST rather than a GET

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "puma", "~> 6.4.0"
 # Used for handling authentication
 gem "gds-sso"
 gem "omniauth-auth0"
-gem "omniauth_openid_connect"
 gem "omniauth-rails_csrf_protection"
 gem "warden"
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "puma", "~> 6.4.0"
 
 # Used for handling authentication
 gem "gds-sso"
-gem "omniauth"
 gem "omniauth-auth0"
 gem "warden"
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem "puma", "~> 6.4.0"
 # Used for handling authentication
 gem "gds-sso"
 gem "omniauth-auth0"
+gem "omniauth_openid_connect"
+gem "omniauth-rails_csrf_protection"
 gem "warden"
 
 # Used for handling authorisation policies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.2)
+    attr_required (1.0.1)
     aws-eventstream (1.3.0)
     aws-partitions (1.856.0)
     aws-sdk-cloudwatch (1.82.0)
@@ -127,6 +129,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
+    bindata (2.4.15)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     brakeman (6.0.1)
@@ -206,6 +209,8 @@ GEM
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     gds-sso (18.1.0)
       oauth2 (~> 2.0)
@@ -254,6 +259,12 @@ GEM
       reline (>= 0.3.8)
     jmespath (1.6.2)
     json (2.6.3)
+    json-jwt (1.16.3)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     jwt (2.7.1)
     language_server-protocol (3.17.0.3)
     lograge (0.14.0)
@@ -313,6 +324,25 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth_openid_connect (0.7.1)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 2.2)
+    openid_connect (2.2.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      net-smtp
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (~> 2.0)
     pagy (6.2.0)
     paper_trail (15.1.0)
       activerecord (>= 6.1)
@@ -337,6 +367,13 @@ GEM
       rspec-support (~> 3.12)
     racc (1.7.3)
     rack (2.2.8)
+    rack-oauth2 (2.2.0)
+      activesupport
+      attr_required
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
     rack-proxy (0.7.7)
@@ -462,6 +499,11 @@ GEM
       hashie
       version_gem (~> 1.1, >= 1.1.1)
     stringio (3.0.8)
+    swd (2.0.2)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)
@@ -472,6 +514,9 @@ GEM
     tzinfo-data (1.2023.3)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
@@ -495,6 +540,10 @@ GEM
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
       warden
+    webfinger (2.1.2)
+      activesupport
+      faraday (~> 2.0)
+      faraday-follow_redirects
     webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -537,6 +586,8 @@ DEPENDENCIES
   i18n-tasks (~> 1.0.13)
   lograge
   omniauth-auth0
+  omniauth-rails_csrf_protection
+  omniauth_openid_connect
   paper_trail
   pg (~> 1.5)
   puma (~> 6.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,9 +96,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
-    aes_key_wrap (1.1.0)
     ast (2.4.2)
-    attr_required (1.0.1)
     aws-eventstream (1.3.0)
     aws-partitions (1.856.0)
     aws-sdk-cloudwatch (1.82.0)
@@ -129,7 +127,6 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
-    bindata (2.4.15)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     brakeman (6.0.1)
@@ -209,8 +206,6 @@ GEM
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-follow_redirects (0.3.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     gds-sso (18.1.0)
       oauth2 (~> 2.0)
@@ -259,12 +254,6 @@ GEM
       reline (>= 0.3.8)
     jmespath (1.6.2)
     json (2.6.3)
-    json-jwt (1.16.3)
-      activesupport (>= 4.2)
-      aes_key_wrap
-      bindata
-      faraday (~> 2.0)
-      faraday-follow_redirects
     jwt (2.7.1)
     language_server-protocol (3.17.0.3)
     lograge (0.14.0)
@@ -327,22 +316,6 @@ GEM
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    omniauth_openid_connect (0.7.1)
-      omniauth (>= 1.9, < 3)
-      openid_connect (~> 2.2)
-    openid_connect (2.2.0)
-      activemodel
-      attr_required (>= 1.0.0)
-      faraday (~> 2.0)
-      faraday-follow_redirects
-      json-jwt (>= 1.16)
-      net-smtp
-      rack-oauth2 (~> 2.2)
-      swd (~> 2.0)
-      tzinfo
-      validate_email
-      validate_url
-      webfinger (~> 2.0)
     pagy (6.2.0)
     paper_trail (15.1.0)
       activerecord (>= 6.1)
@@ -367,13 +340,6 @@ GEM
       rspec-support (~> 3.12)
     racc (1.7.3)
     rack (2.2.8)
-    rack-oauth2 (2.2.0)
-      activesupport
-      attr_required
-      faraday (~> 2.0)
-      faraday-follow_redirects
-      json-jwt (>= 1.11.0)
-      rack (>= 2.1.0)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
     rack-proxy (0.7.7)
@@ -499,11 +465,6 @@ GEM
       hashie
       version_gem (~> 1.1, >= 1.1.1)
     stringio (3.0.8)
-    swd (2.0.2)
-      activesupport (>= 3)
-      attr_required (>= 0.0.5)
-      faraday (~> 2.0)
-      faraday-follow_redirects
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)
@@ -514,9 +475,6 @@ GEM
     tzinfo-data (1.2023.3)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
-    validate_email (0.1.6)
-      activemodel (>= 3.0)
-      mail (>= 2.2.5)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
@@ -540,10 +498,6 @@ GEM
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
       warden
-    webfinger (2.1.2)
-      activesupport
-      faraday (~> 2.0)
-      faraday-follow_redirects
     webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -587,7 +541,6 @@ DEPENDENCIES
   lograge
   omniauth-auth0
   omniauth-rails_csrf_protection
-  omniauth_openid_connect
   paper_trail
   pg (~> 1.5)
   puma (~> 6.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -536,7 +536,6 @@ DEPENDENCIES
   govuk_notify_rails
   i18n-tasks (~> 1.0.13)
   lograge
-  omniauth
   omniauth-auth0
   paper_trail
   pg (~> 1.5)

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -5,18 +5,18 @@ class AuthenticationController < ApplicationController
   layout false
 
   def self.call(env)
-    action(:redirect_to_login).call(env)
+    action(:redirect_to_sign_in).call(env)
   end
 
-  def redirect_to_login
+  def redirect_to_sign_in
     store_location(attempted_path) if request.get?
 
-    redirect_to(login_url(request.query_parameters))
+    redirect_to(sign_in_url(request.query_parameters))
   end
 
-  def login
+  def sign_in
     @is_e2e_user = e2e_user?
-    render "authentications/login", layout: "application"
+    render "authentications/sign_in", layout: "application"
   end
 
   def callback_from_omniauth

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -8,6 +8,10 @@ class AuthenticationController < ApplicationController
     action(:redirect_to_omniauth).call(env)
   end
 
+  def login
+    render "authentications/login", layout: "application"
+  end
+
   def redirect_to_omniauth
     store_location(attempted_path) if request.get?
 
@@ -17,7 +21,7 @@ class AuthenticationController < ApplicationController
       params[:connection] = "Username-Password-Authentication"
     end
 
-    redirect_to ActionDispatch::Http::URL.path_for(path: "/auth/#{default_provider}", params:)
+    redirect_to(login_url, params:)
   end
 
   def e2e_user?

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,6 +1,6 @@
 class AuthenticationController < ApplicationController
   skip_before_action :authenticate_and_check_access
-  protect_from_forgery with: :null_session, only: %i[redirect_to_omniauth]
+  protect_from_forgery with: :null_session, only: %i[redirect_to_sign_in]
 
   layout false
 

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,5 +1,6 @@
 class AuthenticationController < ApplicationController
   skip_before_action :authenticate_and_check_access
+  protect_from_forgery with: :null_session, only: %i[redirect_to_omniauth]
 
   layout false
 

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -14,23 +14,20 @@ class AuthenticationController < ApplicationController
     redirect_to(sign_in_url(request.query_parameters))
   end
 
-  def sign_in
-    @is_e2e_user = e2e_user?
-    render "authentications/sign_in", layout: "application"
-  end
-
   def callback_from_omniauth
     authenticate_user!
     redirect_to stored_location || "/"
   end
 
+  def sign_in
+    @is_e2e_user = e2e_user?
+    render "authentications/sign_in", layout: "application"
+  end
+
   def sign_up
     store_location root_path
-    if default_provider == "auth0"
-      redirect_to "/auth/auth0?screen_hint=signup"
-    else
-      redirect_to "/auth/#{default_provider}"
-    end
+    @is_e2e_user = e2e_user?
+    render "authentications/sign_up", layout: "application"
   end
 
   def sign_out

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -80,15 +80,24 @@ module ApplicationHelper
     end
   end
 
-  def omniauth_authorize_path
-    "/auth/#{Settings.auth_provider}/"
-  end
-
   def sign_in_button(is_e2e_user:)
     govuk_button_to t("sign_in_button"), omniauth_authorize_path, params: sign_in_params(is_e2e_user:), data: { module: "sign-in-button" }
   end
 
-  def sign_in_params(is_e2e_user:)
-    is_e2e_user ? { connection: "Username-Password-Authentication" } : {}
+  def sign_up_button(is_e2e_user:)
+    govuk_button_to t("sign_up_button"), omniauth_authorize_path, params: sign_in_params(is_e2e_user:, login_type: :sign_up), data: { module: "sign-in-button" }
+  end
+
+  def omniauth_authorize_path
+    "/auth/#{Settings.auth_provider}/"
+  end
+
+  def sign_in_params(is_e2e_user:, login_type: :sign_in)
+    {}.tap do |params|
+      if Settings.auth_provider == "auth0"
+        params.merge!({ connection: "Username-Password-Authentication" }) if is_e2e_user
+        params.merge!({ screen_hint: "signup" }) if login_type == :sign_up
+      end
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,4 +79,8 @@ module ApplicationHelper
       OpenStruct.new(label: t("users.has_access.#{access}.name"), value: access, description: t("users.has_access.#{access}.description"))
     end
   end
+
+  def omniauth_authorize_path
+    "/auth/#{Settings.auth_provider}/"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -83,4 +83,12 @@ module ApplicationHelper
   def omniauth_authorize_path
     "/auth/#{Settings.auth_provider}/"
   end
+
+  def login_button(is_e2e_user:)
+    govuk_button_to t("login_button"), omniauth_authorize_path, params: login_params(is_e2e_user:)
+  end
+
+  def login_params(is_e2e_user:)
+    is_e2e_user ? { connection: "Username-Password-Authentication" } : {}
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -84,11 +84,11 @@ module ApplicationHelper
     "/auth/#{Settings.auth_provider}/"
   end
 
-  def login_button(is_e2e_user:)
-    govuk_button_to t("login_button"), omniauth_authorize_path, params: login_params(is_e2e_user:), data: { module: "login-button" }
+  def sign_in_button(is_e2e_user:)
+    govuk_button_to t("sign_in_button"), omniauth_authorize_path, params: sign_in_params(is_e2e_user:), data: { module: "sign-in-button" }
   end
 
-  def login_params(is_e2e_user:)
+  def sign_in_params(is_e2e_user:)
     is_e2e_user ? { connection: "Username-Password-Authentication" } : {}
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,7 +85,7 @@ module ApplicationHelper
   end
 
   def login_button(is_e2e_user:)
-    govuk_button_to t("login_button"), omniauth_authorize_path, params: login_params(is_e2e_user:)
+    govuk_button_to t("login_button"), omniauth_authorize_path, params: login_params(is_e2e_user:), data: { module: "login-button" }
   end
 
   def login_params(is_e2e_user:)

--- a/app/views/authentications/_auto_click_login_js.html.erb
+++ b/app/views/authentications/_auto_click_login_js.html.erb
@@ -1,0 +1,10 @@
+<% content_for :body_end do %>
+  <script>
+    (function() {
+      var loginButton = document.querySelector('[data-module="sign-in-button"]');
+      if (loginButton && typeof loginButton.click === 'function') {
+        loginButton.click();
+      }
+    })();
+  </script>
+<% end %>

--- a/app/views/authentications/login.html.erb
+++ b/app/views/authentications/login.html.erb
@@ -4,6 +4,11 @@
 
 <% content_for :body_end do %>
   <script>
-    document.querySelector('button[type=submit]').click()
+    (function() {
+      var loginButton = document.querySelector('[data-module="login-button"]');
+      if (loginButton && typeof loginButton.click === 'function') {
+        loginButton.click();
+      }
+    })();
   </script>
 <% end %>

--- a/app/views/authentications/login.html.erb
+++ b/app/views/authentications/login.html.erb
@@ -1,7 +1,9 @@
 <% set_page_title(t("page_titles.login")) %>
 
-<%= govuk_button_to 'Login', omniauth_authorize_path, method: :post %>
+<%= login_button(is_e2e_user: @is_e2e_user) %>
 
-<script>
-  document.querySelector('button[type=submit]').click()
-</script>
+<% content_for :body_end do %>
+  <script>
+    document.querySelector('button[type=submit]').click()
+  </script>
+<% end %>

--- a/app/views/authentications/login.html.erb
+++ b/app/views/authentications/login.html.erb
@@ -1,0 +1,7 @@
+<% set_page_title(t("page_titles.login")) %>
+
+<%= govuk_button_to 'Login', omniauth_authorize_path, method: :post %>
+
+<script>
+  document.querySelector('button[type=submit]').click()
+</script>

--- a/app/views/authentications/sign_in.html.erb
+++ b/app/views/authentications/sign_in.html.erb
@@ -1,11 +1,11 @@
-<% set_page_title(t("page_titles.login")) %>
+<% set_page_title(t("page_titles.sign_in")) %>
 
-<%= login_button(is_e2e_user: @is_e2e_user) %>
+<%= sign_in_button(is_e2e_user: @is_e2e_user) %>
 
 <% content_for :body_end do %>
   <script>
     (function() {
-      var loginButton = document.querySelector('[data-module="login-button"]');
+      var loginButton = document.querySelector('[data-module="sign-in-button"]');
       if (loginButton && typeof loginButton.click === 'function') {
         loginButton.click();
       }

--- a/app/views/authentications/sign_in.html.erb
+++ b/app/views/authentications/sign_in.html.erb
@@ -2,13 +2,4 @@
 
 <%= sign_in_button(is_e2e_user: @is_e2e_user) %>
 
-<% content_for :body_end do %>
-  <script>
-    (function() {
-      var loginButton = document.querySelector('[data-module="sign-in-button"]');
-      if (loginButton && typeof loginButton.click === 'function') {
-        loginButton.click();
-      }
-    })();
-  </script>
-<% end %>
+<%= render partial: "authentications/auto_click_login_js" %>

--- a/app/views/authentications/sign_up.html.erb
+++ b/app/views/authentications/sign_up.html.erb
@@ -1,0 +1,5 @@
+<% set_page_title(t("page_titles.sign_up")) %>
+
+<%= sign_up_button(is_e2e_user: @is_e2e_user) %>
+
+<%= render partial: "authentications/auto_click_login_js" %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -55,6 +55,8 @@
 
     <%= yield :footer %>
 
+    <%= yield :body_end %>
+
     <%= vite_client_tag %>
     <%= vite_javascript_tag 'application' %>
   </body>

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -14,7 +14,7 @@ Rails.application.config.before_initialize do
   )
 
   # add developer provider
-  if Rails.env.development?
+  if Rails.env.development? || Rails.env.test?
     Rails.application.config.app_middleware.use(
       OmniAuth::Strategies::Developer,
       fields: [:email],

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -30,3 +30,6 @@ Rails.application.config.before_initialize do
 
   GDS::SSO::Config.auth_valid_for = Settings.auth_valid_for
 end
+
+# Need to do this because Signon allows both GET and POST requests
+OmniAuth.config.allowed_request_methods = %i[post]

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -13,6 +13,14 @@ Rails.application.config.before_initialize do
     },
   )
 
+  # add developer provider
+  if Rails.env.development?
+    Rails.application.config.app_middleware.use(
+      OmniAuth::Strategies::Developer,
+      fields: [:email],
+    )
+  end
+
   # Configure Warden session management middleware
   # swap out the Warden::Manager installed by `gds-sso` gem
   Rails.application.config.app_middleware.swap Warden::Manager, Warden::Manager do |warden|

--- a/config/initializers/warden/strategies/developer.rb
+++ b/config/initializers/warden/strategies/developer.rb
@@ -1,0 +1,15 @@
+require "warden/strategies/omniauth"
+
+Warden::Strategies.add(:developer) do
+  include Warden::Strategies::OmniAuth
+
+private
+
+  def prep_user(auth_hash)
+    User.find_for_auth(
+      provider: auth_hash[:provider],
+      uid: auth_hash[:uid],
+      email: auth_hash[:info][:email],
+    )
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -605,6 +605,7 @@ en:
     routing_page_edit: Edit question %{question_position}’s route
     set_email_form: Set the email address for completed forms
     sign_in: Sign in
+    sign_up: Sign up
     text_settings: How much text will people need to provide?
     type_of_answer: What kind of answer do you need to this question?
     user_missing_organisation: You do not have an organisation set for your account
@@ -751,6 +752,7 @@ en:
     what_is_declaration: What is a declaration?
     what_is_what_happens_next: What is ‘what happens next information’?
   sign_in_button: Sign in
+  sign_up_button: Sign up
   skip_to_main_content: Skip to main content
   status_tag_description_component:
     status: Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -395,7 +395,6 @@ en:
       Any changes you make to a live form will be updated in the form
       immediately.
     notification_title: Important
-  login_button: Login
   maintenance:
     body_html: |
       <p>You’ll be able to use the service later.</p>
@@ -591,7 +590,6 @@ en:
     forbidden: You cannot view this page
     home: Home
     internal_server_error: Sorry, there is a problem with the service
-    login: Login
     maintenance: Sorry, the service is unavailable
     make_changes_live_form: Make your changes live
     make_live_form: Make your form live
@@ -606,6 +604,7 @@ en:
     routing_page_delete: Delete question %{question_position}’s route
     routing_page_edit: Edit question %{question_position}’s route
     set_email_form: Set the email address for completed forms
+    sign_in: Sign in
     text_settings: How much text will people need to provide?
     type_of_answer: What kind of answer do you need to this question?
     user_missing_organisation: You do not have an organisation set for your account
@@ -751,6 +750,7 @@ en:
     what_happens_next_description: Information about what happens next is shown to people when they have completed and submitted a form.
     what_is_declaration: What is a declaration?
     what_is_what_happens_next: What is ‘what happens next information’?
+  sign_in_button: Sign in
   skip_to_main_content: Skip to main content
   status_tag_description_component:
     status: Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -395,6 +395,7 @@ en:
       Any changes you make to a live form will be updated in the form
       immediately.
     notification_title: Important
+  login_button: Login
   maintenance:
     body_html: |
       <p>You’ll be able to use the service later.</p>
@@ -590,6 +591,7 @@ en:
     forbidden: You cannot view this page
     home: Home
     internal_server_error: Sorry, there is a problem with the service
+    login: Login
     maintenance: Sorry, the service is unavailable
     make_changes_live_form: Make your changes live
     make_live_form: Make your form live

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,10 @@ Rails.application.routes.draw do
 
   get "/sign-up" => "authentication#sign_up", as: :sign_up
   get "/sign-out" => "authentication#sign_out", as: :sign_out
+  get "/login" => "authentication#login", as: :login
 
   scope "auth/:provider" do
-    get "/callback" => "authentication#callback_from_omniauth"
+    match "/callback" => "authentication#callback_from_omniauth", via: %i[get post]
   end
 
   get "forms/new" => "forms/change_name#new", as: :new_form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   get "/sign-up" => "authentication#sign_up", as: :sign_up
   get "/sign-out" => "authentication#sign_out", as: :sign_out
-  get "/login" => "authentication#login", as: :login
+  get "/sign-in" => "authentication#sign_in", as: :sign_in
 
   scope "auth/:provider" do
     match "/callback" => "authentication#callback_from_omniauth", via: %i[get post]

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -9,4 +9,6 @@ forms_api:
   auth_key: changeme
 
 # Use mock authentication
+# in development use 'mock_gds_sso' to always be logged in or 'developer' to use a
+# mock flow through omniauth
 auth_provider: mock_gds_sso

--- a/spec/features/login/login_spec.rb
+++ b/spec/features/login/login_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe "Login to the service", type: :feature do
+  let(:user) { create :user, :with_trial_role, name: "Test User", email: "test@example.gov.uk" }
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?creator_id=#{user.id}", req_headers, [].to_json, 200
+    end
+    allow(Settings).to receive(:auth_provider).and_return("developer")
+  end
+
+  it "an unauthenticated user gets redirected through the auth journey" do
+    when_i_visit_the_homepage
+    then_i_am_redirected_to_the_developer_login_page
+    when_i_enter_an_email_address_and_click_login
+    then_i_am_redirected_back_to_the_homepage
+  end
+
+private
+
+  def when_i_visit_the_homepage
+    visit root_path
+  end
+
+  def then_i_am_redirected_to_the_developer_login_page
+    expect(page).to have_field "Email"
+    expect(page).to have_button "Sign In"
+  end
+
+  def when_i_enter_an_email_address_and_click_login
+    fill_in "Email", with: user.email
+    click_on "Sign In"
+  end
+
+  def then_i_am_redirected_back_to_the_homepage
+    expect(page).to have_current_path(root_path)
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
 
-    context "when  auth_provider is not auth0" do
+    context "when auth_provider is not auth0" do
       before do
         allow(Settings).to receive(:auth_provider).and_return("developer")
       end
@@ -210,7 +210,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
 
-    context "when  auth_provider is not auth0" do
+    context "when auth_provider is not auth0" do
       before do
         allow(Settings).to receive(:auth_provider).and_return("developer")
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -166,4 +166,58 @@ RSpec.describe ApplicationHelper, type: :helper do
       )
     end
   end
+
+  describe "#sign_in_button" do
+    context "when user is an e2e user and auth_provider is auth0" do
+      before do
+        allow(Settings).to receive(:auth_provider).and_return("auth0")
+      end
+
+      it "returns a string representing the sign-in button" do
+        expect(helper.sign_in_button(is_e2e_user: true)).to include("Username-Password-Authentication")
+      end
+
+      it "does not include auth0 connection string when sign-in button" do
+        expect(helper.sign_in_button(is_e2e_user: false)).not_to include("Username-Password-Authentication")
+      end
+    end
+
+    context "when  auth_provider is not auth0" do
+      before do
+        allow(Settings).to receive(:auth_provider).and_return("developer")
+      end
+
+      it "does not include auth0 connection string when sign-in button" do
+        expect(helper.sign_in_button(is_e2e_user: true)).not_to include("Username-Password-Authentication")
+      end
+    end
+  end
+
+  describe "#sign_up_button" do
+    context "when user is an e2e user and auth_provider is auth0" do
+      before do
+        allow(Settings).to receive(:auth_provider).and_return("auth0")
+      end
+
+      it "returns a string representing the sign-up button" do
+        expect(helper.sign_up_button(is_e2e_user: true)).to include("Username-Password-Authentication", "signup")
+      end
+
+      context "when user is not an e2e user" do
+        it "returns a string representing the sign-up button" do
+          expect(helper.sign_up_button(is_e2e_user: false)).not_to include("Username-Password-Authentication")
+        end
+      end
+    end
+
+    context "when  auth_provider is not auth0" do
+      before do
+        allow(Settings).to receive(:auth_provider).and_return("developer")
+      end
+
+      it "returns a string representing the sign-up button" do
+        expect(helper.sign_up_button(is_e2e_user: true)).not_to include("signup")
+      end
+    end
+  end
 end

--- a/spec/integration/auth0_spec.rb
+++ b/spec/integration/auth0_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "usage of omniauth-auth0 gem" do
 
       get root_path
 
-      expect(response).to redirect_to(login_path)
+      expect(response).to redirect_to(sign_in_path)
     end
 
     it "authenticates with OmniAuth and Warden" do

--- a/spec/integration/auth0_spec.rb
+++ b/spec/integration/auth0_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe "usage of omniauth-auth0 gem" do
 
       get root_path
 
-      expect(response).to redirect_to("/auth/auth0")
+      expect(response).to redirect_to(login_path)
     end
 
     it "authenticates with OmniAuth and Warden" do
       OmniAuth.config.mock_auth[:auth0] = omniauth_hash
 
-      get "/auth/auth0"
+      post "/auth/auth0"
 
       expect(response).to redirect_to("/auth/auth0/callback")
 
@@ -44,7 +44,7 @@ RSpec.describe "usage of omniauth-auth0 gem" do
   describe "signing out" do
     before do
       OmniAuth.config.mock_auth[:auth0] = omniauth_hash
-      get "/auth/auth0"
+      post "/auth/auth0"
       get "/auth/auth0/callback"
     end
 
@@ -64,7 +64,7 @@ RSpec.describe "usage of omniauth-auth0 gem" do
         allow(described_class).to receive(:find_for_auth).and_call_original
 
         OmniAuth.config.mock_auth[:auth0] = omniauth_hash
-        get "/auth/auth0"
+        post "/auth/auth0"
         get "/auth/auth0/callback"
 
         expect(described_class).to have_received(:find_for_auth).with(
@@ -86,10 +86,7 @@ RSpec.describe "usage of omniauth-auth0 gem" do
 
       logout
 
-      get root_path
-
-      expect(response).to redirect_to "/auth/auth0"
-      follow_redirect!
+      post "/auth/auth0"
 
       expect(response).to redirect_to "/auth/auth0/callback"
       follow_redirect!

--- a/spec/integration/gds_sso_spec.rb
+++ b/spec/integration/gds_sso_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "usage of gds-sso gem" do
 
       get root_path
 
-      expect(response).to redirect_to(login_path)
+      expect(response).to redirect_to(sign_in_path)
     end
 
     it "authenticates with OmniAuth and Warden" do

--- a/spec/integration/gds_sso_spec.rb
+++ b/spec/integration/gds_sso_spec.rb
@@ -34,18 +34,18 @@ RSpec.describe "usage of gds-sso gem" do
       OmniAuth.config.test_mode = true
     end
 
-    it "redirects to OmniAuth when no user is logged in" do
+    it "redirects to login page when no user is logged in" do
       logout
 
       get root_path
 
-      expect(response).to redirect_to("/auth/gds")
+      expect(response).to redirect_to(login_path)
     end
 
     it "authenticates with OmniAuth and Warden" do
       OmniAuth.config.mock_auth[:gds] = omniauth_hash
 
-      get "/auth/gds"
+      post "/auth/gds"
 
       expect(response).to redirect_to(gds_sign_in_path)
 
@@ -99,10 +99,7 @@ RSpec.describe "usage of gds-sso gem" do
 
       logout
 
-      get root_path
-
-      expect(response).to redirect_to "/auth/gds"
-      follow_redirect!
+      post "/auth/gds"
 
       expect(response).to redirect_to "/auth/gds/callback"
       follow_redirect!

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -40,18 +40,10 @@ RSpec.describe AuthenticationController, type: :request do
       expect(controller_spy).to have_received(:redirect_to_omniauth)
     end
 
-    it "redirects to OmniAuth request phase" do
+    it "redirects to login page" do
       get root_path
 
-      expect(response).to redirect_to("/auth/#{Settings.auth_provider}")
-    end
-
-    it "uses the configured OmniAuth provider" do
-      allow(Settings).to receive(:auth_provider).and_return("auth0")
-
-      get root_path
-
-      expect(response).to redirect_to("/auth/auth0")
+      expect(response).to redirect_to(login_url)
     end
 
     it "stores the URL the user is trying to reach for after they have signed in" do
@@ -59,8 +51,7 @@ RSpec.describe AuthenticationController, type: :request do
 
       get live_form_pages_path(42)
 
-      expect(response).to redirect_to("/auth/auth0")
-      get "/auth/auth0"
+      post "/auth/auth0"
 
       expect(response).to redirect_to("/auth/auth0/callback")
       get "/auth/auth0/callback"
@@ -68,27 +59,29 @@ RSpec.describe AuthenticationController, type: :request do
       expect(response).to redirect_to(live_form_pages_path(42))
     end
 
-    context "when the auth provider is auth0" do
-      context "and the user is the end to end test user" do
-        it "uses the Auth0 username/password flow" do
-          allow(Settings).to receive(:auth_provider).and_return("auth0")
+    # TODO: Create new way to trigger e2e test login
+    # This will need to change as the end to end tests will also need to be different
+    # context "when the auth provider is auth0" do
+    #   context "and the user is the end to end test user" do
+    #     it "uses the Auth0 username/password flow" do
+    #       allow(Settings).to receive(:auth_provider).and_return("auth0")
 
-          get root_path, params: { auth: "e2e" }
+    #       get login_url, params: { auth: "e2e" }
 
-          expect(response).to redirect_to("/auth/auth0?connection=Username-Password-Authentication")
-        end
-      end
+    #       expect(response).to redirect_to("/auth/auth0?connection=Username-Password-Authentication")
+    #     end
+    #   end
 
-      context "and the user is not the end to end test user" do
-        it "uses the Auth0 passwordless flow" do
-          allow(Settings).to receive(:auth_provider).and_return("auth0")
+    #   context "and the user is not the end to end test user" do
+    #     it "uses the Auth0 passwordless flow" do
+    #       allow(Settings).to receive(:auth_provider).and_return("auth0")
 
-          get root_path
+    #       get root_path
 
-          expect(response).to redirect_to("/auth/auth0")
-        end
-      end
-    end
+    #       expect(response).to redirect_to("/auth/auth0")
+    #     end
+    #   end
+    # end
 
     context "when the user's session expires" do
       before do
@@ -123,7 +116,7 @@ RSpec.describe AuthenticationController, type: :request do
 
   describe "#callback_from_omniauth" do
     it "is called by OmniAuth provider" do
-      get "/auth/gds"
+      post "/auth/gds"
 
       expect(response).to redirect_to("/auth/gds/callback")
 
@@ -158,7 +151,7 @@ RSpec.describe AuthenticationController, type: :request do
       get sign_up_path
 
       expect(response).to redirect_to "/auth/auth0?screen_hint=signup"
-      get "/auth/auth0?screen_hint=signup"
+      post "/auth/auth0?screen_hint=signup"
 
       expect(response).to redirect_to("/auth/auth0/callback?screen_hint=signup")
       get "/auth/auth0/callback?screen_hint=signup"
@@ -172,7 +165,7 @@ RSpec.describe AuthenticationController, type: :request do
       get sign_up_path
 
       expect(response).to redirect_to "/auth/auth0?screen_hint=signup"
-      get "/auth/auth0?screen_hint=signup"
+      post "/auth/auth0?screen_hint=signup"
 
       expect(response).to redirect_to("/auth/auth0/callback?screen_hint=signup")
       get "/auth/auth0/callback?screen_hint=signup"

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe AuthenticationController, type: :request do
     controller_spy
   end
 
-  describe "#redirect_to_login" do
+  describe "#redirect_to_sign_in" do
     before do
-      allow(controller_spy).to receive(:redirect_to_login).and_call_original
+      allow(controller_spy).to receive(:redirect_to_sign_in).and_call_original
 
       logout
     end
@@ -37,13 +37,13 @@ RSpec.describe AuthenticationController, type: :request do
     it "is called by Warden if user is not logged in" do
       get root_path
 
-      expect(controller_spy).to have_received(:redirect_to_login)
+      expect(controller_spy).to have_received(:redirect_to_sign_in)
     end
 
     it "redirects to login page" do
       get root_path
 
-      expect(response).to redirect_to(login_url)
+      expect(response).to redirect_to(sign_in_url)
     end
 
     it "stores the URL the user is trying to reach for after they have signed in" do
@@ -62,12 +62,12 @@ RSpec.describe AuthenticationController, type: :request do
     it "keeps the query string when redirecting to login page" do
       get root_path, params: { example_param: "value", another_param: "another_value" }
 
-      expect(response).to redirect_to(login_url(example_param: "value", another_param: "another_value"))
+      expect(response).to redirect_to(sign_in_url(example_param: "value", another_param: "another_value"))
     end
 
     context "when the user's session expires" do
       before do
-        allow(controller_spy).to receive(:redirect_to_login).and_call_original
+        allow(controller_spy).to receive(:redirect_to_sign_in).and_call_original
 
         # shorten the auth_valid_for time for testing
         GDS::SSO::Config.auth_valid_for = 1
@@ -84,14 +84,14 @@ RSpec.describe AuthenticationController, type: :request do
 
         get root_path
 
-        expect(controller_spy).not_to have_received(:redirect_to_login)
+        expect(controller_spy).not_to have_received(:redirect_to_sign_in)
 
         # wait for the auth_valid_for time to pass
         sleep(1)
 
         get root_path
 
-        expect(controller_spy).to have_received(:redirect_to_login).once
+        expect(controller_spy).to have_received(:redirect_to_sign_in).once
       end
     end
   end
@@ -216,7 +216,7 @@ RSpec.describe AuthenticationController, type: :request do
 
   describe "#login" do
     it "returns success" do
-      get login_path
+      get sign_in_path
 
       expect(response).to have_http_status(:success)
     end

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -120,11 +120,9 @@ RSpec.describe AuthenticationController, type: :request do
 
   describe "#sign_up" do
     it "redirects to auth0 sign up page when using auth0" do
-      allow(Settings).to receive(:auth_provider).and_return("auth0")
-
       get sign_up_path
 
-      expect(response).to redirect_to "/auth/auth0?screen_hint=signup"
+      expect(response).to be_successful
     end
 
     it "redirects user to homepage after they have signed up" do
@@ -132,7 +130,6 @@ RSpec.describe AuthenticationController, type: :request do
 
       get sign_up_path
 
-      expect(response).to redirect_to "/auth/auth0?screen_hint=signup"
       post "/auth/auth0?screen_hint=signup"
 
       expect(response).to redirect_to("/auth/auth0/callback?screen_hint=signup")
@@ -144,23 +141,12 @@ RSpec.describe AuthenticationController, type: :request do
     it "signs the user in after they have signed up" do
       allow(Settings).to receive(:auth_provider).and_return("auth0")
 
-      get sign_up_path
-
-      expect(response).to redirect_to "/auth/auth0?screen_hint=signup"
       post "/auth/auth0?screen_hint=signup"
 
       expect(response).to redirect_to("/auth/auth0/callback?screen_hint=signup")
       get "/auth/auth0/callback?screen_hint=signup"
 
       expect(request.env["warden"]).to be_authenticated
-    end
-
-    it "redirects to sign in page when not using auth0" do
-      allow(Settings).to receive(:auth_provider).and_return("mock_not_logged_in")
-
-      get sign_up_path
-
-      expect(response).to redirect_to "/auth/mock_not_logged_in"
     end
   end
 

--- a/spec/views/authentications/login.html.erb_spec.rb
+++ b/spec/views/authentications/login.html.erb_spec.rb
@@ -1,0 +1,1 @@
+require "rails_helper"

--- a/spec/views/authentications/login.html.erb_spec.rb
+++ b/spec/views/authentications/login.html.erb_spec.rb
@@ -1,1 +1,19 @@
 require "rails_helper"
+
+describe "authentications/login.html.erb" do
+  before do
+    render template: "authentications/login"
+  end
+
+  it "has the correct title" do
+    expect(view.content_for(:title)).to have_content(t("page_titles.login"))
+  end
+
+  it "has javascript" do
+    expect(view.content_for(:body_end)).to have_selector("script", visible: :all)
+  end
+
+  it "has login form" do
+    expect(rendered).to have_selector("form[action=\"/auth/#{Settings.auth_provider}/\"]")
+  end
+end

--- a/spec/views/authentications/login.html.erb_spec.rb
+++ b/spec/views/authentications/login.html.erb_spec.rb
@@ -16,4 +16,19 @@ describe "authentications/login.html.erb" do
   it "has login form" do
     expect(rendered).to have_selector("form[action=\"/auth/#{Settings.auth_provider}/\"]")
   end
+
+  it "has login button" do
+    expect(rendered).to have_selector("[data-module=\"login-button\"]")
+  end
+
+  context "when @is_e2e_user is true" do
+    before do
+      assign(:is_e2e_user, true)
+      render template: "authentications/login"
+    end
+
+    it "has e2e login button" do
+      expect(rendered).to have_selector("input[type=\"hidden\"][name=\"connection\"][value=\"Username-Password-Authentication\"]", visible: :all)
+    end
+  end
 end

--- a/spec/views/authentications/sign_in.html.erb_spec.rb
+++ b/spec/views/authentications/sign_in.html.erb_spec.rb
@@ -1,33 +1,33 @@
 require "rails_helper"
 
-describe "authentications/login.html.erb" do
+describe "authentications/sign_in.html.erb" do
   before do
-    render template: "authentications/login"
+    render template: "authentications/sign_in"
   end
 
   it "has the correct title" do
-    expect(view.content_for(:title)).to have_content(t("page_titles.login"))
+    expect(view.content_for(:title)).to have_content(t("page_titles.sign_in"))
   end
 
   it "has javascript" do
     expect(view.content_for(:body_end)).to have_selector("script", visible: :all)
   end
 
-  it "has login form" do
+  it "has sign_in form" do
     expect(rendered).to have_selector("form[action=\"/auth/#{Settings.auth_provider}/\"]")
   end
 
-  it "has login button" do
-    expect(rendered).to have_selector("[data-module=\"login-button\"]")
+  it "has sign_in button" do
+    expect(rendered).to have_selector("[data-module=\"sign-in-button\"]")
   end
 
   context "when @is_e2e_user is true" do
     before do
       assign(:is_e2e_user, true)
-      render template: "authentications/login"
+      render template: "authentications/sign_in"
     end
 
-    it "has e2e login button" do
+    it "has e2e sign_in button" do
       expect(rendered).to have_selector("input[type=\"hidden\"][name=\"connection\"][value=\"Username-Password-Authentication\"]", visible: :all)
     end
   end

--- a/spec/views/authentications/sign_up.html.erb_spec.rb
+++ b/spec/views/authentications/sign_up.html.erb_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
-describe "authentications/sign_in.html.erb" do
+describe "authentications/sign_up.html.erb" do
   before do
-    render template: "authentications/sign_in"
+    render template: "authentications/sign_up"
   end
 
   it "has the correct title" do
-    expect(view.content_for(:title)).to have_content(t("page_titles.sign_in"))
+    expect(view.content_for(:title)).to have_content(t("page_titles.sign_up"))
   end
 
   it "has javascript" do


### PR DESCRIPTION
# Change the OmniAuth redirect into a POST rather than a GET

[Trello card](https://trello.com/c/kFUuF91A/1182-fix-security-vulnerability-in-how-we-redirect-users-to-sign-in-page)

This PR changes how users login to our system.

We don't keep a list of user names and passwords within our service to log users in. Instead, we rely on external services to manage users and check users are who they claim to be. When an unauthenticated request is made to our application, we redirect the user to the external service to login and then be redirected back to us.

Each service has a slightly expectations about how users are redirected and what information they need. To manage the differences, we use we use a library called OmniAuth. 

OmniAuth works by creating new routes like `/auth/auth0` and `/auth/gds_sso`.
These routes are the start of the login journey for that service. In our application code, all we need to do to make a user follow that journey is redirect the user to one of the /auth/* routes.

This process is shown in the [authentication flow diagram](https://github.com/alphagov/forms/blob/main/diagrams/sequence-diagrams/authentication.md)
as steps 1-5.

There is a potential security issue with this approach. Because the OmniAuth routes start the auth journey based on a GET request, it's very easy for a user to be sent through them without realising. The user's browser follows redirects automatically. When they try to access our service, they are redirected to the login page without taking any further action to confirm they want to login.

If a user is already logged into an auth provider, they may bounce through the authentication without ever pressing a button.

This [CVE-2015-9284](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284) against OmniAuth explains how it can turn into a vulnerability.

If a user can associate multiple accounts with a service, perhaps a username and password and a google account. It can be possible for a an attacker to trick a victim to associate a google account the attacker owns with the victims account. It's a bit obscure - the victim would have to be logged into both accounts first.

By itself, with our current authentication setup, this isn't a security issue. Forms authentication only allows one identity to be linked to a user account at a time and Auth0 always asks users to login. There is no concept of using other accounts to login. Even when we were migrating away from GDS Signon, a user could only be associated with one login
method. We also only use our Auth0 tenant for our single application. It's not possible to have an account with another service and not have a forms account.

## Why do we need to change if CVE-2015-9284 does not cause us any issues?

Redirecting a user through to an authentication method directly still causes us a few issues:
- Auth0 logs that we are sending [too many requests to the login
  page](https://trello.com/c/OcsYrxXD/1270-spike-how-do-we-stop-bots-from-trying-to-access-sign-in-pages-for-forms-admin). This might be because we redirect any traffic - bots, services like slack which show embedded previews etc.
- We still have the signon omniauth route in production. It will be removed when we clean up the code but user's can be redirected to [https://admin.dev.forms.service.gov.uk/auth/gds]. Because the settings are no longer configured in our service, users are not able to login. It's still possible to trick users to make GET requests to these routes and there may be security issues lurking there.
- If we change our Auth0 config in the future, such as allowing users to link their google accounts, we may open ourselves up to the original OmniAuth CVE.

## What change are we making to secure the service?
We are switching the /auth/* routes to only respond to POST requests. This will stop browsers following redirects straight to the authentication method without a form submit. This is the fix recommended by OmniAuth. They have not made this the default to keep compatibility with existing code and created a new GEM to handle the logic.

This means that our current auth flow must change. Users can no longer be redirected straight to Auth0.
Instead they are redirected to /login, where they must submit a form to make a POST request. The form is actually a single submit button. When the login form is submitted, using a POST request, the user is redirected straight to Auth0. 

This solves the security issue but it does add friction to our login flow.
To fix this, we are using some client-side javascript to automatically press the Login button. To the user, it should feel similar to the redirect, with a slightly awkward page load in between.

This is a compromise.

If it's annoying or causes issues we will remove the javascript and users will need to press the button themselves.

It also removes some of the user intent - it's still possible to send users directly to and authentication provider by giving them a link.

### Do we need to change the e2e tests
No. Because of the javascript which clicks the button for the user, the flow hasn't changed. The admin code has been changed to add the required connection string to the post request form when the `auth=e2e` string is present.

### Does that work across browsers
Yes. It seems to work across all the browsers I used to test it in browserstack.

### Does it work for screen readers etc.
Yes. Screen readers don't read the login page as the redirect happens pretty quickly. It's possible they might in some situations but I think it would ok as reading the login screen makes sense in the context.

### What happens if JS is not enabled or fails?
The login button is not clicked and user must do it themselves.

### Can we provide a direct link to login from our product pages?
Not without relaxing our security constraints on the login page. The form uses a CSRF token to ensure the request came from our site. The product pages could submit a form across domains but would have no way of generating a CSRF token.

We could come up with another way of authenticating the POST request but I think it would be better to change the design to something more traditional.

### How do other sites handle this?
It's more common to have the product pages and service on the same site. That way a login button can be pressed by the user to send them to auth.

### What does the login screen look like?
![localhost_3000_sign-in](https://github.com/alphagov/forms-admin/assets/11035856/8993ab45-319a-476b-af6d-f5e7dc7c26d2)
