### PR TITLE
add archived state tag 

### DIFF
--- a/app/components/form_status_tag_component/view.rb
+++ b/app/components/form_status_tag_component/view.rb
@@ -9,6 +9,7 @@ module FormStatusTagComponent
       {
         draft: "yellow",
         live: "turquoise",
+        archived: "orange",
       }[@status]
     end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -22,6 +22,10 @@ class Form < ActiveResource::Base
     has_live_version ? :live : :draft
   end
 
+  def is_archived?
+    state.to_sym.in?(%i[archived archived_with_draft])
+  end
+
   def all_ready_for_live?
     ready_for_live && email_task_status_service.ready_for_live?
   end

--- a/app/service/form_list_service.rb
+++ b/app/service/form_list_service.rb
@@ -74,10 +74,18 @@ private
     # Create an instance of controller. We are using ApplicationController here.
     view_context = ApplicationController.new.view_context
 
-    html = "<div class='app-form-states'>"
-    html << FormStatusTagComponent::View.new(status: :draft).render_in(view_context) if form.has_draft_version
-    html << FormStatusTagComponent::View.new(status: :live).render_in(view_context) if form.has_live_version
-    html << "</div>"
+    status_mapping = {
+      draft: -> { form.has_draft_version },
+      live: -> { form.has_live_version && !form.is_archived? },
+      archived: -> { form.is_archived? },
+    }
+
+    html_content = status_mapping.map { |status, condition|
+      FormStatusTagComponent::View.new(status:).render_in(view_context) if condition.call
+    }.compact.join
+
+    html = "<div class='app-form-states'>#{html_content}</div>"
+
     html.html_safe
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,7 @@ en:
     link_text: Contact the GOV⁠.⁠UK Forms team
     title: You cannot view this page
   form_statuses:
+    archived: Archived
     draft: Draft
     live: Live
   form_url_component:

--- a/spec/components/form_status_tag_component/form_status_tag_component_preview.rb
+++ b/spec/components/form_status_tag_component/form_status_tag_component_preview.rb
@@ -6,4 +6,8 @@ class FormStatusTagComponent::FormStatusTagComponentPreview < ViewComponent::Pre
   def live_status
     render(FormStatusTagComponent::View.new(status: "live"))
   end
+
+  def archived_status
+    render(FormStatusTagComponent::View.new(status: "archived"))
+  end
 end

--- a/spec/components/form_status_tag_component/view_spec.rb
+++ b/spec/components/form_status_tag_component/view_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe FormStatusTagComponent::View, type: :component do
     end
   end
 
+  describe "archived status" do
+    before do
+      render_inline(described_class.new(status: :archived))
+    end
+
+    it "renders the status text" do
+      expect(page).to have_text("Archived")
+    end
+
+    it "renders status in orange" do
+      expect(page).to have_css(".govuk-tag--orange")
+    end
+  end
+
   describe "string status" do
     it "accepts status as a string" do
       expect(described_class.new(status: "draft").status_colour).to eq "yellow"

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     creator_id { nil }
     ready_for_live { false }
     incomplete_tasks { %i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next] }
+    state { :draft }
 
     transient do
       statuses { { declaration_status: "not_started", make_live_status: "cannot_start", name_status: "completed", pages_status: "not_started", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "not_started" } }
@@ -29,6 +30,7 @@ FactoryBot.define do
     trait :new_form do
       submission_email { "" }
       privacy_policy_url { "" }
+      state { :draft }
     end
 
     trait :with_id do
@@ -54,6 +56,7 @@ FactoryBot.define do
       live_at { Time.zone.now }
       has_draft_version { false }
       has_live_version { true }
+      state { :live }
     end
 
     trait :with_active_resource do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -327,4 +327,38 @@ describe Form, type: :model do
       end
     end
   end
+
+  describe "#is_archived?" do
+    it "returns true if state archived" do
+      form.state = :archived
+      expect(form.is_archived?).to be true
+    end
+
+    it "returns true if state archived with draft" do
+      form.state = :archived_with_draft
+      expect(form.is_archived?).to be true
+    end
+
+    it "returns false if state draft" do
+      form.state = :draft
+      expect(form.is_archived?).to be false
+    end
+
+    it "returns false if state live" do
+      form.state = :live
+      expect(form.is_archived?).to be false
+    end
+
+    it "returns false if state live_with_draft" do
+      form.state = :live_with_draft
+      expect(form.is_archived?).to be false
+    end
+
+    context "when state value is a string" do
+      it "returns true if state archived" do
+        form.state = "archived"
+        expect(form.is_archived?).to be true
+      end
+    end
+  end
 end

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -214,6 +214,7 @@ RSpec.describe FormsController, type: :request do
         has_live_version: false,
         organisation_id: 1,
         creator_id: nil,
+        state: :draft,
       },
        {
          id: 3,
@@ -225,6 +226,7 @@ RSpec.describe FormsController, type: :request do
          has_live_version: false,
          organisation_id: 1,
          creator_id: nil,
+         state: :draft,
        }]
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

- Adds a new method to forms model to map the archived states
- Adds archive tag to form tag component
- updates the form list service to display archive tag

### Screenshot
![image](https://github.com/alphagov/forms-admin/assets/3441519/629d6557-3b5c-403c-bbf3-0a51da5206ac)


Trello card: https://trello.com/c/9QBLASbG/1331-add-archive-tag

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
