### PR TITLE
Change super admin form scope

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,8 +1,15 @@
 class FormsController < ApplicationController
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
+
   def index
-    @forms = policy_scope(Form) || []
+    if @current_user.super_admin?
+      @search_form = Forms::SearchForm.new({ organisation_id: @current_user.organisation_id }.merge(search_params))
+
+      @forms = policy_scope(Form).where(organisation_id: @search_form.organisation_id) || []
+    else
+      @forms = policy_scope(Form) || []
+    end
   end
 
   def show
@@ -36,5 +43,9 @@ private
 
   def mark_complete_form_params
     params.require(:forms_mark_complete_form).permit(:mark_complete).merge(form: current_form)
+  end
+
+  def search_params
+    params.permit(:organisation_id)
   end
 end

--- a/app/form_objects/forms/search_form.rb
+++ b/app/form_objects/forms/search_form.rb
@@ -1,0 +1,7 @@
+class Forms::SearchForm < BaseForm
+  attr_accessor :organisation_id
+
+  def organisation
+    Organisation.find_by(id: organisation_id)
+  end
+end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FormsHelper
+  def forms_table_caption(organisation_name)
+    return t("home.your_forms") if organisation_name.blank?
+
+    t("home.form_table_caption", organisation_name:)
+  end
+
+  def user_organisation_name(user)
+    return nil if user.trial? || user.organisation.blank?
+
+    user.organisation.name
+  end
+end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -16,6 +16,8 @@ class FormPolicy
     def resolve
       if user.trial?
         scope.where(creator_id: user.id)
+      elsif user.super_admin?
+        scope
       else
         scope
           .where(organisation_id: user.organisation.id)

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -22,7 +22,7 @@
 
 <% if @forms.any? %>
   <%= govuk_table do |table| %>
-    <%= table.with_caption(size: 'm', text: @current_user.trial? || @current_user.organisation.blank? ? t("home.your_forms") : t("home.form_table_caption", organisation_name: @current_user.organisation.name)) %>
+    <%= table.with_caption(size: 'm', text: forms_table_caption(@current_user.super_admin? ? @search_form.organisation.name : user_organisation_name(@current_user))) %>
 
     <%= table.with_head do |head|
        head.with_row do |row|

--- a/spec/helpers/forms_helper_spec.rb
+++ b/spec/helpers/forms_helper_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe FormsHelper, type: :helper do
+  describe "#forms_table_caption" do
+    context "when organisation_name is blank" do
+      it 'returns the translated string "home.your_forms"' do
+        expect(helper.forms_table_caption("")).to eq(I18n.t("home.your_forms"))
+        expect(helper.forms_table_caption(nil)).to eq(I18n.t("home.your_forms"))
+      end
+    end
+
+    context "when organisation_name is not blank" do
+      it 'returns the translated string "home.form_table_caption" with the organisation_name' do
+        organisation_name = "Example dept"
+        caption = I18n.t("home.form_table_caption", organisation_name:)
+        expect(helper.forms_table_caption(organisation_name)).to eq(caption)
+      end
+    end
+  end
+
+  describe "#user_organisation_name" do
+    let(:trial_user) { build(:user, :with_trial_role) }
+    let(:user_without_organisation) { build(:user, organisation: nil) }
+    let(:user_with_organisation) { build(:user, role: :editor) }
+
+    context "when user is trial" do
+      it "returns nil" do
+        expect(helper.user_organisation_name(trial_user)).to be_nil
+      end
+    end
+
+    context "when user does not have an organisation" do
+      it "returns nil" do
+        expect(helper.user_organisation_name(user_without_organisation)).to be_nil
+      end
+    end
+
+    context "when user has an organisation" do
+      it "returns the organisation name" do
+        expect(helper.user_organisation_name(user_with_organisation)).to eq(user_with_organisation.organisation.name)
+      end
+    end
+  end
+end

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -176,18 +176,29 @@ describe FormPolicy do
         end
       end
 
-      (User.roles.keys - %w[trial]).each do |role|
-        context "when user is not a trial user but a #{role}" do
-          let(:user) { build(:user, role:) }
+      context "when user has an editor role" do
+        let(:user) { build(:user, role: :editor) }
 
-          before do
-            allow(scope).to receive(:where).with(organisation_id: user.organisation.id)
-          end
+        before do
+          allow(scope).to receive(:where).with(organisation_id: user.organisation.id)
+        end
 
-          it "returns only their organisation records" do
-            policy_scope.resolve
-            expect(scope).to have_received(:where).with(organisation_id: user.organisation.id)
-          end
+        it "returns only their organisation records" do
+          policy_scope.resolve
+          expect(scope).to have_received(:where).with(organisation_id: user.organisation.id)
+        end
+      end
+
+      context "when user has an super_admin role" do
+        let(:user) { build(:user, role: :super_admin) }
+
+        before do
+          allow(scope).to receive(:where)
+        end
+
+        it "is not scoped" do
+          policy_scope.resolve
+          expect(scope).not_to have_received(:where)
         end
       end
     end


### PR DESCRIPTION
### Change the scope for Super_admins to list forms across organisations

Trello card: https://trello.com/c/iZ4Itleq/1226-without-autocomplete-update-forms-list-page-so-that-super-admins-can-see-edit-all-forms-across-all-departments

[Originally](https://github.com/alphagov/forms-admin/pull/831/commits/92aa11a9384e5a3a5399127e78afd33e98d37e18) I had changed the Forms policy scope to return `Form.all`. This turned out to be a mistake which resulted in an extra query to the API for all forms in the system. For example [this log](https://gds.splunkcloud.com/en-GB/app/gds-543-forms/search?sid=1702997850.823783) shows two API calls - one for forms from the organisation being looked at and one very long call for all forms in the DB.

To prevent performance issues again, I've broken the original PR into pieces. This PR changes the scope and adds a parameter for super_admins to query the forms of other organisations. To make it easier to review and show that there can't be the same performance issues, this PR doesn't change the API calls or DB queries used to list forms for users. It only allows super_admins to list forms for other organisations.

## How the extra call happens
We use pundits scope functionality to limit the forms a user can list and view.

In ActiveRecord, scopes are lazy. They return relation objects which don't make DB calls until the values are needed. It's possible to add further queries to the returned objects before the call to the DB is made.

ActiveResource does not support scopes in the same way ActiveRecord does. ActiveResource can merge chained where clauses into single clauses but doesn't do anything further. ActiveResource isn't lazy and always makes API requests to fetch objects.

When a where clause is added to the scope, it still makes the call forall forms and then discards the result.

If Forms where ActiveRecord objects, we could return `scope.all`. In ActiveRecord this wouldn't instantly result in a
query. As it's an ActiveResource object, it makes a call to the API to fetch all forms.

Instead we return the Form class without any other query. There doesn't seem to be a null query object for ActiveResource so I think this is the best we can do and rely on the caller to add a query.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
