### PR TITLE
Configure autocomplete

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -46,6 +46,6 @@ private
   end
 
   def search_params
-    params.permit(:organisation_id)
+    params[:search]&.permit(:organisation_id) || {}
   end
 end

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -39,15 +39,4 @@ document
 
 initAll()
 
-// We set rawAttribute to true to pass the value of the text input to the
-// controller when the autocomplete is being used, so we can detect when the
-// user has cleared the field. We set source to false to overide the DfE
-// component's handling of sort order and synonyms, as described in the code
-// found in
-// https://github.com/DFE-Digital/dfe-autocomplete/blob/36d80e6b5bba67c92cd9ec6982a4e536d1889aed/src/dfe-autocomplete.js#L54C1-L54C1
-// this means the autocomplete will get options straight from the select
-// element, removing the null option, which isn't needed for autocomplete.
-dfeAutocomplete({
-  rawAttribute: true,
-  source: false
-})
+window.dfeAutocomplete = dfeAutocomplete

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,4 +100,22 @@ module ApplicationHelper
       end
     end
   end
+
+  def init_autocomplete_script(show_all_values: false, raw_attribute: false, source: false)
+    content_for(:body_end) do
+      javascript_tag defer: true do
+        "
+      document.addEventListener('DOMContentLoaded', function(event) {
+        if(window.dfeAutocomplete !== undefined && typeof window.dfeAutocomplete === 'function') {
+          dfeAutocomplete({
+            showAllValues: #{show_all_values},
+            rawAttribute: #{raw_attribute},
+            source: #{source}
+          })
+        }
+      });
+        ".html_safe
+      end
+    end
+  end
 end

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -21,20 +21,27 @@
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_form_path) %>
 
 <% if @current_user.super_admin? %>
-  <%= form_with(model: @search_form, scope: '', url: root_path, method: 'get', local: true) do |f| %>
-    <%= f.govuk_collection_select(:organisation_id,
-                                  Organisation.with_users.order(:slug),
-                                  :id,
-                                  :name,
-                                  class: ['govuk-!-width-three-quarters'],
-                                  options: { prompt: t('home.organisation_prompt') },
-                                  label: { text: t('home.search_form_label', organisation_name: @search_form.organisation.name), size: 'm', tag: 'h2' },
-                                  hint: { text: t('home.organisation_hint') })
-                                %>
-                              <%= f.govuk_submit(t("home.change_filter"), secondary: true) %>
-                            <% end %>
-                            <%= govuk_section_break(visible: true, size: 'l') %>
-                          <% end %>
+
+  <%= form_with(model: @search_form, scope: :search, url: root_path, method: 'get', local: true) do |f| %>
+    <%= render DfE::Autocomplete::View.new(
+      f,
+      attribute_name: :organisation_id,
+      form_field: f.govuk_collection_select(:organisation_id,
+                                            Organisation.with_users.order(:slug),
+                                            :id,
+                                            :name,
+                                            class: ['govuk-!-width-three-quarters'],
+                                            options: { prompt: t('home.organisation_prompt') },
+                                            label: { text: t('home.search_form_label', organisation_name: @search_form.organisation.name), size: 'm', tag: 'h2' },
+                                            hint: { text: t('home.organisation_hint') },
+                                           ),
+    html_attributes: { 'data-show-all-values' => 'true'},
+    )%>
+  <%= f.govuk_submit(t("home.change_filter"), secondary: true) %>
+  <% end %>
+
+  <%= govuk_section_break(visible: true, size: 'l') %>
+<% end %>
 
 <% if @forms.any? %>
   <%= govuk_table do |table| %>
@@ -68,3 +75,5 @@
     end %>
   <% end %>
 <% end %>
+
+<%= init_autocomplete_script(show_all_values: true, raw_attribute: false, source: false) %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -48,9 +48,9 @@
 
     <%= yield :footer %>
 
-    <%= yield :body_end %>
-
     <%= vite_client_tag %>
     <%= vite_javascript_tag 'application' %>
+
+    <%= yield :body_end %>
   </body>
 </html>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -70,3 +70,5 @@
     <% end %>
   </div>
 </div>
