### PR TITLE
Add group status

### DIFF
--- a/app/components/group_list_component/view.html.erb
+++ b/app/components/group_list_component/view.html.erb
@@ -1,0 +1,30 @@
+<% if @groups.empty? %>
+  <h2 class="govuk-heading-m">
+    <%= @title %>
+  </h2>
+
+  <p class="govuk-body">
+    <%= @empty_message %>
+  </p>
+<% else %>
+  <%= govuk_table do |table| %>
+    <%= table.with_caption(size: 'm', text: @title) %>
+
+    <%= table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(header: true, text: t('groups.group_list.name'))
+        row.with_cell(header: true, text: t('groups.group_list.created_by'), numeric: true)
+      end
+    end %>
+
+    <%= table.with_body do |body|
+      @groups.each do |group|
+        body.with_row do |row|
+          row.with_cell { govuk_link_to(group.name, group) }
+          row.with_cell(numeric: true) { t('groups.group_list.created_by_unknown') }
+        end
+      end
+    end %>
+  <% end %>
+<% end %>
+

--- a/app/components/group_list_component/view.rb
+++ b/app/components/group_list_component/view.rb
@@ -1,0 +1,10 @@
+module GroupListComponent
+  class View < ViewComponent::Base
+    def initialize(groups:, title:, empty_message:)
+      super
+      @groups = groups
+      @title = title
+      @empty_message = empty_message
+    end
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,7 +5,8 @@ class GroupsController < ApplicationController
 
   # GET /groups
   def index
-    @groups = policy_scope(Group)
+    @active_groups = policy_scope(Group).active
+    @trial_groups = policy_scope(Group).trial
   end
 
   # GET /groups/1

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -11,6 +11,8 @@ class Group < ApplicationRecord
   validates :name, presence: true
   before_create :set_external_id
 
+  enum :status, { trial: "trial", active: "active" }, validate: true
+
   def to_param
     external_id
   end

--- a/app/views/groups/_group.html.erb
+++ b/app/views/groups/_group.html.erb
@@ -1,1 +1,4 @@
-<h1 class="govuk-heading-l"><%= group.name %></h1>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= t("groups.status_caption.#{group.status}") %></span><span class="govuk-visually-hidden"> - </span>
+  <%= group.name %>
+</h1>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,5 +1,4 @@
-<% set_page_title("Groups") %>
-<% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>
+<% set_page_title(t("page_titles.group_index")) %>
 
 <% content_for :notification_banner_content do %>
   <%= notice %>
@@ -7,19 +6,19 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-      Groups
+    <h1 class="govuk-heading-l">
+      <%= t("page_titles.group_index") %>
     </h1>
 
-    <%= govuk_summary_list do |summary_list|
-      @groups.each do |group|
-        summary_list.with_row do |row|
-          row.with_value { govuk_link_to(group.name, group) }
-          row.with_action(text: "Change", href:edit_group_path(group), visually_hidden_text: 'name')
-        end
-      end
-    end %>
+    <%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: "You're not in any active groups.") %>
+    <%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: "You're not in any trial groups.") %>
 
-    <%= govuk_button_link_to "New group", new_group_path, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
+    <%= govuk_button_link_to t("groups.index.create_group"), new_group_path, class:"govuk-!-margin-top-3", secondary: true %>
+
+    <div class="govuk-!-margin-top-3">
+      <%= govuk_details(summary_text: t("groups.index.group_explainer_title")) do %>
+        <%= t("groups.index.group_explainer_body_html") %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,15 +1,25 @@
 <% content_for :back_link, govuk_back_link_to(groups_path, t("back_link.groups")) %>
 
-<%= render @group %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @group.trial? %>
+      <%= govuk_notification_banner(title_text: t("groups.show.trial_banner.title")) do |nb| %>
+        <%= t("groups.show.trial_banner.body_html") %>
+      <% end %>
+    <% end %>
 
-<div class="govuk-button-group">
-  <%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %>
-</div>
+    <%= render @group %>
 
-<% if @forms.any? %>
-  <%= govuk_table(**FormListService.call(forms: @forms, current_user: @current_user, group: @group).data) %>
-<% end %>
+    <div class="govuk-button-group">
+      <%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %>
+    </div>
 
-<div>
-  <%= govuk_button_to("Delete group", @group, method: :delete, warning: true, class: "govuk-!-margin-bottom-3 govuk-!-margin-top-3" ) %>
+    <% if @forms.any? %>
+      <%= govuk_table(**FormListService.call(forms: @forms, current_user: @current_user, group: @group).data) %>
+    <% end %>
+
+    <div>
+      <%= govuk_button_to("Delete group", @group, method: :delete, warning: true, class: "govuk-!-margin-bottom-3 govuk-!-margin-top-3" ) %>
+    </div>
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,16 @@ en:
       created_by: Created by
       created_by_unknown: Unknown
       name: Group name
