### PR TITLE
Deny access for super-admins authenticated without Auth0 via Google workspace

### DIFF
--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -45,3 +45,10 @@ OmniAuth.config.allowed_request_methods = %i[post]
 OAuth2.configure do |config|
   config.silence_extra_tokens_warning = true
 end
+
+# store the auth0 connection used to login in the warden session
+Warden::Manager.after_authentication do |user, auth, _opts|
+  if user.provider == "auth0"
+    auth.session["auth0_connection_strategy"] = auth.env["omniauth.auth"][:extra][:raw_info][:auth0_connection_strategy]
+  end
+end

--- a/spec/features/mou/view_signed_mous_spec.rb
+++ b/spec/features/mou/view_signed_mous_spec.rb
@@ -14,7 +14,8 @@ describe "Check which MOUs have been signed", type: :feature do
     end
 
     mou_signatures
-    login_as user
+
+    login_as_super_admin_user
   end
 
   it "super_admin's can see the MOUs page" do

--- a/spec/features/users/set_organisation_spec.rb
+++ b/spec/features/users/set_organisation_spec.rb
@@ -71,7 +71,7 @@ private
   end
 
   def given_i_am_a_super_admin_in_the_government_digital_service_organisation
-    @user = create(:user, role: "super_admin", organisation: gds_org)
+    @user = create(:super_admin_user, organisation: gds_org)
     login_as @user
 
     visit edit_user_path(@user.id)

--- a/spec/features/users/set_role_spec.rb
+++ b/spec/features/users/set_role_spec.rb
@@ -14,10 +14,6 @@ describe "Set or change a user's role", type: :feature do
     [build(:form, id: 2, creator_id: 2, organisation_id: nil, name: "Trial form")]
   end
 
-  let(:super_admin_user) do
-    create(:super_admin_user, id: 1, organisation: gds_org)
-  end
-
   let(:trial_user) do
     create(:user, :with_trial_role, id: 2)
   end
@@ -27,10 +23,12 @@ describe "Set or change a user's role", type: :feature do
       mock.get "/api/v1/forms?organisation_id=1", headers, org_forms.to_json, 200
       mock.get "/api/v1/forms?creator_id=2", headers, trial_forms.to_json, 200
     end
+
+    super_admin_user.organisation = gds_org
   end
 
   it "A trial user sees only forms they have created" do
-    login_as trial_user
+    login_as_trial_user
     then_i_can_see_the_trial_user_forms
     then_i_cannot_see_the_org_forms
   end
@@ -41,11 +39,12 @@ describe "Set or change a user's role", type: :feature do
       mock.patch "/api/v1/forms/update-organisation-for-creator?creator_id=2&organisation_id=1", post_headers, nil, 204
     end
 
-    login_as super_admin_user
+    login_as_super_admin_user
     when_i_change_the_trial_users_role_to_editor
     reset_session!
 
-    login_as trial_user.reload
+    trial_user.reload
+    login_as_trial_user
     then_i_can_see_the_trial_user_forms
     then_i_can_see_the_org_forms
   end

--- a/spec/integration/auth0_spec.rb
+++ b/spec/integration/auth0_spec.rb
@@ -1,13 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "usage of omniauth-auth0 gem" do
-  before do
-    allow(Settings).to receive(:auth_provider).and_return("auth0")
+  include AuthenticationFeatureHelpers
 
+  before do
+    set_run_callbacks(true)
+    allow(Settings).to receive(:auth_provider).and_return("auth0")
     OmniAuth.config.test_mode = true
   end
 
   after do
+    set_run_callbacks(false)
     OmniAuth.config.mock_auth[:auth0] = nil
     OmniAuth.config.test_mode = false
   end
@@ -64,6 +67,7 @@ RSpec.describe "usage of omniauth-auth0 gem" do
         allow(described_class).to receive(:find_for_auth).and_call_original
 
         OmniAuth.config.mock_auth[:auth0] = omniauth_hash
+
         post "/auth/auth0"
         get "/auth/auth0/callback"
 
@@ -135,6 +139,112 @@ RSpec.describe "usage of omniauth-auth0 gem" do
       expect(strategy.options[:client_secret]).to eq("abcd")
       expect(strategy.options[:callback_path]).to eq("/auth/auth0/callback")
       expect(strategy.options[:authorize_params][:connection]).to be_nil
