### PR TITLE
Refactor guidance markdown code for reusability

### DIFF
--- a/app/components/markdown_editor_component/view.html.erb
+++ b/app/components/markdown_editor_component/view.html.erb
@@ -13,6 +13,7 @@
                         aria: { describedby: "#{form_field_id}-hint" },
                         "data-module": "markdown-editor-toolbar",
                         "data-ajax-markdown-source": true,
+                        "data-allow-headings": allow_headings,
                         "data-i18n": translations[:toolbar].to_json())  %>
 
       <%= f.govuk_submit preview_button_translation, secondary: true,  name: "route_to", value: "preview", class: "app-markdown-editor__preview-button","data-ajax-markdown-trigger": true %>
@@ -23,7 +24,7 @@
             <%= t("markdown_editor.formatting_help.formatting_help_section_heading") %>
           </h2>
         <% end %>
-        <% %w[links headings bulleted_lists numbered_lists].each do |format_name| %>
+        <% allowed_formats.each do |format_name| %>
           <h3 class="govuk-heading-m"><%= t("markdown_editor.formatting_help.#{format_name}.heading") %></h3>
 
           <%= simple_format(t("markdown_editor.formatting_help.#{format_name}.instructions")) %>

--- a/app/components/markdown_editor_component/view.rb
+++ b/app/components/markdown_editor_component/view.rb
@@ -3,7 +3,7 @@
 module MarkdownEditorComponent
   class View < ViewComponent::Base
     include GOVUKDesignSystemFormBuilder::BuilderHelper
-    attr_reader :attribute_name, :f, :render_preview_path, :preview_html, :form_model, :label, :hint
+    attr_reader :attribute_name, :f, :render_preview_path, :preview_html, :form_model, :label, :hint, :allow_headings
 
     def initialize(attribute_name,
                    preview_html:,
@@ -12,6 +12,7 @@ module MarkdownEditorComponent
                    label: nil,
                    hint: nil,
                    render_preview_path: nil,
+                   allow_headings: true,
                    local_translations: {})
       super
       @attribute_name = attribute_name
@@ -21,11 +22,16 @@ module MarkdownEditorComponent
       @form_model = form_model
       @label = label
       @hint = hint
+      @allow_headings = allow_headings
       @local_translations = local_translations
     end
 
     def form_field_id
       govuk_field_id(form_model, attribute_name)
+    end
+
+    def allowed_formats
+      ["links", *(%w[headings] if allow_headings), "bulleted_lists", "numbered_lists"]
     end
 
     def preview_button_translation

--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -51,7 +51,7 @@ class Pages::GuidanceController < PagesController
   end
 
   def render_preview
-    guidance_form = Pages::GuidanceForm.new(guidance_markdown: params[:guidance_markdown])
+    guidance_form = Pages::GuidanceForm.new(guidance_markdown: params[:markdown])
     guidance_form.validate
 
     render json: { preview_html: preview_html(guidance_form), errors: guidance_form.errors[:guidance_markdown] }.to_json

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -20,7 +20,8 @@ document
   .forEach(element => {
     markdownEditorToolbar(
       element,
-      JSON.parse(element.getAttribute('data-i18n'))
+      JSON.parse(element.getAttribute('data-i18n')),
+      element.getAttribute('data-allow-headings') === 'true'
     )
     element.addEventListener('paste', pasteListener)
   })

--- a/app/frontend/javascript/ajax-markdown-preview/index.js
+++ b/app/frontend/javascript/ajax-markdown-preview/index.js
@@ -39,7 +39,7 @@ const triggerAjaxMarkdownPreview = async () => {
         redirect: 'follow',
         referrerPolicy: 'same-origin',
         body: JSON.stringify({
-          guidance_markdown: store.source.value,
+          markdown: store.source.value,
           authenticity_token: store.authenticityToken
         })
       })

