### PR TITLE
Update dfe autocomplete

### DIFF
--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -2,14 +2,6 @@ $govuk-images-path: "@govuk/assets/images/";
 $govuk-fonts-path: "@govuk/assets/fonts/";
 $govuk-global-styles: true;
 
-// TODO: Remove this when dfe-autocomplete stops relying on the mixin
-// Add empty mixin to stop dfe-autocomplete breaking
-@mixin govuk-if-ie8 {
-  @if false {
-    @content;
-  }
-}
-
 @import "@govuk/all";
 @import "dfe-autocomplete/src/dfe-autocomplete";
 @import "../styles/app_memorandum_of_understanding";

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "app",
       "dependencies": {
-        "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete#36d80e6b5bba67c92cd9ec6982a4e536d1889aed",
+        "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete#11738c0e25778162e26eb7ab5e22a6ffce671b08",
         "govuk-frontend": "~5.0.0",
         "turndown": "^7.1.2"
       },
@@ -5109,8 +5109,8 @@
     },
     "node_modules/dfe-autocomplete": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/dfe-autocomplete.git#36d80e6b5bba67c92cd9ec6982a4e536d1889aed",
-      "integrity": "sha512-0x3yWmL/q3dQGnUW5T8hFRRUhqIwa82agax7VItaE2DWwleZN2lsb/zYJ61ew/A+R1zAYl2CUYqeZ6Q9p4FaUw==",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/dfe-autocomplete.git#11738c0e25778162e26eb7ab5e22a6ffce671b08",
+      "integrity": "sha512-t4d4vNTTT6w0To0BJhtwq30lNimNTwmiQkIy8dNwbbl0xYCzcuPumzdfPlEtPhlXilvH7ZyzhO7GlSW1ixfVng==",
       "license": "MIT",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vite-plugin-ruby": "^5.0.0"
   },
   "dependencies": {
-    "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete#36d80e6b5bba67c92cd9ec6982a4e536d1889aed",
+    "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete#11738c0e25778162e26eb7ab5e22a6ffce671b08",
     "govuk-frontend": "~5.0.0",
     "turndown": "^7.1.2"
   },


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->None

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Updates the dfe-autocomplete package to the latest commit in that repo. This means that:

- we no longer compile the package on every `npm install` - we'll use the precompiled version of the JS instead. This is what caused our build failures on #858.
- we can remove the govuk-if-ie8 mixin workaround we added in #738, since the package no longer uses that mixin. I've done that in this PR.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
