### PR TITLE
Change super admin scope

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,8 +1,15 @@
 class FormsController < ApplicationController
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
+
   def index
-    @forms = policy_scope(Form) || []
+    if @current_user.super_admin?
+      @search_form = Forms::SearchForm.new({ organisation_id: @current_user.organisation_id }.merge(search_params))
+
+      @forms = policy_scope(Form).where(organisation_id: @search_form.organisation_id) || []
+    else
+      @forms = policy_scope(Form) || []
+    end
   end
 
   def show
@@ -36,5 +43,9 @@ private
 
   def mark_complete_form_params
     params.require(:forms_mark_complete_form).permit(:mark_complete).merge(form: current_form)
+  end
+
+  def search_params
+    params.permit(:organisation_id)
   end
 end

--- a/app/form_objects/forms/search_form.rb
+++ b/app/form_objects/forms/search_form.rb
@@ -1,0 +1,7 @@
+class Forms::SearchForm < BaseForm
+  attr_accessor :organisation_id
+
+  def organisation
+    Organisation.find_by(id: organisation_id)
+  end
+end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FormsHelper
+  def forms_table_caption(organisation_name)
+    return t("home.your_forms") if organisation_name.blank?
+
+    t("home.form_table_caption", organisation_name:)
+  end
+
+  def user_organisation_name(user)
+    return nil if user.trial? || user.organisation.blank?
+
+    user.organisation.name
+  end
+end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -4,6 +4,8 @@ class Form < ActiveResource::Base
   headers["X-API-Token"] = Settings.forms_api.auth_key
 
   belongs_to :organisation
+  belongs_to :creator, class_name: "User"
+
   has_many :pages
 
   def self.find_live(id)
@@ -96,6 +98,13 @@ class Form < ActiveResource::Base
 
     Sentry.capture_exception(e)
     nil
+  end
+
+  # ActiveResource doesn't support belongs_to optional: true
+  # Because not all forms returned by the API with have a creator_id
+  # we need to check if the attribute exists before trying to access it
+  def creator_id
+    attributes.include?("creator_id") && attributes["creator_id"] || nil
   end
 
 private

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,4 +5,6 @@ class Organisation < ApplicationRecord
   has_many :users
 
   has_many :mou_signatures
+
+  scope :with_users, -> { joins(:users).distinct }
 end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -16,9 +16,10 @@ class FormPolicy
     def resolve
       if user.trial?
         scope.where(creator_id: user.id)
+      elsif user.super_admin?
+        scope.all
       else
-        scope
-          .where(organisation_id: user.organisation.id)
+        scope.where(organisation_id: user.organisation.id)
       end
     end
   end
@@ -31,6 +32,8 @@ class FormPolicy
   end
 
   def can_view_form?
+    return true if user.super_admin?
+
     if user.trial?
       user_is_form_creator
     else

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -28,7 +28,7 @@
                                   :name,
                                   class: ['govuk-!-width-three-quarters'],
                                   options: { prompt: t('home.organisation_prompt') },
-                                  label: { text: forms_table_caption(@search_form.organisation.name), size: 'm', tag: 'h2' },
+                                  label: { text: t('home.search_form_label', organisation_name: @search_form.organisation.name), size: 'm', tag: 'h2' },
                                   hint: { text: t('home.organisation_hint') })
                                 %>
                               <%= f.govuk_submit(t("home.change_filter"), secondary: true) %>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -20,13 +20,30 @@
 
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_form_path) %>
 
+<% if @current_user.super_admin? %>
+  <%= form_with(model: @search_form, scope: '', url: root_path, method: 'get', local: true) do |f| %>
+    <%= f.govuk_collection_select(:organisation_id,
+                                  Organisation.with_users.order(:slug),
+                                  :id,
+                                  :name,
+                                  class: ['govuk-!-width-three-quarters'],
+                                  options: { prompt: t('home.organisation_prompt') },
+                                  label: { text: forms_table_caption(@search_form.organisation.name), size: 'm', tag: 'h2' },
+                                  hint: { text: t('home.organisation_hint') })
+                                %>
+                              <%= f.govuk_submit(t("home.change_filter"), secondary: true) %>
+                            <% end %>
+                            <%= govuk_section_break(visible: true, size: 'l') %>
+                          <% end %>
+
 <% if @forms.any? %>
   <%= govuk_table do |table| %>
-    <%= table.with_caption(size: 'm', text: @current_user.trial? || @current_user.organisation.blank? ? t("home.your_forms") : t("home.form_table_caption", organisation_name: @current_user.organisation.name)) %>
+    <%= table.with_caption(size: 'm', text: forms_table_caption(@current_user.super_admin? ? @search_form.organisation.name : user_organisation_name(@current_user))) %>
 
     <%= table.with_head do |head|
        head.with_row do |row|
         row.with_cell(header: true, text: t("home.form_name_heading"))
