### PR TITLE
Introduce way of synchronizing MailChimp lists with users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,9 @@ gem "paper_trail"
 # For obtaining CloudWatch metrics
 gem "aws-sdk-cloudwatch", "~> 1.86"
 
+# For Mailchimp audience integration
+gem "MailchimpMarketing", "~> 3.0"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    MailchimpMarketing (3.0.80)
+      excon (>= 0.76.0, < 1)
+      json (~> 2.1, >= 2.1.0)
     actioncable (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -178,6 +181,7 @@ GEM
     dry-cli (1.0.0)
     dumb_delegator (1.0.0)
     erubi (1.12.0)
+    excon (0.109.0)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -518,6 +522,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  MailchimpMarketing (~> 3.0)
   activeresource (~> 6.1)
   aws-sdk-cloudwatch (~> 1.86)
   axe-core-rspec

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -65,3 +65,8 @@ basic_auth:
     govuk_content_id: "00000000-0000-0000-0000-000000000000"
 
 forms_env: local
+
+mailchimp:
+  api_key:
+  api_prefix: changme
+  lists: [changeme]

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,8 @@
 # Use real authentication
 auth_provider: gds_sso
+
+mailchimp:
+  api_prefix: "us12"
+  lists:
+    - c9cc8511c6
+    - ef5e72c003

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -14,3 +14,9 @@ forms_runner:
 
 # No default strategy as Warden test mode is used
 auth_provider: ""
+
+mailchimp:
+  api_prefix: "prefix"
+  lists:
+    - list-1
+    - list-2

--- a/lib/tasks/mailchimp.rake
+++ b/lib/tasks/mailchimp.rake
@@ -1,0 +1,71 @@
+require "digest"
+require "MailchimpMarketing"
+
+namespace :mailchimp do
+  desc "Synchronise Mailchimp audiences with the users in the database"
+  task synchronize_audiences: :environment do
+    mailchimp_api_key = ENV["MAILCHIMP_API_KEY"]
+    mailchimp_server_prefix = ENV["MAILCHIMP_SERVER_PREFIX"]
+    mailchimp_lists = ENV["MAILCHIMP_LISTS"]
+
+    puts "Mailchimp server prefix: #{mailchimp_server_prefix}"
+    puts "Mailchimp lists: #{mailchimp_lists}"
+
+    mailchimp = MailchimpMarketing::Client.new
+    mailchimp.set_config({
+      api_key: mailchimp_api_key,
+      server: mailchimp_server_prefix,
+    })
+
+    list_ids = mailchimp_lists
+                  .split(",")
+                  .map(&:strip)
+
+    db_email_addresses = User.pluck(:email).to_set
+
+    puts "There are #{list_ids.length} lists to synchronize"
+    list_ids.each do |list_id|
+      puts "List id: #{list_id}"
+
+      target_list = mailchimp.lists.get_list(list_id)
+      target_list or raise
+
+      puts "Found Mailchimp list: #{target_list['name']}"
+      puts "Mailchimp list has #{target_list['stats']['member_count']} members"
+
+      existing_members = mailchimp.lists.get_list_members_info(list_id)
+      list_email_addresses = existing_members["members"]
+                               .map { |member| member["email_address"] }
+                               .to_set
+
+      deleted_users = list_email_addresses - db_email_addresses
+      added_users = db_email_addresses - list_email_addresses
+
+      puts "There are #{added_users.size} to subscribe"
+      puts "There are #{deleted_users.size} to unsubscribe"
+
+      puts "Subscribing any new users..."
+      added_users.each do |email|
+        subscriber_hash = Digest::MD5.hexdigest email.downcase
+        mailchimp.lists.set_list_member(
+          list_id,
+          subscriber_hash,
+          {
+            "email_address" => email,
+            "status_if_new" => "subscribed",
+          },
+        )
+      rescue MailchimpMarketing::ApiError
+        warn "Could not subscribe user with subscriber hash #{subscriber_hash} to list #{list_id}. Continuing"
+      end
+
+      puts "Unsubscribing any removed users..."
+      deleted_users.each do |email|
+        subscriber_hash = Digest::MD5.hexdigest email.downcase
+        mailchimp.lists.delete_list_member_permanent(list_id, subscriber_hash)
+      rescue MailchimpMarketing::ApiError
+        warn "Could not unsubscribe user with subscriber hash #{subscriber_hash} from list #{list_id}. Continuing"
+      end
+    end
+  end
+end

--- a/lib/tasks/mailchimp.rake
+++ b/lib/tasks/mailchimp.rake
@@ -4,9 +4,9 @@ require "MailchimpMarketing"
 namespace :mailchimp do
   desc "Synchronise Mailchimp audiences with the users in the database"
   task synchronize_audiences: :environment do
-    mailchimp_api_key = ENV["MAILCHIMP_API_KEY"]
-    mailchimp_server_prefix = ENV["MAILCHIMP_SERVER_PREFIX"]
-    mailchimp_lists = ENV["MAILCHIMP_LISTS"]
+    mailchimp_api_key = Settings.mailchimp.api_key
+    mailchimp_server_prefix = Settings.mailchimp.api_prefix
+    mailchimp_lists = Settings.mailchimp.lists
 
     puts "Mailchimp server prefix: #{mailchimp_server_prefix}"
     puts "Mailchimp lists: #{mailchimp_lists}"
@@ -17,14 +17,10 @@ namespace :mailchimp do
       server: mailchimp_server_prefix,
     })
 
