### PR TITLE
Fix view tests which show markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "govuk_design_system_formbuilder"
 gem "dfe-autocomplete", require: "dfe/autocomplete", github: "DFE-Digital/dfe-autocomplete", ref: "11738c0e25778162e26eb7ab5e22a6ffce671b08"
 
 # Our own custom markdown renderer
-gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.5.0"
+gem "govuk-forms-markdown", require: "govuk_forms_markdown", github: "alphagov/govuk-forms-markdown", tag: "0.5.0"
 
 # For structured logging
 gem "lograge"

--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -1,5 +1,3 @@
-require "govuk_forms_markdown"
-
 class Pages::GuidanceController < PagesController
   def new
     guidance_form = Pages::GuidanceForm.new(page_heading: draft_question.page_heading,

--- a/app/form_objects/pages/guidance_form.rb
+++ b/app/form_objects/pages/guidance_form.rb
@@ -1,5 +1,3 @@
-require "govuk_forms_markdown"
-
 class Pages::GuidanceForm < BaseForm
   include GuidanceValidation
 

--- a/app/models/draft_question.rb
+++ b/app/models/draft_question.rb
@@ -1,5 +1,3 @@
-require "govuk_forms_markdown"
-
 class DraftQuestion < ApplicationRecord
   include QuestionTextValidation
   include GuidanceValidation

--- a/app/validators/markdown_validator.rb
+++ b/app/validators/markdown_validator.rb
@@ -1,5 +1,3 @@
-require "govuk_forms_markdown"
-
 class MarkdownValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return true if value.blank?


### PR DESCRIPTION
## Fix govuk-forms-markdown require issue in tests

When running view specs in isolation, for example, the show live view spec, it fails as GovukFormsMarkdown could not be resolved.

The tests only fail when run on their own.

To fix this issue, the Gemfile is changed to specify the require line.

After making this change, it's possible to remove the individual require's from other files.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