--- a/app/frontend/javascript/ajax-markdown-preview/index.test.js
+++ b/app/frontend/javascript/ajax-markdown-preview/index.test.js
@@ -93,6 +93,19 @@ describe('AJAX Markdown preview', () => {
     test('preview is called on page load', async () => {
       expect(target.innerHTML).toBe(jsonResponse.preview_html)
 
+      expect(global.fetch).toHaveBeenCalledWith('/endpoint', {
+        body: '{"markdown":"## This is a markdown heading"}',
+        cache: 'no-cache',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': undefined
+        },
+        method: 'POST',
+        mode: 'same-origin',
+        redirect: 'follow',
+        referrerPolicy: 'same-origin'
+      })
       expect(global.fetch).toHaveBeenCalledTimes(1)
     })
 

--- a/app/frontend/javascript/markdown-editor-toolbar/index.js
+++ b/app/frontend/javascript/markdown-editor-toolbar/index.js
@@ -46,22 +46,26 @@ const buttonGroupConfiguration = [
   [
     {
       identifier: 'h2',
-      callback: addH2
+      callback: addH2,
+      isHeading: true
     },
     {
       identifier: 'h3',
-      callback: addH3
+      callback: addH3,
+      isHeading: true
     }
   ],
-  [{ identifier: 'link', callback: addLink }],
+  [{ identifier: 'link', callback: addLink, isHeading: false }],
   [
     {
       identifier: 'bullet-list',
-      callback: addUnorderedList
+      callback: addUnorderedList,
+      isHeading: false
     },
     {
       identifier: 'numbered-list',
-      callback: addOrderedList
+      callback: addOrderedList,
+      isHeading: false
     }
   ]
 ]
@@ -82,17 +86,24 @@ const getButtonText = (identifier, i18n) => {
   return i18n[snakeCaseIdentifier]
 }
 
-const createButtonGroup = (configurationGroup, textArea, i18n) => {
+const createButtonGroup = (
+  configurationGroup,
+  textArea,
+  i18n,
+  allowHeadings
+) => {
   const buttonGroup = document.createElement('div')
   buttonGroup.classList.add('app-markdown-editor__toolbar-button-group')
-  const buttons = configurationGroup.map(buttonConfig =>
-    createButton(
-      textArea,
-      getButtonText(buttonConfig.identifier, i18n),
-      buttonConfig.callback,
-      buttonConfig.identifier
+  const buttons = configurationGroup
+    .filter(button => allowHeadings || !button.isHeading)
+    .map(buttonConfig =>
+      createButton(
+        textArea,
+        getButtonText(buttonConfig.identifier, i18n),
+        buttonConfig.callback,
+        buttonConfig.identifier
+      )
     )
-  )
 
   buttons.forEach(button => buttonGroup.appendChild(button))
   return buttonGroup
@@ -198,14 +209,15 @@ const addButtonFocusEvents = buttons => {
  * Adds a copy button to an element.
  * @param {HTMLElement} textArea - The textarea whose contents are being formatted by the toolbar.
  * @param {Object} i18n - An object containing translations for the toolbar button text.
+ * @param {Boolean} allowHeadings - whether the markdown field allows headings
  */
-const markdownEditorToolbar = (textArea, i18n) => {
+const markdownEditorToolbar = (textArea, i18n, allowHeadings = true) => {
   const toolbar = createToolbarForTextArea(textArea)
   textArea.parentNode.insertBefore(toolbar, textArea)
 
   buttonGroupConfiguration
     .map(buttonConfiguration =>
-      createButtonGroup(buttonConfiguration, textArea, i18n)
+      createButtonGroup(buttonConfiguration, textArea, i18n, allowHeadings)
     )
     .forEach(buttonGroup => toolbar.appendChild(buttonGroup))
 

--- a/app/models/concerns/guidance_validation.rb
+++ b/app/models/concerns/guidance_validation.rb
@@ -12,7 +12,7 @@ private
   def markdown_length_and_tags
     return true if guidance_markdown.blank?
 
-    markdown_validation = GovukFormsMarkdown.validate(guidance_markdown)
+    markdown_validation = GovukFormsMarkdown.validate(guidance_markdown, allow_headings: true)
 
     return true if markdown_validation[:errors].empty?
 

--- a/app/models/concerns/guidance_validation.rb
+++ b/app/models/concerns/guidance_validation.rb
@@ -4,26 +4,10 @@ module GuidanceValidation
   included do
     validate :guidance_fields_presence
     validates :page_heading, length: { maximum: 250 }
-    validate :markdown_length_and_tags
+    validates :guidance_markdown, markdown: { allow_headings: true }
   end
 
 private
-
-  def markdown_length_and_tags
-    return true if guidance_markdown.blank?
-
-    markdown_validation = GovukFormsMarkdown.validate(guidance_markdown, allow_headings: true)
-
-    return true if markdown_validation[:errors].empty?
-
-    tag_errors = markdown_validation[:errors].excluding(:too_long)
-
-    if tag_errors.any?
-      errors.add(:guidance_markdown, :unsupported_markdown_syntax)
-    elsif markdown_validation[:errors].include?(:too_long)
-      errors.add(:guidance_markdown, :too_long)
-    end
-  end
 
   def guidance_fields_presence
     if page_heading.present? && guidance_markdown.blank?

--- a/app/validators/markdown_validator.rb
+++ b/app/validators/markdown_validator.rb
@@ -1,0 +1,19 @@
+require "govuk_forms_markdown"
+
+class MarkdownValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return true if value.blank?
+
+    markdown_validation = GovukFormsMarkdown.validate(value, allow_headings: options.fetch(:allow_headings))
+
+    return true if markdown_validation[:errors].empty?
+
+    tag_errors = markdown_validation[:errors].excluding(:too_long)
+
+    if tag_errors.any?
+      record.errors.add(attribute, :unsupported_markdown_syntax)
+    elsif markdown_validation[:errors].include?(:too_long)
+      record.errors.add(attribute, :too_long)
+    end
+  end
+end

--- a/spec/components/markdown_editor_component/markdown_editor_component_preview.rb
+++ b/spec/components/markdown_editor_component/markdown_editor_component_preview.rb
@@ -29,4 +29,16 @@ class MarkdownEditorComponent::MarkdownEditorComponentPreview < ViewComponent::P
                                                write_tab_text: "Write guidance",
                                              }))
   end
+
+  def with_headings_disallowed
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, Pages::GuidanceForm.new,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+
+    render(MarkdownEditorComponent::View.new(:guidance_markdown,
+                                             form_builder:,
+                                             preview_html: "<p>No markdown added</p>",
+                                             form_model: Pages::GuidanceForm.new,
+                                             label: "Add some markdown",
+                                             hint: "Use Markdown to format your content. Formatting help can be found below.", allow_headings: false))
+  end
 end

--- a/spec/components/markdown_editor_component/view_spec.rb
+++ b/spec/components/markdown_editor_component/view_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
     {}
   end
 
+  let(:allow_headings) { true }
+
   let(:markdown_editor) do
     described_class.new(:guidance_markdown,
                         form_builder:,
@@ -20,7 +22,8 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
                         form_model: Pages::GuidanceForm.new,
                         label: "Add some markdown",
                         hint: "Use Markdown to format your content. Formatting help can be found below.",
-                        local_translations:)
+                        local_translations:,
+                        allow_headings:)
   end
 
   before do
@@ -122,6 +125,20 @@ RSpec.describe MarkdownEditorComponent::View, type: :component do
             },
           },
         )
