### PR TITLE
Use email address as link text on list of users

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -18,10 +18,10 @@
     <%= table.with_body do |body|
       users.each do |user|
         body.with_row do |row|
+          row.with_cell( text: user.name || t("users.index.name_blank"))
           row.with_cell do
-            govuk_link_to(user.name || t("users.index.name_blank"), edit_user_path(user))
+            govuk_link_to(user.email, edit_user_path(user))
           end
-          row.with_cell( text: user.email)
           row.with_cell( text: user.organisation&.name || t("users.index.organisation_blank"))
           row.with_cell( text: t("users.roles.#{user.role}.name"))
           row.with_cell( text: t("users.has_access.#{user.has_access}.name"))

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -16,12 +16,12 @@ describe "users/index.html.erb" do
     expect(rendered).to have_css("h1.govuk-heading-l", text: /Users/)
   end
 
-  it "contains a link to edit with name" do
-    expect(rendered).to have_link(users.first.name, href: edit_user_path(users.first))
+  it "contains the user's name" do
+    expect(rendered).to have_text(users.first.name)
   end
 
-  it "contains email" do
-    expect(rendered).to have_text(users.first.email)
+  it "contains the user's email as a link to the edit page" do
+    expect(rendered).to have_link(users.first.email, href: edit_user_path(users.first))
   end
 
   it "contains organisation name" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/UOgSrjeL/1439-users-list-page-multiple-links-have-identical-link-text-and-context-no-name-set

Previously on the users page, we linked from the user's name to the edit user page. This failed guideline 2.4.4 of the Web Content Accessibility Guidelines, as it meant that when multiple users have the same name (either because their actual names are identical, or because they didn't have names set), there would be multiple links with the same link context.

This PR makes the user's email address the link instead of the user's name. This prevents the issue, as email addresses are unique in our service.

### Screenshots
#### Before
![Screenshot of a table with headings for name, email address, organisation, role and access. The entries for the name column are all hyperlinks, the other columns are plain text. Several of the entries in the name column have the identical link text 'No name set'](https://github.com/alphagov/forms-admin/assets/5861235/1fea6edf-545c-493f-ab29-b8ee056beb57)

#### After
![Screenshot of a table with headings for name, email address, organisation, role and access. The entries for the email address column are all hyperlinks, the other columns are plain text. Each entry in the email address column has unique link text.](https://github.com/alphagov/forms-admin/assets/5861235/a2fa035d-b348-4c57-8671-8798c42d2d89)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
