### PR TITLE
Rework payment link page content

### DIFF
--- a/app/views/forms/payment_link/new.html.erb
+++ b/app/views/forms/payment_link/new.html.erb
@@ -17,16 +17,30 @@
       <%= t('payment_link_form.body_html') %>
 
       <h2 class="govuk-heading-m">
+        <%= t('payment_link_form.setting_up_govuk_pay.heading') %>
+      </h2>
+
+      <%= t('payment_link_form.setting_up_govuk_pay.body_html') %>
+
+      <h2 class="govuk-heading-m">
+        <%= t('payment_link_form.creating_your_payment_link.heading') %>
+      </h2>
+
+      <p><%= t('payment_link_form.creating_your_payment_link.body') %></p>
+
+      <h3 class="govuk-heading-s"><%= t('payment_link_form.set_up_your_payment_link.heading') %></h3>
+
+      <%= t('payment_link_form.set_up_your_payment_link.body_html') %>
+
+      <h3 class="govuk-heading-s"><%= t('payment_link_form.how_this_will_help_processors.heading') %></h3>
+
+      <%= t('payment_link_form.how_this_will_help_processors.body_html') %>
+
+      <h2 class="govuk-heading-m">
         <%= t('payment_link_form.how_this_will_work.heading') %>
       </h2>
 
       <%= t('payment_link_form.how_this_will_work.body_html') %>
-
-      <h2 class="govuk-heading-m">
-        <%= t('payment_link_form.setting_up_a_payment_link.heading') %>
-      </h2>
-
-      <%= t('payment_link_form.setting_up_a_payment_link.body_html') %>
 
       <%= f.govuk_text_field :payment_url, label: {  size: 'm' }, spellcheck: "false"  %>
       <%= f.govuk_submit t('payment_link_form.submit_button') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -657,35 +657,59 @@ en:
     submit_save: Save question
   payment_link_form:
     body_html: |
-      <p>You can set up a payment page (called a ‘payment link’) on GOV.UK Pay - this lets someone make a payment after submitting their form. </p>
+      <p>You can use <a href="https://payments.service.gov.uk/" target="_blank"" rel="noreferrer noopener"">GOV.UK Pay (opens in a new tab)</a> to set up a payment page (called a ‘payment link’).</p>
 
-      <p>You’ll first need to create your payment link in GOV.UK Pay. You can then copy and paste its URL in the box below.</p>
+      <p>Once it’s set up, you can copy and paste the payment link URL into the box below. This will add a payment page to the end of your form.</p>
+    creating_your_payment_link:
+      body: Once you have a GOV.UK Pay account you can “add a new service” and start creating your payment link.
+      heading: Creating your payment link in GOV.UK Pay
     heading: Add a link to a payment page on GOV.UK Pay
+    how_this_will_help_processors:
+      body_html: |
+        <p>The form reference number will be included in the form submission email sent to your processing email address.</p>
+
+        <p>This can help match up form submissions with payments in GOV.UK Pay.</p>
+
+        <p><a href="https://www.payments.service.gov.uk/govuk-payment-pages/" target="_blank" rel="noreferrer noopener">Find out more about creating a GOV.UK Pay payment link (opens in a new tab)</a></p>
+      heading: How this will help people processing your forms
     how_this_will_work:
       body_html: |
-        <p>Once someone's submitted their form they'll see a confirmation page showing: </p>
+        <p>Once someone’s submitted their form they’ll see a confirmation page showing:</p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li>a blue banner saying “You still need to pay”</li>
-          <li>their GOV.UK Forms reference number</li>
-          <li>a green ‘Continue to pay’ button - this will take them to GOV.UK Pay to make their payment</li>
+          <li>their form’s unique reference number</li>
+          <li>the ‘what happens next’ information you’ve added</li>
+          <li>a green “Continue to pay” button - this will take them to GOV.UK Pay to make their payment</li>
         </ul>
 
-        <p>The reference number will also be included in a confirmation email, if someone chooses to receive this - along with any 'what happens next' information you've added.</p>
+        <p>The reference number, payment link and ‘what happens next’ information will also be included in a confirmation email for form fillers - if they choose to receive this.</p>
       heading: How this will work for people filling in your form
-    setting_up_a_payment_link:
+    set_up_your_payment_link:
       body_html: |
-        <p>Before you can take payments using a payment link you’ll need to:</p>
+        <p>GOV.UK Forms adds a unique 8-character reference to each form submission.</p>
+
+        <p>When creating a payment link in GOV.UK Pay, you’ll be asked “Do your users already have a payment reference?”</p>
+
+        <p>Select “Yes”.</p>
+
+        <p>This means the form reference number will automatically be sent through to GOV.UK Pay when someone makes a payment.</p>
+
+        <p>When asked to fill in the “Name of payment reference” field, enter “Form reference number”.</p>
+      heading: Set up your payment link to use a form’s unique reference number
+    setting_up_govuk_pay:
+      body_html: |
+        <p>You’ll need to set up a GOV.UK Pay account if you do not already have one.</p>
+
+        <p>You’ll also need to talk to your organisation’s finance team to:</p>
 
         <ul class="govuk-list govuk-list--bullet">