-    list_ids = mailchimp_lists
-                  .split(",")
-                  .map(&:strip)
-
     db_email_addresses = User.pluck(:email).to_set
 
-    puts "There are #{list_ids.length} lists to synchronize"
-    list_ids.each do |list_id|
+    puts "There are #{mailchimp_lists.length} lists to synchronize"
+    mailchimp_lists.each do |list_id|
       puts "List id: #{list_id}"
 
       target_list = mailchimp.lists.get_list(list_id)

--- a/spec/lib/tasks/mailchimp.rake_spec.rb
+++ b/spec/lib/tasks/mailchimp.rake_spec.rb
@@ -1,0 +1,116 @@
+require "rake"
+
+require "rails_helper"
+
+RSpec.describe "mailchimp.rake" do
+  describe "synchronize_audiences" do
+    subject(:task){
+      Rake::Task["mailchimp:synchronize_audiences"]
+        .tap(&:reenable)
+    }
+
+    let(:mailchimp_client){
+      instance_double("MailchimpMarketing::Client")
+    }
+
+    let(:mailchimp_client_lists){
+      instance_double("MailchimpMarketing::ListsApi")
+    }
+
+    before do
+      # Rake.application.options.trace = true
+
+      Rake.application.rake_require "tasks/mailchimp"
+      Rake::Task.define_task(:environment)
+
+
+      create :user, email: "add@domain.org"
+      create :user, email: "keep@domain.org"
+
+      allow(MailchimpMarketing::Client).to receive(:new).and_return(mailchimp_client)
+
+      allow(mailchimp_client).to receive(:set_config)
+      allow(mailchimp_client).to receive(:lists).and_return(mailchimp_client_lists)
+
+      allow(mailchimp_client_lists).to receive(:set_list_member)
+      allow(mailchimp_client_lists).to receive(:delete_list_member_permanent)
+
+      allow(mailchimp_client_lists).to receive(:get_list) do |list_id|
+        case list_id
+        when "list-1"
+          {
+            "name" => "List 1",
+            "stats" => {
+              "member_count" => 2,
+            },
+          }
+        when "list-2"
+          {
+            "name" => "List 2",
+            "stats" => {
+              "member_count" => 2,
+            },
+          }
+        else
+          raise "Unknown list id"
+        end
+      end
+
+      allow(mailchimp_client_lists).to receive(:get_list_members_info) do |list_id|
+        case list_id
+        when "list-1"
+          {
+            "members" => [
+              { "email_address" => "keep@domain.org" },
+              { "email_address" => "remove@domain.org" },
+            ]
+          }
+        when "list-2"
+          {
+            "members" => [
+              { "email_address" => "keep@domain.org" },
+              { "email_address" => "remove@domain.org" },
+            ]
+          }
+        else
+          raise "Unknown list id"
+        end
+      end
+
+      ENV["MAILCHIMP_API_KEY"] = "KEY"
+      ENV["MAILCHIMP_SERVER_PREFIX"] = "PREFIX"
+      ENV["MAILCHIMP_LISTS"] = "list-1,list-2"
+    end
+
+    it "adds users to MailChimp who appear in the database, but not in the mailing list" do
+      expect(mailchimp_client_lists).to receive(:set_list_member).with(
+        "list-1",
+        anything,
+        {
+          "email_address" => "add@domain.org",
+          "status_if_new" => "subscribed",
+        },
+      )
+
+      expect(mailchimp_client_lists).to receive(:set_list_member).with(
+        "list-2",
+        anything,
+        {
+          "email_address" => "add@domain.org",
+          "status_if_new" => "subscribed",
+        },
+      )
+
+      task.invoke
+    end
+
+    it "removes users from MailChimp who do not appear in the database, but do appear in the mailing list" do
+      removed_email_hash = Digest::MD5.hexdigest "remove@domain.org"
+
+      expect(mailchimp_client_lists).to receive(:delete_list_member_permanent).with("list-1", removed_email_hash)
+      expect(mailchimp_client_lists).to receive(:delete_list_member_permanent).with("list-2", removed_email_hash)
+
+      task.invoke
+    end
+  end
+end

