### PR TITLE
Log hash of session.id if session exists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,6 +47,7 @@ class ApplicationController < ActionController::Base
     payload[:user_ip] = user_ip(request.env.fetch("HTTP_X_FORWARDED_FOR", ""))
     payload[:form_id] = params[:form_id] if params[:form_id].present?
     payload[:page_id] = params[:page_id] if params[:page_id].present?
+    payload[:session_id_hash] = Digest::SHA256.hexdigest session.id.to_s if session.exists?
   end
 
   def clear_draft_questions_data

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,7 @@ module FormsAdmin
         h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
         h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
         h[:exception] = event.payload[:exception] if event.payload[:exception]
+        h[:session_id_hash] = event.payload[:session_id_hash] if event.payload[:session_id_hash]
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

It's difficult to trace users behaviour over multiple pages.

Individual page requests aren't linked by any values.

Guessing based on URLs and client IP is the only way to reconstruct user's journeys through forms.

This commit adds a hash of the user's session id to the request logs.

This value is will be stable across individual page request so can be used to connect multiple requests.

We don't log the session id directly as it would leak information that could be used to retrieve user's data.

This PR implements the same changes already made in alphagov/forms-runner#487, see the messages in that PR for more discussion.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?