### PR TITLE
Add assertion on draft question before question controller actions

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -1,4 +1,8 @@
 class Pages::QuestionsController < PagesController
+  before_action do
+    raise "No answer type set for draft question" if draft_question.answer_type.blank?
+  end
+
   def new
     @question_form = Pages::QuestionForm.new(answer_type: draft_question.answer_type,
                                              question_text: draft_question.question_text,


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We often have errors logged where users somehow end up on the `forms/:id/pages/new/question` without having a `DraftQuestion` set-up. See examples on https://govuk-forms.sentry.io/issues/4200026265.

We're not sure how this is happening (there are multiple potential routes), but investigating is hampered by the fact that we get a really unhelpful error message currently, from within the template:

```
ActionView::Template::Error
no implicit conversion of Hash into String
```

The traceback takes us to a line 7 in the component template at `app/components/page_settings_summary_component/view.html.erb` [[1](https://github.com/alphagov/forms-admin/blob/e0eb7b1b23021fd217d73b813132b1679f99463a/app/components/page_settings_summary_component/view.html.erb#L7)], which tries to access the translation `draft_question.answer_type` but can't because the `answer_type` string is empty.

This commit adds an assertion on the draft question answer type; I think we shouldn't be showing users this page before the answer type is chosen.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?