### PR TITLE
Bump bundler from 2.4.10 to 2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 USER ruby
 
 COPY --chown=ruby:ruby Gemfile* ./
-RUN gem install bundler -v 2.4.10
+
 RUN bundle config set --local without development:test \
   && bundle config set --local jobs "$(nproc)"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -567,4 +567,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.10
+   2.5.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -516,9 +516,11 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Bumps [bundler](https://rubygems.org/gems/bundler) from 2.4.10 to 2.5.3.
- [Release notes](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.5.3)
- [Changelog](https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md)
- [Commits](rubygems/rubygems@bundler-v2.4.10...bundler-v2.5.3)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?