### PR TITLE
Add payment links task

### DIFF
--- a/app/components/task_list_component/_index.scss
+++ b/app/components/task_list_component/_index.scss
@@ -21,6 +21,16 @@
   @include govuk-font($size:24, $weight: bold);
 }
 
+.app-task-list__subsection {
+  display: table;
+  margin-top: 0;
+  @include govuk-font($size:19, $weight: bold);
+
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(6);
+  }
+}
+
 .app-task-list__section-number {
   display: table-cell;
 
@@ -41,7 +51,7 @@
 
 .app-task-list__items {
   @include govuk-font($size: 19);
-  @include govuk-responsive-margin(9, "bottom");
+  @include govuk-responsive-margin(6, "bottom");
   list-style: none;
   padding-left: 0;
   @include govuk-media-query($from: tablet) {

--- a/app/components/task_list_component/view.html.erb
+++ b/app/components/task_list_component/view.html.erb
@@ -7,10 +7,13 @@
   <% sections.each do |section| %>
     <% unless section.rows.empty? && section.body_text.blank? %>
       <li>
-        <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number"><%= section.number %>. </span> <%= section.title %>
-        </h2>
-
+        <% if section.subsection %>
+          <h3 class="app-task-list__subsection"><%= section.title %></h3>
+        <% else %>
+          <h2 class="app-task-list__section">
+            <span class="app-task-list__section-number"><%= section.number %>. </span> <%= section.title %>
+          </h2>
+        <% end %>
         <% if section.body_text.present? %>
         <div class="app-task-list__body">
           <%= simple_format(section.body_text) %>

--- a/app/components/task_list_component/view.rb
+++ b/app/components/task_list_component/view.rb
@@ -2,7 +2,7 @@ module TaskListComponent
   class View < GovukComponent::Base
     attr_accessor :sections, :completed_task_count, :total_task_count
 
-    Section = Struct.new(:rows, :title, :number, :body_text, keyword_init: true)
+    Section = Struct.new(:rows, :title, :number, :subsection, :body_text, keyword_init: true)
 
     def initialize(completed_task_count: nil, total_task_count: nil, sections: [], classes: [], html_attributes: {})
       @count = 0
@@ -29,9 +29,10 @@ module TaskListComponent
     def build_section(section_fields)
       title = section_fields.fetch(:title)
       rows = section_fields.fetch(:rows) { [] }
-      number = counter
+      number = section_fields.fetch(:section_number)
       body_text = section_fields[:body_text]
-      Section.new(rows: build_rows(rows), title:, number:, body_text:)
+      subsection = section_fields.fetch(:subsection)
+      Section.new(rows: build_rows(rows), title:, number:, body_text:, subsection:)
     end
 
     def build_rows(rows)

--- a/app/components/task_list_component/view.rb
+++ b/app/components/task_list_component/view.rb
@@ -69,6 +69,7 @@ module TaskListComponent
         in_progress: "blue",
         cannot_start: "grey",
         not_started: "grey",
+        optional: "grey",
       }[status.downcase.to_sym]
     end
 

--- a/app/controllers/forms/payment_link_controller.rb
+++ b/app/controllers/forms/payment_link_controller.rb
@@ -1,0 +1,27 @@
+module Forms
+  class PaymentLinkController < ApplicationController
+    after_action :verify_authorized
+
+    def new
+      authorize current_form, :can_view_form?
+      @payment_link_form = PaymentLinkForm.new(form: current_form).assign_form_values
+    end
+
+    def create
+      authorize current_form, :can_view_form?
+      @payment_link_form = PaymentLinkForm.new(payment_link_form_params)
+
+      if @payment_link_form.submit
+        redirect_to form_path(@payment_link_form.form), success: t("banner.success.form.payment_link_saved")
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+  private
+
+    def payment_link_form_params
+      params.require(:forms_payment_link_form).permit(:payment_url).merge(form: current_form)
+    end
+  end
+end

--- a/app/form_objects/forms/payment_link_form.rb
+++ b/app/form_objects/forms/payment_link_form.rb
@@ -1,0 +1,24 @@
+require "uri"
+
+class Forms::PaymentLinkForm < BaseForm
+  attr_accessor :form, :payment_url
+
+  validates :payment_url, url: true, if: -> { payment_url.present? }
+  validate :is_pay_url?, if: -> { payment_url.present? }
+
+  def submit
+    return false if invalid?
+
+    form.payment_url = payment_url
+    form.save!
+  end
+
+  def assign_form_values
+    self.payment_url = form.payment_url
+    self
+  end
+
+  def is_pay_url?
+    errors.add :payment_url, :url unless payment_url.starts_with?("https://www.gov.uk/payments/")
+  end
+end

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -18,10 +18,10 @@ class FormTaskListService
 
   def all_sections
     sections = [
-      section_1,
-      section_3,
-      section_4,
-      section_5,
+      create_form_section,
+      email_address_section,
+      privacy_and_contact_details_section,
+      make_form_live_section,
     ]
 
     sections.insert(1, section_2) if FeatureService.enabled?(:payment_links)
@@ -35,24 +35,24 @@ private
     @form.has_live_version ? "edit" : "create"
   end
 
-  def section_1
+  def create_form_section
     {
-      title: I18n.t("forms.task_list_#{create_or_edit}.section_1.title"),
-      rows: section_1_tasks,
+      title: I18n.t("forms.task_list_#{create_or_edit}.create_form_section.title"),
+      rows: create_form_section_tasks,
     }
   end
 
-  def section_1_tasks
+  def create_form_section_tasks
     question_path = if @form.pages.any?
                       form_pages_path(@form.id)
                     else
                       start_new_question_path(@form.id)
                     end
     [
-      { task_name: I18n.t("forms.task_list_#{create_or_edit}.section_1.name"), path: change_form_name_path(@form.id), status: @task_statuses[:name_status] },
-      { task_name: I18n.t("forms.task_list_#{create_or_edit}.section_1.questions"), path: question_path, status: @task_statuses[:pages_status] },
-      { task_name: I18n.t("forms.task_list_#{create_or_edit}.section_1.declaration"), path: declaration_path(@form.id), status: @task_statuses[:declaration_status] },
-      { task_name: I18n.t("forms.task_list_#{create_or_edit}.section_1.what_happens_next"), path: what_happens_next_path(@form.id), status: @task_statuses[:what_happens_next_status] },
+      { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_section.name"), path: change_form_name_path(@form.id), status: @task_statuses[:name_status] },
+      { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_section.questions"), path: question_path, status: @task_statuses[:pages_status] },
+      { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_section.declaration"), path: declaration_path(@form.id), status: @task_statuses[:declaration_status] },
+      { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_section.what_happens_next"), path: what_happens_next_path(@form.id), status: @task_statuses[:what_happens_next_status] },
     ]
   end
 
@@ -69,16 +69,16 @@ private
     ]
   end
 
-  def section_3
+  def email_address_section
     section = {
-      title: I18n.t("forms.task_list_#{create_or_edit}.section_3.title"),
+      title: I18n.t("forms.task_list_#{create_or_edit}.email_address_section.title"),
     }
 
     if Pundit.policy(@current_user, @form).can_change_form_submission_email?
-      section[:rows] = section_3_tasks
+      section[:rows] = email_address_section_tasks
     else
       section[:body_text] = I18n.t(
-        "forms.task_list_create.section_3.if_not_permitted.body_text",
+        "forms.task_list_create.email_address_section.if_not_permitted.body_text",
         submission_email: @form.submission_email,
       )
     end
@@ -86,43 +86,43 @@ private
     section
   end
 
-  def section_3_tasks
-    hint_text = I18n.t("forms.task_list_#{create_or_edit}.section_3.hint_text_html", submission_email: @form.submission_email) if @form.submission_email.present?
-    [{ task_name: I18n.t("forms.task_list_#{create_or_edit}.section_3.email"), path: submission_email_form_path(@form.id), hint_text:, status: @task_statuses[:submission_email_status] },
-     { task_name: I18n.t("forms.task_list_#{create_or_edit}.section_3.confirm_email"), path: submission_email_code_path(@form.id), status: @task_statuses[:confirm_submission_email_status], active: can_enter_submission_email_code }]
+  def email_address_section_tasks
+    hint_text = I18n.t("forms.task_list_#{create_or_edit}.email_address_section.hint_text_html", submission_email: @form.submission_email) if @form.submission_email.present?
+    [{ task_name: I18n.t("forms.task_list_#{create_or_edit}.email_address_section.email"), path: submission_email_form_path(@form.id), hint_text:, status: @task_statuses[:submission_email_status] },
+     { task_name: I18n.t("forms.task_list_#{create_or_edit}.email_address_section.confirm_email"), path: submission_email_code_path(@form.id), status: @task_statuses[:confirm_submission_email_status], active: can_enter_submission_email_code }]
   end
 
-  def section_4
+  def privacy_and_contact_details_section
     {
-      title: I18n.t("forms.task_list_#{create_or_edit}.section_4.title"),
-      rows: section_4_tasks,
+      title: I18n.t("forms.task_list_#{create_or_edit}.privacy_and_contact_details_section.title"),
+      rows: privacy_and_contact_details_section_tasks,
     }
   end
 
-  def section_4_tasks
+  def privacy_and_contact_details_section_tasks
     [
-      { task_name: I18n.t("forms.task_list_#{create_or_edit}.section_4.privacy_policy"), path: privacy_policy_path(@form.id), status: @task_statuses[:privacy_policy_status] },
-      { task_name: I18n.t("forms.task_list_#{create_or_edit}.section_4.contact_details"), path: contact_details_path(@form.id), status: @task_statuses[:support_contact_details_status] },
+      { task_name: I18n.t("forms.task_list_#{create_or_edit}.privacy_and_contact_details_section.privacy_policy"), path: privacy_policy_path(@form.id), status: @task_statuses[:privacy_policy_status] },
+      { task_name: I18n.t("forms.task_list_#{create_or_edit}.privacy_and_contact_details_section.contact_details"), path: contact_details_path(@form.id), status: @task_statuses[:support_contact_details_status] },
     ]
   end
 
-  def section_5
+  def make_form_live_section
     section = {
-      title: I18n.t("forms.task_list_#{create_or_edit}.section_5.title"),
+      title: I18n.t("forms.task_list_#{create_or_edit}.make_form_live_section.title"),
     }
 
     if Pundit.policy(@current_user, @form).can_make_form_live?
-      section[:rows] = section_5_tasks
+      section[:rows] = make_form_live_section_tasks
     else
-      section[:body_text] = I18n.t("forms.task_list_create.section_5.if_not_permitted.body_text")
+      section[:body_text] = I18n.t("forms.task_list_create.make_form_live_section.if_not_permitted.body_text")
     end
 
     section
   end
 
-  def section_5_tasks
+  def make_form_live_section_tasks
     [{
-      task_name: I18n.t("forms.task_list_#{create_or_edit}.section_5.make_live"),
+      task_name: I18n.t("forms.task_list_#{create_or_edit}.make_form_live_section.make_live"),
       path: @form.all_ready_for_live? ? make_live_path(@form.id) : "",
       status: @task_statuses[:make_live_status],
       active: @form.all_ready_for_live?,

--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -39,6 +39,8 @@ private
     {
       title: I18n.t("forms.task_list_#{create_or_edit}.create_form_section.title"),
       rows: create_form_section_tasks,
+      section_number: 1,
+      subsection: false,
     }
   end
 
@@ -60,6 +62,8 @@ private
     {
       title: I18n.t("forms.task_list_#{create_or_edit}.section_2.title"),
       rows: section_2_tasks,
+      section_number: nil,
+      subsection: true,
     }
   end
 
@@ -72,6 +76,8 @@ private
   def email_address_section
     section = {
       title: I18n.t("forms.task_list_#{create_or_edit}.email_address_section.title"),
+      section_number: 2,
+      subsection: false,
     }
 
     if Pundit.policy(@current_user, @form).can_change_form_submission_email?
@@ -96,6 +102,8 @@ private
     {
       title: I18n.t("forms.task_list_#{create_or_edit}.privacy_and_contact_details_section.title"),
       rows: privacy_and_contact_details_section_tasks,
+      section_number: 3,
+      subsection: false,
     }
   end
 
@@ -109,6 +117,8 @@ private
   def make_form_live_section
     section = {
       title: I18n.t("forms.task_list_#{create_or_edit}.make_form_live_section.title"),
+      section_number: 4,
+      subsection: false,
     }
 
     if Pundit.policy(@current_user, @form).can_make_form_live?

--- a/app/views/forms/payment_link/new.html.erb
+++ b/app/views/forms/payment_link/new.html.erb
@@ -1,0 +1,35 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.payment_link_form'), @payment_link_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(form_path, t("back_link.form_create")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with(model: @payment_link_form, url: payment_link_path) do |f| %>
+      <% if @payment_link_form&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <span class="govuk-caption-l"><%= @payment_link_form.form.name %></span>
+      <h1 class="govuk-heading-l">
+        <%= t('payment_link_form.heading') %>
+      </h1>
+
+      <%= t('payment_link_form.body_html') %>
+
+      <h2 class="govuk-heading-m">
+        <%= t('payment_link_form.how_this_will_work.heading') %>
+      </h2>
+
+      <%= t('payment_link_form.how_this_will_work.body_html') %>
+
+      <h2 class="govuk-heading-m">
+        <%= t('payment_link_form.setting_up_a_payment_link.heading') %>
+      </h2>
+
+      <%= t('payment_link_form.setting_up_a_payment_link.body_html') %>
+
+      <%= f.govuk_text_field :payment_url, label: {  size: 'm' }, spellcheck: "false"  %>
+      <%= f.govuk_submit t('payment_link_form.submit_button') %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,7 @@ en:
         page_moved: "‘%{question_text}’ has moved %{direction} to number %{position}"
         pages_saved: Your questions have been saved
         pages_saved_and_section_completed: Your questions have been saved and marked as complete
+        payment_link_saved: Your payment link has been saved
         privacy_details_saved: Your privacy information link has been saved
         support_details_saved: Your contact details for support have been saved
         what_happens_next_saved: Your information about what happens next has been saved
@@ -621,6 +622,7 @@ en:
     name_settings: Ask for a person’s name
     new_page_form: Edit question
     not_found: Page not found
+    payment_link_form: Add a link to a payment page on GOV.UK Pay
     privacy_policy_form: Provide a link to privacy information for this form
     routing_page: Add a question route
     routing_page_delete: Delete question %{question_position}’s route
@@ -653,6 +655,38 @@ en:
     optional: "%{question_text} (optional)"
     question: Question
     submit_save: Save question
+  payment_link_form:
+    body_html: |
+      <p>You can set up a payment page (called a ‘payment link’) on GOV.UK Pay - this lets someone make a payment after submitting their form. </p>
+
+      <p>You’ll first need to create your payment link in GOV.UK Pay. You can then copy and paste its URL in the box below.</p>
+    heading: Add a link to a payment page on GOV.UK Pay
+    how_this_will_work:
+      body_html: |
+        <p>Once someone's submitted their form they'll see a confirmation page showing: </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>a blue banner saying “You still need to pay”</li>
+          <li>their GOV.UK Forms reference number</li>
+          <li>a green ‘Continue to pay’ button - this will take them to GOV.UK Pay to make their payment</li>
+        </ul>
+
+        <p>The reference number will also be included in a confirmation email,  someone chooses to receive this - along with any 'what happens next' information you've added.</p>
+      heading: How this will work for people filling in your form
+    setting_up_a_payment_link:
+      body_html: |
+        <p>Before you can take payments using a payment link you’ll need to:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>set up a GOV.UK Pay account if you don't have one</li>
+          <li>talk to your local finance team to set up a payment service provider (PSP)</li>
+        </ul>
+
+        <p class="govuk-inset-text">It may be up to several months before you’re ready to take payments. This depends on the PSP arrangements for your department.</p>
+
+        <p><a href="https://www.payments.service.gov.uk/govuk-payment-pages/">Find out more about GOV.UK Pay payment links (opens in a new tab)</a></p>
+      heading: Setting up a ‘payment link’ on GOV.UK Pay
+    submit_button: Save and continue
   phase_banner:
     after_link: will help us improve it.
     before_link: This is a new service, your

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,7 @@ en:
       title_edit: Edit your form
       your_questions: Your questions
     task_list_create:
-      section_1:
+      create_form_section:
         declaration: Add a declaration for people to agree to
         name: Edit the name of your form
         questions: Add and edit your questions
@@ -187,7 +187,7 @@ en:
       section_2:
         payment_link: Add a link to a payment page on GOV.UK Pay
         title: Optional tasks
-      section_3:
+      email_address_section:
         confirm_email: Enter the email address confirmation code
         email: Set the email address completed forms will be sent to
         hint_text_html: Completed forms will be sent to:<br> %{submission_email}
@@ -197,17 +197,17 @@ en:
 
             Editor accounts can change the email address completed forms are sent to.
         title: Set email address for completed forms
-      section_4:
+      privacy_and_contact_details_section:
         contact_details: Provide contact details for support
         privacy_policy: Provide a link to privacy information for this form
         title: Provide privacy and contact details
-      section_5:
+      make_form_live_section:
         if_not_permitted:
           body_text: You cannot make a form live with a trial account.
         make_live: Make your form live
         title: Make your form live
     task_list_edit:
-      section_1:
+      create_form_section:
         declaration: Edit the declaration for people to agree to
         name: Edit the name of your form
         questions: Edit your questions
@@ -216,16 +216,16 @@ en:
       section_2:
         payment_link: Add a link to a payment page on GOV.UK Pay
         title: Optional tasks
-      section_3:
+      email_address_section:
         confirm_email: Enter the email address confirmation code
         email: Edit the email address completed forms will be sent to
         hint_text_html: Completed forms will be sent to:<br> %{submission_email}
         title: Email address for completed forms
-      section_4:
+      privacy_and_contact_details_section:
         contact_details: Edit the contact details for support
         privacy_policy: Edit the link to privacy information for this form
         title: Privacy and contact details
-      section_5:
+      make_form_live_section:
         make_live: Make your changes live
         title: Make your changes live
   forms_delete_confirmation_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,6 +184,9 @@ en:
         title: Create your form
         what_happens_next: Add information about what happens next
       section_2:
+        payment_link: Add a link to a payment page on GOV.UK Pay
+        title: Optional tasks
+      section_3:
         confirm_email: Enter the email address confirmation code
         email: Set the email address completed forms will be sent to
         hint_text_html: Completed forms will be sent to:<br> %{submission_email}
@@ -193,11 +196,11 @@ en:
 
             Editor accounts can change the email address completed forms are sent to.
         title: Set email address for completed forms
-      section_3:
+      section_4:
         contact_details: Provide contact details for support
         privacy_policy: Provide a link to privacy information for this form
         title: Provide privacy and contact details
-      section_4:
+      section_5:
         if_not_permitted:
           body_text: You cannot make a form live with a trial account.
         make_live: Make your form live
@@ -210,15 +213,18 @@ en:
         title: Your form
         what_happens_next: Edit the information about what happens next
       section_2:
+        payment_link: Add a link to a payment page on GOV.UK Pay
+        title: Optional tasks
+      section_3:
         confirm_email: Enter the email address confirmation code
         email: Edit the email address completed forms will be sent to
         hint_text_html: Completed forms will be sent to:<br> %{submission_email}
         title: Email address for completed forms
-      section_3:
+      section_4:
         contact_details: Edit the contact details for support
         privacy_policy: Edit the link to privacy information for this form
         title: Privacy and contact details
-      section_4:
+      section_5:
         make_live: Make your changes live
         title: Make your changes live
   forms_delete_confirmation_form:
@@ -775,6 +781,7 @@ en:
     completed: Completed
     in_progress: In progress
     not_started: Not started
+    optional: Optional
   trial_role_warning:
     content_html: |
       <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,9 +184,6 @@ en:
         questions: Add and edit your questions
         title: Create your form
         what_happens_next: Add information about what happens next
-      section_2:
-        payment_link: Add a link to a payment page on GOV.UK Pay
-        title: Optional tasks
       email_address_section:
         confirm_email: Enter the email address confirmation code
         email: Set the email address completed forms will be sent to
@@ -197,15 +194,18 @@ en:
 
             Editor accounts can change the email address completed forms are sent to.
         title: Set email address for completed forms
-      privacy_and_contact_details_section:
-        contact_details: Provide contact details for support
-        privacy_policy: Provide a link to privacy information for this form
-        title: Provide privacy and contact details
       make_form_live_section:
         if_not_permitted:
           body_text: You cannot make a form live with a trial account.
         make_live: Make your form live
         title: Make your form live
+      privacy_and_contact_details_section:
+        contact_details: Provide contact details for support
+        privacy_policy: Provide a link to privacy information for this form
+        title: Provide privacy and contact details
+      section_2:
+        payment_link: Add a link to a payment page on GOV.UK Pay
+        title: Optional tasks
     task_list_edit:
       create_form_section:
         declaration: Edit the declaration for people to agree to
@@ -213,21 +213,21 @@ en:
         questions: Edit your questions
         title: Your form
         what_happens_next: Edit the information about what happens next
-      section_2:
-        payment_link: Add a link to a payment page on GOV.UK Pay
-        title: Optional tasks
       email_address_section:
         confirm_email: Enter the email address confirmation code
         email: Edit the email address completed forms will be sent to
         hint_text_html: Completed forms will be sent to:<br> %{submission_email}
         title: Email address for completed forms
+      make_form_live_section:
+        make_live: Make your changes live
+        title: Make your changes live
       privacy_and_contact_details_section:
         contact_details: Edit the contact details for support
         privacy_policy: Edit the link to privacy information for this form
         title: Privacy and contact details
-      make_form_live_section:
-        make_live: Make your changes live
-        title: Make your changes live
+      section_2:
+        payment_link: Add a link to a payment page on GOV.UK Pay
+        title: Optional tasks
   forms_delete_confirmation_form:
     confirm_deletion_form: Are you sure you want to delete this draft?
     confirm_deletion_form_live_form: Deleting this draft will not remove the live form.
@@ -671,7 +671,7 @@ en:
           <li>a green ‘Continue to pay’ button - this will take them to GOV.UK Pay to make their payment</li>
         </ul>
 
-        <p>The reference number will also be included in a confirmation email,  someone chooses to receive this - along with any 'what happens next' information you've added.</p>
+        <p>The reference number will also be included in a confirmation email, if someone chooses to receive this - along with any 'what happens next' information you've added.</p>
       heading: How this will work for people filling in your form
     setting_up_a_payment_link:
       body_html: |
@@ -684,7 +684,7 @@ en:
 
         <p class="govuk-inset-text">It may be up to several months before you’re ready to take payments. This depends on the PSP arrangements for your department.</p>
 
-        <p><a href="https://www.payments.service.gov.uk/govuk-payment-pages/">Find out more about GOV.UK Pay payment links (opens in a new tab)</a></p>
+        <p><a href="https://www.payments.service.gov.uk/govuk-payment-pages/" target="_blank" rel="noreferrer noopener">Find out more about GOV.UK Pay payment links (opens in a new tab)</a></p>
       heading: Setting up a ‘payment link’ on GOV.UK Pay
     submit_button: Save and continue
   phase_banner:

--- a/config/locales/forms/payment_link.yml
+++ b/config/locales/forms/payment_link.yml
@@ -1,0 +1,16 @@
+en:
+  helpers:
+    label:
+      forms_payment_link_form:
+        payment_url: Enter the URL of your GOV.UK Pay payment link 
+    hint:
+      forms_payment_link_form:
+        payment_url: |-
+          For example, https://gov.uk/payments/your-payment-link
+  activemodel:
+    errors:
+      models:
+        forms/payment_link_form:
+          attributes:
+            payment_url:
+              url: Enter a link in the correct format, like https://www.gov.uk/payments/organisation/service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
     post "/contact-details" => "forms/contact_details#create", as: :contact_details_create
     get "/declaration" => "forms/declaration#new", as: :declaration
     post "/declaration" => "forms/declaration#create", as: :declaration_create
+    get "/payment-link" => "forms/payment_link#new", as: :payment_link
+    post "/payment-link" => "forms/payment_link#create", as: :payment_link_create
 
     scope "/pages" do
       get "/" => "pages#index", as: :form_pages

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,7 @@ features:
   metrics_for_form_creators_enabled: false
   notify_original_submission_email_of_change: false
   check_your_question_enabled: false
+  payment_links: false
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/spec/components/task_list_component/task_list_component_preview.rb
+++ b/spec/components/task_list_component/task_list_component_preview.rb
@@ -2,6 +2,8 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
   def default
     render(TaskListComponent::View.new(sections: [
       { title: "Make a form",
+        section_number: 1,
+        subsection: false,
         rows: [
           { task_name: "Edit the name of your form", path: "#", status: :completed, active: true },
           { task_name: "Edit the questions of your form", path: "#", status: :not_started, active: true },
@@ -9,13 +11,19 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
           { task_name: "Edit the information about what happens next", path: "#", status: :cannot_start, active: false },
         ] },
       { title: "Do something else with a form",
+        section_number: 2,
+        subsection: false,
         rows: [
           { task_name: "Edit the email address", path: "#", status: :cannot_start },
           { task_name: "Confirm the submission email address", path: "#", status: :cannot_start, active: false },
         ] },
       { title: "Read this",
+        section_number: nil,
+        subsection: true,
         body_text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet ex nisl. Maecenas at erat mi. Nunc feugiat egestas ligula ac feugiat. Nam et dictum felis.\n\nCras cursus leo vitae vestibulum dictum. Donec sit amet turpis faucibus, bibendum leo vel, fermentum lacus." },
       { title: "Do yet another thing with a form",
+        section_number: 3,
+        subsection: false,
         rows: [
           { task_name: "Edit the privacy link", path: "#", status: :cannot_start },
           { task_name: "Edit the contact details", path: "#", status: :cannot_start, active: false },
@@ -31,18 +39,36 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
     render(TaskListComponent::View.new(sections: [{
       title: "Section with body instead of rows",
       body_text: "There are no tasks for you to do yet.\n\nMaybe there will be some later.",
+      section_number: 1,
+      subsection: false,
     }]))
   end
 
   def section_without_body_or_rows
     render(TaskListComponent::View.new(sections: [
-      { title: "Make a form", rows: [] },
+      { title: "Make a form",
+        rows: [],
+        section_number: 1,
+        subsection: false },
+    ]))
+  end
+
+  def subsection
+    render(TaskListComponent::View.new(sections: [
+      { title: "Make a form",
+        rows: [
+          { task_name: "Edit the name of your form", path: "#", active: true },
+        ],
+        section_number: nil,
+        subsection: true },
     ]))
   end
 
   def without_status
     render(TaskListComponent::View.new(sections: [
       { title: "Make a form",
+        section_number: 1,
+        subsection: false,
         rows: [
           { task_name: "Edit the name of your form", path: "#", active: true },
           { task_name: "Edit the email address", path: "#" },
@@ -53,6 +79,8 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
   def with_hint
     render(TaskListComponent::View.new(sections: [
       { title: "Make a form",
+        section_number: 1,
+        subsection: false,
         rows: [
           { task_name: "Edit the name of your form", path: "#", status: :not_started, active: true },
           { task_name: "Edit the questions of your form", path: "#", status: :cannot_start, active: false, hint_text: "You can only complete this step if you have entered a name for your form" },
@@ -65,6 +93,8 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
   def with_confirm_set
     render(TaskListComponent::View.new(sections: [
       { title: "Make a form",
+        section_number: 1,
+        subsection: false,
         rows: [
           { task_name: "Edit the name of your form", path: "#", active: true, status: :completed, hint_text: "Describe your form clearly", confirm_path: "#confirm-path" },
           { task_name: "Edit the questions of your form", path: "#", status: :not_started, active: true },
@@ -80,6 +110,8 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
              total_task_count: "4",
              sections: [
                { title: "Make a form",
+                 section_number: 1,
+                 subsection: false,
                  rows: [
                    { task_name: "Edit the name of your form", path: "#", active: true, status: :completed, hint_text: "Describe your form clearly", confirm_path: "#confirm-path" },
                    { task_name: "Edit the questions of your form", path: "#", status: :not_started, active: true },
@@ -96,6 +128,8 @@ class TaskListComponent::TaskListComponentPreview < ViewComponent::Preview
              total_task_count: "4",
              sections: [
                { title: "Make a form",
+                 section_number: 1,
+                 subsection: false,
                  rows: [
                    { task_name: "Edit the name of your form", path: "#", active: true, status: :completed, hint_text: "Describe your form clearly", confirm_path: "#confirm-path" },
                    { task_name: "Edit the questions of your form", path: "#", status: :completed, active: true },

--- a/spec/components/task_list_component/view_spec.rb
+++ b/spec/components/task_list_component/view_spec.rb
@@ -8,11 +8,15 @@ RSpec.describe TaskListComponent::View, type: :component do
     before do
       render_inline(described_class.new(sections: [
         { title: "section a",
+          section_number: 1,
+          subsection: false,
           rows: [
             { task_name: "task a", path: "#", status:, active: },
             { task_name: "task b", path: "#", status:, active: },
           ] },
         { title: "section 2",
+          section_number: 2,
+          subsection: false,
           rows: [
             { task_name: "task c", path: "#", status:, active: },
             { task_name: "task d", path: "#", status:, active: },
@@ -49,7 +53,7 @@ RSpec.describe TaskListComponent::View, type: :component do
   context "when given a section body instead of any rows" do
     before do
       render_inline(described_class.new(sections: [
-        { title: "section title", body_text: "section body" },
+        { title: "section title", body_text: "section body", section_number: 1, subsection: false },
       ]))
     end
 
@@ -64,6 +68,8 @@ RSpec.describe TaskListComponent::View, type: :component do
     it "can render HTML in the section body" do
       render_inline(described_class.new(sections: [{
         title: "section title",
+        section_number: 1,
+        subsection: false,
         body_text: "section\n\nbody",
       }]))
 
@@ -74,7 +80,7 @@ RSpec.describe TaskListComponent::View, type: :component do
   context "when given an empty rows array" do
     before do
       render_inline(described_class.new(sections: [
-        { title: "section title", rows: [] },
+        { title: "section title", rows: [], section_number: 1, subsection: false },
       ]))
     end
 
@@ -83,15 +89,41 @@ RSpec.describe TaskListComponent::View, type: :component do
     end
   end
 
+  context "when given a subsection" do
+    before do
+      render_inline(described_class.new(sections: [
+        { title: "subsection a",
+          section_number: 1,
+          subsection: true,
+          rows: [
+            { task_name: "task a", path: "#", status:, active: },
+            { task_name: "task b", path: "#", status:, active: },
+          ] },
+      ]))
+    end
+
+    it "renders a level 3 heading with the subsection name" do
+      expect(page).to have_css("h3", text: "subsection a")
+    end
+
+    it "does not show the section number" do
+      expect(page).not_to have_text("1")
+    end
+  end
+
   describe "summary text with count of completed tasks and total number of tasks" do
     context "when given no task completion values" do
       before do
         render_inline(described_class.new(sections: [
           { title: "section a",
+            section_number: 1,
+            subsection: false,
             rows: [
               { task_name: "task a", path: "#", status:, active: },
             ] },
           { title: "section 2",
+            section_number: 2,
+            subsection: false,
             rows: [
               { task_name: "task d", path: "#", status:, active: },
             ] },
@@ -107,10 +139,14 @@ RSpec.describe TaskListComponent::View, type: :component do
       before do
         render_inline(described_class.new(completed_task_count: "23", total_task_count: "34", sections: [
           { title: "section a",
+            section_number: 1,
+            subsection: false,
             rows: [
               { task_name: "task a", path: "#", status:, active: },
             ] },
           { title: "section 2",
+            section_number: 2,
+            subsection: false,
             rows: [
               { task_name: "task d", path: "#", status:, active: },
             ] },
@@ -125,10 +161,14 @@ RSpec.describe TaskListComponent::View, type: :component do
         before do
           render_inline(described_class.new(completed_task_count: "34", total_task_count: "34", sections: [
             { title: "section a",
+              section_number: 1,
+              subsection: false,
               rows: [
                 { task_name: "task a", path: "#", status:, active: },
               ] },
             { title: "section 2",
+              section_number: 2,
+              subsection: false,
               rows: [
                 { task_name: "task d", path: "#", status:, active: },
               ] },

--- a/spec/form_objects/forms/payment_link_form_spec.rb
+++ b/spec/form_objects/forms/payment_link_form_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Forms::PaymentLinkForm, type: :model do
+  describe "Payment URL" do
+    let(:form) do
+      build(:form, :live)
+    end
+
+    context "when given a Pay URL" do
+      it "validates succesfully" do
+        payment_link_form = described_class.new(form:, payment_url: "https://www.gov.uk/payments/test-org/test-service")
+
+        expect(payment_link_form).to be_valid
+      end
+    end
+
+    context "when given a blank payment_url" do
+      it "validates successfully" do
+        payment_link_form = described_class.new(form:, payment_url: "")
+
+        expect(payment_link_form).to be_valid
+      end
+    end
+
+    context "when given a value that is not a url" do
+      it "returns a validation error" do
+        payment_link_form = described_class.new(form:, payment_url: "not-a-url")
+
+        payment_link_form.validate(:payment_url)
+
+        expect(payment_link_form.errors.full_messages_for(:payment_url)).to include(
+          "Payment url Enter a link in the correct format, like https://www.gov.uk/payments/organisation/service",
+        )
+      end
+    end
+
+    context "when given a value that does not start with GOV.UK Pay formatting" do
+      it "returns a validation error" do
+        payment_link_form = described_class.new(form:, payment_url: "http://www.example.com")
+
+        payment_link_form.validate(:payment_url)
+
+        expect(payment_link_form.errors.full_messages_for(:payment_url)).to include(
+          "Payment url Enter a link in the correct format, like https://www.gov.uk/payments/organisation/service",
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/forms/payment_link_controller_spec.rb
+++ b/spec/requests/forms/payment_link_controller_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe Forms::PaymentLinkController, type: :request do
+  let(:form) do
+    build(:form, :live, id: 2, payment_url: "https://www.example.com")
+  end
+
+  let(:updated_form) do
+    new_form = form
+    new_form.payment_url = "https://www.gov.uk/payments/organisation/service"
+    new_form
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+      mock.put "/api/v1/forms/2", req_headers
+    end
+
+    ActiveResourceMock.mock_resource(form,
+                                     {
+                                       read: { response: form, status: 200 },
+                                       update: { response: updated_form, status: 200 },
+                                     })
+
+    login_as_editor_user
+  end
+
+  describe "#new" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.put "/api/v1/forms/2", post_headers
+        mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+      end
+      get payment_link_path(form_id: 2)
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+  end
+
+  describe "#create" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2", req_headers, form.to_json, 200
+        mock.put "/api/v1/forms/2", post_headers
+      end
+      post payment_link_path(form_id: 2), params: { forms_payment_link_form: { payment_url: "https://www.gov.uk/payments/organisation/service" } }
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+
+    it "Updates the form on the API" do
+      expect(updated_form).to have_been_updated
+    end
+
+    it "Redirects you to the form overview page" do
+      expect(response).to redirect_to(form_path(2))
+    end
+  end
+end

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe FormTaskListService do
   let(:current_user) { build(:editor_user) }
 
-  describe ".task_counts" do
+  describe ".task_counts", feature_payment_links: false do
     let(:statuses) { OpenStruct.new(attributes: { declaration_status: "completed", make_live_status: "not_started", name_status: "completed", pages_status: "completed", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "completed" }) }
     let(:form) { build(:form, task_statuses: statuses) }
     let(:email_task_status_service) { instance_double(EmailTaskStatusService) }
@@ -24,6 +24,20 @@ describe FormTaskListService do
         expect(EmailTaskStatusService).to have_received(:new)
         expect(result.task_counts).to eq expected_hash
       end
+
+      context "with payment links enabled", feature_payment_links: true do
+        let(:form_without_payment_link) { build(:form, task_statuses: statuses_without_payment_link) }
+        let(:statuses_without_payment_link) { OpenStruct.new(attributes: { declaration_status: "completed", make_live_status: "not_started", name_status: "completed", pages_status: "completed", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "completed" }) }
+        let(:form_with_payment_link) { build(:form, task_statuses: statuses_with_payment_link) }
+        let(:statuses_with_payment_link) { OpenStruct.new(attributes: { declaration_status: "completed", make_live_status: "not_started", name_status: "completed", pages_status: "completed", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "completed", payment_link_status: "optional" }) }
+
+        it "does not include the payment link status in the task count" do
+          result_without_payment_link = described_class.new(form: form_without_payment_link, current_user:)
+          result_with_payment_link = described_class.new(form: form_with_payment_link, current_user:)
+
+          expect(result_without_payment_link.task_counts).to eq result_with_payment_link.task_counts
+        end
+      end
     end
 
     context "when the user has the trial role" do
@@ -40,7 +54,7 @@ describe FormTaskListService do
     end
   end
 
-  describe "#all_sections" do
+  describe "#all_sections", feature_payment_links: false do
     let(:form) { build(:form, :new_form, id: 1) }
 
     let(:all_sections) { described_class.call(form:, current_user:).all_sections }
@@ -52,6 +66,13 @@ describe FormTaskListService do
     it "returns 4 sections" do
       expected_sections = [{ title: "Task 1" }, { title: "Task 2" }, { title: "Task 3" }, { title: "Task 4" }]
       expect(all_sections.count).to eq expected_sections.count
+    end
+
+    context "when payment links enabled", feature_payment_links: true do
+      it "returns 5 sections" do
+        expected_sections = [{ title: "Task 1" }, { title: "Task 2" }, { title: "Task 3" }, { title: "Task 4" }, { title: "Task 5" }]
+        expect(all_sections.count).to eq expected_sections.count
+      end
     end
 
     describe "section 1 tasks" do
@@ -96,7 +117,20 @@ describe FormTaskListService do
       end
     end
 
-    describe "section 2 tasks" do
+    describe "section 2 tasks", feature_payment_links: true do
+      let(:section) do
+        all_sections[1]
+      end
+
+      let(:section_rows) { section[:rows] }
+
+      it "has link to payment link settings" do
+        expect(section_rows.first[:task_name]).to eq "Add a link to a payment page on GOV.UK Pay"
+        expect(section_rows.first[:path]).to eq "/forms/1/payment-link"
+      end
+    end
+
+    describe "section 3 tasks" do
       let(:section) do
         all_sections[1]
       end
@@ -119,7 +153,7 @@ describe FormTaskListService do
         end
 
         it "has hint text explaining where completed forms will be sent to" do
-          expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_list_create.section_2.hint_text_html", submission_email: form.submission_email)
+          expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_list_create.section_3.hint_text_html", submission_email: form.submission_email)
         end
 
         it "has the correct default status" do
@@ -212,14 +246,14 @@ describe FormTaskListService do
         it "has text explaining where completed forms will be sent to" do
           expect(section[:body_text])
             .to eq I18n.t(
-              "forms.task_list_create.section_2.if_not_permitted.body_text",
+              "forms.task_list_create.section_3.if_not_permitted.body_text",
               submission_email: form.submission_email,
             )
         end
       end
     end
 
-    describe "section 3 tasks" do
+    describe "section 4 tasks" do
       let(:section) do
         all_sections[2]
       end
@@ -242,7 +276,7 @@ describe FormTaskListService do
       end
     end
 
-    describe "section 4 tasks" do
+    describe "section 5 tasks" do
       let(:section) do
         all_sections[3]
       end
@@ -281,11 +315,11 @@ describe FormTaskListService do
         end
 
         it "describes the section title correctly" do
-          expect(section[:title]).to eq I18n.t("forms.task_list_edit.section_4.make_live")
+          expect(section[:title]).to eq I18n.t("forms.task_list_edit.section_5.make_live")
         end
 
         it "describes the task correctly" do
-          expect(section_rows.first[:task_name]).to eq I18n.t("forms.task_list_edit.section_4.make_live")
+          expect(section_rows.first[:task_name]).to eq I18n.t("forms.task_list_edit.section_5.make_live")
         end
       end
 
@@ -299,7 +333,7 @@ describe FormTaskListService do
         it "has text explaining that trial users cannot make forms live" do
           expect(section[:body_text])
             .to eq I18n.t(
-              "forms.task_list_create.section_4.if_not_permitted.body_text",
+              "forms.task_list_create.section_5.if_not_permitted.body_text",
             )
         end
       end

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -75,7 +75,7 @@ describe FormTaskListService do
       end
     end
 
-    describe "section 1 tasks" do
+    describe "create form section tasks" do
       let(:section) do
         all_sections.first
       end
@@ -130,7 +130,7 @@ describe FormTaskListService do
       end
     end
 
-    describe "section 3 tasks" do
+    describe "email address section tasks" do
       let(:section) do
         all_sections[1]
       end
@@ -153,7 +153,7 @@ describe FormTaskListService do
         end
 
         it "has hint text explaining where completed forms will be sent to" do
-          expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_list_create.section_3.hint_text_html", submission_email: form.submission_email)
+          expect(section_rows.first[:hint_text]).to eq I18n.t("forms.task_list_create.email_address_section.hint_text_html", submission_email: form.submission_email)
         end
 
         it "has the correct default status" do
@@ -246,14 +246,14 @@ describe FormTaskListService do
         it "has text explaining where completed forms will be sent to" do
           expect(section[:body_text])
             .to eq I18n.t(
-              "forms.task_list_create.section_3.if_not_permitted.body_text",
+              "forms.task_list_create.email_address_section.if_not_permitted.body_text",
               submission_email: form.submission_email,
             )
         end
       end
     end
 
-    describe "section 4 tasks" do
+    describe "privacy and contact details tasks" do
       let(:section) do
         all_sections[2]
       end
@@ -276,7 +276,7 @@ describe FormTaskListService do
       end
     end
 
-    describe "section 5 tasks" do
+    describe "make form live section tasks" do
       let(:section) do
         all_sections[3]
       end
@@ -315,11 +315,11 @@ describe FormTaskListService do
         end
 
         it "describes the section title correctly" do
-          expect(section[:title]).to eq I18n.t("forms.task_list_edit.section_5.make_live")
+          expect(section[:title]).to eq I18n.t("forms.task_list_edit.make_form_live_section.make_live")
         end
 
         it "describes the task correctly" do
-          expect(section_rows.first[:task_name]).to eq I18n.t("forms.task_list_edit.section_5.make_live")
+          expect(section_rows.first[:task_name]).to eq I18n.t("forms.task_list_edit.make_form_live_section.make_live")
         end
       end
 
@@ -333,7 +333,7 @@ describe FormTaskListService do
         it "has text explaining that trial users cannot make forms live" do
           expect(section[:body_text])
             .to eq I18n.t(
-              "forms.task_list_create.section_5.if_not_permitted.body_text",
+              "forms.task_list_create.make_form_live_section.if_not_permitted.body_text",
             )
         end
       end


### PR DESCRIPTION
### What problem does this pull request solve?
https://trello.com/c/VEe72eLB/1357-add-backend-code-to-support-saving-payment-links-for-a-form

This PR relies on changes to forms-api here https://github.com/alphagov/forms-api/pull/443

Work here is mainly behind the `payment_links` feature flag.

Adds an optional section to the task list, in which a payment link can be set. 

For a payment link to be valid, it needs to be a url which matches this regex `/\Ahttps:\/\/www\.gov\.uk\/payments\/.+\/.+/` - in other words, it goes https://www.gov.uk/payments/something/something

Payment links are not currently used in the runner, so adding them will not affect the previews for forms.
### Things to consider when reviewing


- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