+    index:
+      active_title: Active groups
+      create_group: Create a group
+      group_explainer_body_html: |
+        <p>Each form is created inside a group. People can be invited to a group to create and edit forms in it.</p>
+        <p>If you need access to an existing form or group, ask someone who has access to that group to invite you.</p>
+        <p>When a group is first created it will be a ‘trial’ group. That means you cannot make any forms in the group live. You can request for a group to be upgraded to an ‘active’ group if you need to make forms live.</p>
+        <p>If you’re not sure if you should make a new group, speak with your organisation’s GOV.UK publishing team.</p>
+      group_explainer_title: What is a ‘group’?
+      trial_title: Trial groups
     show:
       edit_group_name: Change the name of this group
   guidance:
@@ -619,6 +629,7 @@ en:
     email_code_sent: Confirmation code sent
     error_prefix: 'Error: '
     forbidden: You cannot view this page
+    group_index: Your groups
     home: Home
     internal_server_error: Sorry, there is a problem with the service
     maintenance: Sorry, the service is unavailable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,6 +250,11 @@ en:
       trial_title: Trial groups
     show:
       edit_group_name: Change the name of this group
+      trial_banner:
+        body_html: |
+          <h2 class="govuk-heading-m">This is a ‘trial’ group</h2>
+          <p>You can create forms in this group and test them, but you cannot make them live.</p>
+        title: Important
     status_caption:
       active: Active group
       trial: Trial group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,6 +250,9 @@ en:
       trial_title: Trial groups
     show:
       edit_group_name: Change the name of this group
+    status_caption:
+      active: Active group
+      trial: Trial group
   guidance:
     add_guidance: Add guidance
     guidance: Guidance

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,10 @@ en:
     confirm_deletion_page: Are you sure you want to delete this page?
   groups:
     form_table_caption: Forms in ‘%{group_name}’
+    group_list:
+      created_by: Created by
+      created_by_unknown: Unknown
+      name: Group name
     show:
       edit_group_name: Change the name of this group
   guidance:

--- a/db/migrate/20240308113842_add_status_to_groups.rb
+++ b/db/migrate/20240308113842_add_status_to_groups.rb
@@ -1,0 +1,5 @@
+class AddStatusToGroups < ActiveRecord::Migration[7.1]
+  def change
+    add_column :groups, :status, :string, default: "trial"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_27_074047) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_08_113842) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_27_074047) do
     t.datetime "updated_at", null: false
     t.text "external_id", null: false
     t.bigint "organisation_id"
+    t.string "status", default: "trial"
     t.index ["external_id"], name: "index_groups_on_external_id", unique: true
     t.index ["organisation_id"], name: "index_groups_on_organisation_id"
   end

--- a/spec/components/group_list_component/group_list_component_preview.rb
+++ b/spec/components/group_list_component/group_list_component_preview.rb
@@ -1,0 +1,11 @@
+class GroupListComponent::GroupListComponentPreview < ViewComponent::Preview
+  include FactoryBot::Syntax::Methods
+
+  def default
+    render(GroupListComponent::View.new(groups: [], title: "Your Groups", empty_message: "There are no groups to display"))
+  end
+
+  def with_groups
+    render(GroupListComponent::View.new(groups: [build(:group), build(:group)], title: "Your active groups", empty_message: "There are no active groups to display"))
+  end
+end

--- a/spec/components/group_list_component/view_spec.rb
+++ b/spec/components/group_list_component/view_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe GroupListComponent::View, type: :component do
+  subject(:group_list) { described_class.new(groups:, title:, empty_message:) }
+
+  let(:groups) { create_list(:group, 3) }
+  let(:title) { "Your Groups" }
+  let(:empty_message) { "There are no groups to display" }
+
+  describe "rendering component" do
+    before do
+      render_inline(group_list)
+    end
+
+    it "renders the title as a table caption" do
+      expect(page).to have_css("caption", text: title)
+    end
+
+    it "renders a table with the groups" do
+      expect(page).to have_css("table")
+      expect(page).to have_css("tr", count: 4)
+    end
+
+    context "when there are no groups" do
+      let(:groups) { [] }
+
+      it "renders a message" do
+        expect(page).to have_css("p", text: empty_message)
+      end
+
+      it "shows the title as a heading" do
+        expect(page).to have_css("h2", text: title)
+      end
+    end
+  end
+end

