### PR TITLE
Switch how we build users by using their respective factory instead of inline editing role attribute or traits

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,7 +31,7 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create_list :editor_user, 3, organisation: test_org
 
   # create extra super admins
-  FactoryBot.create_list :user, 3, organisation: gds, role: :super_admin
+  FactoryBot.create_list :super_admin_user, 3, organisation: gds
 
   # while we're using Signon it is possible to have users who aren't linked to
   # the same organisation as in Signon, or who have an organisation that isn't

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create :organisation, slug: "department-for-testing"
 
   # create extra editors
-  FactoryBot.create_list :user, 3, organisation: test_org, role: :editor
+  FactoryBot.create_list :editor_user, 3, organisation: test_org
 
   # create extra super admins
   FactoryBot.create_list :user, 3, organisation: gds, role: :super_admin

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -15,7 +15,7 @@ describe "Set or change a user's role", type: :feature do
   end
 
   let(:super_admin_user) do
-    create(:user, role: :super_admin, id: 1, organisation: gds_org)
+    create(:super_admin_user, id: 1, organisation: gds_org)
   end
 
   let(:trial_user) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -156,7 +156,7 @@ describe User, type: :model do
       end
 
       it "returns false when changing from editor to #{role_value}" do
-        user = create(:user, role: :editor)
+        user = create(:editor_user)
 
         user.update!(role: role_value)
         expect(user).not_to be_trial_user_upgraded

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -47,7 +47,7 @@ describe FormPolicy do
     end
 
     context "with a super_admin" do
-      let(:user) { build :user, role: :super_admin, organisation: }
+      let(:user) { build :super_admin_user, organisation: }
 
       it { is_expected.to permit_actions(%i[can_view_form]) }
 
@@ -190,7 +190,7 @@ describe FormPolicy do
       end
 
       context "when user has an super_admin role" do
-        let(:user) { build(:user, role: :super_admin) }
+        let(:user) { build(:super_admin_user) }
 
         before do
           allow(scope).to receive(:where)

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -5,11 +5,11 @@ describe FormPolicy do
 
   let(:organisation) { build :organisation, id: 1, slug: "gds" }
   let(:form) { build :form, organisation_id: 1, creator_id: 123 }
-  let(:user) { build :user, role: :editor, organisation: }
+  let(:user) { build :editor_user, organisation: }
 
   context "with no organisation set" do
     context "with editor role" do
-      let(:user) { build :user, :with_no_org, role: :editor }
+      let(:user) { build :editor_user, :with_no_org }
 
       it "raises an error" do
         expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
@@ -27,7 +27,7 @@ describe FormPolicy do
 
   describe "#can_view_form?" do
     context "with an editor role" do
-      let(:user) { build :user, role: :editor, organisation: }
+      let(:user) { build :editor_user, organisation: }
 
       it { is_expected.to permit_actions(%i[can_view_form]) }
 
@@ -38,7 +38,7 @@ describe FormPolicy do
       end
 
       context "with an organisation not in the organisation table" do
-        let(:user) { build :user, :with_unknown_org, role: :editor, organisation_slug: "gds" }
+        let(:user) { build :editor_user, :with_unknown_org, organisation_slug: "gds" }
 
         it "raises an error" do
           expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
@@ -177,7 +177,7 @@ describe FormPolicy do
       end
 
       context "when user has an editor role" do
-        let(:user) { build(:user, role: :editor) }
+        let(:user) { build(:editor_user) }
 
         before do
           allow(scope).to receive(:where).with(organisation_id: user.organisation.id)

--- a/spec/policies/mou_signature_policy_spec.rb
+++ b/spec/policies/mou_signature_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe MouSignaturePolicy do
   subject(:policy) { described_class.new(user, :mouSignature) }
 
-  let(:user) { build :user, role: :super_admin }
+  let(:user) { build :super_admin_user }
 
   context "with super admin" do
     it { is_expected.to permit_actions(%i[can_manage_mous]) }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -11,7 +11,7 @@ describe UserPolicy do
   end
 
   context "with editor" do
-    let(:user) { build :user, role: :editor }
+    let(:user) { build :editor_user }
 
     it { is_expected.to forbid_actions(%i[can_manage_user]) }
   end
@@ -26,7 +26,7 @@ describe UserPolicy do
     end
 
     context "with editor" do
