### PR TITLE
Fix delete form in group

### DIFF
--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -63,7 +63,7 @@ module Forms
     end
 
     def delete_form(form)
-      success_url = root_path
+      success_url = form.group.present? ? group_path(form.group) : root_path
 
       authorize form, :can_view_form?
       if form.destroy

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -106,6 +106,10 @@ class Form < ActiveResource::Base
     nil
   end
 
+  after_destroy do
+    group_form&.destroy
+  end
+
 private
 
   def has_routing_conditions

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -16,6 +16,29 @@ describe Form, type: :model do
     end
   end
 
+  describe "#destroy" do
+    context "when form is in a group" do
+      it "destroys the group" do
+        group = create :group
+        GroupForm.create!(group:, form_id: form.id)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.post "/api/v1/forms", post_headers, { id: 1 }.to_json, 200
+          mock.delete "/api/v1/forms/1", delete_headers, nil, 204
+        end
+
+        # form must exist for ActiveResource to delete it
+        form.save!
+
+        expect {
+          form.destroy
+        }.to change(GroupForm, :count).by(-1)
+
+        expect(GroupForm.find_by(form_id: form.id)).to be_nil
+      end
+    end
+  end
+
   describe "#status" do
     context "when form has not been made live" do
       it "returns 'draft'" do

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -168,22 +168,33 @@ RSpec.describe FormsController, type: :request do
 
   describe "Destroying an existing form" do
     describe "Given a valid form" do
+      let(:group) { create :group }
+
       before do
         ActiveResourceMock.mock_resource(form,
                                          {
                                            read: { response: form, status: 200 },
                                            delete: { response: {}, status: 200 },
                                          })
+        GroupForm.create!(group:, form_id: form.id) if group.present?
         allow(Pundit).to receive(:authorize).and_return(true)
         delete destroy_form_path(form_id: 2, forms_delete_confirmation_form: { confirm_deletion: "true" })
       end
 
-      it "Redirects you to the home screen" do
-        expect(response).to redirect_to(root_path)
+      it "redirects you to the group page" do
+        expect(response).to redirect_to(group_path(group))
       end
 
-      it "Deletes the form on the API" do
+      it "deletes the form on the API" do
         expect(form).to have_been_deleted
+      end
+
+      context "when the form is not in a group" do
+        let(:group) { nil }
+
+        it "redirects to the home page" do
+          expect(response).to redirect_to(root_path)
+        end
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/16aEvxcI/1419-add-start-button-to-create-forms-in-group

Allow deleting of forms and redirecting to the correct location when forms are within group.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
