### PR TITLE
Convert delete page button to a link

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -74,8 +74,6 @@ private
     # if user chose to save and reload current page
     return redirect_to edit_question_path(current_form, @page), success: "Your changes have been saved" if params[:save_preview]
 
-    return redirect_to delete_page_path(current_form, @page) if params[:delete]
-
     # Default: either edit the next page or create a new one
     if @page.has_next_page?
       redirect_to edit_question_path(current_form, @page.next_page)

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -47,5 +47,5 @@
     <%= f.govuk_submit t('pages.submit_save'), name: :save_preview, secondary: true %>
   <% end %>
 
-  <%= f.govuk_submit t('pages.delete_question'), name: :delete, warning: true unless is_new_page %>
+  <%= govuk_button_link_to t('pages.delete_question'), delete_page_path(form_id: form_object.id, page_id: page_object.id), warning: true unless is_new_page %>
 <% end %>

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -56,7 +56,7 @@ describe "pages/_form.html.erb", type: :view do
     let(:is_new_page) { false }
 
     it "contains a link to add guidance" do
-      expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: guidance_edit_path(form_id: form.id, page_id: page.id))
+      expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: guidance_edit_path(form_id: 1, page_id: 2))
     end
 
     it "has no hidden field for the answer type" do
@@ -64,7 +64,7 @@ describe "pages/_form.html.erb", type: :view do
     end
 
     it "has a delete button" do
-      expect(rendered).to have_button("delete")
+      expect(rendered).to have_link(text: I18n.t("pages.delete_question"), href: delete_page_path(form_id: form.id, page_id: page.id))
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Theres no real reason for us to submit a form to redirect to delete question page. This is part of refactoring that we will be doing to the "Edit Question" page call to actions to make it easier for form creators. There should be no visual change to the user and these changes helps simplify the controllers private method which works out which submit button was pressed.

![image](https://github.com/alphagov/forms-admin/assets/3441519/6858408c-1bcf-4e32-934a-cb03a0b7f750)


Also something worth noting that as part of these changes it highlighted that we didn't actually have any request specs for delete from "Edit question" page

Trello card: https://trello.com/c/4fXdQIRk/1230-simplify-calls-to-action-ctas-at-the-bottom-of-the-edit-question-page

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