-      let(:user) { build :user, role: :editor }
+      let(:user) { build :editor_user }
 
       it "returns nil" do
         expect(policy_scope.resolve).to be_nil

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe UserPolicy do
   subject(:policy) { described_class.new(user, records) }
 
-  let(:user) { build :user, role: :super_admin }
+  let(:user) { build :super_admin_user }
   let!(:records) { create_list :user, 5 }
 
   context "with super admin" do

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Forms::ChangeNameController, type: :request do
   end
 
   let(:organisation) { build :organisation, id: 1, slug: "test-org" }
-  let(:user) { build :user, role: :editor, id: 1, organisation: }
+  let(:user) { build :editor_user, id: 1, organisation: }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::MakeLiveController, type: :request do
-  let(:user) { build :user, role: :editor }
+  let(:user) { build :editor_user }
 
   let(:form) do
     build(:form,

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
   include ActionView::Helpers::TextHelper
 
   let(:organisation) { build :organisation, id: 1, slug: "test-org" }
-  let(:user) { build :user, role: :editor, id: 1, organisation: }
+  let(:user) { build :editor_user, id: 1, organisation: }
   let(:form) { build :form, id: 1, creator_id: 1, organisation_id: 1, has_live_version: }
   let(:live_form) { form.clone }
   let(:has_live_version) { false }
@@ -118,7 +118,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when current user has a government email address not ending with .gov.uk" do
-      let(:user) { build :user, email: "user@alb.example", role: :editor, id: 1 }
+      let(:user) { build :editor_user, email: "user@alb.example", id: 1 }
 
       it "redirects to the email code sent page" do
         expect(response).to redirect_to(submission_email_code_sent_path(form.id))

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe FormsController, type: :request do
           mock.get "/api/v1/forms/2/pages", headers, form.pages.to_json, 200
         end
 
-        login_as build(:user, :with_no_org, role: :editor)
+        login_as build(:editor_user, :with_no_org)
 
         get form_path(2)
       end
@@ -240,7 +240,7 @@ RSpec.describe FormsController, type: :request do
       before do
         ActiveResource::HttpMock.reset! # not expecting any API calls
 
-        login_as build(:user, :with_no_org, role: :editor)
+        login_as build(:editor_user, :with_no_org)
 
         get root_path
       end
@@ -391,7 +391,7 @@ RSpec.describe FormsController, type: :request do
 
     context "with a user with no organisation" do
       let(:user) do
-        build :user, :with_no_org, role: :editor
+        build :editor_user, :with_no_org
       end
 
       it "returns 403 Forbidden" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe UsersController, type: :request do
   end
 
   describe "#update" do
-    let(:user) { create(:user, role: :editor) }
+    let(:user) { create(:editor_user) }
     let(:role) { :super_admin }
 
     context "when logged in as a super admin" do

--- a/spec/service/email_task_status_service_spec.rb
+++ b/spec/service/email_task_status_service_spec.rb
@@ -5,7 +5,7 @@ describe EmailTaskStatusService do
     described_class.new(form:)
   end
 
-  let(:current_user) { build(:user, role: :editor) }
+  let(:current_user) { build(:editor_user) }
 
   describe "#ready_for_live?" do
     context "when mandatory tasks have not been completed" do

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe FormTaskListService do
-  let(:current_user) { build(:user, role: :editor) }
+  let(:current_user) { build(:editor_user) }
 
   describe ".task_counts" do
     let(:statuses) { OpenStruct.new(attributes: { declaration_status: "completed", make_live_status: "not_started", name_status: "completed", pages_status: "completed", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "completed" }) }

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -33,7 +33,7 @@ module AuthenticationFeatureHelpers
   end
 
   def super_admin_user
-    @super_admin_user ||= FactoryBot.create(:user, role: :super_admin, organisation: test_org)
+    @super_admin_user ||= FactoryBot.create(:super_admin_user, organisation: test_org)
   end
 
   def editor_user

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -37,7 +37,7 @@ module AuthenticationFeatureHelpers
   end
 
   def editor_user
-    @editor_user ||= FactoryBot.create(:user, role: :editor, organisation: test_org)
+    @editor_user ||= FactoryBot.create(:editor_user, organisation: test_org)
   end
 
   def trial_user

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "forms/index.html.erb" do
-  let(:user) { build :user, role: :editor }
+  let(:user) { build :editor_user }
   let(:forms) { [] }
 
   before do
@@ -67,7 +67,7 @@ describe "forms/index.html.erb" do
     end
 
     context "with a user has no organisation" do
-      let(:user) { build :user, :with_no_org, role: :editor }
+      let(:user) { build :editor_user, :with_no_org }
 
       it "has a table caption without an organisation name" do
         expect(rendered).to have_css(".govuk-table__caption", text: "Your forms")
@@ -108,7 +108,7 @@ describe "forms/index.html.erb" do
     end
 
     context "and a user does not have the trial role" do
-      let(:user) { build :user, role: :editor }
+      let(:user) { build :editor_user }
 
       it "does not display a banner" do
         expect(rendered).not_to have_text(I18n.t("trial_role_warning.heading"))
@@ -116,7 +116,7 @@ describe "forms/index.html.erb" do
     end
 
     context "and a user already has the editor role" do
-      let(:user) { build :user, role: :editor }
+      let(:user) { build :editor_user }
 
       it "does not display a banner" do
         expect(rendered).not_to have_text(I18n.t("role_upgrade.heading"))

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "forms/show.html.erb" do
-  let(:user) { build :user, role: :editor }
+  let(:user) { build :editor_user }
   let(:form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", pages:) }
   let(:pages) { [{ id: 183, question_text: "What is your address?", hint_text: "", answer_type: "address", next_page: nil }] }
 
@@ -69,7 +69,7 @@ describe "forms/show.html.erb" do
   end
 
   context "and a user does not have the trial role" do
-    let(:user) { build :user, role: :editor }
+    let(:user) { build :editor_user }
 
     it "does not display a banner" do
       expect(rendered).not_to have_text(I18n.t("trial_role_warning.heading"))

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "users/edit.html.erb" do
   let(:user) do
-    build :user, role: :editor, id: 1, organisation_id: 1
+    build :editor_user, id: 1, organisation_id: 1
   end
 
   before do
@@ -20,7 +20,7 @@ describe "users/edit.html.erb" do
     end
 
     context "with a user with no name set" do
-      let(:user) { build(:user, :with_no_name, role: :editor, id: 1) }
+      let(:user) { build(:editor_user, :with_no_name, id: 1) }
 
       it "is the users's email address" do
         expect(view.content_for(:title)).to eq user.email
@@ -28,7 +28,7 @@ describe "users/edit.html.erb" do
     end
 
     context "with a user with a blank name" do
-      let(:user) { build(:user, name: "", role: :editor, id: 1) }
+      let(:user) { build(:editor_user, name: "", id: 1) }
 
       it "is the users's email address" do
         expect(view.content_for(:title)).to eq user.email
@@ -55,7 +55,7 @@ describe "users/edit.html.erb" do
 
     context "with user from GOV.UK Signon" do
       let(:user) do
-        build :user, :with_unknown_org, role: :editor, id: 1, organisation_slug: "department-for-testing"
+        build :editor_user, :with_unknown_org, id: 1, organisation_slug: "department-for-testing"
       end
 
       it "contains organisation slug from GOV.UK Signon" do
@@ -103,7 +103,7 @@ describe "users/edit.html.erb" do
   end
 
   context "with a user with no name set" do
-    let(:user) { build(:user, :with_no_name, role: :editor, id: 1) }
+    let(:user) { build(:editor_user, :with_no_name, id: 1) }
 
     it "shows no name set" do
       expect(rendered).to have_text("No name set")
@@ -111,7 +111,7 @@ describe "users/edit.html.erb" do
   end
 
   context "with a user with an unknown organisation" do
-    let(:user) { build(:user, :with_unknown_org, role: :editor, id: 1) }
+    let(:user) { build(:editor_user, :with_unknown_org, id: 1) }
 
     it "shows the organisation slug" do
       expect(rendered).to have_text("unknown-org")
@@ -127,7 +127,7 @@ describe "users/edit.html.erb" do
   end
 
   context "with a user with no organisation set" do
-    let(:user) { build(:user, :with_no_org, role: :editor, id: 1) }
+    let(:user) { build(:editor_user, :with_no_org, id: 1) }
 
     it "shows no organisation set" do
       expect(rendered).to have_text("No organisation set")


### PR DESCRIPTION
### What problem does this pull request solve?

This only refactors editors and super admin. I'll do another PR for trial users which has raised some errors in existing tests where the factory that was being generated was in an invalid state and it wasn't picked up because we were either changing only the role or using the trial_user trait.


Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