+    end
+  end
+
+  describe "Google workspace integration" do
+    let(:form) { build :form, :with_active_resource, id: 1, name: "Apply for a juggling license" }
+    let(:org_forms) { [] }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms?organisation_id=1", api_get_request_headers, org_forms.to_json, 200
+      end
+    end
+
+    context "when a super-admin user is logged in" do
+      let(:user) { super_admin_user }
+
+      context "and authenticated via Google" do
+        [
+          "/",
+          "/users",
+        ].each do |path|
+          it "when accessing #{path}, returns http code 200 for #{path}" do
+            user.provider = "auth0"
+            omniauth_hash[:info][:email] = user.email
+            omniauth_hash[:extra][:raw_info][:auth0_connection_strategy] = "google-apps"
+
+            OmniAuth.config.mock_auth[:auth0] = omniauth_hash
+
+            post "/auth/auth0"
+
+            expect(response).to redirect_to("/auth/auth0/callback")
+
+            get "/auth/auth0/callback"
+
+            get path
+
+            expect(response).to have_http_status(:ok)
+          end
+        end
+      end
+
+      context "and didn't authenticate via Google" do
+        [
+          "/",
+          "/users",
+        ].each do |path|
+          context "when accessing #{path}" do
+            before do
+              user.provider = "auth0"
+              omniauth_hash[:info][:email] = user.email
+              omniauth_hash[:extra][:raw_info][:auth0_connection_strategy] = "email"
+
+              OmniAuth.config.mock_auth[:auth0] = omniauth_hash
+
+              post "/auth/auth0"
+
+              get "/auth/auth0/callback"
+
+              get path
+            end
+
+            it "returns http code 403 for #{path}" do
+              expect(response).to have_http_status(:forbidden)
+            end
+
+            it "renders the access denied page" do
+              expect(response).to render_template("errors/access_denied")
+              expect(response.body).to include("if you think this is incorrect.")
+            end
+          end
+        end
+      end
+    end
+
+    context "when a non-super-admin user is logged in" do
+      let(:user) { editor_user }
+
+      context "and authenticated via Google" do
+        [
+          "/",
+        ].each do |path|
+          context "when accessing #{path}," do
+            %w[google-apps invalid-connection].each do |connection|
+              context "and using #{connection}," do
+                it "returns http code 200 for #{path}" do
+                  user.provider = "auth0"
+                  omniauth_hash[:info][:email] = user.email
+                  omniauth_hash[:extra][:raw_info][:auth0_connection_strategy] = connection
+
+                  OmniAuth.config.mock_auth[:auth0] = omniauth_hash
+
+                  post "/auth/auth0"
+
+                  expect(response).to redirect_to("/auth/auth0/callback")
+
+                  get "/auth/auth0/callback"
+
+                  get path
+
+                  expect(response).to have_http_status(:ok)
+                end
+              end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe UsersController, type: :request do
     context "when logged in as a super admin" do
       before do
         login_as_super_admin_user
+
         get users_path
       end
 

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -46,6 +46,11 @@ module AuthenticationFeatureHelpers
 
   def login_as_super_admin_user
     login_as super_admin_user
+
+    # All super-admins should have logged in via Auth0 with the Google workspace login
+    Warden.on_next_request do |proxy|
+      proxy.session["auth0_connection_strategy"] = "google-apps"
+    end
   end
 
   def login_as_editor_user

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -5,12 +5,18 @@ module AuthenticationFeatureHelpers
 
   @cached_gds_sso_mock_invalid = ENV["GDS_SSO_MOCK_INVALID"]
 
+  @run_callbacks = false
+
+  def set_run_callbacks(value)
+    @run_callbacks = value
+  end
+
   def login_as(user, opts = {})
     if %i[gds_sso mock_gds_sso].include? Settings.auth_provider.to_sym
       ENV["GDS_SSO_MOCK_INVALID"] = @cached_gds_sso_mock_invalid
       GDS::SSO.test_user = user
     else
-      opts[:run_callbacks] ||= false # Callbacks are from gds-sso gem
+      opts[:run_callbacks] = @run_callbacks # Callbacks are from gds-sso gem
     end
 
     super user, opts


### PR DESCRIPTION
### What problem does this pull request solve?

We want to ensure that all super-admins have logged in using MFA. We do this by checking that the Auth0 connection used by the super-admin user was the Google workspace connection. 

This is achieved by storing the value of the `auth0_connection_strategy` custom claim from the ID token from Auth0 in the warden session. We then can check that value in the existing `authenticate_and_check_access` before action.

For now, if this check fails we just show the access denied screen . We may change this is to something more useful in the future.

Trello card: https://trello.com/c/UdtU9PZC

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