-          <li>set up a GOV.UK Pay account if you don't have one</li>
-          <li>talk to your local finance team to set up a payment service provider (PSP)</li>
+          <li>make sure you’re allowed to take payments in this way</li>
+          <li>set up a payment service provider (PSP)</li>
         </ul>
 
-        <p class="govuk-inset-text">It may be up to several months before you’re ready to take payments. This depends on the PSP arrangements for your department.</p>
-
-        <p><a href="https://www.payments.service.gov.uk/govuk-payment-pages/" target="_blank" rel="noreferrer noopener">Find out more about GOV.UK Pay payment links (opens in a new tab)</a></p>
-      heading: Setting up a ‘payment link’ on GOV.UK Pay
+        <p class="govuk-inset-text">It could be up to several months before you’re ready to take payments. This depends on the PSP arrangements for your organisation.</p>
+      heading: Setting up GOV.UK Pay
     submit_button: Save and continue
   phase_banner:
     after_link: will help us improve it.

--- a/spec/views/forms/payment_link/new.html.erb_spec.rb
+++ b/spec/views/forms/payment_link/new.html.erb_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe "forms/payment_link/new.html.erb" do
+  let(:current_form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1") }
+  let(:payment_link_form) { Forms::PaymentLinkForm.new(form: current_form).assign_form_values }
+
+  before do
+    assign(:payment_link_form, payment_link_form)
+    allow(view).to receive(:form_path).and_return("/forms/1")
+    allow(view).to receive(:payment_link_path).and_return("/forms/1/payment-link")
+    render template: "forms/payment_link/new"
+  end
+
+  it "contains a top-level heading" do
+    expect(rendered).to have_css("h1", text: I18n.t("payment_link_form.heading"))
+  end
+
+  it "contains the introductory paragraph" do
+    expect(rendered).to include(I18n.t("payment_link_form.body_html"))
+  end
+
+  it "contains information about setting up GOV.UK Pay" do
+    expect(rendered).to have_css("h2", text: I18n.t("payment_link_form.setting_up_govuk_pay.heading"))
+    expect(rendered).to include(I18n.t("payment_link_form.setting_up_govuk_pay.body_html"))
+  end
+
+  it "contains information about creating your payment link" do
+    expect(rendered).to have_css("h2", text: I18n.t("payment_link_form.creating_your_payment_link.heading"))
+    expect(rendered).to have_text(I18n.t("payment_link_form.creating_your_payment_link.body"))
+  end
+
+  it "contains information about setting up your payment link with a reference number" do
+    expect(rendered).to have_css("h3", text: I18n.t("payment_link_form.set_up_your_payment_link.heading"))
+    expect(rendered).to include(I18n.t("payment_link_form.set_up_your_payment_link.body_html"))
+  end
+
+  it "contains information about how this helps processors" do
+    expect(rendered).to have_css("h3", text: I18n.t("payment_link_form.how_this_will_help_processors.heading"))
+    expect(rendered).to include(I18n.t("payment_link_form.how_this_will_help_processors.body_html"))
+  end
+
+  it "contains information about how this appears to form fillers" do
+    expect(rendered).to have_css("h2", text: I18n.t("payment_link_form.how_this_will_work.heading"))
+    expect(rendered).to include(I18n.t("payment_link_form.how_this_will_work.body_html"))
+  end
+
+  it "includes a form field for entering your link" do
+    expect(rendered).to have_field(I18n.t("helpers.label.forms_payment_link_form.payment_url"))
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/sPNwCAJJ/1391-iterate-design-content-for-payment-links-feature-following-testing

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Since our initial implementation of the payment link page, the MVP content has changed. This PR updates the page to match those changes. The main changes are:

- a small update to the order of the page
- a new 'Creating your payment link in GOV.UK Pay' section which covers the specifics of setting up a GOV.UK Pay link to receive a reference from Forms.

This PR also adds a view test to give us more confidence that this page is displaying correctly.

### Screenshots:
#### Before
![Screen Shot 2024-03-07 at 12 35 18](https://github.com/alphagov/forms-admin/assets/5861235/eac4a76b-5afc-4777-ba8c-e34c350d0236)

#### After
![Screen Shot 2024-03-07 at 12 33 46](https://github.com/alphagov/forms-admin/assets/5861235/5b94e240-78b0-4ead-91f1-c6eb407a1a71)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
