### PR TITLE
Add markdown editor to what happens next field

### DIFF
--- a/app/controllers/forms/what_happens_next_controller.rb
+++ b/app/controllers/forms/what_happens_next_controller.rb
@@ -1,14 +1,17 @@
 module Forms
   class WhatHappensNextController < ApplicationController
     after_action :verify_authorized
+
     def new
       authorize current_form, :can_view_form?
       @what_happens_next_form = WhatHappensNextForm.new(form: current_form).assign_form_values
+      @preview_html = preview_html(@what_happens_next_form)
     end
 
     def create
       authorize current_form, :can_view_form?
       @what_happens_next_form = WhatHappensNextForm.new(**what_happens_next_form_params)
+      @preview_html = preview_html(@what_happens_next_form)
 
       if @what_happens_next_form.submit
         redirect_to form_path(@what_happens_next_form.form), success: t("banner.success.form.what_happens_next_saved")
@@ -17,10 +20,24 @@ module Forms
       end
     end
 
+    def render_preview
+      authorize current_form, :can_view_form?
+      @what_happens_next_form = WhatHappensNextForm.new(what_happens_next_markdown: params[:markdown])
+      @what_happens_next_form.validate
+
+      render json: { preview_html: preview_html(@what_happens_next_form), errors: @what_happens_next_form.errors[:what_happens_next_markdown] }.to_json
+    end
+
   private
 
     def what_happens_next_form_params
-      params.require(:forms_what_happens_next_form).permit(:what_happens_next_text).merge(form: current_form)
+      params.require(:forms_what_happens_next_form).permit(:what_happens_next_text, :what_happens_next_markdown).merge(form: current_form)
+    end
+
+    def preview_html(what_happens_next_form)
+      return t("guidance.no_guidance_added_html") if what_happens_next_form.what_happens_next_markdown.blank?
+
+      GovukFormsMarkdown.render(what_happens_next_form.what_happens_next_text)
     end
   end
 end

--- a/app/controllers/forms/what_happens_next_controller.rb
+++ b/app/controllers/forms/what_happens_next_controller.rb
@@ -13,10 +13,19 @@ module Forms
       @what_happens_next_form = WhatHappensNextForm.new(**what_happens_next_form_params)
       @preview_html = preview_html(@what_happens_next_form)
 
-      if @what_happens_next_form.submit
-        redirect_to form_path(@what_happens_next_form.form), success: t("banner.success.form.what_happens_next_saved")
-      else
-        render :new
+      case params[:route_to].to_sym
+      when :preview
+        if @what_happens_next_form.valid?
+          render :new, status: :ok
+        else
+          render :new, status: :unprocessable_entity
+        end
+      when :save_and_continue
+        if @what_happens_next_form.submit
+          redirect_to form_path(@what_happens_next_form.form), success: t("banner.success.form.what_happens_next_saved")
+        else
+          render :new, status: :unprocessable_entity
+        end
       end
     end
 
@@ -37,7 +46,7 @@ module Forms
     def preview_html(what_happens_next_form)
       return t("guidance.no_guidance_added_html") if what_happens_next_form.what_happens_next_markdown.blank?
 
-      GovukFormsMarkdown.render(what_happens_next_form.what_happens_next_text)
+      GovukFormsMarkdown.render(what_happens_next_form.what_happens_next_markdown, allow_headings: false)
     end
   end
 end

--- a/app/forms/forms/what_happens_next_form.rb
+++ b/app/forms/forms/what_happens_next_form.rb
@@ -2,6 +2,7 @@ class Forms::WhatHappensNextForm < BaseForm
   attr_accessor :form, :what_happens_next_text, :what_happens_next_markdown
 
   validates :what_happens_next_text, length: { maximum: 2000 }
+  validates :what_happens_next_markdown, markdown: { allow_headings: false }
 
   def submit
     return false if invalid?

--- a/app/forms/forms/what_happens_next_form.rb
+++ b/app/forms/forms/what_happens_next_form.rb
@@ -1,5 +1,5 @@
 class Forms::WhatHappensNextForm < BaseForm
-  attr_accessor :form, :what_happens_next_text
+  attr_accessor :form, :what_happens_next_text, :what_happens_next_markdown
 
   validates :what_happens_next_text, length: { maximum: 2000 }
 
@@ -7,11 +7,13 @@ class Forms::WhatHappensNextForm < BaseForm
     return false if invalid?
 
     form.what_happens_next_text = what_happens_next_text
+    form.what_happens_next_markdown = what_happens_next_markdown
     form.save!
   end
 
   def assign_form_values
     self.what_happens_next_text = form.what_happens_next_text