+        row.with_cell(header: true, text: t("home.form_creator_heading")) if @current_user.super_admin?
         row.with_cell(header: true, text: t("home.form_status_heading"), numeric: true)
       end
     end %>
@@ -41,6 +58,7 @@
               govuk_link_to(form.name, form_path(form.id))
             end
           end
+          row.with_cell { form&.creator&.name.presence || t("home.no_form_creator") } if @current_user.super_admin?
           row.with_cell(numeric: true) do
             html = ""
             html << render(FormStatusTagComponent::View.new(status: :draft)) if form.has_draft_version

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -388,9 +388,10 @@ en:
     form_table_caption: "%{organisation_name} forms"
     main_heading: GOV.UK Forms
     no_form_creator: Unknown
-    organisation_hint: Change which organisation you are viewing
+    organisation_hint: Change which organisation’s forms you’re viewing
     organisation_prompt: Select an organisation
     preview: Preview this form
+    search_form_label: You’re viewing %{organisation_name} forms
     your_forms: Your forms
   internal_server_error:
     body: Please try again later.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,11 +380,16 @@ en:
       user_upgrade_request:
         met_requirements: Confirm that you meet these requirements
   home:
+    change_filter: Change
     create_a_form: Create a form
+    form_creator_heading: Created by
     form_name_heading: Form name
     form_status_heading: Status
     form_table_caption: "%{organisation_name} forms"
     main_heading: GOV.UK Forms
+    no_form_creator: Unknown
+    organisation_hint: Change which organisation you are viewing
+    organisation_prompt: Select an organisation
     preview: Preview this form
     your_forms: Your forms
   internal_server_error:

--- a/spec/features/mou/view_signed_mous_spec.rb
+++ b/spec/features/mou/view_signed_mous_spec.rb
@@ -23,7 +23,7 @@ describe "Check which MOUs have been signed", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=#{user.organisation.id}", req_headers, [].to_json, 200
+      mock.get "/api/v1/forms", req_headers, [].to_json, 200
       mock.get "/api/v1/forms?creator_id=#{user.id}", req_headers, [].to_json, 200
     end
 

--- a/spec/features/mou/view_signed_mous_spec.rb
+++ b/spec/features/mou/view_signed_mous_spec.rb
@@ -24,7 +24,7 @@ describe "Check which MOUs have been signed", type: :feature do
   before do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms", req_headers, [].to_json, 200
-      mock.get "/api/v1/forms?creator_id=#{user.id}", req_headers, [].to_json, 200
+      mock.get "/api/v1/forms?organisation_id=#{user.organisation_id}", req_headers, [].to_json, 200
     end
 
     mou_signatures

--- a/spec/features/users/set_organisation_spec.rb
+++ b/spec/features/users/set_organisation_spec.rb
@@ -24,8 +24,8 @@ feature "Set or change a user's organisation", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=1", req_headers, test_org_forms.to_json, 200
-      mock.get "/api/v1/forms?organisation_id=2", req_headers, gds_forms.to_json, 200
+      mock.get "/api/v1/forms", req_headers, test_org_forms.to_json, 200
+      mock.get "/api/v1/forms", req_headers, gds_forms.to_json, 200
     end
 
     create_list :user, 6, organisation: test_org
@@ -43,8 +43,7 @@ feature "Set or change a user's organisation", type: :feature do
   scenario "Super admin can change their own organisation" do
     given_i_am_a_super_admin_in_the_government_digital_service_organisation
     when_i_change_my_organisation_to_test_org
-    then_i_cannot_see_the_government_digital_service_forms
-    but_i_can_see_the_test_org_forms
+    then_the_current_users_organisation_name_is_updated
   end
 
 private
@@ -95,13 +94,9 @@ private
     click_button "Save"
   end
 
-  def then_i_cannot_see_the_government_digital_service_forms
-    visit root_path
-    expect(page).not_to have_text "Test GDS Form"
-  end
-
-  def but_i_can_see_the_test_org_forms
-    visit root_path
-    expect(page).to have_text "Test Org Form"
+  def then_the_current_users_organisation_name_is_updated
+    user_table_row = page.find(".govuk-table tr", text: super_admin_user.name)
+    expect(user_table_row).to have_text "Test Org"
+    expect(user_table_row).not_to have_text gds_org
   end
 end

--- a/spec/features/users/set_organisation_spec.rb
+++ b/spec/features/users/set_organisation_spec.rb
@@ -26,6 +26,7 @@ feature "Set or change a user's organisation", type: :feature do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms", req_headers, test_org_forms.to_json, 200
       mock.get "/api/v1/forms", req_headers, gds_forms.to_json, 200
