### PR TITLE
Add feature flag and a new mailer

### DIFF
--- a/app/mailers/submission_email_mailer.rb
+++ b/app/mailers/submission_email_mailer.rb
@@ -13,4 +13,16 @@ class SubmissionEmailMailer < GovukNotifyRails::Mailer
 
     mail(to: new_submission_email)
   end
+
+  def notify_submission_email_has_changed(live_email:, form_name:, current_user:)
+    set_template(Settings.govuk_notify.live_submission_email_of_no_further_form_submissions)
+
+    set_personalisation(
+      form_creator_name: current_user.name,
+      form_creator_email: current_user.email,
+      form_name:,
+    )
+
+    mail(to: live_email)
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,6 +21,7 @@ forms_product_page:
 govuk_notify:
   api_key: changeme
   submission_email_confirmation_code_email_template_id: ce2638ab-754c-416d-8df6-c0ccb5e1a688
+  live_submission_email_of_no_further_form_submissions: a8c43931-af3d-48ff-b5b2-dbc444796dec
   user_upgrade_template_id: 5ec25494-c045-4cf6-9009-2f122e3339f4
   zendesk_reply_to_id: 0acefa17-04b5-4614-a2ad-6c7f17dd26ab
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
   metrics_for_form_creators_enabled: false
+  notify_original_submission_email_of_change: false
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,6 +22,7 @@ describe "Settings" do
     features = settings[:features]
 
     include_examples expected_value_test, :metrics_for_form_creators_enabled, features, false
+    include_examples expected_value_test, :notify_original_submission_email_of_change, features, false
   end
 
   describe "forms_api" do

--- a/spec/mailers/previews/submission_email_mailer_preview.rb
+++ b/spec/mailers/previews/submission_email_mailer_preview.rb
@@ -8,4 +8,12 @@ class SubmissionEmailMailerPreview < ActionMailer::Preview
       current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com"),
     )
   end
+
+  def notify_submission_email_has_changed
+    SubmissionEmailMailer.notify_submission_email_has_changed(
+      live_email: "testing@example.com",
+      form_name: "My fantastic form",
+      current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com"),
+    )
+  end
 end

--- a/spec/mailers/submission_email_mailer_spec.rb
+++ b/spec/mailers/submission_email_mailer_spec.rb
@@ -1,40 +1,69 @@
 require "rails_helper"
 
 describe SubmissionEmailMailer, type: :mailer do
-  let(:mail) do
-    described_class.confirmation_code_email(
-      new_submission_email: "test@example.com",
-      form_name: "Testing API",
-      confirmation_code: "654321",
-      notify_response_id: "abc-123",
-      current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com", confirmation_code: "654321"),
-    )
+  describe "#confirmation_code_email" do
+    let(:mail) do
+      described_class.confirmation_code_email(
+        new_submission_email: "test@example.com",
+        form_name: "Testing API",
+        confirmation_code: "654321",
+        notify_response_id: "abc-123",
+        current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com", confirmation_code: "654321"),
+      )
+    end
+
+    describe "sending an email to a given submission email to check its correct and receiving emails" do
+      it "sends an email with the correct template" do
+        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.submission_email_confirmation_code_email_template_id)
+      end
+
+      it "sends an email to the temporary submission email address" do
+        expect(mail.to).to eq(["test@example.com"])
+      end
+
+      it "includes the confirmation code" do
+        expect(mail.govuk_notify_personalisation[:form_submission_email_code]).to eq("654321")
+      end
+
+      it "includes the form creators details" do
+        expect(mail.govuk_notify_personalisation[:form_creator_name]).to eq("Joe Bloggs")
+        expect(mail.govuk_notify_personalisation[:form_creator_email]).to eq("example@example.com")
+      end
+
+      it "includes the form name" do
+        expect(mail.govuk_notify_personalisation[:form_name]).to eq("Testing API")
+      end
+
+      it "includes a UUID reference when the form was submit and can be used to find email in notify" do
+        expect(mail.govuk_notify_reference).to eq("abc-123")
+      end
+    end
   end
 
-  describe "sending an email to a given submission email to check its correct and receiving emails" do
-    it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.submission_email_confirmation_code_email_template_id)
+  describe "#notify_submission_email_has_changed" do
+    let(:mail) do
+      described_class.notify_submission_email_has_changed(live_email: "test@example.com",
+                                                          form_name: "Testing API",
+                                                          current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com"))
     end
 
-    it "sends an email to the temporary submission email address" do
-      expect(mail.to).to eq(["test@example.com"])
-    end
+    describe "sending an email to notify confirmed submission email not to expect future form submissions" do
+      it "sends an email with the correct template" do
+        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.live_submission_email_of_no_further_form_submissions)
+      end
 
-    it "includes the confirmation code" do
-      expect(mail.govuk_notify_personalisation[:form_submission_email_code]).to eq("654321")
-    end
+      it "sends an email to the live submission email address" do
+        expect(mail.to).to eq(["test@example.com"])
+      end
 
-    it "includes the form creators details" do
-      expect(mail.govuk_notify_personalisation[:form_creator_name]).to eq("Joe Bloggs")
-      expect(mail.govuk_notify_personalisation[:form_creator_email]).to eq("example@example.com")
-    end
+      it "includes the form creators details" do
+        expect(mail.govuk_notify_personalisation[:form_creator_name]).to eq("Joe Bloggs")
+        expect(mail.govuk_notify_personalisation[:form_creator_email]).to eq("example@example.com")
+      end
 
-    it "includes the form name" do
-      expect(mail.govuk_notify_personalisation[:form_name]).to eq("Testing API")
-    end
-
-    it "includes a UUID reference when the form was submit and can be used to find email in notify" do
-      expect(mail.govuk_notify_reference).to eq("abc-123")
+      it "includes the form name" do
+        expect(mail.govuk_notify_personalisation[:form_name]).to eq("Testing API")
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card:  https://trello.com/c/XletoC1y/1235-notify-a-confirmed-submission-email-that-it-will-no-longer-be-receiving-form-submissions-and-update-confirmation-page-content

This PR lays the ground work for the feature which will notify a form processing team that a live forms submission email address has changed and not to expect further form submissions. 

Visiting `http://localhost:3000/rails/mailers` you will see a "preview" of the mailer and an example of whats personalisation is sent to GOV.UK notify

Another PR will follow which will integrate the feature flag and the mailer into the service.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