+    self.what_happens_next_markdown = form.what_happens_next_markdown
     self
   end
 end

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -16,3 +16,4 @@ $govuk-suppressed-warnings: (
 @import "../../components/header_component/";
 @import "../../components/markdown_editor_component";
 @import "../../components/metrics_summary_component";
+@import "../styles/app_preview_area";

--- a/app/frontend/styles/_app_preview_area.scss
+++ b/app/frontend/styles/_app_preview_area.scss
@@ -1,0 +1,5 @@
+.app-preview-area {
+  border: 2px solid $govuk-border-colour;
+  padding: 30px;
+  margin: 0 0 1em;
+}

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -37,7 +37,18 @@
         </p>
       <% end %>
 
-      <%= f.govuk_text_area :what_happens_next_text, max_chars: 2000, label: {size: 'm' } %>
+
+      <% if @what_happens_next_form.what_happens_next_markdown.nil? %>
+        <%= f.govuk_text_area :what_happens_next_text, max_chars: 2000, label: {size: 'm' } %>
+      <% else %>
+        <%= render MarkdownEditorComponent::View.new(:what_happens_next_markdown,
+          form_builder: f,
+          render_preview_path: what_happens_next_render_preview_path(@what_happens_next_form.form),
+          preview_html: @preview_html,
+          form_model: @what_happens_next_form,
+          label: "Enter some information to tell people what will happen next",
+          hint: nil) %>
+      <% end %>
 
       <%= f.govuk_submit t("save_and_continue") %>
     <% end %>

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -47,10 +47,11 @@
           preview_html: @preview_html,
           form_model: @what_happens_next_form,
           label: "Enter some information to tell people what will happen next",
-          hint: nil) %>
+          hint: nil,
+          allow_headings: false) %>
       <% end %>
 
-      <%= f.govuk_submit t("save_and_continue") %>
+      <%= f.govuk_submit t("save_and_continue"), name: "route_to", value: "save_and_continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/live/show_form.html.erb
+++ b/app/views/live/show_form.html.erb
@@ -28,7 +28,11 @@
     <% end %>
 
     <h3 class="govuk-heading-m"><%= t('show_live_form.what_happens_next') %></h3>
-    <p><%= form.what_happens_next_text %></p>
+    <% if form.what_happens_next_markdown.present? %>
+      <%= GovukFormsMarkdown.render(form.what_happens_next_markdown) %>
+    <% else %>
+      <p><%= form.what_happens_next_text %></p>
+    <% end %>
     <%= govuk_details(summary_text: t('show_live_form.what_is_what_happens_next'), text: t('show_live_form.what_happens_next_description')) %>
 
     <h3 class="govuk-heading-m"><%= t('show_live_form.submission_email') %></h3>

--- a/app/views/live/show_form.html.erb
+++ b/app/views/live/show_form.html.erb
@@ -28,11 +28,13 @@
     <% end %>
 
     <h3 class="govuk-heading-m"><%= t('show_live_form.what_happens_next') %></h3>
-    <% if form.what_happens_next_markdown.present? %>
-      <%= GovukFormsMarkdown.render(form.what_happens_next_markdown) %>
-    <% else %>
-      <p><%= form.what_happens_next_text %></p>
-    <% end %>
+    <div class="app-preview-area">
+      <% if form.what_happens_next_markdown.present? %>
+        <%= GovukFormsMarkdown.render(form.what_happens_next_markdown).html_safe %>
+      <% else %>
+        <%= simple_format(form.what_happens_next_text, {}, sanitize_options: { tags: ["a", "ol", "ul", "li", "p"], attributes: %w[href class rel target title] })  %>
+      <% end %>
+    </div>
     <%= govuk_details(summary_text: t('show_live_form.what_is_what_happens_next'), text: t('show_live_form.what_happens_next_description')) %>
 
     <h3 class="govuk-heading-m"><%= t('show_live_form.submission_email') %></h3>

--- a/config/locales/forms/what_happens_next.yml
+++ b/config/locales/forms/what_happens_next.yml
@@ -11,3 +11,6 @@ en:
             what_happens_next_text:
               too_long: The information about what happens next cannot be longer than 2,000 characters
               blank: Enter information about what happens next
+            what_happens_next_markdown:
+              unsupported_markdown_syntax: The information about what happens next can only contain formatting for links, bulleted lists (*), or numbered lists (1.)
+              too_long: The information about what happens next cannot be longer than 5,000 characters

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     post "/make-live" => "forms/make_live#create", as: :make_live_create
     get "/what-happens-next" => "forms/what_happens_next#new", as: :what_happens_next
     post "/what-happens-next" => "forms/what_happens_next#create", as: :what_happens_next_create
