### PR TITLE
Remove specification of Auth0 connection

### DIFF
--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -12,7 +12,6 @@ Rails.application.config.before_initialize do
       env["omniauth.strategy"].options[:domain] = Settings.auth0.domain
       env["omniauth.strategy"].options[:authorize_params] = {
         scope: "openid email",
-        connection: is_e2e ? "Username-Password-Authentication" : "email",
       }
 
       # append the auth query param in e2e tests to ensure the correct client is used in the callback

--- a/spec/integration/auth0_spec.rb
+++ b/spec/integration/auth0_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "usage of omniauth-auth0 gem" do
       expect(strategy.options[:client_id]).to eq("4321")
       expect(strategy.options[:client_secret]).to eq("dcba")
       expect(strategy.options[:callback_path]).to eq("/auth/auth0/callback?auth=e2e")
-      expect(strategy.options[:authorize_params][:connection]).to eq("Username-Password-Authentication")
+      expect(strategy.options[:authorize_params][:connection]).to be_nil
     end
 
     it "uses default client when auth is not set to e2e" do
@@ -134,7 +134,7 @@ RSpec.describe "usage of omniauth-auth0 gem" do
       expect(strategy.options[:client_id]).to eq("1234")
       expect(strategy.options[:client_secret]).to eq("abcd")
       expect(strategy.options[:callback_path]).to eq("/auth/auth0/callback")
-      expect(strategy.options[:authorize_params][:connection]).to eq("email")
+      expect(strategy.options[:authorize_params][:connection]).to be_nil
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?
In order for the home realm discovery feature of Auth0's Google Workspace integration to work, we need to stop specifying the connection Auth0 should use, so that it can be inferred by Auth0 based on email address domain.

This will effectively switch on Google login for all users with the "digital.cabinet-office.gov.uk" email address domain.

The restriction of access to super-admins logging in via any other mechanism will be in a subsequent PR.

Trello card: https://trello.com/c/UdtU9PZC

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
