### PR TITLE
Force form states to be displayed inline instead of wrapping

### DIFF
--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -4,6 +4,7 @@ $govuk-global-styles: true;
 
 @import "@govuk/all";
 @import "dfe-autocomplete/src/dfe-autocomplete";
+@import "../styles/app_form_states";
 @import "../styles/app_memorandum_of_understanding";
 @import "../styles/app_preview_area";
 @import "../styles/app_select_options";

--- a/app/frontend/styles/_app_form_states.scss
+++ b/app/frontend/styles/_app_form_states.scss
@@ -1,0 +1,6 @@
+.app-form-states {
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+  gap: 5px;
+}

--- a/app/service/form_list_service.rb
+++ b/app/service/form_list_service.rb
@@ -74,9 +74,10 @@ private
     # Create an instance of controller. We are using ApplicationController here.
     view_context = ApplicationController.new.view_context
 
-    html = ""
+    html = "<div class='app-form-states'>"
     html << FormStatusTagComponent::View.new(status: :draft).render_in(view_context) if form.has_draft_version
     html << FormStatusTagComponent::View.new(status: :live).render_in(view_context) if form.has_live_version
+    html << "</div>"
     html.html_safe
   end
 

--- a/spec/service/form_list_service_spec.rb
+++ b/spec/service/form_list_service_spec.rb
@@ -68,7 +68,7 @@ describe FormListService do
             { text: "<a class=\"govuk-link\" href=\"/forms/#{form.id}\">#{form.name}</a>" },
             {
               numeric: true,
-              text: "<strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n",
+              text: "<div class='app-form-states'><strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n</div>",
             },
           ])
         end
@@ -89,7 +89,7 @@ describe FormListService do
               { text: current_user.name },
               {
                 numeric: true,
-                text: "<strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n",
+                text: "<div class='app-form-states'><strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n</div>",
               },
             ])
           end


### PR DESCRIPTION
### What problem does this pull request solve?
Previously, states would wrap and overlap each other because they had no padding. This wrap wraps a flexbox contain around it and forces the two states to always be inline with 5px padding between them.

### Screenshots - Before

![image](https://github.com/alphagov/forms-admin/assets/3441519/87243db7-a510-4933-a5d1-bd02b3a55446)


### Screenshots - After

![image](https://github.com/alphagov/forms-admin/assets/3441519/45c5f138-6b34-4e27-9261-b007c1fbbd1c)

Trello card:  https://trello.com/c/ePWiTjCg/1260-show-which-user-made-each-form
<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