+    post "/what-happens-next-preview" => "forms/what_happens_next#render_preview", as: :what_happens_next_render_preview
     get "/contact-details" => "forms/contact_details#new", as: :contact_details
     post "/contact-details" => "forms/contact_details#create", as: :contact_details_create
     get "/declaration" => "forms/declaration#new", as: :declaration

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     support_url { nil }
     support_url_text { nil }
     what_happens_next_text { nil }
+    what_happens_next_markdown { nil }
     declaration_text { nil }
     question_section_completed { false }
     declaration_section_completed { false }

--- a/spec/forms/what_happens_next_form_spec.rb
+++ b/spec/forms/what_happens_next_form_spec.rb
@@ -1,49 +1,69 @@
 require "rails_helper"
 
 RSpec.describe Forms::WhatHappensNextForm, type: :model do
+  let(:what_happens_next_form) { described_class.new(form:, what_happens_next_text:, what_happens_next_markdown:) }
+  let(:what_happens_next_text) { nil }
+  let(:what_happens_next_markdown) { nil }
+
   context "when form is live" do
     let(:form) do
       build(:form, :live)
     end
 
     describe "validations" do
-      describe "Character length" do
-        it "is valid if less than 2000 characters" do
-          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a")
+      describe "what_happens_next_text" do
+        describe "Character length" do
+          it "is valid if less than 2000 characters" do
+            what_happens_next_form.what_happens_next_text = "a"
 
-          expect(what_happens_next_form).to be_valid
+            expect(what_happens_next_form).to be_valid
+          end
+
+          it "is valid if 2000 characters" do
+            what_happens_next_form.what_happens_next_text = "a" * 2000
+
+            expect(what_happens_next_form).to be_valid
+          end
+
+          it "is invalid if more than 2000 characters" do
+            what_happens_next_form.what_happens_next_text = "a" * 2001
+            error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
+
+            expect(what_happens_next_form).not_to be_valid
+
+            what_happens_next_form.validate(:what_happens_next_text)
+
+            expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
+              "What happens next text #{error_message}",
+            )
+          end
         end
 
-        it "is valid if 2000 characters" do
-          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a" * 2000)
+        it "is valid if blank" do
+          what_happens_next_form.what_happens_next_text = ""
 
           expect(what_happens_next_form).to be_valid
-        end
-
-        it "is invalid if more than 2000 characters" do
-          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a" * 2001)
-          error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
-
-          expect(what_happens_next_form).not_to be_valid
-
-          what_happens_next_form.validate(:what_happens_next_text)
-
-          expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
-            "What happens next text #{error_message}",
-          )
         end
       end
 
-      it "is valid if blank" do
-        what_happens_next_form = described_class.new(form:, what_happens_next_text: "")
+      describe "what_happens_next_markdown" do
+        let(:what_happens_next_text) { nil }
+        let(:what_happens_next_markdown) { "a" }
 
-        expect(what_happens_next_form).to be_valid
+        it_behaves_like "a markdown field with headings disallowed" do
+          let(:model) { what_happens_next_form }
+          let(:attribute) { :what_happens_next_markdown }
+        end
+
+        it "is valid if blank" do
+          expect(what_happens_next_form).to be_valid
+        end
       end
     end
 
     describe "#submit" do
       it "returns false if the data is invalid" do
-        what_happens_next_form = described_class.new(form:, what_happens_next_text: ("abc" * 2001))
+        what_happens_next_form.what_happens_next_text = "abc" * 2001
         expect(what_happens_next_form.submit).to eq false
       end
 
@@ -63,37 +83,53 @@ RSpec.describe Forms::WhatHappensNextForm, type: :model do
     end
 
     describe "validations" do
-      describe "Character length" do
-        it "is valid if less than 2000 characters" do
-          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a")
+      describe "what_happens_next_text" do
+        describe "Character length" do
+          it "is valid if less than 2000 characters" do
+            what_happens_next_form.what_happens_next_text = "a"
 
-          expect(what_happens_next_form).to be_valid
+            expect(what_happens_next_form).to be_valid
+          end
+
+          it "is valid if 2000 characters" do
+            what_happens_next_form.what_happens_next_text = "a" * 2000
+
+            expect(what_happens_next_form).to be_valid
+          end
+
+          it "is invalid if more than 2000 characters" do
+            what_happens_next_form.what_happens_next_text = "a" * 2001
+            error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
+
+            expect(what_happens_next_form).not_to be_valid
+
+            what_happens_next_form.validate(:what_happens_next_text)
+
+            expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
+              "What happens next text #{error_message}",
+            )
+          end
         end
 
