### PR TITLE
Let super_admin edit forms from all organisations

### DIFF
--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -31,6 +31,8 @@ class FormPolicy
   end
 
   def can_view_form?
+    return true if user.super_admin?
+
     if user.trial?
       user_is_form_creator
     else

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -26,25 +26,35 @@ describe FormPolicy do
   end
 
   describe "#can_view_form?" do
-    (User.roles.keys - %w[trial]).each do |role|
-      context "with a form #{role}" do
-        let(:user) { build :user, role:, organisation: }
+    context "with an editor role" do
+      let(:user) { build :user, role: :editor, organisation: }
+
+      it { is_expected.to permit_actions(%i[can_view_form]) }
+
+      context "but from another organisation" do
+        let(:organisation) { build :organisation, id: 2, slug: "non-gds" }
+
+        it { is_expected.to forbid_actions(%i[can_view_form]) }
+      end
+
+      context "with an organisation not in the organisation table" do
+        let(:user) { build :user, :with_unknown_org, role: :editor, organisation_slug: "gds" }
+
+        it "raises an error" do
+          expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+        end
+      end
+    end
+
+    context "with a super_admin" do
+      let(:user) { build :user, role: :super_admin, organisation: }
+
+      it { is_expected.to permit_actions(%i[can_view_form]) }
+
+      context "and a form from another organisation" do
+        let(:organisation) { build :organisation, id: 2, slug: "non-gds" }
 
         it { is_expected.to permit_actions(%i[can_view_form]) }
-
-        context "but from another organisation" do
-          let(:organisation) { build :organisation, id: 2, slug: "non-gds" }
-
-          it { is_expected.to forbid_actions(%i[can_view_form]) }
-        end
-
-        context "with an organisation not in the organisation table" do
-          let(:user) { build :user, :with_unknown_org, role:, organisation_slug: "gds" }
-
-          it "raises an error" do
-            expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
-          end
-        end
       end
     end
 

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -257,6 +257,30 @@ RSpec.describe FormsController, type: :request do
         expect(ActiveResource::HttpMock.requests).to be_empty
       end
     end
+
+    context "with a user with a super_admin account" do
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms?organisation_id=#{super_admin_user.organisation.id}", headers, forms_response.to_json, 200
+        end
+
+        login_as_super_admin_user
+        get root_path
+      end
+
+      it "returns 200 OK" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the index page" do
+        expect(response).to render_template("forms/index")
+      end
+
+      it "makes a call to the API" do
+        forms_request = ActiveResource::Request.new(:get, "/api/v1/forms?organisation_id=#{super_admin_user.organisation.id}", {}, headers)
+        expect(ActiveResource::HttpMock.requests).to include forms_request
+      end
+    end
   end
 
   describe "#mark_pages_section_completed" do


### PR DESCRIPTION
### Allow super_admins to change all forms

Trello card: https://trello.com/c/iZ4Itleq/1226-without-autocomplete-update-forms-list-page-so-that-super-admins-can-see-edit-all-forms-across-all-departments

This PR changes the forms policy to allow super_admins to access all forms.

This is a smaller change than the [previous PR](https://github.com/alphagov/forms-admin/pull/831), which changed the policy for individual forms, the scope and added a new autocomplete input to allow super_admins to list all forms.

This PR doesn't suffer the same performance issues because it does not change the calls to the API.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