--- a/spec/lib/tasks/mailchimp.rake_spec.rb
+++ b/spec/lib/tasks/mailchimp.rake_spec.rb
@@ -4,25 +4,24 @@ require "rails_helper"
 
 RSpec.describe "mailchimp.rake" do
   describe "synchronize_audiences" do
-    subject(:task){
+    subject(:task) do
       Rake::Task["mailchimp:synchronize_audiences"]
         .tap(&:reenable)
-    }
+    end
 
-    let(:mailchimp_client){
+    let(:mailchimp_client) do
       instance_double("MailchimpMarketing::Client")
-    }
+    end
 
-    let(:mailchimp_client_lists){
+    let(:mailchimp_client_lists) do
       instance_double("MailchimpMarketing::ListsApi")
-    }
+    end
 
     before do
       # Rake.application.options.trace = true
 
       Rake.application.rake_require "tasks/mailchimp"
       Rake::Task.define_task(:environment)
-
 
       create :user, email: "add@domain.org"
       create :user, email: "keep@domain.org"
@@ -63,23 +62,21 @@ RSpec.describe "mailchimp.rake" do
             "members" => [
               { "email_address" => "keep@domain.org" },
               { "email_address" => "remove@domain.org" },
-            ]
+            ],
           }
         when "list-2"
           {
             "members" => [
               { "email_address" => "keep@domain.org" },
               { "email_address" => "remove@domain.org" },
-            ]
+            ],
           }
         else
           raise "Unknown list id"
         end
       end
 
-      ENV["MAILCHIMP_API_KEY"] = "KEY"
-      ENV["MAILCHIMP_SERVER_PREFIX"] = "PREFIX"
-      ENV["MAILCHIMP_LISTS"] = "list-1,list-2"
+      ENV["SETTINGS__MAILCHIMP__API_KEY"] = "KEY"
     end
 
     it "adds users to MailChimp who appear in the database, but not in the mailing list" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/iQOMKY1h/364-add-rake-task-to-automatically-add-new-users-to-mailchimp-mailing-lists

We have a database table full of user information, and we have some MailChimp lists that we'd like to contain all the same email addresses.

We're happy for the synchronization to happen out-of-band with regular user management activities, so we've built it as a Rake task that will be run on a schedule. The scheduling will be handled at the infrastructure level, in the `forms-deploy` repository.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
