### PR TITLE
Change live and draft tag colours

### DIFF
--- a/app/components/form_status_tag_component/view.rb
+++ b/app/components/form_status_tag_component/view.rb
@@ -7,8 +7,8 @@ module FormStatusTagComponent
 
     def status_colour
       {
-        draft: "purple",
-        live: "blue",
+        draft: "yellow",
+        live: "turquoise",
       }[@status]
     end
 

--- a/spec/components/form_status_tag_component/view_spec.rb
+++ b/spec/components/form_status_tag_component/view_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe FormStatusTagComponent::View, type: :component do
       expect(page).to have_text("Draft")
     end
 
-    it "renders draft status in purple" do
-      expect(page).to have_css(".govuk-tag--purple")
+    it "renders draft status in yellow" do
+      expect(page).to have_css(".govuk-tag--yellow")
     end
   end
 
@@ -24,15 +24,15 @@ RSpec.describe FormStatusTagComponent::View, type: :component do
       expect(page).to have_text("Live")
     end
 
-    it "renders status in blue" do
-      expect(page).to have_css(".govuk-tag--blue")
+    it "renders status in turquoise" do
+      expect(page).to have_css(".govuk-tag--turquoise")
     end
   end
 
   describe "string status" do
     it "accepts status as a string" do
-      expect(described_class.new(status: "draft").status_colour).to eq "purple"
-      expect(described_class.new(status: "live").status_colour).to eq "blue"
+      expect(described_class.new(status: "draft").status_colour).to eq "yellow"
+      expect(described_class.new(status: "live").status_colour).to eq "turquoise"
     end
   end
 end

--- a/spec/features/form/create_or_edit_a_form_spec.rb
+++ b/spec/features/form/create_or_edit_a_form_spec.rb
@@ -91,7 +91,7 @@ private
   def then_i_should_have_a_draft_form
     expect(page.find("h1")).to have_text "Create a form"
     expect(page.find("h1")).to have_text form.name
-    expect(page.find(".govuk-tag.govuk-tag--purple")).to have_text "Draft"
+    expect(page.find(".govuk-tag.govuk-tag--yellow")).to have_text "Draft"
     expect_page_to_have_no_axe_errors(page)
   end
 

--- a/spec/features/form/make_changes_live_spec.rb
+++ b/spec/features/form/make_changes_live_spec.rb
@@ -37,13 +37,13 @@ feature "Make changes live", type: :feature do
 
     click_link form.name
     expect(page.find("h1")).to have_text form.name
-    expect(page).to have_css ".govuk-tag.govuk-tag--blue", text: "Live"
+    expect(page).to have_css ".govuk-tag.govuk-tag--turquoise", text: "Live"
     expect_page_to_have_no_axe_errors(page)
 
     click_link_or_button "Create a draft to edit"
     expect(page.find("h1")).to have_text "Edit your form"
     expect(page.find("h1")).to have_text form.name
-    expect(page).to have_css ".govuk-tag.govuk-tag--purple", text: "Draft"
+    expect(page).to have_css ".govuk-tag.govuk-tag--yellow", text: "Draft"
     expect_page_to_have_no_axe_errors(page)
 
     click_link "Make your changes live"

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -60,9 +60,9 @@ describe "forms/index.html.erb" do
       end
 
       expect(status_tags).to eq [
-        [{ text: "Draft", colour: "purple" }],
-        [{ text: "Live", colour: "blue" }],
-        [{ text: "Draft", colour: "purple" }, { text: "Live", colour: "blue" }],
+        [{ text: "Draft", colour: "yellow" }],
+        [{ text: "Live", colour: "turquoise" }],
+        [{ text: "Draft", colour: "yellow" }, { text: "Live", colour: "turquoise" }],
       ]
     end
 

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -36,7 +36,7 @@ describe "forms/show.html.erb" do
     let(:form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", pages: []) }
 
     it "rendered draft tag " do
-      expect(rendered).to have_css(".govuk-tag.govuk-tag--purple", text: "Draft")
+      expect(rendered).to have_css(".govuk-tag.govuk-tag--yellow", text: "Draft")
     end
 
     it "has a back link to the forms page" do
@@ -52,7 +52,7 @@ describe "forms/show.html.erb" do
     end
 
     it "rendered draft tag" do
-      expect(rendered).to have_css(".govuk-tag.govuk-tag--purple", text: "Draft")
+      expect(rendered).to have_css(".govuk-tag.govuk-tag--yellow", text: "Draft")
     end
 
     it "does not contain a link to delete the form" do

--- a/spec/views/live/show_form.html.erb_spec.rb
+++ b/spec/views/live/show_form.html.erb_spec.rb
@@ -26,7 +26,7 @@ describe "live/show_form.html.erb", feature_metrics_for_form_creators_enabled: f
   end
 
   it "rendered live tag" do
-    expect(rendered).to have_css(".govuk-tag.govuk-tag--blue", text: "Live")
+    expect(rendered).to have_css(".govuk-tag.govuk-tag--turquoise", text: "Live")
   end
 
   it "contains a link to preview the form" do

--- a/spec/views/live/show_pages.html.erb_spec.rb
+++ b/spec/views/live/show_pages.html.erb_spec.rb
@@ -21,6 +21,6 @@ describe "live/show_pages.html.erb" do
   end
 
   it "rendered live tag" do
-    expect(rendered).to have_css(".govuk-tag.govuk-tag--blue", text: "Live")
+    expect(rendered).to have_css(".govuk-tag.govuk-tag--turquoise", text: "Live")
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/RFWi2tB5/1401-update-draft-and-live-tags

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Changes the colour of 'live' tags to turquoise, and 'draft' tags to yellow.

### Screenshots
Form list:
![A list of statuses, showing 'Draft' in yellow, and 'Live' in turquoise](https://github.com/alphagov/forms-admin/assets/5861235/275ff67e-2976-408f-9ab4-f17595fa6070)

Create/edit a form (task list) page
![The name of the form, followed by a large heading saying 'Create a form', followed by a yellow 'Draft' tag, and a preview link](https://github.com/alphagov/forms-admin/assets/5861235/30ec85cf-333c-4c93-8b49-837d008b4392)

Add and edit questions page:
![The name of the form, followed by a large heading saying 'Add and edit your questions', followed by a yellow 'Draft' tag](https://github.com/alphagov/forms-admin/assets/5861235/e1dd01c9-38b5-47c7-8f91-4befa2f7bda3)

Live form view:
![a large heading containing the name of the form, followed by a turquoise 'Live' tag](https://github.com/alphagov/forms-admin/assets/5861235/4870f479-a5ef-4cc8-a87d-52bc6ef4b5d9)

Live form questions view:
![The name of the form, followed by a large heading saying 'Your questions', followed by a turquoise 'Live' tag](https://github.com/alphagov/forms-admin/assets/5861235/f379a1d8-18e6-4a35-9859-7bb8d77c684f)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