+      mock.get "/api/v1/forms?organisation_id=#{gds_forms.first.organisation_id}", req_headers, gds_forms.to_json, 200
     end
 
     create_list :user, 6, organisation: test_org

--- a/spec/helpers/forms_helper_spec.rb
+++ b/spec/helpers/forms_helper_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe FormsHelper, type: :helper do
+  describe "#forms_table_caption" do
+    context "when organisation_name is blank" do
+      it 'returns the translated string "home.your_forms"' do
+        expect(helper.forms_table_caption("")).to eq(I18n.t("home.your_forms"))
+        expect(helper.forms_table_caption(nil)).to eq(I18n.t("home.your_forms"))
+      end
+    end
+
+    context "when organisation_name is not blank" do
+      it 'returns the translated string "home.form_table_caption" with the organisation_name' do
+        organisation_name = "Example dept"
+        caption = I18n.t("home.form_table_caption", organisation_name:)
+        expect(helper.forms_table_caption(organisation_name)).to eq(caption)
+      end
+    end
+  end
+
+  describe "#user_organisation_name" do
+    let(:trial_user) { build(:user, :with_trial_role) }
+    let(:user_without_organisation) { build(:user, organisation: nil) }
+    let(:user_with_organisation) { build(:user, role: :editor) }
+
+    context "when user is trial" do
+      it "returns nil" do
+        expect(helper.user_organisation_name(trial_user)).to be_nil
+      end
+    end
+
+    context "when user does not have an organisation" do
+      it "returns nil" do
+        expect(helper.user_organisation_name(user_without_organisation)).to be_nil
+      end
+    end
+
+    context "when user has an organisation" do
+      it "returns the organisation name" do
+        expect(helper.user_organisation_name(user_with_organisation)).to eq(user_with_organisation.organisation.name)
+      end
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -27,4 +27,23 @@ RSpec.describe Organisation, type: :model do
       expect(described_class.new).to be_versioned
     end
   end
+
+  describe "scopes" do
+    describe ".with_users" do
+      it "returns organisations with distinct users" do
+        organisation1 = FactoryBot.create(:organisation, slug: "org_1")
+        organisation2 = FactoryBot.create(:organisation, slug: "org_2")
+
+        FactoryBot.create(:user, organisation: organisation1)
+        FactoryBot.create(:user, organisation: organisation1)
+        FactoryBot.create(:user, organisation: organisation2)
+
+        organisations_with_users = described_class.with_users
+
+        expect(organisations_with_users).to include(organisation1)
+        expect(organisations_with_users).to include(organisation2)
+        expect(organisations_with_users.size).to eq(2)
+      end
+    end
+  end
 end

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -257,6 +257,30 @@ RSpec.describe FormsController, type: :request do
         expect(ActiveResource::HttpMock.requests).to be_empty
       end
     end
+
+    context "with a user with a super_admin account" do
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms", headers, forms_response.to_json, 200
+        end
+
+        login_as_super_admin_user
+        get root_path
+      end
+
+      it "returns 200 OK" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the index page" do
+        expect(response).to render_template("forms/index")
+      end
+
+      it "makes a call to the API" do
+        forms_request = ActiveResource::Request.new(:get, "/api/v1/forms", {}, headers)
+        expect(ActiveResource::HttpMock.requests).to include forms_request
+      end
+    end
   end
 
   describe "#mark_pages_section_completed" do

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -262,6 +262,7 @@ RSpec.describe FormsController, type: :request do
       before do
         ActiveResource::HttpMock.respond_to do |mock|
           mock.get "/api/v1/forms", headers, forms_response.to_json, 200
+          mock.get "/api/v1/forms?organisation_id=#{super_admin_user.organisation.id}", headers, forms_response.to_json, 200
         end
 
         login_as_super_admin_user

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -7,6 +7,7 @@ describe "forms/index.html.erb" do
   before do
     assign(:current_user, user)
     assign(:forms, forms)
+    assign(:search_form, OpenStruct.new(forms:))
     render template: "forms/index"
   end
 


### PR DESCRIPTION
### Allow Super admins to view forms accross organisations

Trello card https://trello.com/c/iZ4Itleq/1226-without-autocomplete-update-forms-list-page-so-that-super-admins-can-see-edit-all-forms-across-all-departments

![image](https://github.com/alphagov/forms-admin/assets/11035856/e4fb3015-340f-4d04-9ea3-b9232e9742c6)

This PR gives super admins the permissions to list, view and modify all forms.

It also changes the super admins home page to let them easily list forms from other organisations. There currently isn't a way for them to list forms owned by trial users which are not owned by an organisation.

A few points to note:
- Super admins see an extra column, Created by, which shows which user first created the form. If that isn't available, "Unknown" is shown. Editors and trial users don't see the column.
- The list of organisations only shows organisations with a least one user to cut down on the size of the list.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
