### PR TITLE
Deny access to users from restricting organisations

### DIFF
--- a/app/views/errors/access_denied.html.erb
+++ b/app/views/errors/access_denied.html.erb
@@ -1,9 +1,11 @@
 <% set_page_title(t("page_titles.access_denied")) %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.access_denied') %></h1>
-    <%= simple_format(t('forbidden.body_html', link: contact_link(t('forbidden.link_text')))) %>
+    <%= simple_format(
+      @current_user.organisation_restricted_access? ?
+        t('forbidden.body_html_org_restricted') :
+        t('forbidden.body_html', link: contact_link(t('forbidden.link_text')))
+    )%>
   </div>
 </div>
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
       You do not have permission to view this page.
 
       %{link} if you think this is incorrect.
+    body_html_org_restricted: Your GOV.UK publishing team is managing the creation of forms for your department. Please contact them to discuss your form needs.
     link_text: Contact the GOV⁠.⁠UK Forms team
     title: You cannot view this page
   form_statuses:

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -90,6 +90,36 @@ RSpec.describe ApplicationController, type: :request do
 
         it "renders the access denied page" do
           expect(response).to render_template("errors/access_denied")
+          expect(response.body).to include("if you think this is incorrect.")
+        end
+      end
+    end
+
+    context "when a user is logged in from an access restricting organisation" do
+      let(:user) { create :user, :trial, email: User::EMAIL_DOMAIN_DENYLIST.first }
+
+      before do
+        login_as user
+      end
+
+      [
+        "/",
+        "/users",
+        "/forms/1",
+      ].each do |path|
+        context "when accessing #{path}" do
+          before do
+            get path
+          end
+
+          it "returns http code 403 for #{path}" do
+            expect(response).to have_http_status(:forbidden)
+          end
+
+          it "renders the access denied by organisation page" do
+            expect(response).to render_template("errors/access_denied")
+            expect(response.body).to include(I18n.t("forbidden.body_html_org_restricted"))
+          end
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?
Some publishing and content teams are concerned about access to trial accounts. This PR adds a denylist list of email domains, and restricts access to users with matching email domains on user creation. This won't affect existing users.

Users that have their access denied by this mechanism will be shown a customised access denied error page, with content to indicate the user should contact their publishing team to arrange access, rather than GOV.UK Forms.
 
Trello card: https://trello.com/c/L6fNhbAM/1222-deny-access-to-new-forms-admin-users-with-specific-email-domains

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
