### PR TITLE
Remove email_confirmations_enabled feature flag

### DIFF
--- a/app/views/forms/contact_details/new.html.erb
+++ b/app/views/forms/contact_details/new.html.erb
@@ -16,11 +16,9 @@
 
       <%= t("contact_details.new.body_html") %>
 
-      <% if FeatureService.enabled?(:email_confirmations_enabled) %>
-        <p class="govuk-!-margin-bottom-6">
-          <%= t("contact_details.new.email_confirmation_hint_html") %>
-        </p>
-      <% end %>
+      <p class="govuk-!-margin-bottom-6">
+        <%= t("contact_details.new.email_confirmation_hint_html") %>
+      </p>
 
       <%= f.govuk_check_boxes_fieldset :contact_details_supplied, legend: { text: t('contact_details.new.title') }, hint: { text: t('contact_details.new.hint') } do %>
         <%= f.govuk_check_box :contact_details_supplied, :supply_email, checked: @contact_details_form.check_email? do %>

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -22,20 +22,18 @@
         We’ll send you an email to let you know the outcome. You’ll usually get a response within 10 working days.
       <% end %>
 
-      <% if FeatureService.enabled?(:email_confirmations_enabled) %>
-        <p>
-          This content will be:
-        </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li> shown to people when they've completed and submitted a form
-          <li> included in an email confirmation, if they choose to receive this
-        </ul>
+      <p>
+        This content will be:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li> shown to people when they've completed and submitted a form
+        <li> included in an email confirmation, if they choose to receive this
+      </ul>
 
-        <p>
-          The optional email confirmation will also include the contact details you provide for the form,
-          and the date and time of submission. It will not include a copy of their answers.
-        </p>
-      <% end %>
+      <p>
+        The optional email confirmation will also include the contact details you provide for the form,
+        and the date and time of submission. It will not include a copy of their answers.
+      </p>
 
       <%= render MarkdownEditorComponent::View.new(:what_happens_next_markdown,
         form_builder: f,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,5 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
-  email_confirmations_enabled: false
   metrics_for_form_creators_enabled: false
 
 forms_api:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,7 +1,3 @@
-# Used to add feature flags in the app to control access to certain features.
-features:
-  email_confirmations_enabled: true
-
 forms_api:
   # URL to form-api endpoints
   base_url: http://localhost:9292

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,7 +22,6 @@ describe "Settings" do
     features = settings[:features]
 
     include_examples expected_value_test, :metrics_for_form_creators_enabled, features, false
-    include_examples expected_value_test, :email_confirmations_enabled, features, false
   end
 
   describe "forms_api" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/bXjqCIVe/1192-remove-confirmation-email-feature-flag

Removes the feature flag from forms-admin. We're happily using this feature in all of our environments at this point, and we know that most form fillers are using it, so we can safely tidy up this flag.

Still to come: 
- removing the flag in forms-runner
- removing the flag variables from forms-deploy

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