+
+<%= init_autocomplete_script(show_all_values: false, raw_attribute: true, source: false) %>

--- a/spec/features/form/super_admin_view_forms_spec.rb
+++ b/spec/features/form/super_admin_view_forms_spec.rb
@@ -5,7 +5,6 @@ feature "View forms", type: :feature do
   let(:other_org) { create :organisation, id: 2, slug: "Other org" }
   let(:other_org_user) { create :user, organisation: other_org }
   let(:other_org_forms) { [build(:form, id: 2, organisation_id: other_org.id, name: "Other org form")] }
-  # let(:other_org_forms) { [build (:form, id: 1, name: "Apply for a juggling license", organisation_id: other_org.id)] }
 
   let(:req_headers) do
     {

--- a/spec/features/form/super_admin_view_forms_spec.rb
+++ b/spec/features/form/super_admin_view_forms_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+feature "View forms", type: :feature do
+  let(:org_forms) { [build(:form, id: 1, name: "Org form")] }
+  let(:other_org) { create :organisation, id: 2, slug: "Other org" }
+  let(:other_org_user) { create :user, organisation: other_org }
+  let(:other_org_forms) { [build(:form, id: 2, organisation_id: other_org.id, name: "Other org form")] }
+  # let(:other_org_forms) { [build (:form, id: 1, name: "Apply for a juggling license", organisation_id: other_org.id)] }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?organisation_id=#{super_admin_user.organisation_id}", req_headers, org_forms.to_json, 200
+      mock.get "/api/v1/forms?organisation_id=#{other_org.id}", req_headers, other_org_forms.to_json, 200
+    end
+
+    # Orgs only show in the autocomplete if they have at least one user
+    other_org_user
+    login_as_super_admin_user
+  end
+
+  scenario "Super admin can use autcomplete to view other org's forms" do
+    visit root_path
+    when_i_change_the_organisation
+    then_i_should_see_the_forms_for_that_organisation
+  end
+
+  def when_i_change_the_organisation
+    fill_in "search-organisation-id-field", with: other_org.name.to_s
+    page.send_keys :enter
+    click_button "Change"
+  end
+
+  def then_i_should_see_the_forms_for_that_organisation
+    expect(page).to have_content(other_org_forms.first.name)
+  end
+end

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe FormsController, type: :request do
           end
 
           login_as_super_admin_user
-          get root_path, params: { organisation_id: organisation.id }
+          get root_path, params: { search: { organisation_id: organisation.id } }
         end
 
         it "makes a call to the API with the search query" do


### PR DESCRIPTION
### Add autocomplete for super_admins looking at other org's forms

Trello card: https://trello.com/c/2MPQysX1/1233-add-autocomplete-functionality-to-forms-list-input-text-component-for-orgs

Super admins currently can choose to see other organisations forms using a select box on the homepage. This commit enhances the select box to an autocomplete box.

![image](https://github.com/alphagov/forms-admin/assets/11035856/81bcd42c-a517-4d8d-822a-e85ce82b87fe)

We already use the accessible autocomplete component to choose organisation in the users#edit page.
The autocomplete box on the homepage is also chooses organisation but behaves differently.

It is more like a select box than a text box. There is no way to clear it and submit an empty value, which the users page requires. It also shows all values like a select box to allow the user to list the organisations which are available to choose.

These differences in configuration mean we need a way to change how the autcomplete component is initialised. The component isn't very flexible and [can only be initialised once per page](https://github.com/DFE-Digital/dfe-autocomplete/blob/main/src/wrapper.js).

There are a few ways round this:
- put in a PR for the library to export `setupAccessibleAutoComplete` itself so we can provide custom options per autocomplete
- use different javascript entrypoints on pages which use the component with configuration in
- use a custom script to set the options in views

As we only use one auotcomplete component per page, I went with the last option as it seems the least intrusive. I think the PR approach may be better in the future if we use a lot of autocompletes.

We add the javascript to the bottom of the body and mark it with defer. As modules are loaded using defer, this should ensure our inline script is loaded after the application bundle.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
