### PR TITLE
Content updates for WHN page and page title, plus contact details page 

### DIFF
--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(title_with_error_prefix(t('pages_titles.what_happens_next_form'), @what_happens_next_form.errors.present?)) %>
+<% set_page_title(title_with_error_prefix(t("page_titles.what_happens_next_form"), @what_happens_next_form.errors.present?)) %>
 <% content_for :back_link, govuk_back_link_to(form_path(@what_happens_next_form.form), t("back_link.form_create")) %>
 
 

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -23,17 +23,18 @@
       <% end %>
 
       <% if FeatureService.enabled?(:email_confirmations_enabled) %>
-        <p class="govuk-!-margin-bottom-6">
-      <p> This content will be:
-        <ul> 
+        <p>
+          This content will be:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
           <li> shown to people when they've completed and submitted a form
           <li> included in an email confirmation, if they choose to receive this
         </ul>
-      </p>
 
-      <p>
-      The optional email confirmation will also include the contact details you provide for the form, and the date and time of submission. It will not include a copy of their answers.
-      </p>
+        <p>
+          The optional email confirmation will also include the contact details you provide for the form,
+          and the date and time of submission. It will not include a copy of their answers.
+        </p>
       <% end %>
 
       <%= f.govuk_text_area :what_happens_next_text, max_chars: 2000, label: {size: 'm' } %>

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(title_with_error_prefix(t('page_titles.make_live_form'), @what_happens_next_form.errors.present?)) %>
+<% set_page_title(title_with_error_prefix(t('pages_titles.what_happens_next_form'), @what_happens_next_form.errors.present?)) %>
 <% content_for :back_link, govuk_back_link_to(form_path(@what_happens_next_form.form), t("back_link.form_create")) %>
 
 
@@ -14,9 +14,7 @@
         <%= t("page_titles.what_happens_next_form") %>
       </h1>
 
-      <p>This page will be shown after someone has completed and submitted the form to let them know it’s been submitted successfully.</p>
-
-      <p>Add some content to let people know what will happen next and when, so they know what to expect.</p>
+      <p>Add some information to tell people what will happen after they've submitted their form, and when - so they know what to expect.</p>
 
       <h2 class="govuk-heading-s">Example</h2>
 
@@ -26,11 +24,16 @@
 
       <% if FeatureService.enabled?(:email_confirmations_enabled) %>
         <p class="govuk-!-margin-bottom-6">
-          This content will also be included in an email confirming that a form’s been
-          submitted - if people choose to receive this. The email will include the date and
-          time of submission, and contact details for support. It will not contain
-          a copy of someone’s answers.
-        </p>
+      <p> This content will be:
+        <ul> 
+          <li> shown to people when they've completed and submitted a form
+          <li> included in an email confirmation, if they choose to receive this
+        </ul>
+      </p>
+
+      <p>
+      The optional email confirmation will also include the contact details you provide for the form, and the date and time of submission. It will not include a copy of their answers.
+      </p>
       <% end %>
 
       <%= f.govuk_text_area :what_happens_next_text, max_chars: 2000, label: {size: 'm' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -605,7 +605,7 @@ en:
     user_missing_organisation: You do not have an organisation set for your account
     user_upgrade_request_confirmation: Request to upgrade to editor account received
     user_upgrade_request_new: Requirements to upgrade to an editor account
-    what_happens_next_form: Form submitted page
+    what_happens_next_form: Add information about what happens next
     your_changes_are_live: Your changes are live
     your_form_is_live: Your form is live
   pages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
           You need to provide at least one way for people to get help if they get stuck.
         </p>
 
-         <p>
+        <p>
           Contact information will be shown:
         </p>
         <ul class="govuk-list govuk-list--bullet">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,13 +71,17 @@ en:
     new:
       body_html: |
         <p>
-          You need to provide at least one way for people to get help if they get stuck while filling in this form.
+          You need to provide at least one way for people to get help if they get stuck.
         </p>
 
-        <p>
-          The contact information will be displayed at the bottom of every page of the form.
+         <p>
+          Contact information will be shown:
         </p>
-      email_confirmation_hint_html: It will also be included in an email confirming that a form’s been submitted - if people choose to receive this. The email will include the date and time of submission. It will not contain a copy of someone’s answers.
+        <ul class="govuk-list govuk-list--bullet">
+          <li>at the bottom of every page of the form</li>
+          <li>in an email confirming the date and time a form was submitted - if someone chooses to receive this</li>
+        </ul>
+      email_confirmation_hint_html: The optional email confirmation will also include the 'what happens next' information you provide. It will not contain a copy of their answers.
       hint: Select at least one option
       title: How can people get help with filling in this form?
   contact_govuk_forms: contact the GOV.UK Forms team


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: (https://trello.com/c/BCge3DIm/1189-iterate-content-in-forms-admin-for-confirmation-email-feature-post-testing)

Updates to content following UR which revealed that form creators didn't notice the content we'd added previously to flag that WHN and contact details info will also appear in a confirmation email (if requested)

![image](https://github.com/alphagov/forms-admin/assets/3441519/3e88d2f9-2b4e-4fd4-bf83-a9f2087d4488)

---

![image](https://github.com/alphagov/forms-admin/assets/3441519/18203410-f13c-428f-a080-e9c8887bfc58)



### Things to consider when reviewing

- Is the code correct? (I'm an HTML/coding novice!)
- Is the fact that I've changed the WHN page title going to have any dodgy knock-on effects elsewhere?
- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