+      end
+    end
+  end
+
+  describe "allowed_formats" do
+    it "returns the allowed formats including headings" do
+      expect(markdown_editor.allowed_formats).to eq(%w[links headings bulleted_lists numbered_lists])
+    end
+
+    context "when headings are not allowed" do
+      let(:allow_headings) { false }
+
+      it "returns the allowed formats without headings" do
+        expect(markdown_editor.allowed_formats).to eq(%w[links bulleted_lists numbered_lists])
       end
     end
   end

--- a/spec/forms/pages/guidance_form_spec.rb
+++ b/spec/forms/pages/guidance_form_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe Pages::GuidanceForm, type: :model do
   end
 
   describe "validations" do
+    it_behaves_like "a markdown field with headings allowed" do
+      let(:model) { guidance_form }
+      let(:attribute) { :guidance_markdown }
+    end
+
     it "is invalid if page heading is nil" do
       error_message = I18n.t("activemodel.errors.models.pages/guidance_form.attributes.page_heading.blank")
       guidance_form.page_heading = nil

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -279,10 +279,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
   end
 
   describe "#render_preview" do
-    let(:guidance_markdown) { "### Markdown" }
+    let(:markdown) { "### Markdown" }
 
     before do
-      post guidance_render_preview_path(form_id: form.id), params: { guidance_markdown: }
+      post guidance_render_preview_path(form_id: form.id), params: { markdown: }
     end
 
     it "returns a JSON object containing the converted HTML" do
