### PR TITLE
Use setup phase to change Auth0 client for E2E tests

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,7 +95,7 @@ module ApplicationHelper
   def sign_in_params(is_e2e_user:, login_type: :sign_in)
     {}.tap do |params|
       if Settings.auth_provider == "auth0"
-        params.merge!({ connection: "Username-Password-Authentication" }) if is_e2e_user
+        params.merge!({ auth: "e2e" }) if is_e2e_user
         params.merge!({ screen_hint: "signup" }) if login_type == :sign_up
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,6 +50,8 @@ auth_valid_for: 86400 # the time after which re-authentication is required, in s
 auth0:
   client_id: changeme
   client_secret:
+  e2e_client_id: changeme
+  e2e_client_secret:
   domain: changeme.uk.auth0.com
 
 basic_auth:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -174,11 +174,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it "returns a string representing the sign-in button" do
-        expect(helper.sign_in_button(is_e2e_user: true)).to include("Username-Password-Authentication")
+        expect(helper.sign_in_button(is_e2e_user: true)).to include("e2e")
       end
 
-      it "does not include auth0 connection string when sign-in button" do
-        expect(helper.sign_in_button(is_e2e_user: false)).not_to include("Username-Password-Authentication")
+      it "does not include e2e string when not the e2e user" do
+        expect(helper.sign_in_button(is_e2e_user: false)).not_to include("e2e")
       end
     end
 
@@ -187,8 +187,8 @@ RSpec.describe ApplicationHelper, type: :helper do
         allow(Settings).to receive(:auth_provider).and_return("developer")
       end
 
-      it "does not include auth0 connection string when sign-in button" do
-        expect(helper.sign_in_button(is_e2e_user: true)).not_to include("Username-Password-Authentication")
+      it "does not include e2e string when not the e2e user" do
+        expect(helper.sign_in_button(is_e2e_user: true)).not_to include("e2e")
       end
     end
   end
@@ -200,12 +200,12 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it "returns a string representing the sign-up button" do
-        expect(helper.sign_up_button(is_e2e_user: true)).to include("Username-Password-Authentication", "signup")
+        expect(helper.sign_up_button(is_e2e_user: true)).to include("e2e", "signup")
       end
 
       context "when user is not an e2e user" do
         it "returns a string representing the sign-up button" do
-          expect(helper.sign_up_button(is_e2e_user: false)).not_to include("Username-Password-Authentication")
+          expect(helper.sign_up_button(is_e2e_user: false)).not_to include("e2e")
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?
This PR changes forms-admin’s OmniAuth middleware config to allow request-time modification of the auth strategy using the [setup phase](https://github.com/omniauth/omniauth/wiki/Setup-Phase). This lets us examine the request params to determine if it is from the E2E tests, and modify things like the client ID and client secret to use the E2E Auth0 application created in https://github.com/alphagov/forms-deploy/pull/539

Trello card: https://trello.com/c/QYU1ZGjU

### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