--- a/spec/factories/models/groups.rb
+++ b/spec/factories/models/groups.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :group do
     name { "My Group" }
-
     organisation { association :organisation, id: 1, slug: "test-org" }
+    status { :trial }
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Group, type: :model do
       group = build :group, organisation: nil
       expect(group).not_to be_valid
     end
+
+    it "cannot be set to an invalid status" do
+      group = build :group, status: :invalid
+      expect(group).to be_invalid
+    end
+
+    it "is invalid without a status" do
+      group = build :group, status: nil
+      expect(group).not_to be_valid
+    end
   end
 
   describe "before_create" do
@@ -155,6 +165,18 @@ RSpec.describe Group, type: :model do
 
         expect(described_class.for_user(user)).to eq [group1]
       end
+    end
+  end
+
+  describe "status" do
+    it "has a default status of trial" do
+      group = described_class.build(name: "Test Group")
+      expect(group.status).to eq("trial")
+    end
+
+    it "can be set to active" do
+      group = build :group, status: :active
+      expect(group).to be_valid
     end
   end
 end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "/groups", type: :request do
       create_list :group, 3, organisation: other_org
 
       get groups_url
-      expect(assigns(:groups)).to eq groups
+      expect(assigns(:trial_groups)).to eq groups
     end
 
     context "when the user is a super-admin" do
@@ -66,7 +66,7 @@ RSpec.describe "/groups", type: :request do
         create_list :group, 3, organisation_id: 2
 
         get groups_url
-        expect(assigns(:groups)).to eq Group.all
+        expect(assigns(:trial_groups)).to eq Group.trial
       end
     end
   end

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -1,15 +1,27 @@
 require "rails_helper"
 
 RSpec.describe "groups/index", type: :view do
-  let(:groups) { create_list :group, 2, name: "Name" }
+  let(:trial_groups) { create_list :group, 2 }
+  let(:active_groups) { create_list :group, 2, status: :active }
 
   before do
-    assign(:groups, groups)
+    assign(:trial_groups, trial_groups)
+    assign(:active_groups, active_groups)
+
+    render
   end
 
   it "renders a list of groups" do
-    render
-    cell_selector = ".govuk-summary-list__value"
-    assert_select cell_selector, text: Regexp.new("Name".to_s), count: 2
+    trial_groups.each do |group|
+      expect(rendered).to have_link(group.name, href: group_path(group))
+    end
+
+    active_groups.each do |group|
+      expect(rendered).to have_link(group.name, href: group_path(group))
+    end
+  end
+
+  it "shows a create group button" do
+    expect(rendered).to have_link("Create a group", href: new_group_path)
   end
 end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "groups/show", type: :view do
     expect(rendered).to have_css "h1.govuk-heading-l", text: "My Group"
   end
 
+  it "renders the status of the group" do
+    expect(rendered).to have_css ".govuk-caption-l", text: t("groups.status_caption.trial")
+  end
+
   it "has a link to the change group name page" do
     expect(rendered).to have_link "Change the name of this group", href: edit_group_path(group)
   end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -71,4 +71,28 @@ RSpec.describe "groups/show", type: :view do
       ]
     end
   end
+
+  context "when the group is a trial group" do
+    let(:group) { create :group, :trial, name: "trial group" }
+
+    it "renders the status of the group" do
+      expect(rendered).to have_css ".govuk-caption-l", text: t("groups.status_caption.trial")
+    end
+
+    it "shows a notification banner" do
+      expect(rendered).to have_css ".govuk-notification-banner"
+    end
+  end
+
+  context "when the group is an active group" do
+    let(:group) { create :group, :active, name: "Active group" }
+
+    it "renders the status of the group" do
+      expect(rendered).to have_css ".govuk-caption-l", text: t("groups.status_caption.active")
+    end
+
+    it "does not show a notification banner" do
+      expect(rendered).not_to have_css ".govuk-notification-banner"
+    end
+  end
 end


### PR DESCRIPTION
### Add group status

Trello card: https://trello.com/c/5uZvQ5w1/1410-add-group-status-active-trial

See the trello card for details and design.

This PR adds a status to Groups which will be used to decide if forms within the group can be made live or not.

An enum is added to the Groups DB and the views updated to show the status of groups.


![image](https://github.com/alphagov/forms-admin/assets/11035856/37cd070e-17ca-4679-9c2a-c34eb0f02f94)

![image](https://github.com/alphagov/forms-admin/assets/11035856/b3324ab9-4c0d-4c14-b2cd-4d3255b62e47)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
