### PR TITLE
Fix super admin user for developers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -124,6 +124,8 @@ private
   end
 
   def auth_strategy_permitted?
+    return true if %w[mock_gds_sso developer].include? Settings.auth_provider
+
     @current_user.super_admin? ? PRIVILEGED_AUTH0_CONNECTION_STRATEGIES.include?(warden.session["auth0_connection_strategy"]) : true
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

In commit bcac184 we restricted use of the super admin role to users signed in with Google SSO. However, running forms-admin locally generally Auth0 is not used. This commit adds a quick bypass for this scenario, so developers can still use super admin roles locally.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?