### PR TITLE
Introduce MakeFormLive service

### DIFF
--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -14,18 +14,10 @@ module Forms
 
       return redirect_to form_path(@make_live_form.form) unless user_wants_to_make_form_live
 
-      already_live = @make_live_form.form.has_live_version
-
       @make_form_live_service = MakeFormLiveService.call(draft_form: current_form)
 
       if make_form_live
-        confirmation_page_title = if already_live
-                                    I18n.t("page_titles.your_changes_are_live")
-                                  else
-                                    I18n.t("page_titles.your_form_is_live")
-                                  end
-
-        render "confirmation", locals: { current_form:, confirmation_page_title: }
+        render "confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title }
       else
         render_new
       end

--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -16,7 +16,9 @@ module Forms
 
       already_live = @make_live_form.form.has_live_version
 
-      if @make_live_form.submit
+      @make_form_live_service = MakeFormLiveService.call(draft_form: current_form)
+
+      if make_form_live
         render_confirmation(already_live ? :changes : :form)
       else
         render_new
@@ -49,6 +51,10 @@ module Forms
 
     def user_wants_to_make_form_live
       @make_live_form.valid? && @make_live_form.made_live?
+    end
+
+    def make_form_live
+      @make_live_form.valid? && @make_form_live_service.make_live
     end
   end
 end

--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -19,7 +19,13 @@ module Forms
       @make_form_live_service = MakeFormLiveService.call(draft_form: current_form)
 
       if make_form_live
-        render_confirmation(already_live ? :changes : :form)
+        confirmation_page_title = if already_live
+                                    I18n.t("page_titles.your_changes_are_live")
+                                  else
+                                    I18n.t("page_titles.your_form_is_live")
+                                  end
+
+        render "confirmation", locals: { current_form:, confirmation_page_title: }
       else
         render_new
       end
@@ -37,16 +43,6 @@ module Forms
       else
         render "make_your_form_live", locals: { current_form: }
       end
-    end
-
-    def render_confirmation(made_live)
-      @confirmation_page_title = if made_live == :changes
-                                   I18n.t("page_titles.your_changes_are_live")
-                                 else
-                                   I18n.t("page_titles.your_form_is_live")
-                                 end
-
-      render "confirmation", locals: { current_form: }
     end
 
     def user_wants_to_make_form_live

--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -11,14 +11,13 @@ module Forms
       authorize current_form, :can_make_form_live?
 
       @make_live_form = MakeLiveForm.new(**make_live_form_params)
+
+      return redirect_to form_path(@make_live_form.form) unless user_wants_to_make_form_live
+
       already_live = @make_live_form.form.has_live_version
 
       if @make_live_form.submit
-        if @make_live_form.made_live?
-          render_confirmation(already_live ? :changes : :form)
-        else
-          redirect_to form_path(@make_live_form.form)
-        end
+        render_confirmation(already_live ? :changes : :form)
       else
         render_new
       end
@@ -46,6 +45,10 @@ module Forms
                                  end
 
       render "confirmation", locals: { current_form: }
+    end
+
+    def user_wants_to_make_form_live
+      @make_live_form.valid? && @make_live_form.made_live?
     end
   end
 end

--- a/app/form_objects/forms/make_live_form.rb
+++ b/app/form_objects/forms/make_live_form.rb
@@ -6,15 +6,6 @@ class Forms::MakeLiveForm < BaseForm
   validates :confirm_make_live, presence: true, inclusion: { in: CONFIRM_LIVE_VALUES.values }
 
   validate :required_parts_of_form_completed
-
-  def submit
-    return false if invalid?
-    # we are valid and didn't need to save
-    return true unless made_live?
-
-    form.make_live!
-  end
-
   def made_live?
     confirm_make_live == CONFIRM_LIVE_VALUES[:made_live]
   end

--- a/app/service/make_form_live_service.rb
+++ b/app/service/make_form_live_service.rb
@@ -1,0 +1,15 @@
+class MakeFormLiveService
+  class << self
+    def call(**args)
+      new(**args)
+    end
+  end
+
+  def initialize(draft_form:)
+    @draft_form = draft_form
+  end
+
+  def make_live
+    @draft_form.make_live!
+  end
+end

--- a/app/service/make_form_live_service.rb
+++ b/app/service/make_form_live_service.rb
@@ -12,4 +12,12 @@ class MakeFormLiveService
   def make_live
     @draft_form.make_live!
   end
+
+  def page_title
+    if @draft_form.has_live_version
+      I18n.t("page_titles.your_changes_are_live")
+    else
+      I18n.t("page_titles.your_form_is_live")
+    end
+  end
 end

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -1,8 +1,8 @@
-<% set_page_title(@confirmation_page_title) %>
+<% set_page_title(confirmation_page_title) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_panel(title_text: @confirmation_page_title) %>
+    <%= govuk_panel(title_text: confirmation_page_title) %>
 
     <h2 class="govuk-heading-m"><%= t('make_live.confirmation.form_name') %></h2>
 

