### PR TITLE
Add Rake task to create custom organisation in database

### DIFF
--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -10,4 +10,20 @@ namespace :organisations do
       OrganisationsFetcher.new.call
     end
   end
+
+  desc "Add organisation that is not in GOV.UK organisation database"
+  task :create, %i[name] => :environment do |_, args|
+    usage_message = "usage: rails organisations:create[<name>]".freeze
+    abort usage_message if args[:name].blank?
+
+    organisation = Organisation.find_by(name: args[:name])
+    abort "Organisation already exists: #{organisation.inspect}" if organisation
+
+    organisation = Organisation.create!(
+      slug: args[:name].parameterize,
+      name: args[:name],
+    )
+
+    puts "Created #{organisation.inspect}"
+  end
 end

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -1,0 +1,55 @@
+require "rake"
+
+require "rails_helper"
+
+RSpec.describe "organisations.rake" do
+  before do
+    # Rake.application.options.trace = true
+
+    Rake.application.rake_require "tasks/organisations"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "organisations:create" do
+    subject(:task) do
+      Rake::Task["organisations:create"]
+        .tap(&:reenable) # make sure task is invoked every time
+    end
+
+    it "creates an organisation" do
+      expect(Organisation.find_by(name: "Global Test Organisation"))
+        .to be_nil
+
+      expect { task.invoke("Global Test Organisation") }.to output(/Created/).to_stdout
+
+      expect(Organisation.find_by(name: "Global Test Organisation"))
+        .to be_truthy
+    end
+
+    it "does not recreate already existing organisations" do
+      test_org = create :organisation, name: "Department for Testing", slug: "dft", govuk_content_id: Faker::Internet.uuid
+      test_org.clear_changes_information
+
+      expect { task.invoke("Department for Testing") }
+        .to output(/already exists/).to_stderr
+        .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+
+      expect(test_org.previous_changes).to be_empty
+    end
+
+    [
+      ["Global Test Organisation", "global-test-organisation"],
+      ["Testing, Validating and Verifying Service", "testing-validating-and-verifying-service"],
+      ["Head Tester’s Department", "head-tester-s-department"],
+    ].each do |name, slug|
+      describe "given organisation name \"#{name}\"" do
+        it "generates the organisation slug \"#{slug}\"" do
+          expect { task.invoke(name) }.to output(/Created/).to_stdout
+
+          expect(Organisation.find_by(name:))
+            .to have_attributes(slug:)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Currently when we want to add an organisation to the forms-admin database we either have to rely on it being in the GOV.UK organisations API, or use the AWS data API and an SQL command to add it [[1](https://github.com/alphagov/forms-team/wiki/How-to-add-an-organisation-to-GOV.UK-Forms)].

This PR adds a Rake task we can run using the forms-cli, which should be safer and easier.

I've tested this on my local machine.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?