### PR TITLE
Fix warning about multiple access tokens on login

### DIFF
--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -33,3 +33,9 @@ end
 
 # Need to do this because Signon allows both GET and POST requests
 OmniAuth.config.allowed_request_methods = %i[post]
+
+# Silence the warning about extra tokens - we expect id and access_token from
+# auth0 see https://gitlab.com/oauth-xx/oauth2/#global-configuration
+OAuth2.configure do |config|
+  config.silence_extra_tokens_warning = true
+end


### PR DESCRIPTION
When a user signs in with Auth0 an error is logged:

```
OAuth2::AccessToken.from_hash: hash contained more than one 'token' key (["access_token", "id_token"]); using "access_token".
```

These logs can be seen using the splunk query:

`index="*forms" "OAuth2::AccessToken.from_hash"`

This happens because Auth0 returns both id and access tokens in the openid callback phase of login.

This is expected behaviour and the ruby OAuth library gives instructions for silencing the warning in the
[project readme](https://gitlab.com/oauth-xx/oauth2/#global-configuration).

For more context, Auth0 has a [blog post explaining the function of the tokens](https://auth0.com/blog/id-token-access-token-what-is-the-difference/).

### What problem does this pull request solve?

Trello card: https://trello.com/c/hXhsGW6r/1371-investigate-warnings-from-oauth2-in-production

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
