### PR TITLE
Add form creation within groups

### DIFF
--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -1,0 +1,40 @@
+class GroupFormsController < ApplicationController
+  before_action :set_group
+  after_action :verify_authorized
+
+  # GET /groups/:group_id/forms/new
+  def new
+    @group_form = GroupForm.new(group: @group)
+    authorize @group_form
+
+    @name_form = Forms::NameForm.new
+  end
+
+  # POST /groups/:group_id/forms
+  def create
+    @group_form = GroupForm.new(group: @group)
+    authorize @group_form
+
+    @form = Form.new(creator_id: @current_user.id)
+    @name_form = Forms::NameForm.new(name_form_params(@form))
+
+    if @name_form.submit
+      @group_form.form_id = @form.id
+      @group_form.save!
+
+      redirect_to form_path(@form)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def set_group
+    @group = Group.find_by(external_id: params[:group_id])
+  end
+
+  def name_form_params(form)
+    params.require(:forms_name_form).permit(:name).merge(form:)
+  end
+end

--- a/app/policies/group_form_policy.rb
+++ b/app/policies/group_form_policy.rb
@@ -1,0 +1,6 @@
+class GroupFormPolicy < ApplicationPolicy
+  def new?
+    record.group && Pundit.policy!(user, record.group).show?
+  end
+  alias_method :create?, :new?
+end

--- a/app/views/group_forms/new.html.erb
+++ b/app/views/group_forms/new.html.erb
@@ -1,0 +1,7 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.change_name_form'), @name_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(group_path(@group)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render @name_form, url: group_forms_path %>
+  </div>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -16,6 +16,8 @@
   <%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %>
 </div>
 
+<%= govuk_start_button(text: t("home.create_a_form"), href: new_group_form_path(@group)) %>
+
 <% if @forms.any? %>
   <%= govuk_table(**FormListService.call(forms: @forms, current_user: @current_user, group: @group).data) %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,7 +133,9 @@ Rails.application.routes.draw do
     get "/signed", to: "mou_signatures#confirmation", as: :confirmation
   end
 
-  resources :groups
+  resources :groups do
+    resources :forms, controller: :group_forms, only: %i[new create]
+  end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page
   match "/403", to: "errors#forbidden", as: :error_403, via: :all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,10 +46,7 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create_list :user, 3, :with_trial_role
 
   # create some test groups
-  test_group = FactoryBot.create :group, name: "Test Service", organisation: gds
+  FactoryBot.create :group, name: "Test Group", organisation: gds
   FactoryBot.create :group, name: "Ministry of Tests forms", organisation: test_org
   FactoryBot.create :group, name: "Ministry of Tests forms - secret!", organisation: test_org
-
-  # Add a form to a group
-  test_group.group_forms.create! form_id: 1
 end