--- a/spec/form_objects/forms/make_live_form_spec.rb
+++ b/spec/form_objects/forms/make_live_form_spec.rb
@@ -12,63 +12,6 @@ RSpec.describe Forms::MakeLiveForm, type: :model do
         "Confirm make live #{error_message}",
       )
     end
-  end
-
-  describe "#submit" do
-    let(:make_live_form) { described_class.new(form: build(:form, :with_pages, :with_support, what_happens_next_markdown: "We usually respond to applications within 10 working days.")) }
-
-    context "when form is invalid" do
-      it "returns false" do
-        expect(make_live_form.submit).to eq false
-      end
-
-      it "sets error messages" do
-        make_live_form.submit
-        expect(make_live_form.errors.full_messages_for(:confirm_make_live)).to include(
-          "Confirm make live #{error_message}",
-        )
-      end
-    end
-
-    context "when admin user decides not to make form live" do
-      before do
-        make_live_form.confirm_make_live = "not_made_live"
-      end
-
-      it "returns true" do
-        expect(make_live_form.submit).to eq true
-      end
-
-      it "sets no error messages" do
-        make_live_form.submit
-        expect(make_live_form.errors).to be_empty
-      end
-    end
-
-    context "when form is being made live" do
-      let(:form) { build(:form, :ready_for_live) }
-
-      around do |example|
-        travel_to(Time.zone.local(2021, 1, 1, 4, 30, 0)) do
-          example.run
-        end
-      end
-
-      before do
-        make_live_form.form = form
-        allow(make_live_form.form).to receive(:make_live!).and_return(:make_live_called)
-        make_live_form.confirm_make_live = "made_live"
-      end
-
-      it "makes form live" do
-        expect(make_live_form.submit).to eq :make_live_called
-      end
-
-      it "sets no error messages" do
-        make_live_form.submit
-        expect(make_live_form.errors).to be_empty
-      end
-    end
 
     context "when form is being made live but not all the required sections have been completed" do
       let(:make_live_form) { build :make_live_form }

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
 
       context "and that form has not been made live before" do
         it "has the page title 'Your form is live'" do
-          expect(assigns(:confirmation_page_title)).to eq "Your form is live"
+          expect(response.body).to include "Your form is live"
         end
       end
 
@@ -136,7 +136,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
         end
 
         it "has the page title 'Your changes are live'" do
-          expect(assigns(:confirmation_page_title)).to eq "Your changes are live"
+          expect(response.body).to include "Your changes are live"
         end
       end
     end

--- a/spec/service/make_form_live_service_spec.rb
+++ b/spec/service/make_form_live_service_spec.rb
@@ -14,4 +14,20 @@ describe MakeFormLiveService do
       make_form_live_service.make_live
     end
   end
+
+  describe "#page_title" do
+    it "returns a page title" do
+      expect(make_form_live_service.page_title).to eq I18n.t("page_titles.your_form_is_live")
+    end
+
+    context "when a form was previously live and changes are being made live" do
+      before do
+        draft_form.has_live_version = true
+      end
+
+      it "returns a different page title" do
+        expect(make_form_live_service.page_title).to eq I18n.t("page_titles.your_changes_are_live")
+      end
+    end
+  end
 end

--- a/spec/service/make_form_live_service_spec.rb
+++ b/spec/service/make_form_live_service_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe MakeFormLiveService do
+  let(:make_form_live_service) { described_class.call(draft_form:) }
+  let(:draft_form) { build :form, :ready_for_live, id: 1 }
+
+  describe "#make_live" do
+    before do
+      allow(draft_form).to receive(:make_live!).and_return(true)
+    end
+
+    it "calls make_live! on the current form" do
+      expect(draft_form).to receive(:make_live!)
+      make_form_live_service.make_live
+    end
+  end
+end

--- a/spec/views/forms/make_live/confirmation.html.erb_spec.rb
+++ b/spec/views/forms/make_live/confirmation.html.erb_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
 
 describe "forms/make_live/confirmation.html.erb" do
+  let(:current_form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1") }
+
   before do
-    without_partial_double_verification do
-      allow(view).to receive(:current_form).and_return(OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1"))
-    end
-    assign(:confirmation_page_title, "Your form is live")
-    render template: "forms/make_live/confirmation"
+    render template: "forms/make_live/confirmation", locals: { current_form:, confirmation_page_title: "Your form is live" }
   end
 
   it "contains a confirmation panel with a title" do


### PR DESCRIPTION
### Relates to 
- https://github.com/alphagov/forms-admin/pull/845

### What problem does this pull request solve?

Instead of Form Object having responsibility for making a form live and any other events that occured as a result of those changes, it would be much better for a service to do it instead.

This PR introduces a service which (for the time being),
- make a form live
- calculate what page title should be returned

Trello card:  https://trello.com/c/XletoC1y/1235-notify-a-confirmed-submission-email-that-it-will-no-longer-be-receiving-form-submissions-and-update-confirmation-page-content

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
