### PR TITLE
update MakeFormLiveService to notify live form submission if the email has changed

### DIFF
--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -14,7 +14,7 @@ module Forms
 
       return redirect_to form_path(@make_live_form.form) unless user_wants_to_make_form_live
 
-      @make_form_live_service = MakeFormLiveService.call(draft_form: current_form)
+      @make_form_live_service = MakeFormLiveService.call(draft_form: current_form, current_user:)
 
       if make_form_live
         render "confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title }

--- a/app/service/make_form_live_service.rb
+++ b/app/service/make_form_live_service.rb
@@ -14,7 +14,7 @@ class MakeFormLiveService
   def make_live
     @draft_form.make_live!
 
-    if live_form_submission_email_has_changed
+    if FeatureService.enabled?(:notify_original_submission_email_of_change) && live_form_submission_email_has_changed
       SubmissionEmailMailer.notify_submission_email_has_changed(
         live_email: @current_live_form.submission_email,
         form_name: @current_live_form.name,

--- a/app/service/make_form_live_service.rb
+++ b/app/service/make_form_live_service.rb
@@ -5,12 +5,24 @@ class MakeFormLiveService
     end
   end
 
-  def initialize(draft_form:)
+  def initialize(draft_form:, current_user:)
     @draft_form = draft_form
+    @current_live_form = Form.find_live(draft_form.id) if draft_form.has_live_version
+    @current_user = current_user
   end
 
   def make_live
     @draft_form.make_live!
+
+    if live_form_submission_email_has_changed
+      SubmissionEmailMailer.notify_submission_email_has_changed(
+        live_email: @current_live_form.submission_email,
+        form_name: @current_live_form.name,
+        current_user: @current_user,
+      ).deliver_now
+    end
+
+    true
   end
 
   def page_title
@@ -19,5 +31,11 @@ class MakeFormLiveService
     else
       I18n.t("page_titles.your_form_is_live")
     end
+  end
+
+private
+
+  def live_form_submission_email_has_changed
+    @draft_form.has_live_version && @current_live_form.submission_email != @draft_form.submission_email
   end
 end

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.post "/api/v1/forms/2/make-live", post_headers
         mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+        mock.get "/api/v1/forms/2/live", req_headers, form.to_json, 200
       end
 
       login_as user

--- a/spec/service/make_form_live_service_spec.rb
+++ b/spec/service/make_form_live_service_spec.rb
@@ -1,8 +1,16 @@
 require "rails_helper"
 
 describe MakeFormLiveService do
-  let(:make_form_live_service) { described_class.call(draft_form:) }
+  let(:make_form_live_service) { described_class.call(draft_form:, current_user:) }
   let(:draft_form) { build :form, :ready_for_live, id: 1 }
+  let(:live_form) { draft_form }
+  let(:current_user) { build :user }
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
 
   describe "#make_live" do
     before do
@@ -13,6 +21,48 @@ describe MakeFormLiveService do
       expect(draft_form).to receive(:make_live!)
       make_form_live_service.make_live
     end
+
+    it "does not call the SubmissionEmailMailer" do
+      expect(SubmissionEmailMailer).not_to receive(:notify_submission_email_has_changed)
+      make_form_live_service.make_live
+    end
+
+    context "when draft form has live version" do
+      let(:live_form) { build :form, :live }
+      let(:draft_form) do
+        live_form.clone
+      end
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms/#{live_form.id}/live", req_headers, live_form.to_json, 200
+        end
+      end
+
+      context "when submission email has not been changed" do
+        it "does not call the SubmissionEmailMailer" do
+          expect(SubmissionEmailMailer).not_to receive(:notify_submission_email_has_changed)
+
+          make_form_live_service.make_live
+        end
+      end
+
+      context "when submission email has changed" do
+        before do
+          draft_form.submission_email = "i-have-changed@example.com"
+        end
+
+        it "calls the SubmissionEmailMailer" do
+          expect(SubmissionEmailMailer).to receive(:notify_submission_email_has_changed).with(
+            live_email: live_form.submission_email,
+            form_name: live_form.name,
+            current_user:,
+          ).and_call_original
+
+          make_form_live_service.make_live
+        end
+      end
+    end
   end
 
   describe "#page_title" do
@@ -20,9 +70,16 @@ describe MakeFormLiveService do
       expect(make_form_live_service.page_title).to eq I18n.t("page_titles.your_form_is_live")
     end
 
-    context "when a form was previously live and changes are being made live" do
+    context "when changes to live form are being made live" do
+      let(:live_form) { build :form, :live }
+      let(:draft_form) do
+        live_form.clone
+      end
+
       before do
-        draft_form.has_live_version = true
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms/#{live_form.id}/live", req_headers, live_form.to_json, 200
+        end
       end
 
       it "returns a different page title" do

--- a/spec/service/make_form_live_service_spec.rb
+++ b/spec/service/make_form_live_service_spec.rb
@@ -52,14 +52,22 @@ describe MakeFormLiveService do
           draft_form.submission_email = "i-have-changed@example.com"
         end
 
-        it "calls the SubmissionEmailMailer" do
-          expect(SubmissionEmailMailer).to receive(:notify_submission_email_has_changed).with(
-            live_email: live_form.submission_email,
-            form_name: live_form.name,
-            current_user:,
-          ).and_call_original
+        it "does not call the SubmissionEmailMailer" do
+          expect(SubmissionEmailMailer).not_to receive(:notify_submission_email_has_changed)
 
           make_form_live_service.make_live
+        end
+
+        context "when notify_original_submission_email_of_change feature is enabled", feature_notify_original_submission_email_of_change: true do
+          it "calls the SubmissionEmailMailer" do
+            expect(SubmissionEmailMailer).to receive(:notify_submission_email_has_changed).with(
+              live_email: live_form.submission_email,
+              form_name: live_form.name,
+              current_user:,
+            ).and_call_original
+
+            make_form_live_service.make_live
+          end
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

This PR updates the existing `MakeFormLiveService` to send an email to the live forms submission address, as a means of informing the form processing team that the live form now has a new submission email address and no further emails with be sent to that email address.

This is behind a feature flag which is disabled at the moment. I tested this in dev with a forms-deploy branch that enabled the feature and it worked without any issues.

Trello card: https://trello.com/c/XletoC1y/1235-notify-a-confirmed-submission-email-that-it-will-no-longer-be-receiving-form-submissions-and-update-confirmation-page-content

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