--- a/spec/policies/group_form_policy_spec.rb
+++ b/spec/policies/group_form_policy_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe GroupFormPolicy do
+  subject(:policy) { described_class.new(user, group_form) }
+
+  let(:group) { build :group, id: 1 }
+  let(:group_form) { GroupForm.new(group:) }
+
+  context "when user can access group" do
+    let(:user) { build :editor_user, groups: [group] }
+
+    it { is_expected.to permit_all_actions }
+  end
+
+  context "when user cannot access group" do
+    let(:user) { build :editor_user }
+
+    it { is_expected.to forbid_all_actions }
+  end
+end

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe "/groups/:group_id/forms", type: :request do
+  let(:group) { create :group }
+
+  let(:valid_attributes) do
+    { name: "Test form" }
+  end
+  let(:invalid_attributes) do
+    { name: "" }
+  end
+
+  before do
+    create(:membership, user: editor_user, group:)
+    login_as_editor_user
+  end
+
+  describe "GET /new" do
+    before do
+      get new_group_form_url(group)
+    end
+
+    it "renders a successful response" do
+      expect(response).to have_http_status :ok
+    end
+
+    it "renders the change name form" do
+      assert_select "form[action=?][method=?]", group_forms_path, :post do
+        assert_select "input[name=?]", "forms_name_form[name]"
+      end
+    end
+
+    it "has a back link to the group page" do
+      rendered = Capybara.string(response.body)
+      expect(rendered).to have_link "Back", href: group_path(group)
+    end
+
+    context "when the current user does not have access to the group" do
+      it "denies access" do
+        other_group = create :group
+
+        get new_group_form_url(other_group)
+
+        expect(response).to have_http_status :forbidden
+      end
+    end
+
+    context "when the group does not exist" do
+      it "returns a forbidden status code" do
+        get new_group_form_url("nonsense")
+
+        expect(response).to have_http_status :forbidden
+      end
+    end
+  end
+
+  describe "POST /" do
+    context "with valid parameters" do
+      let(:new_form_id) { 1 }
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.post "/api/v1/forms", post_headers, { id: new_form_id }.to_json, 200
+        end
+      end
+
+      it "creates a new form" do
+        post group_forms_url(group), params: { forms_name_form: valid_attributes }
+
+        expected_request = ActiveResource::Request.new(:post, "/api/v1/forms", nil, post_headers)
+        expect(ActiveResource::HttpMock.requests).to include expected_request
+      end
+
+      it "associates the new form with the group" do
+        expect {
+          post group_forms_url(group), params: { forms_name_form: valid_attributes }
+        }.to change(GroupForm, :count).by(1)
+
+        expect(GroupForm.last).to have_attributes(group_id: group.id, form_id: new_form_id)
+      end
+
+      it "redirects to the created form" do
+        post group_forms_url(group), params: { forms_name_form: valid_attributes }
+        expect(response).to redirect_to(form_url(new_form_id))
+      end
+    end
+
+    context "with invalid parameters" do
+      before do
+        ActiveResource::HttpMock.reset! # not expecting any API calls
+      end
+
+      it "does not create a new form" do
+        expect {
+          post group_forms_url(group), params: { forms_name_form: invalid_attributes }
+        }.to change(GroupForm, :count).by(0)
+
+        expect(ActiveResource::HttpMock.requests).to be_empty
+      end
+
+      it "renders a response with 422 status" do
+        post group_forms_url(group), params: { forms_name_form: invalid_attributes }
+        expect(response).to have_http_status :unprocessable_entity
+      end
+
+      it "renders the change name form with an error" do
+        post group_forms_url(group), params: { forms_name_form: invalid_attributes }
+
+        expect(assigns[:name_form]).to be_truthy
+        expect(response).to render_template("group_forms/new")
+        expect(response).to render_template("form_objects/forms/_name_form")
+        expect(response.body).to include I18n.t("error_summary.heading")
+      end
+    end
+
+    context "when the current user does not have access to the group" do
+      it "denies access" do
+        other_group = create :group
+
+        post group_forms_url(other_group), params: { forms_name_form: valid_attributes }
+
+        expect(response).to have_http_status :forbidden
+      end
+    end
+
+    context "when the group does not exist" do
+      it "returns a forbidden status code" do
+        post group_forms_url("nonsense"), params: { forms_name_form: valid_attributes }
+
+        expect(response).to have_http_status :forbidden
+      end
+    end
+  end
+end

--- a/spec/routing/group_forms_routing_spec.rb
+++ b/spec/routing/group_forms_routing_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe GroupFormsController, type: :routing do
+  describe "routing" do
+    it "routes to #new" do
+      expect(get: "/groups/1/forms/new").to route_to("group_forms#new", group_id: "1")
+    end
+
+    it "routes to #create" do
+      expect(post: "/groups/1/forms").to route_to("group_forms#create", group_id: "1")
+    end
+  end
+
+  describe "path helpers" do
+    it "uses the group external ID" do
+      group = create :group
+      expect(get: new_group_form_path(group)).to route_to("group_forms#new", group_id: group.external_id)
+    end
+  end
+end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -95,4 +95,11 @@ RSpec.describe "groups/show", type: :view do
       expect(rendered).not_to have_css ".govuk-notification-banner"
     end
   end
+
+  it "has a start button to create a new form" do
+    render
+    expect(rendered).to have_css ".govuk-button--start", text: "Create a form" do |start_button|
+      expect(start_button).to match_selector :link, href: new_group_form_path(group)
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

We want members of a group to be able to create forms in that group. This PR adds the necessary controller, routing, policy, and view changes to add a button to create a form within a group.

We also took the approach in tests that forms within groups will be the new default, and have updated tests we were changing anyway to adopt this approach. Hopefully this means refactoring to remove the legacy "form without a group" case is easier in future. This also highlighted the need for feature testing of creation of groups, which will follow in a future PR.

Trello card: https://trello.com/c/16aEvxcI

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
