### PR TITLE
Make tables take up full width of page

### DIFF
--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -4,21 +4,17 @@
   <%= notice %>
 <% end%>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      <%= t("page_titles.group_index") %>
-    </h1>
+<h1 class="govuk-heading-l">
+  <%= t("page_titles.group_index") %>
+</h1>
 
-    <%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: "You're not in any active groups.") %>
-    <%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: "You're not in any trial groups.") %>
+<%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: "You're not in any active groups.") %>
+<%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: "You're not in any trial groups.") %>
 
-    <%= govuk_button_link_to t("groups.index.create_group"), new_group_path, class:"govuk-!-margin-top-3", secondary: true %>
+<%= govuk_button_link_to t("groups.index.create_group"), new_group_path, class:"govuk-!-margin-top-3", secondary: true %>
 
-    <div class="govuk-!-margin-top-3">
-      <%= govuk_details(summary_text: t("groups.index.group_explainer_title")) do %>
-        <%= t("groups.index.group_explainer_body_html") %>
-      <% end %>
-    </div>
-  </div>
+<div class="govuk-!-margin-top-3">
+  <%= govuk_details(summary_text: t("groups.index.group_explainer_title")) do %>
+    <%= t("groups.index.group_explainer_body_html") %>
+  <% end %>
 </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -7,19 +7,19 @@
         <%= t("groups.show.trial_banner.body_html") %>
       <% end %>
     <% end %>
-
-    <%= render @group %>
-
-    <div class="govuk-button-group">
-      <%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %>
-    </div>
-
-    <% if @forms.any? %>
-      <%= govuk_table(**FormListService.call(forms: @forms, current_user: @current_user, group: @group).data) %>
-    <% end %>
-
-    <div>
-      <%= govuk_button_to("Delete group", @group, method: :delete, warning: true, class: "govuk-!-margin-bottom-3 govuk-!-margin-top-3" ) %>
-    </div>
   </div>
+</div>
+
+<%= render @group %>
+
+<div class="govuk-button-group">
+  <%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %>
+</div>
+
+<% if @forms.any? %>
+  <%= govuk_table(**FormListService.call(forms: @forms, current_user: @current_user, group: @group).data) %>
+<% end %>
+
+<div>
+  <%= govuk_button_to("Delete group", @group, method: :delete, warning: true, class: "govuk-!-margin-bottom-3 govuk-!-margin-top-3" ) %>
 </div>


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want more horizontal space for our tables of forms/groups, so this commit removes the two-thirds width grid containers.

This brings these pages into line with the current designs in Figma/our prototypes [[1]].

[1]: https://www.figma.com/file/D2DtaS68qRvVZgtxaBQNjd/User-management---moving-to-a-'group'-model-for-public-beta?type=design&node-id=124-7025&mode=design&t=0jENmoJ9JAJG8Gaa-0

<details>
<summary><h3>Screenshots</h3></summary>

#### Groups page

##### Before

![Screenshot of groups page /groups before this change](https://github.com/alphagov/forms-admin/assets/503614/f81d0400-b16c-4072-a39f-2f9b24364a49)

##### After

![Screenshot of groups page /groups after this change](https://github.com/alphagov/forms-admin/assets/503614/81e9c235-4b42-4c60-aab1-7f54a3f0ed4a)

#### Group forms page

##### Before

![Screenshot of group forms page /groups/:group_id before this change](https://github.com/alphagov/forms-admin/assets/503614/1355bb8c-b909-4a60-a25f-613fff815089)

##### After

![Screenshot of group forms page /groups/:group_id after this change](https://github.com/alphagov/forms-admin/assets/503614/73fffff8-ba07-4954-83cc-a30ff4168848)

</details>

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?