### PR TITLE
Bump the version of the dfe-autocomplete gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "govuk_design_system_formbuilder", "~> 5.0.0"
 
 # The autocomplete component is not currently published as a gem, if changing
 # the hash, also change in package.json
-gem "dfe-autocomplete", require: "dfe/autocomplete", github: "DFE-Digital/dfe-autocomplete", ref: "36d80e6b5bba67c92cd9ec6982a4e536d1889aed"
+gem "dfe-autocomplete", require: "dfe/autocomplete", github: "DFE-Digital/dfe-autocomplete", ref: "11738c0e25778162e26eb7ab5e22a6ffce671b08"
 
 # Our own custom markdown renderer
 gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-autocomplete.git
-  revision: 36d80e6b5bba67c92cd9ec6982a4e536d1889aed
-  ref: 36d80e6b5bba67c92cd9ec6982a4e536d1889aed
+  revision: 11738c0e25778162e26eb7ab5e22a6ffce671b08
+  ref: 11738c0e25778162e26eb7ab5e22a6ffce671b08
   specs:
     dfe-autocomplete (0.1.0)
       actionview (>= 7.0.2.3)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
This commit bumps the dfe-autocomplete version in the Gemfile to match the version we're using in our package.json. In this case I don't think we expect any behaviour changes as a result of this, but the versions should be in sync.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
