### PR TITLE
Remove references to what_happens_next_text field

### DIFF
--- a/app/controllers/forms/what_happens_next_controller.rb
+++ b/app/controllers/forms/what_happens_next_controller.rb
@@ -40,7 +40,7 @@ module Forms
   private
 
     def what_happens_next_form_params
-      params.require(:forms_what_happens_next_form).permit(:what_happens_next_text, :what_happens_next_markdown).merge(form: current_form)
+      params.require(:forms_what_happens_next_form).permit(:what_happens_next_markdown).merge(form: current_form)
     end
 
     def preview_html(what_happens_next_form)

--- a/app/forms/forms/what_happens_next_form.rb
+++ b/app/forms/forms/what_happens_next_form.rb
@@ -1,19 +1,16 @@
 class Forms::WhatHappensNextForm < BaseForm
-  attr_accessor :form, :what_happens_next_text, :what_happens_next_markdown
+  attr_accessor :form, :what_happens_next_markdown
 
-  validates :what_happens_next_text, length: { maximum: 2000 }
   validates :what_happens_next_markdown, markdown: { allow_headings: false }
 
   def submit
     return false if invalid?
 
-    form.what_happens_next_text = what_happens_next_text
     form.what_happens_next_markdown = what_happens_next_markdown
     form.save!
   end
 
   def assign_form_values
-    self.what_happens_next_text = form.what_happens_next_text
     self.what_happens_next_markdown = form.what_happens_next_markdown
     self
   end

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -37,19 +37,14 @@
         </p>
       <% end %>
 
-
-      <% if @what_happens_next_form.what_happens_next_markdown.nil? %>
-        <%= f.govuk_text_area :what_happens_next_text, max_chars: 2000, label: {size: 'm' } %>
-      <% else %>
-        <%= render MarkdownEditorComponent::View.new(:what_happens_next_markdown,
-          form_builder: f,
-          render_preview_path: what_happens_next_render_preview_path(@what_happens_next_form.form),
-          preview_html: @preview_html,
-          form_model: @what_happens_next_form,
-          label: "Enter some information to tell people what will happen next",
-          hint: nil,
-          allow_headings: false) %>
-      <% end %>
+      <%= render MarkdownEditorComponent::View.new(:what_happens_next_markdown,
+        form_builder: f,
+        render_preview_path: what_happens_next_render_preview_path(@what_happens_next_form.form),
+        preview_html: @preview_html,
+        form_model: @what_happens_next_form,
+        label: "Enter some information to tell people what will happen next",
+        hint: nil,
+        allow_headings: false) %>
 
       <%= f.govuk_submit t("save_and_continue"), name: "route_to", value: "save_and_continue" %>
     <% end %>

--- a/app/views/live/show_form.html.erb
+++ b/app/views/live/show_form.html.erb
@@ -29,11 +29,7 @@
 
     <h3 class="govuk-heading-m"><%= t('show_live_form.what_happens_next') %></h3>
     <div class="app-preview-area">
-      <% if form.what_happens_next_markdown.present? %>
-        <%= GovukFormsMarkdown.render(form.what_happens_next_markdown).html_safe %>
-      <% else %>
-        <%= simple_format(form.what_happens_next_text, {}, sanitize_options: { tags: ["a", "ol", "ul", "li", "p"], attributes: %w[href class rel target title] })  %>
-      <% end %>
+      <%= GovukFormsMarkdown.render(form.what_happens_next_markdown).html_safe %>
     </div>
     <%= govuk_details(summary_text: t('show_live_form.what_is_what_happens_next'), text: t('show_live_form.what_happens_next_description')) %>
 

--- a/config/locales/forms/what_happens_next.yml
+++ b/config/locales/forms/what_happens_next.yml
@@ -1,16 +1,9 @@
 en:
-  helpers:
-    label:
-      forms_what_happens_next_form:
-        what_happens_next_text: Enter some information to tell people what will happen next
   activemodel:
     errors:
       models:
         forms/what_happens_next_form:
           attributes:
-            what_happens_next_text:
-              too_long: The information about what happens next cannot be longer than 2,000 characters
-              blank: Enter information about what happens next
             what_happens_next_markdown:
               unsupported_markdown_syntax: The information about what happens next can only contain formatting for links, bulleted lists (*), or numbered lists (1.)
               too_long: The information about what happens next cannot be longer than 5,000 characters

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -12,7 +12,6 @@ FactoryBot.define do
     support_phone { nil }
     support_url { nil }
     support_url_text { nil }
-    what_happens_next_text { nil }
     what_happens_next_markdown { nil }
     declaration_text { nil }
     question_section_completed { false }