@@ -294,7 +294,7 @@ RSpec.describe Pages::GuidanceController, type: :request do
     end
 
     context "when markdown is blank" do
-      let(:guidance_markdown) { "" }
+      let(:markdown) { "" }
 
       it "returns a JSON object containing the converted HTML" do
         expect(response.body).to eq({ preview_html: I18n.t("guidance.no_guidance_added_html"), errors: [] }.to_json)
@@ -306,7 +306,7 @@ RSpec.describe Pages::GuidanceController, type: :request do
     end
 
     context "when markdown contains forbidden syntax" do
-      let(:guidance_markdown) { "# A level one heading" }
+      let(:markdown) { "# A level one heading" }
 
       it "returns a JSON object containing the converted HTML" do
         expect(response.body).to eq({ preview_html: "<p class=\"govuk-body\">A level one heading</p>", errors: [I18n.t("activemodel.errors.models.pages/guidance_form.attributes.guidance_markdown.unsupported_markdown_syntax")] }.to_json)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require_relative "support/matchers/active_resource/have_been_updated"
 require_relative "support/matchers/active_resource/have_been_read"
 require_relative "support/matchers/active_resource/have_been_deleted"
 require_relative "support/shared_examples/axe_core"
+require_relative "support/shared_examples/markdown_validation"
 
 require "simplecov"
 

--- a/spec/support/shared_examples/markdown_validation.rb
+++ b/spec/support/shared_examples/markdown_validation.rb
@@ -1,0 +1,38 @@
+RSpec.shared_examples "validates markdown" do
+  it "is invalid if markdown contains unsupported tags" do
+    model.send("#{attribute}=", "# Heading level 1")
+    expect(model).to be_invalid
+    expect(model.errors.map(&:type)).to include :unsupported_markdown_syntax
+  end
+
+  it "is invalid if markdown is over 5000 characters" do
+    model.send("#{attribute}=", "A" * 5001)
+    expect(model).to be_invalid
+    expect(model.errors.map(&:type)).to include :too_long
+  end
+end
+
+RSpec.shared_examples "a markdown field with headings allowed" do
+  it_behaves_like "validates markdown"
+
+  it "is valid if markdown contains supported headings" do
+    model.send("#{attribute}=", "## Heading level 2")
+    expect(model).to be_valid
+  end
+end
+
+RSpec.shared_examples "a markdown field with headings disallowed" do
+  it_behaves_like "validates markdown"
+
+  it "is invalid if markdown contains level 2 headings" do
+    model.send("#{attribute}=", "## Heading level 2")
+    expect(model).to be_invalid
+    expect(model.errors.map(&:type)).to include :unsupported_markdown_syntax
+  end
+
+  it "is invalid if markdown contains level 3 headings" do
+    model.send("#{attribute}=", "### Heading level 3")
+    expect(model).to be_invalid
+    expect(model.errors.map(&:type)).to include :unsupported_markdown_syntax
+  end
+end

--- a/spec/validator/markdown_validator_spec.rb
+++ b/spec/validator/markdown_validator_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+class MarkdownModelWithHeadingsAllowed
+  include ActiveModel::Model
+  attr_accessor :markdown
+
+  validates :markdown, markdown: { allow_headings: true }
+end
+
+class MarkdownModelWithHeadingsDisallowed
+  include ActiveModel::Model
+  attr_accessor :markdown
+
+  validates :markdown, markdown: { allow_headings: false }
+end
+
+RSpec.describe MarkdownValidator do
+  it_behaves_like "a markdown field with headings allowed" do
+    let(:model) { MarkdownModelWithHeadingsAllowed.new }
+    let(:attribute) { :markdown }
+  end
+
+  context "with headings disallowed" do
+    it_behaves_like "a markdown field with headings disallowed" do
+      let(:model) { MarkdownModelWithHeadingsDisallowed.new }
+      let(:attribute) { :markdown }
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/AbPj2LRr/1191-allow-markdown-on-confirmation-page-what-happens-next-content

Makes some refactors to the guidance and markdown code to make reusing the component easier. Originally part of #792 

Contains:
- Updating the markdown parameter name used by the AJAX preview to make it more generic
- Making allowing markdown headings configurable, so we can resuse code between guidance and WHN markdown
- Add a markdown validator that can be reused between models

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
