### PR TITLE
Add org select for superadmins

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,4 +5,6 @@ class Organisation < ApplicationRecord
   has_many :users
 
   has_many :mou_signatures
+
+  scope :with_users, -> { where(User.where("organisation_id = organisations.id").arel.exists) }
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -6,5 +6,5 @@ class Organisation < ApplicationRecord
 
   has_many :mou_signatures
 
-  scope :with_users, -> { where(User.where("organisation_id = organisations.id").arel.exists) }
+  scope :with_users, -> { where(User.where("organisation_id = organisations.id").arel.exists).order(:name) }
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -6,5 +6,5 @@ class Organisation < ApplicationRecord
 
   has_many :mou_signatures
 
-  scope :with_users, -> { where(User.where("organisation_id = organisations.id").arel.exists).order(:name) }
+  scope :with_users, -> { joins(:users).distinct.order(:name) }
 end

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -20,6 +20,22 @@
 
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_form_path) %>
 
+<% if @current_user.super_admin? %>
+  <%= form_with(model: @search_form, scope: '', url: root_path, method: 'get', local: true) do |f| %>
+    <%= f.govuk_collection_select(:organisation_id,
+                                  Organisation.with_users.order(:slug),
+                                  :id,
+                                  :name,
+                                  class: ['govuk-!-width-three-quarters'],
+                                  options: { prompt: t('home.organisation_prompt') },
+                                  label: { text: t('home.search_form_label', organisation_name: @search_form.organisation.name), size: 'm', tag: 'h2' },
+                                  hint: { text: t('home.organisation_hint') })
+                                %>
+                              <%= f.govuk_submit(t("home.change_filter"), secondary: true) %>
+                            <% end %>
+                            <%= govuk_section_break(visible: true, size: 'l') %>
+                          <% end %>
+
 <% if @forms.any? %>
   <%= govuk_table do |table| %>
     <%= table.with_caption(size: 'm', text: forms_table_caption(@current_user.super_admin? ? @search_form.organisation.name : user_organisation_name(@current_user))) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,12 +380,16 @@ en:
       user_upgrade_request:
         met_requirements: Confirm that you meet these requirements
   home:
+    change_filter: Change
     create_a_form: Create a form
     form_name_heading: Form name
     form_status_heading: Status
     form_table_caption: "%{organisation_name} forms"
     main_heading: GOV.UK Forms
+    organisation_hint: Change which organisation’s forms you’re viewing
+    organisation_prompt: Select an organisation
     preview: Preview this form
+    search_form_label: You’re viewing %{organisation_name} forms
     your_forms: Your forms
   internal_server_error:
     body: Please try again later.

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Organisation, type: :model do
   describe "scopes" do
     describe ".with_users" do
       it "returns organisations with distinct users" do
-        organisation1 = FactoryBot.create(:organisation, slug: "org_1")
         organisation2 = FactoryBot.create(:organisation, slug: "org_2")
+        organisation1 = FactoryBot.create(:organisation, slug: "org_1")
 
         FactoryBot.create(:user, organisation: organisation1)
         FactoryBot.create(:user, organisation: organisation1)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Organisation, type: :model do
 
         organisations_with_users = described_class.with_users
 
-        expect(organisations_with_users).to include(organisation1)
-        expect(organisations_with_users).to include(organisation2)
+        expect(organisations_with_users.first).to eq(organisation1)
+        expect(organisations_with_users.last).to eq(organisation2)
         expect(organisations_with_users.size).to eq(2)
       end
     end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -27,4 +27,23 @@ RSpec.describe Organisation, type: :model do
       expect(described_class.new).to be_versioned
     end
   end
+
+  describe "scopes" do
+    describe ".with_users" do
+      it "returns organisations with distinct users" do
+        organisation1 = FactoryBot.create(:organisation, slug: "org_1")
+        organisation2 = FactoryBot.create(:organisation, slug: "org_2")
+
+        FactoryBot.create(:user, organisation: organisation1)
+        FactoryBot.create(:user, organisation: organisation1)
+        FactoryBot.create(:user, organisation: organisation2)
+
+        organisations_with_users = described_class.with_users
+
+        expect(organisations_with_users).to include(organisation1)
+        expect(organisations_with_users).to include(organisation2)
+        expect(organisations_with_users.size).to eq(2)
+      end
+    end
+  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Organisation, type: :model do
   describe "scopes" do
     describe ".with_users" do
       it "returns organisations with distinct users" do
+        FactoryBot.create(:organisation, slug: "org_3")
         organisation2 = FactoryBot.create(:organisation, slug: "org_2")
         organisation1 = FactoryBot.create(:organisation, slug: "org_1")
 
@@ -40,9 +41,7 @@ RSpec.describe Organisation, type: :model do
 
         organisations_with_users = described_class.with_users
 
-        expect(organisations_with_users.first).to eq(organisation1)
-        expect(organisations_with_users.last).to eq(organisation2)
-        expect(organisations_with_users.size).to eq(2)
+        expect(organisations_with_users).to eq([organisation1, organisation2])
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/iZ4Itleq/1226-without-autocomplete-update-forms-list-page-so-that-super-admins-can-see-edit-all-forms-across-all-departments

Add a select list of organisations with users for super_admins to choose from on forms#index.

![image](https://github.com/alphagov/forms-admin/assets/11035856/f0dfba65-5597-401c-86bb-d4bc4d6f4114)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
