### PR TITLE
Change back buttons for forms in groups

### DIFF
--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,6 +1,12 @@
 <% set_page_title(current_form.name) %>
 
-<% content_for :back_link, current_form.has_live_version ? govuk_back_link_to(live_form_path(current_form.id), t("back_link.form_view")) : govuk_back_link_to(root_path, t("back_link.forms")) %>
+<% if current_form.has_live_version %>
+  <% content_for :back_link, govuk_back_link_to(live_form_path(current_form.id), t("back_link.form_view")) %>
+<% elsif current_form.group.present? %>
+  <% content_for :back_link, govuk_back_link_to(group_path(current_form.group), t("back_link.group", group_name: current_form.group.name)) %>
+<% else %>
+  <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/live/show_form.html.erb
+++ b/app/views/live/show_form.html.erb
@@ -1,6 +1,10 @@
 <% set_page_title(form.name) %>
 
-<% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>
+<% if form.group.present? %>
+  <% content_for :back_link, govuk_back_link_to(group_path(form.group), t("back_link.group", group_name: form.group.name)) %>
+<% else %>
+  <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
     form_edit: Back to edit your form
     form_view: Back to your form
     forms: Back to your forms
+    group: Back to %{group_name}
     group_show: Back to your forms
     groups: Back to your groups
   banner:

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 describe "forms/show.html.erb" do
   let(:user) { build :editor_user }
-  let(:form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", pages:) }
-  let(:pages) { [{ id: 183, question_text: "What is your address?", hint_text: "", answer_type: "address", next_page: nil }] }
+  let(:form) { build :form, :with_pages, id: 1, name: "Form 1", form_slug: "form-1" }
 
   before do
     assign(:current_user, user)
@@ -32,9 +31,7 @@ describe "forms/show.html.erb" do
     expect(rendered).to have_selector(".app-task-list__summary", text: "You’ve completed 12 of 20 tasks.")
   end
 
-  context "when form states is a draft" do
-    let(:form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", pages: []) }
-
+  context "when form state is draft" do
     it "rendered draft tag " do
       expect(rendered).to have_css(".govuk-tag.govuk-tag--yellow", text: "Draft")
     end
@@ -44,8 +41,8 @@ describe "forms/show.html.erb" do
     end
   end
 
-  context "when form states is a live" do
-    let(:form) { OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2", status: "live", has_live_version: true, pages: []) }
+  context "when form state is live or draft_live" do
+    let(:form) { build :form, :live, id: 2 }
 
     it "has a back link to the live form page" do
       expect(view.content_for(:back_link)).to have_link("Back", href: "/forms/2/live")

--- a/spec/views/live/show_form.html.erb_spec.rb
+++ b/spec/views/live/show_form.html.erb_spec.rb
@@ -5,11 +5,17 @@ describe "live/show_form.html.erb", feature_metrics_for_form_creators_enabled: f
   let(:what_happens_next) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:form_metadata) { OpenStruct.new(has_draft_version: false) }
   let(:form) { build(:form, :live, id: 2, declaration_text: declaration, what_happens_next_markdown: what_happens_next, live_at: 1.week.ago) }
+  let(:group) { create(:group, name: "Group 1") }
   let(:metrics_data) { nil }
 
   before do
     allow(view).to receive(:live_form_pages_path).and_return("/live-form-pages-path")
     allow(form).to receive(:metrics_data).and_return(metrics_data)
+
+    if group.present?
+      GroupForm.create!(form_id: form.id, group_id: group.id)
+    end
+
     render(template: "live/show_form", locals: { form_metadata:, form: })
   end
 
@@ -17,8 +23,8 @@ describe "live/show_form.html.erb", feature_metrics_for_form_creators_enabled: f
     expect(view.content_for(:title)).to have_content(form.name.to_s)
   end
 
-  it "back link is set to root" do
-    expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
+  it "back link is set to group page" do
+    expect(view.content_for(:back_link)).to have_link("Back to Group 1", href: group_path(group))
   end
 
   it "contains page heading" do
@@ -132,6 +138,14 @@ describe "live/show_form.html.erb", feature_metrics_for_form_creators_enabled: f
 
     it "renders the metrics summary component" do
       expect(rendered).to have_text(I18n.t("metrics_summary.description.complete_week"))
+    end
+  end
+
+  context "when form is not in a group" do
+    let(:group) { nil }
+
+    it "back link is set to root" do
+      expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
     end
   end
 end


### PR DESCRIPTION
## Change back links on tasklist and live form pages for forms in groups

Trello card: https://trello.com/c/16aEvxcI/1419-add-start-button-to-create-forms-in-group

When a form is part of a group the back link on the tasklist page will go to the `Group#show` rather than `root_path`.

This PR updates the links for forms and the live form view and related tests.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
