### PR TITLE
Fix govuk-typography-responsive deprecation warning

### DIFF
--- a/app/components/metrics_summary_component/_index.scss
+++ b/app/components/metrics_summary_component/_index.scss
@@ -9,7 +9,7 @@
 }
 
 .app-metrics__big-number {
-  @include govuk-typography-responsive(19);
+  @include govuk-font-size(19);
   @include govuk-typography-common;
 
   padding: govuk-spacing(1) govuk-spacing(0);
@@ -28,7 +28,7 @@
 }
 
 .app-metrics__big-number-number {
-  @include govuk-typography-responsive(48);
+  @include govuk-font-size(48);
   @include govuk-typography-weight-bold;
 
   display: block;


### PR DESCRIPTION
### What problem does this pull request solve?

Fixes a deprecation warning in govuk-frontend related to the govuk-typography-responsive mixin. This mixin was renamed `govuk-font-size` in [v5.1.0 of GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/releases/tag/v5.1.0) and the old name is now deprecated.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
