### PR TITLE
Restrict access to Groups to members

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -29,6 +29,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     @group.organisation = current_user.organisation
+    @group.memberships.build(user: current_user, added_by: current_user)
 
     authorize @group
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,6 +6,8 @@ class Group < ApplicationRecord
 
   has_many :group_forms, dependent: :restrict_with_exception
 
+  scope :for_user, ->(user) { joins(:memberships).where(memberships: { user_id: user.id }) }
+
   validates :name, presence: true
   before_create :set_external_id
 

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -8,6 +8,7 @@ class GroupPolicy < ApplicationPolicy
     user.super_admin? || user.organisation_id == record.organisation_id
   end
   alias_method :edit?, :show?
+  alias_method :index?, :show?
   alias_method :update?, :edit?
   alias_method :destroy?, :edit?
 
@@ -16,7 +17,7 @@ class GroupPolicy < ApplicationPolicy
       if user.super_admin?
         scope.all
       else
-        scope.where(organisation_id: user.organisation_id)
+        scope.for_user(user)
       end
     end
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -125,4 +125,36 @@ RSpec.describe Group, type: :model do
       expect { group.destroy! }.to raise_error ActiveRecord::DeleteRestrictionError
     end
   end
+
+  describe "scopes" do
+    describe ".for_user" do
+      it "returns groups that the user is a member of" do
+        user = create :user
+        group1 = create :group
+        group2 = create :group
+        create :group
+        create :membership, user:, group: group1
+        create :membership, user:, group: group2
+
+        expect(described_class.for_user(user)).to eq [group1, group2]
+      end
+
+      it "returns an empty array if the user is not a member of any groups" do
+        user = create :user
+        create :group
+
+        expect(described_class.for_user(user)).to eq []
+      end
+
+      it "does not return groups that the user is not a member of" do
+        user = create :user
+        group1 = create :group
+        create :group
+        create :group
+        create :membership, user:, group: group1
+
+        expect(described_class.for_user(user)).to eq [group1]
+      end
+    end
+  end
 end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe GroupPolicy do
+  subject(:policy) { described_class.new(user, group) }
+
+  let(:user) { build :editor_user }
+  let(:group) { build :group, organisation_id: user.organisation_id }
+
+  context "when user is super_admin" do
+    let(:user) { build :super_admin_user }
+
+    it { is_expected.to permit_actions(%i[create edit show destroy update index]) }
+
+    context "and user belongs to a different organisation than the group" do
+      let(:group) { build :group, organisation_id: user.organisation_id + 1 }
+
+      it "allows show, edit, update or destroy" do
+        expect(policy).to permit_actions(%i[show edit update destroy])
+      end
+    end
+
+    it "scope resolves to all groups" do
+      expect(GroupPolicy::Scope.new(user, Group).resolve).to eq(Group.all)
+    end
+  end
+
+  context "when user is editor" do
+    it { is_expected.to permit_actions(%i[create edit show destroy update index]) }
+
+    context "and user belongs to a different organisation than the group" do
+      let(:group) { build :group, organisation_id: user.organisation_id + 1 }
+
+      it "does not allow show, edit, update or destroy" do
+        expect(policy).to forbid_actions(%i[show edit update destroy])
+      end
+    end
+
+    it "scope resolves to groups for user in same organisation" do
+      expect(GroupPolicy::Scope.new(user, Group).resolve).to eq(Group.for_user(user))
+    end
+  end
+end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -39,9 +39,15 @@ RSpec.describe "/groups", type: :request do
       expect(response).to be_successful
     end
 
-    it "shows all groups in the user's organisation" do
-      groups = create_list :group, 3, organisation_id: 1
+    it "shows all groups the user is a member of" do
+      groups = create_list :group, 3, organisation: editor_user.organisation
+      groups.each do |group|
+        create :membership, user: editor_user, group:
+      end
 
+      # groups outside of organisation or not a member of
+      # should not be shown
+      create :group, organisation: editor_user.organisation
       create_list :group, 3, organisation: other_org
 
       get groups_url


### PR DESCRIPTION
### Restrict access to groups

Trello card: https://trello.com/c/OOy3MZps/1417-restrict-who-can-view-groups-to-group-members

Restrict access to list, view, modify and delete groups to only users who are members of that group.

Except for super_admins, who are able to access all groups.

This commit changes the group policy. It adds tests for the existing policy and the new scope and restrictions.

The policy scope delegates to a scope on the model because that seems a better place to implement and test it.

To support this work the group controller has been modified so that when a user creates a group, they are added to it.

The controller spec has also been updated because users will no longer be able to see all groups within their organisation, only those they are a member of.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
