### PR TITLE
Add AWS application load balancer trace ID to logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,6 +48,7 @@ class ApplicationController < ActionController::Base
     payload[:form_id] = params[:form_id] if params[:form_id].present?
     payload[:page_id] = params[:page_id] if params[:page_id].present?
     payload[:session_id_hash] = Digest::SHA256.hexdigest session.id.to_s if session.exists?
+    payload[:trace_id] = request.env["HTTP_X_AMZN_TRACE_ID"].presence
   end
 
   def clear_draft_questions_data

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,6 +72,7 @@ module FormsAdmin
         h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
         h[:exception] = event.payload[:exception] if event.payload[:exception]
         h[:session_id_hash] = event.payload[:session_id_hash] if event.payload[:session_id_hash]
+        h[:trace_id] = event.payload[:trace_id] if event.payload[:trace_id]
       end
     end
   end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -20,6 +20,29 @@ RSpec.describe ApplicationController, type: :request do
     login_as_editor_user
   end
 
+  context "when there is a application load balancer trace ID" do
+    let(:payloads) { [] }
+    let(:payload) { payloads.last }
+
+    let!(:subscriber) do
+      ActiveSupport::Notifications.subscribe("process_action.action_controller") do |_, _, _, _, payload|
+        payloads << payload
+      end
+    end
+
+    before do
+      get root_path, headers: { "HTTP_X_AMZN_TRACE_ID": "Root=1-63441c4a-abcdef012345678912345678" }
+    end
+
+    after do
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    it "adds the trace ID to the instrumentation payload" do
+      expect(payload).to include(trace_id: "Root=1-63441c4a-abcdef012345678912345678")
+    end
+  end
+
   context "when the service is in maintenance mode" do
     let(:bypass_ips) { " " }
     let(:expect_response_to_redirect) { true }


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be able to correlate our Elastic Load Balancer logs with app logs. This is particularly useful when there is a `460` error because the client has closed the connection for taking too long.

This PR adds the `X-Amzn-Trace-Id` header [[1]] to our request logging.

[1]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?