### PR TITLE
Remove mismatched memberships

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -6,6 +6,10 @@ class Membership < ApplicationRecord
   validate :user_and_group_in_same_organisation
   validates :user, uniqueness: { scope: :group }
 
+  def self.destroy_invalid_organisation_memberships(user)
+    Membership.joins(:group).where(user:).where.not(groups: { organisation_id: user.organisation_id }).destroy_all
+  end
+
 private
 
   def user_and_group_in_same_organisation

--- a/app/service/user_update_service.rb
+++ b/app/service/user_update_service.rb
@@ -15,6 +15,7 @@ private
   def on_user_update
     add_organisation_to_user_forms if @user.trial_user_upgraded?
     add_organisation_to_user_mou if @user.given_organisation?
+    update_user_memberships
   end
 
   def add_organisation_to_user_forms
@@ -23,5 +24,9 @@ private
 
   def add_organisation_to_user_mou
     MouSignature.add_mou_signature_organisation(@user)
+  end
+
+  def update_user_memberships
+    Membership.destroy_invalid_organisation_memberships(@user)
   end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -45,15 +45,44 @@ RSpec.describe Membership, type: :model do
     expect { membership.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
   end
 
-  it "removes mismatched memberships" do
-    org1 = create :organisation, id: 1, slug: "test-org"
-    org2 = create :organisation, id: 2, slug: "ministry-of-testing"
-    user = create :user, organisation: org1
-    group = create :group, organisation: org1
-    membership = create(:membership, user:, group:)
+  describe ".destroy_invalid_organisation_memberships" do
+    it "does not remove memberships for the same organisation" do
+      org1 = create :organisation, id: 1, slug: "test-org"
+      user = create :user, organisation: org1
+      group = create :group, organisation: org1
+      membership = create(:membership, user:, group:)
 
-    user.organisation = org2
-    described_class.destroy_invalid_organisation_memberships(user)
-    expect(described_class.exists?(membership.id)).to be false
+      described_class.destroy_invalid_organisation_memberships(user)
+      expect(described_class.exists?(membership.id)).to be true
+    end
+
+    it "removes mismatched memberships" do
+      org1 = create :organisation, id: 1, slug: "test-org"
+      org2 = create :organisation, id: 2, slug: "ministry-of-testing"
+      user = create :user, organisation: org1
+      group = create :group, organisation: org1
+      membership = create(:membership, user:, group:)
+
+      user.organisation = org2
+      described_class.destroy_invalid_organisation_memberships(user)
+      expect(described_class.exists?(membership.id)).to be false
+    end
+
+    it "does not remove memberships for other users" do
+      org1 = create :organisation, id: 1, slug: "test-org"
+      org2 = create :organisation, id: 2, slug: "ministry-of-testing"
+
+      user1 = create :user, organisation: org1
+      user2 = create :user, organisation: org1
+
+      group = create :group, organisation: org1
+      create(:membership, user: user1, group:)
+      membership2 = create(:membership, user: user2, group:)
+
+      user2.organisation = org2
+
+      described_class.destroy_invalid_organisation_memberships(user1)
+      expect(described_class.exists?(membership2.id)).to be true
+    end
   end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -44,4 +44,16 @@ RSpec.describe Membership, type: :model do
     membership = build(:membership, user:, group:)
     expect { membership.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
   end
+
+  it "removes mismatched memberships" do
+    org1 = create :organisation, id: 1, slug: "test-org"
+    org2 = create :organisation, id: 2, slug: "ministry-of-testing"
+    user = create :user, organisation: org1
+    group = create :group, organisation: org1
+    membership = create(:membership, user:, group:)
+
+    user.organisation = org2
+    described_class.destroy_invalid_organisation_memberships(user)
+    expect(described_class.exists?(membership.id)).to be false
+  end
 end

--- a/spec/service/user_update_service_spec.rb
+++ b/spec/service/user_update_service_spec.rb
@@ -14,18 +14,35 @@ describe UserUpdateService do
       expect(user_update_service.update_user).to be true
     end
 
-    it "does not run add_organisation_to_user_forms if user is not updated" do
-      allow(user).to receive(:update).and_return(false)
-      allow(Form).to receive(:update_organisation_for_creator)
+    it "calls remove_membership if user is updated" do
+      allow(user).to receive(:update).and_return(true)
+      allow(Membership).to receive(:destroy_invalid_organisation_memberships)
       user_update_service.update_user
-      expect(Form).not_to have_received(:update_organisation_for_creator)
+      expect(Membership).to have_received(:destroy_invalid_organisation_memberships).with(user)
     end
 
-    it "does not run add_organisation_to_user_mou if user is not updated" do
-      allow(user).to receive(:update).and_return(false)
-      allow(MouSignature).to receive(:add_mou_signature_organisation)
-      user_update_service.update_user
-      expect(MouSignature).not_to have_received(:add_mou_signature_organisation)
+    context "when user is not updated" do
+      before do
+        allow(user).to receive(:update).and_return(false)
+      end
+
+      it "does not run add_organisation_to_user_forms if user is not updated" do
+        allow(Form).to receive(:update_organisation_for_creator)
+        user_update_service.update_user
+        expect(Form).not_to have_received(:update_organisation_for_creator)
+      end
+
+      it "does not run add_organisation_to_user_mou if user is not updated" do
+        allow(MouSignature).to receive(:add_mou_signature_organisation)
+        user_update_service.update_user
+        expect(MouSignature).not_to have_received(:add_mou_signature_organisation)
+      end
+
+      it "does not call remove_membership if user is not updated" do
+        allow(Membership).to receive(:destroy_invalid_organisation_memberships)
+        user_update_service.update_user
+        expect(Membership).not_to have_received(:destroy_invalid_organisation_memberships).with(user)
+      end
     end
 
     context "when changing user role" do


### PR DESCRIPTION
### Remove old organisation groups when a member changes organisation

Trello card: https://trello.com/c/elvPhWEc/1381-add-association-between-groups-users-and-forms-slice-2

When a User changes organisation they should no longer be a member of the old organisation's groups.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
