### PR TITLE
Fix `User#role_changed_to_editor?`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,7 +94,12 @@ class User < ApplicationRecord
   end
 
   def role_changed_to_editor?
-    role_changed_to_editor = editor? && !versions.empty? && versions.last.reify.role != "editor"
+    return false unless editor?
+
+    last_version = !versions.empty? && versions.last.reify
+    return false unless last_version
+
+    role_changed_to_editor = last_version.role != "editor"
     if role_changed_to_editor
       self.paper_trail_event = "Role upgrade reported"
       paper_trail.save_with_version

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -340,6 +340,16 @@ describe User, type: :model do
           end
         end
       end
+
+      %i[editor super_admin].each do |role|
+        context "when user is created with #{role} role" do
+          let(:user) { create :user, role: }
+
+          it "returns false" do
+            expect(user.role_changed_to_editor?).to be false
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When a user has been created with an editor role the `role_changed_to_editor?` method raised the exception:

```
undefined method `role' for nil:NilClass
```

This was happening because the reification of the last version was `nil`.

I found this when playing around in local development with the `developer` auth provider and signing in as one of the users from the database seed. Currently in production users won't be created with the editor role, but that might change, so I fixed it. Plus it's nice not to have errors in development :sweat_smile:.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?