### PR TITLE
Rename ID param in groups routing

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -59,7 +59,7 @@ private
 
   # Use callbacks to share common setup or constraints between actions.
   def set_group
-    @group = Group.find_by(external_id: params[:external_id])
+    @group = Group.find_by(external_id: params[:group_id])
   end
 
   # Only allow a list of trusted parameters through.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,7 +131,7 @@ Rails.application.routes.draw do
     get "/signed", to: "mou_signatures#confirmation", as: :confirmation
   end
 
-  resources :groups, param: :external_id
+  resources :groups, param: :group_id
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page
   match "/403", to: "errors#forbidden", as: :error_403, via: :all

--- a/spec/routing/groups_routing_spec.rb
+++ b/spec/routing/groups_routing_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe GroupsController, type: :routing do
     end
 
     it "routes to #show" do
-      expect(get: "/groups/1").to route_to("groups#show", external_id: "1")
+      expect(get: "/groups/1").to route_to("groups#show", group_id: "1")
     end
 
     it "routes to #edit" do
-      expect(get: "/groups/1/edit").to route_to("groups#edit", external_id: "1")
+      expect(get: "/groups/1/edit").to route_to("groups#edit", group_id: "1")
     end
 
     it "routes to #create" do
@@ -23,15 +23,22 @@ RSpec.describe GroupsController, type: :routing do
     end
 
     it "routes to #update via PUT" do
-      expect(put: "/groups/1").to route_to("groups#update", external_id: "1")
+      expect(put: "/groups/1").to route_to("groups#update", group_id: "1")
     end
 
     it "routes to #update via PATCH" do
-      expect(patch: "/groups/1").to route_to("groups#update", external_id: "1")
+      expect(patch: "/groups/1").to route_to("groups#update", group_id: "1")
     end
 
     it "routes to #destroy" do
-      expect(delete: "/groups/1").to route_to("groups#destroy", external_id: "1")
+      expect(delete: "/groups/1").to route_to("groups#destroy", group_id: "1")
+    end
+  end
+
+  describe "path helpers" do
+    it "uses the external ID" do
+      group = create :group
+      expect(get: group_path(group)).to route_to("groups#show", group_id: group.external_id)
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be able to use `:group_id` in other routes in future, this commit renames the param for the `/groups` resource routes, which influences routes under that path. This will be useful when we start having sub-resources, such as forms in groups.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?