### PR TITLE
Change Form access policy for forms in groups

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -10,6 +10,10 @@ class Form < ActiveResource::Base
     find(:one, from: "#{prefix}forms/#{id}/live")
   end
 
+  def group
+    group_form&.group
+  end
+
   def qualifying_route_pages
     Page.qualifying_route_pages(pages)
   end
@@ -110,5 +114,9 @@ private
 
   def email_task_status_service
     @email_task_status_service ||= EmailTaskStatusService.new(form: self)
+  end
+
+  def group_form
+    GroupForm.find_by_form_id(id)
   end
 end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -34,6 +34,7 @@ class FormPolicy
 
   def can_view_form?
     return true if user.super_admin?
+    return user.groups.include?(form.group) if form.group.present?
 
     if user.trial?
       user_is_form_creator

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -354,4 +354,16 @@ describe Form, type: :model do
       end
     end
   end
+
+  describe "#group" do
+    it "returns nil if form is not in a group" do
+      expect(form.group).to be_nil
+    end
+
+    it "returns the group if form is in a group" do
+      group = create :group
+      GroupForm.create!(form_id: form.id, group_id: group.id)
+      expect(form.group).to eq group
+    end
+  end
 end


### PR DESCRIPTION
### Update form policy to allow access to group members

Trello card: https://trello.com/c/16aEvxcI/1419-add-start-button-to-create-forms-in-group

Change the Form policy. If the form is part of a group, allow access if the user is a member of the group, otherwise deny access, unless the user is a super_admin.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
