### PR TITLE
Prevent specs from calling forms-api

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,8 @@ ENV["RACK_ENV"] ||= "test"
 ENV["RAILS_ENV"] ||= "test"
 
 require_relative "../config/environment"
+# Prevent specs from calling a running forms-api instance
+ActiveResource::HttpMock.disable_net_connection!
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When writing specs locally, it is easy to accidentally forget to mock ActiveResource requests to forms-api if that app is running at the same time.

This commit adds a line to our spec helper file to disable all network calls via ActiveResource. Now if we forget to mock something, an error will be raised even if forms-api is running.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?