### PR TITLE
Add join model for groups and forms

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,6 +4,8 @@ class Group < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
 
+  has_many :group_forms, dependent: :restrict_with_exception
+
   validates :name, presence: true
   before_create :set_external_id
 

--- a/app/models/group_form.rb
+++ b/app/models/group_form.rb
@@ -1,0 +1,10 @@
+class GroupForm < ApplicationRecord
+  self.primary_key = %i[form_id group_id]
+  self.table_name = :groups_form_ids
+
+  belongs_to :group
+
+  def form
+    Form.find(form_id)
+  end
+end

--- a/db/migrate/20240227074047_create_join_table_form_group.rb
+++ b/db/migrate/20240227074047_create_join_table_form_group.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableFormGroup < ActiveRecord::Migration[7.1]
+  def change
+    create_join_table :forms, :groups, table_name: :groups_form_ids do |t|
+      t.index :group_id
+      t.index :form_id, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_23_134039) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_27_074047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_23_134039) do
     t.bigint "organisation_id"
     t.index ["external_id"], name: "index_groups_on_external_id", unique: true
     t.index ["organisation_id"], name: "index_groups_on_organisation_id"
+  end
+
+  create_table "groups_form_ids", id: false, force: :cascade do |t|
+    t.bigint "form_id", null: false
+    t.bigint "group_id", null: false
+    t.index ["form_id"], name: "index_groups_form_ids_on_form_id", unique: true
+    t.index ["group_id"], name: "index_groups_form_ids_on_group_id"
   end
 
   create_table "memberships", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,7 +46,10 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create_list :user, 3, :with_trial_role
 
   # create some test groups
-  FactoryBot.create :group, name: "Test Service", organisation: gds
+  test_group = FactoryBot.create :group, name: "Test Service", organisation: gds
   FactoryBot.create :group, name: "Ministry of Tests forms", organisation: test_org
   FactoryBot.create :group, name: "Ministry of Tests forms - secret!", organisation: test_org
+
+  # Add a form to a group
+  test_group.group_forms.create! form_id: 1
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/elvPhWEc/1381-add-association-between-groups-users-and-forms-slice-2 <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We would like groups to have zero or more forms.

Ideally we would do this without adding data to the form record in the forms-api database about data in the forms-admin database. This leads us to using a join table, so we can associate groups with forms but also do the reverse lookup. Normally to use a join table in Rails we use the `has_and_belongs_to_many` association [[1]]. However, models in ActiveResource cannot be associated with models in ActiveRecord [[2]]. This means we can't use any of the usual methods to maintain the association.

I spent a long time banging my head against the wall trying to find a way around this. This commit takes the approach of having an explicit join model. It's clunky, but is the best approach I've tried so far. It doesn't rely too much on understanding Rails magic, and it doesn't require writing any SQL.

Probably the proper fix for this issue is keeping the form records and the group records in the same database, but that is outside the scope of the ticket I'm working on.

[1]: https://guides.rubyonrails.org/association_basics.html#the-has-and-belongs-to-many-association
[2]: https://github.com/rails/activeresource/issues/292

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?