@@ -35,7 +34,7 @@ FactoryBot.define do
     trait :ready_for_live do
       with_pages
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
-      what_happens_next_text { "We usually respond to applications within 10 working days." }
+      what_happens_next_markdown { "We usually respond to applications within 10 working days." }
       question_section_completed { true }
       declaration_section_completed { true }
       ready_for_live { true }

--- a/spec/forms/make_live_form_spec.rb
+++ b/spec/forms/make_live_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
   end
 
   describe "#submit" do
-    let(:make_live_form) { described_class.new(form: build(:form, :with_pages, :with_support, what_happens_next_text: "We usually respond to applications within 10 working days.")) }
+    let(:make_live_form) { described_class.new(form: build(:form, :with_pages, :with_support, what_happens_next_markdown: "We usually respond to applications within 10 working days.")) }
 
     context "when form is invalid" do
       it "returns false" do

--- a/spec/forms/what_happens_next_form_spec.rb
+++ b/spec/forms/what_happens_next_form_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::WhatHappensNextForm, type: :model do
-  let(:what_happens_next_form) { described_class.new(form:, what_happens_next_text:, what_happens_next_markdown:) }
-  let(:what_happens_next_text) { nil }
+  let(:what_happens_next_form) { described_class.new(form:, what_happens_next_markdown:) }
   let(:what_happens_next_markdown) { nil }
 
   context "when form is live" do
@@ -11,43 +10,7 @@ RSpec.describe Forms::WhatHappensNextForm, type: :model do
     end
 
     describe "validations" do
-      describe "what_happens_next_text" do
-        describe "Character length" do
-          it "is valid if less than 2000 characters" do
-            what_happens_next_form.what_happens_next_text = "a"
-
-            expect(what_happens_next_form).to be_valid
-          end
-
-          it "is valid if 2000 characters" do
-            what_happens_next_form.what_happens_next_text = "a" * 2000
-
-            expect(what_happens_next_form).to be_valid
-          end
-
-          it "is invalid if more than 2000 characters" do
-            what_happens_next_form.what_happens_next_text = "a" * 2001
-            error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
-
-            expect(what_happens_next_form).not_to be_valid
-
-            what_happens_next_form.validate(:what_happens_next_text)
-
-            expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
-              "What happens next text #{error_message}",
-            )
-          end
-        end
-
-        it "is valid if blank" do
-          what_happens_next_form.what_happens_next_text = ""
-
-          expect(what_happens_next_form).to be_valid
-        end
-      end
-
       describe "what_happens_next_markdown" do
-        let(:what_happens_next_text) { nil }
         let(:what_happens_next_markdown) { "a" }
 
         it_behaves_like "a markdown field with headings disallowed" do
@@ -63,16 +26,16 @@ RSpec.describe Forms::WhatHappensNextForm, type: :model do
 
     describe "#submit" do
       it "returns false if the data is invalid" do
-        what_happens_next_form.what_happens_next_text = "abc" * 2001
+        what_happens_next_form.what_happens_next_markdown = "# abc"
         expect(what_happens_next_form.submit).to eq false
       end
 
       it "sets the form's attribute value" do
-        form = OpenStruct.new(what_happens_next_text: "abc")
+        form = OpenStruct.new(what_happens_next_markdown: "abc")
         what_happens_next_form = described_class.new(form:)
-        what_happens_next_form.what_happens_next_text = "Thank you for submitting"
+        what_happens_next_form.what_happens_next_markdown = "Thank you for submitting"
         what_happens_next_form.submit
-        expect(what_happens_next_form.form.what_happens_next_text).to eq "Thank you for submitting"
+        expect(what_happens_next_form.form.what_happens_next_markdown).to eq "Thank you for submitting"
       end
     end
   end
@@ -83,43 +46,7 @@ RSpec.describe Forms::WhatHappensNextForm, type: :model do
     end
 
     describe "validations" do
-      describe "what_happens_next_text" do
-        describe "Character length" do
-          it "is valid if less than 2000 characters" do
-            what_happens_next_form.what_happens_next_text = "a"
-
-            expect(what_happens_next_form).to be_valid
-          end
-
-          it "is valid if 2000 characters" do
-            what_happens_next_form.what_happens_next_text = "a" * 2000
-
-            expect(what_happens_next_form).to be_valid
-          end
-
-          it "is invalid if more than 2000 characters" do
-            what_happens_next_form.what_happens_next_text = "a" * 2001
-            error_message = I18n.t("activemodel.errors.models.forms/what_happens_next_form.attributes.what_happens_next_text.too_long")
-
-            expect(what_happens_next_form).not_to be_valid
-
-            what_happens_next_form.validate(:what_happens_next_text)
-
-            expect(what_happens_next_form.errors.full_messages_for(:what_happens_next_text)).to include(
-              "What happens next text #{error_message}",
-            )
-          end
-        end
-
-        it "is valid if blank" do
-          what_happens_next_form.what_happens_next_text = ""
-
-          expect(what_happens_next_form).to be_valid
-        end
-      end
-
       describe "what_happens_next_markdown" do