-        it "is valid if 2000 characters" do
-          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a" * 2000)
+        it "is valid if blank" do
+          what_happens_next_form.what_happens_next_text = ""
 
           expect(what_happens_next_form).to be_valid
-        end
-
-        it "is invalid if more than 2000 characters" do
-          what_happens_next_form = described_class.new(form:, what_happens_next_text: "a" * 2001)
-          error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
-
-          expect(what_happens_next_form).not_to be_valid
-
-          what_happens_next_form.validate(:what_happens_next_text)
-
-          expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
-            "What happens next text #{error_message}",
-          )
         end
       end
 
-      it "is valid if blank" do
-        what_happens_next_form = described_class.new(form:, what_happens_next_text: "")
+      describe "what_happens_next_markdown" do
+        let(:what_happens_next_text) { nil }
+        let(:what_happens_next_markdown) { "a" }
 
-        expect(what_happens_next_form).to be_valid
+        it_behaves_like "a markdown field with headings disallowed" do
+          let(:model) { what_happens_next_form }
+          let(:attribute) { :what_happens_next_markdown }
+        end
+
+        it "is valid if blank" do
+          expect(what_happens_next_form).to be_valid
+        end
       end
     end
 

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -85,12 +85,16 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
   end
 
   describe "#create" do
+    let(:what_happens_next_text) { "Wait until you get a reply" }
+    let(:what_happens_next_markdown) { nil }
+    let(:route_to) { "save_and_continue" }
+
     before do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
         mock.put "/api/v1/forms/2", post_headers
       end
-      post what_happens_next_path(form_id: 2), params: { forms_what_happens_next_form: { what_happens_next_text: "Wait until you get a reply" } }
+      post what_happens_next_path(form_id: 2), params: { forms_what_happens_next_form: { what_happens_next_text:, what_happens_next_markdown: }, route_to: }
     end
 
     it "Reads the form from the API" do
@@ -103,6 +107,108 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
 
     it "Redirects you to the form overview page" do
       expect(response).to redirect_to(form_path(2))
+    end
+
+    context "when previewing markdown" do
+      let(:route_to) { "preview" }
+      let(:what_happens_next_text) { nil }
+      let(:what_happens_next_markdown) { "[a link](https://example.com)" }
+
+      it "reads the existing form" do
+        expect(form).to have_been_read
+      end
+
+      it "renders the what happens next template" do
+        expect(response).to have_rendered("forms/what_happens_next/new")
+      end
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the guidance markdown as html" do
+        expect(response.body).to include('<a href="https://example.com" class="govuk-link" rel="noreferrer noopener" target="_blank">a link</a>')
+      end
+
+      context "when markdown is invalid" do
+        let(:what_happens_next_markdown) { "# A level one heading" }
+
+        it "reads the existing form" do
+          expect(form).to have_been_read
+        end
+
+        it "renders the template" do
+          expect(response).to have_rendered("forms/what_happens_next/new")
+        end
+
+        it "returns 422" do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context "when saving markdown" do
+      let(:route_to) { "save_and_continue" }
+
+      it "reads the existing form" do
+        expect(form).to have_been_read
+      end
+
+      it "redirects the user to the form overview page" do
+        expect(response).to redirect_to(form_path(2))
+      end
+
+      context "when markdown is invalid" do
+        let(:what_happens_next_markdown) { "# A level one heading" }
+
+        it "returns 422" do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "renders the template" do
+          expect(response).to have_rendered("forms/what_happens_next/new")
+        end
+      end
+    end
+  end
+
+  describe "#render_preview" do
+    let(:markdown) { "- Markdown" }
+
+    before do
+      post what_happens_next_render_preview_path(form_id: form.id), params: { markdown: }
+    end
+
+    it "returns a JSON object containing the converted HTML" do
+      expect(response.body).to eq({ preview_html: "<ul class=\"govuk-list govuk-list--bullet\">\n  <li>Markdown</li>\n\n</ul>", errors: [] }.to_json)
+    end
+
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "when markdown is blank" do
+      let(:markdown) { "" }
+
+      it "returns a JSON object containing the converted HTML" do
+        expect(response.body).to eq({ preview_html: I18n.t("guidance.no_guidance_added_html"), errors: [] }.to_json)
+      end
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when markdown contains forbidden syntax" do
+      let(:markdown) { "# A level one heading" }
+
+      it "returns a JSON object containing the converted HTML" do
+        expect(response.body).to eq({ preview_html: "<p class=\"govuk-body\">A level one heading</p>", errors: [I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_markdown.unsupported_markdown_syntax")] }.to_json)
+      end
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
       start_page: 1,
       organisation_id: 1,
       what_happens_next_text: "Good things come to those who wait",
+      what_happens_next_markdown: nil,
       live_at: nil,
       has_live_version: false,
     }.to_json
@@ -21,6 +22,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
       id: 2,
       organisation_id: 1,
       what_happens_next_text: "",
+      what_happens_next_markdown: nil,
       live_at: nil,
       has_live_version: false,
     )
@@ -33,6 +35,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
       id: 2,
       organisation_id: 1,
       what_happens_next_text: "Wait until you get a reply",
+      what_happens_next_markdown: nil,
       live_at: nil,
       has_live_version: false,
     })

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -76,7 +76,12 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
         mock.put "/api/v1/forms/2", post_headers
         mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
       end
