### PR TITLE
allow all editors/super admins to see who created a form

### DIFF
--- a/app/service/form_list_service.rb
+++ b/app/service/form_list_service.rb
@@ -15,7 +15,7 @@ class FormListService
     @forms = forms
     @current_user = current_user
     @search_form = search_form
-    if current_user.super_admin?
+    unless current_user.trial?
       @list_of_creator_id = forms.map(&:creator_id).uniq
       @list_of_creators = User.where(id: @list_of_creator_id)
                                .select(:id, :name)
@@ -42,7 +42,7 @@ private
   def head
     [
       I18n.t("home.form_name_heading"),
-      (current_user.super_admin? ? { text: I18n.t("home.created_by") } : nil),
+      (current_user.trial? ? nil : { text: I18n.t("home.created_by") }),
       { text: I18n.t("home.form_status_heading"), numeric: true },
     ].compact
   end
@@ -50,7 +50,7 @@ private
   def rows
     forms.map do |form|
       [{ text: form_name_link(form) },
-       (current_user.super_admin? ? { text: find_creator_name(form) } : nil),
+       (current_user.trial? ? nil : { text: find_creator_name(form) }),
        { text: form_status_tags(form), numeric: true }].compact
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?
Originally, only super admins could view "created by" column in the list of forms. This was because we wanted to make sure the application could handle it. If we do deploy this and things go wrong we can easily revert this commit and we can review the situation.

The reason why only editor/super admins can see this column is that trial users should not be able to see forms created by other users (even in the same organisation) and it seemed wasteful to have a column in the report which is populated with their name for each form they create.

### Screenshots - Trial user does not see "created by" column

![image](https://github.com/alphagov/forms-admin/assets/3441519/61052ce2-165b-45f2-84a7-8355ce095fdb)


### Screenshot - Editor/Super admin see "created by" column

![image](https://github.com/alphagov/forms-admin/assets/3441519/7bd20eae-95ad-4a2d-a99f-7c2dda665165)

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