-        let(:what_happens_next_text) { nil }
         let(:what_happens_next_markdown) { "a" }
 
         it_behaves_like "a markdown field with headings disallowed" do
@@ -135,16 +62,16 @@ RSpec.describe Forms::WhatHappensNextForm, type: :model do
 
     describe "#submit" do
       it "returns false if the data is invalid" do
-        what_happens_next_form = described_class.new(form:, what_happens_next_text: ("abc" * 2001))
+        what_happens_next_form = described_class.new(form:, what_happens_next_markdown: "# a level one heading")
         expect(what_happens_next_form.submit).to eq false
       end
 
       it "sets the form's attribute value" do
-        form = OpenStruct.new(what_happens_next_text: "abc")
+        form = OpenStruct.new(what_happens_next_markdown: "abc")
         what_happens_next_form = described_class.new(form:)
-        what_happens_next_form.what_happens_next_text = "Thank you for submitting"
+        what_happens_next_form.what_happens_next_markdown = "Thank you for submitting"
         what_happens_next_form.submit
-        expect(what_happens_next_form.form.what_happens_next_text).to eq "Thank you for submitting"
+        expect(what_happens_next_form.form.what_happens_next_markdown).to eq "Thank you for submitting"
       end
     end
   end

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
       submission_email: "submission@email.com",
       start_page: 1,
       organisation_id: 1,
-      what_happens_next_text: "Good things come to those who wait",
-      what_happens_next_markdown: nil,
+      what_happens_next_markdown: "Good things come to those who wait",
       live_at: nil,
       has_live_version: false,
     }.to_json
@@ -21,8 +20,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
       submission_email: "submission@email.com",
       id: 2,
       organisation_id: 1,
-      what_happens_next_text: "",
-      what_happens_next_markdown: nil,
+      what_happens_next_markdown: "",
       live_at: nil,
       has_live_version: false,
     )
@@ -34,8 +32,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
       submission_email: "submission@email.com",
       id: 2,
       organisation_id: 1,
-      what_happens_next_text: "Wait until you get a reply",
-      what_happens_next_markdown: nil,
+      what_happens_next_markdown: "Wait until you get a reply",
       live_at: nil,
       has_live_version: false,
     })
@@ -90,8 +87,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
   end
 
   describe "#create" do
-    let(:what_happens_next_text) { "Wait until you get a reply" }
-    let(:what_happens_next_markdown) { nil }
+    let(:what_happens_next_markdown) { "Wait until you get a reply" }
     let(:route_to) { "save_and_continue" }
 
     before do
@@ -100,7 +96,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
         mock.put "/api/v1/forms/2", post_headers
       end
       allow(Pundit).to receive(:authorize).and_return(true)
-      post what_happens_next_path(form_id: 2), params: { forms_what_happens_next_form: { what_happens_next_text:, what_happens_next_markdown: }, route_to: }
+      post what_happens_next_path(form_id: 2), params: { forms_what_happens_next_form: { what_happens_next_markdown: }, route_to: }
     end
 
     it "checks the user is authorised to view the form" do
@@ -121,7 +117,6 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
 
     context "when previewing markdown" do
       let(:route_to) { "preview" }
-      let(:what_happens_next_text) { nil }
       let(:what_happens_next_markdown) { "[a link](https://example.com)" }
 
       it "reads the existing form" do

--- a/spec/views/live/show_form.html.erb_spec.rb
+++ b/spec/views/live/show_form.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe "live/show_form.html.erb", feature_metrics_for_form_creators_enabled: f
   let(:declaration) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:what_happens_next) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:form_metadata) { OpenStruct.new(has_draft_version: false) }
-  let(:form) { build(:form, :live, id: 2, declaration_text: declaration, what_happens_next_text: what_happens_next, live_at: 1.week.ago) }
+  let(:form) { build(:form, :live, id: 2, declaration_text: declaration, what_happens_next_markdown: what_happens_next, live_at: 1.week.ago) }
   let(:metrics_data) { nil }
 
   before do
@@ -67,7 +67,7 @@ describe "live/show_form.html.erb", feature_metrics_for_form_creators_enabled: f
   end
 
   it "contains what happens next text" do
-    expect(rendered).to have_content(form.what_happens_next_text)
+    expect(rendered).to have_content(form.what_happens_next_markdown)
   end
 
   it "contains the submission email" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/AbPj2LRr/1191-allow-markdown-on-confirmation-page-what-happens-next-content

Remove all references to the what_happens_next_text field, which we no longer use as it has been replaced by what_happens_next_markdown. Once this is done we can remove it from the runner and from the API.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