+      allow(Pundit).to receive(:authorize).and_return(true)
       get what_happens_next_path(form_id: 2)
+    end
+
+    it "checks the user is authorised to view the form" do
+      expect(Pundit).to have_received(:authorize)
     end
 
     it "Reads the form from the API" do
@@ -94,7 +99,12 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
         mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
         mock.put "/api/v1/forms/2", post_headers
       end
+      allow(Pundit).to receive(:authorize).and_return(true)
       post what_happens_next_path(form_id: 2), params: { forms_what_happens_next_form: { what_happens_next_text:, what_happens_next_markdown: }, route_to: }
+    end
+
+    it "checks the user is authorised to view the form" do
+      expect(Pundit).to have_received(:authorize)
     end
 
     it "Reads the form from the API" do
@@ -176,7 +186,12 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
     let(:markdown) { "- Markdown" }
 
     before do
+      allow(Pundit).to receive(:authorize).and_return(true)
       post what_happens_next_render_preview_path(form_id: form.id), params: { markdown: }
+    end
+
+    it "checks the user is authorised to view the form" do
+      expect(Pundit).to have_received(:authorize)
     end
 
     it "returns a JSON object containing the converted HTML" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/AbPj2LRr/1191-allow-markdown-on-confirmation-page-what-happens-next-content
Also fixes: https://trello.com/c/fAC4f0CM/503-hmtl-appears-in-the-what-happens-next-content-on-a-live-forms-details-page

This PR adds the markdown editor component to the what happens next page. The markdown editor will be shown when the what_happens_next_markdown field is anything other than `nil`. This means that once we've done the migration in the API this field should start appearing immediately.

As part of this PR we:
- add the component to the what happens next page
- render the what happens next HTML and markdown on the live form page

To do in other PRs:
- convert the HTML content in the API into markdown and store it in this new field
- cleanup: delete the old field and all the logic related to it which we no longer need

### Testing locally
If you want to see the markdown editor on your local machine, set up (using the Rails API or the seed file) a form with `what_happens_next_markdown` equal to `""` (or any markdown string). 

### Screenshots
#### What happens next field before conversion step in API
![A plaintext field with the label 'Enter some information to tell people what will happen next', follwed by a green 'Save and continue' button. The field has a HTML link in it](https://github.com/alphagov/forms-admin/assets/5861235/d2173e69-24a2-4d1f-81b7-9a9320b9a1dd)

#### What happens next field after conversion step in API
![A markdown editor for a field with the label 'Enter some information to tell people what will happen next', follwed by a green 'Save and continue' button. The markdown editor has toolbar buttons for links, bullets and numbered lists, as well as tabs for writing and previewing content, and a 'Formatting help' link. The field has a markdown link and a bulleted list in it](https://github.com/alphagov/forms-admin/assets/5861235/1cabf575-3afa-41ac-893e-f4302b28640e)

#### What happens next markdown field (with unsupported markdown)
![The same markdown field as above. This time the user has added a level 2 heading, and the field has a red inline error with the text "Error: The information about what happens next can only contain formatting for links, bulleted lists (*), or numbered lists (1.)"](https://github.com/alphagov/forms-admin/assets/5861235/2a09e4de-c444-43b5-958f-9e9fd0db4c7d)

#### What happens next preview on live form page
![The what happens next text shown in context on the live form page between the questions and submission email. The markdown from the precious steps has been rendered to HTML inside a 2px grey border.](https://github.com/alphagov/forms-admin/assets/5861235/d7db311e-6d40-40cd-a5b8-22466b0bb226)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
