### PR TITLE
Update dfe-autocomplete to fix missing suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "app",
       "dependencies": {
-        "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete#11738c0e25778162e26eb7ab5e22a6ffce671b08",
+        "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete#8e7389ff62a38bc8880323f6c58eed9c8d10f080",
         "govuk-frontend": "~5.0.0",
         "turndown": "^7.1.2"
       },
@@ -5105,8 +5105,8 @@
     },
     "node_modules/dfe-autocomplete": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/dfe-autocomplete.git#11738c0e25778162e26eb7ab5e22a6ffce671b08",
-      "integrity": "sha512-t4d4vNTTT6w0To0BJhtwq30lNimNTwmiQkIy8dNwbbl0xYCzcuPumzdfPlEtPhlXilvH7ZyzhO7GlSW1ixfVng==",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/dfe-autocomplete.git#8e7389ff62a38bc8880323f6c58eed9c8d10f080",
+      "integrity": "sha512-Oto8h6+PwH1esJx8XwZiFb7CYT2zcCATpsIIBKT0i3AjZvTABKwtaxdGs45uw72+pE5PqYhNlwfpcaRfpe48gA==",
       "license": "MIT",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vite-plugin-ruby": "^5.0.0"
   },
   "dependencies": {
-    "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete#11738c0e25778162e26eb7ab5e22a6ffce671b08",
+    "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete#8e7389ff62a38bc8880323f6c58eed9c8d10f080",
     "govuk-frontend": "~5.0.0",
     "turndown": "^7.1.2"
   },


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/OxtbRF0O/1349-companies-house-does-not-appear-in-list-of-organisations-in-forms-admin-autocomplete

Updates to the latest dfe-autocomplete commit. This includes a change (https://github.com/DFE-Digital/dfe-autocomplete/pull/20) to fix a bug with suggestions not appearing when they contain trailing whitespace.

We were seeing this bug when trying to enter Companies House in the organisation input. For some reason Companies House has a trailing space in the Organisations API and this meant it did not appear in autocomplete suggestions (see screenshots). 

### Screenshots
#### Before
![Screenshot of an autocomplete component where the user has typed 'Compa'. The component has added 'Companies House' as an inline hint, but has not returned any suggestions underneath the input.](https://github.com/alphagov/forms-admin/assets/5861235/8828e133-af8a-4983-a2c2-8ec6fce7558f)

#### After
![Screenshot of an autocomplete component where the user has typed 'Compa'. The component has added 'Companies House' as an inline hint, and it appears as a suggestion underneath the input.](https://github.com/alphagov/forms-admin/assets/5861235/e6a24e15-c0a8-4e7c-b50c-caf15d76fa76)


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
