### PR TITLE
Inform form creators that we will email form processing teams when submission email address has changed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,6 +94,10 @@ class ApplicationController < ActionController::Base
     @current_form ||= Form.find(params[:form_id])
   end
 
+  def current_live_form
+    @current_live_form ||= Form.find_live(params[:form_id])
+  end
+
 private
 
   def authenticate_and_check_access

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -9,10 +9,4 @@ class Forms::LiveController < ApplicationController
     authorize current_form, :can_view_form?
     render template: "live/show_pages", locals: { form: current_live_form }
   end
-
-private
-
-  def current_live_form
-    Form.find_live(params[:form_id])
-  end
 end

--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -39,6 +39,8 @@ module Forms
 
     def submission_email_confirmed
       authorize current_form, :can_change_form_submission_email?
+
+      render :submission_email_confirmed, locals: { live_submission_email_updated: live_submission_email_updated? }
     end
 
   private
@@ -53,6 +55,12 @@ module Forms
 
     def submission_email_form
       @submission_email_form ||= SubmissionEmailForm.new(form: current_form).assign_form_values
+    end
+
+    def live_submission_email_updated?
+      return false unless FeatureService.enabled?(:notify_original_submission_email_of_change) && current_form.has_live_version
+
+      current_live_form.submission_email != current_form.submission_email
     end
   end
 end

--- a/app/views/forms/submission_email/submission_email_confirmed.html.erb
+++ b/app/views/forms/submission_email/submission_email_confirmed.html.erb
@@ -2,7 +2,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(title_text:  t("page_titles.confirm_email_success")) %>
 
-    <%= t('email_code_success.body_html', submission_email: @submission_email_form.form.submission_email) %>
+    <% if live_submission_email_updated %>
+      <%= simple_format(t("email_code_success.live_submission_email_changed_body_html", new_submission_email: @submission_email_form.form.submission_email)) %>
+    <% else %>
+      <%= simple_format(t('email_code_success.body_html', submission_email: @submission_email_form.form.submission_email)) %>
+    <% end %>
 
     <p><%= govuk_link_to(t('email_code_success.continue'), form_path) %></p>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,8 +127,12 @@ en:
     sub_heading: What you need to do next
     what_happens_next_body_html: "<p>The recipient will be asked to give you the code. You need to enter the code to confirm the email address.</p>\n"
   email_code_success:
-    body_html: "<p>Completed forms will be sent to %{submission_email}.</p>\n"
+    body_html: Completed forms will be sent to %{submission_email}.
     continue: Continue creating a form
+    live_submission_email_changed_body_html: |
+      When you make this draft form live, completed forms will be sent to %{new_submission_email}.
+
+      When you make the form live, we’ll send an email to the previous email address to let them know they’ll no longer receive completed forms.
   environment_names:
     dev: Development
     local: Local


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card:  https://trello.com/c/XletoC1y/1235-notify-a-confirmed-submission-email-that-it-will-no-longer-be-receiving-form-submissions-and-update-confirmation-page-content

<details>
<summary>Screenshot: For first draft or if the submission email has not changed between draft  live version</summary>

![image](https://github.com/alphagov/forms-admin/assets/3441519/8dec39f7-47d7-4d0a-ba79-87fc42646158)


</details>

<details>
<summary>Screenshot: When submission email has changed between draft  live version</summary>

![image](https://github.com/alphagov/forms-admin/assets/3441519/6a39ba74-5d09-43e3-b17b-65a582ce4bbe)



</details>

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
