### PR TITLE
Add list of forms to group show view

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -11,6 +11,7 @@ class GroupsController < ApplicationController
   # GET /groups/1
   def show
     authorize @group
+    @forms = @group.group_forms.map(&:form)
   end
 
   # GET /groups/new

--- a/app/service/form_list_service.rb
+++ b/app/service/form_list_service.rb
@@ -3,7 +3,7 @@ class FormListService
   include ActionView::Helpers::UrlHelper
   include GovukRailsCompatibleLinkHelper
 
-  attr_accessor :forms, :current_user, :organisation
+  attr_accessor :forms, :current_user, :organisation, :group
 
   class << self
     def call(**args)
@@ -11,10 +11,11 @@ class FormListService
     end
   end
 
-  def initialize(forms:, current_user:, organisation: nil)
+  def initialize(forms:, current_user:, organisation: nil, group: nil)
     @forms = forms
     @current_user = current_user
     @organisation = organisation || (current_user.trial? ? nil : current_user.organisation)
+    @group = group
     unless current_user.trial?
       @list_of_creator_id = forms.map(&:creator_id).uniq
       @list_of_creators = User.where(id: @list_of_creator_id)
@@ -34,6 +35,8 @@ class FormListService
 private
 
   def caption
+    return I18n.t("groups.form_table_caption", group_name: group.name) if group.present?
+
     return I18n.t("home.your_forms") if organisation.blank?
 
     I18n.t("home.form_table_caption", organisation_name: organisation.name)

--- a/app/views/groups/_group.html.erb
+++ b/app/views/groups/_group.html.erb
@@ -1,3 +1,1 @@
 <h1 class="govuk-heading-l"><%= group.name %></h1>
-
-<p class="govuk-body">There is nothing to show about groups yet.</p>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,14 +1,15 @@
 <% content_for :back_link, govuk_back_link_to(groups_path, t("back_link.groups")) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<%= render @group %>
 
-    <%= render @group %>
+<div class="govuk-button-group">
+  <%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %>
+</div>
 
-    <div>
-      <%= govuk_button_link_to("Edit group", edit_group_path(@group), class: "govuk-!-margin-bottom-3 govuk-!-margin-top-3" ) %>
-      <%= govuk_button_to("Delete group", @group, method: :delete, warning: true, class: "govuk-!-margin-bottom-3 govuk-!-margin-top-3" ) %>
-    </div>
+<% if @forms.any? %>
+  <%= govuk_table(**FormListService.call(forms: @forms, current_user: @current_user, group: @group).data) %>
+<% end %>
 
-  </div>
+<div>
+  <%= govuk_button_to("Delete group", @group, method: :delete, warning: true, class: "govuk-!-margin-bottom-3 govuk-!-margin-top-3" ) %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,6 +232,10 @@ en:
     confirm_deletion_form: Are you sure you want to delete this draft?
     confirm_deletion_form_live_form: Deleting this draft will not remove the live form.
     confirm_deletion_page: Are you sure you want to delete this page?
+  groups:
+    form_table_caption: Forms in ‘%{group_name}’
+    show:
+      edit_group_name: Change the name of this group
   guidance:
     add_guidance: Add guidance
     guidance: Guidance

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -1,14 +1,70 @@
 require "rails_helper"
 
 RSpec.describe "groups/show", type: :view do
-  let(:group) { create :group, name: "Name" }
+  let(:current_user) { create :user }
+  let(:forms) { [] }
+  let(:group) { create :group, name: "My Group" }
 
   before do
+    assign(:current_user, current_user)
     assign(:group, group)
+    assign(:forms, forms)
+    render
   end
 
-  it "renders attributes in <p>" do
-    render
-    expect(rendered).to match(/Name/)
+  it "renders the group name in <h1>" do
+    expect(rendered).to have_css "h1.govuk-heading-l", text: "My Group"
+  end
+
+  it "has a link to the change group name page" do
+    expect(rendered).to have_link "Change the name of this group", href: edit_group_path(group)
+  end
+
+  context "when the group has no forms" do
+    let(:forms) { [] }
+
+    it "does not have a table of forms" do
+      expect(rendered).not_to have_table
+    end
+  end
+
+  context "when the group has one of more forms" do
+    let(:forms) do
+      [
+        build(:form, id: 1, name: "Form 1", has_draft_version: true, has_live_version: false),
+        build(:form, id: 2, name: "Form 2", has_draft_version: false, has_live_version: true),
+        build(:form, id: 3, name: "Form 3", has_draft_version: true, has_live_version: true),
+      ]
+    end
+
+    it "renders a table listing the forms" do
+      expect(rendered).to have_table "Forms in ‘My Group’"
+      expect(rendered).to have_css "tbody .govuk-table__row", count: 3
+    end
+
+    it "renders a link for each form" do
+      expect(rendered).to have_link("Form 1", href: form_path(1))
+      expect(rendered).to have_link("Form 2", href: live_form_path(2))
+      expect(rendered).to have_link("Form 3", href: live_form_path(3))
+    end
+
+    it "renders a status tag for each form" do
+      page = Capybara.string(rendered.html)
+      table_rows = page.find_all("tbody .govuk-table__row")
+      status_tags = table_rows.map do |row|
+        row.find_all(".govuk-tag").map do |status_tag|
+          {
+            text: status_tag.text,
+            colour: status_tag[:class].delete_prefix("govuk-tag govuk-tag--").strip,
+          }
+        end
+      end
+
+      expect(status_tags).to eq [
+        [{ text: "Draft", colour: "yellow" }],
+        [{ text: "Live", colour: "turquoise" }],
+        [{ text: "Draft", colour: "yellow" }, { text: "Live", colour: "turquoise" }],
+      ]
+    end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/elvPhWEc/1381-add-association-between-groups-users-and-forms-slice-2 <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Update the group show view to render a list of the forms associated with that group.

### Screenshots

![Screenshot of group page with three forms](https://github.com/alphagov/forms-admin/assets/503614/f2617282-c5f9-419e-b402-a83131001d83)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?