### PR TITLE
Add closed attribute to organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -6,5 +6,6 @@ class Organisation < ApplicationRecord
 
   has_many :mou_signatures
 
+  scope :not_closed, -> { where(closed: false) }
   scope :with_users, -> { joins(:users).distinct.order(:name) }
 end

--- a/db/migrate/20240320070145_add_closed_to_organisation.rb
+++ b/db/migrate/20240320070145_add_closed_to_organisation.rb
@@ -1,0 +1,5 @@
+class AddClosedToOrganisation < ActiveRecord::Migration[7.1]
+  def change
+    add_column :organisations, :closed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_08_113842) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_20_070145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,6 +89,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_08_113842) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "closed", default: false
     t.index ["govuk_content_id"], name: "index_organisations_on_govuk_content_id", unique: true
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,6 +26,7 @@ if HostingEnvironment.local_development? && User.none?
   test_org = FactoryBot.create :organisation, slug: "test-org"
   FactoryBot.create :organisation, slug: "ministry-of-tests"
   FactoryBot.create :organisation, slug: "department-for-testing"
+  FactoryBot.create :organisation, slug: "closed-org", closed: true
 
   # create extra editors
   FactoryBot.create_list :editor_user, 3, organisation: test_org

--- a/lib/organisations_fetcher.rb
+++ b/lib/organisations_fetcher.rb
@@ -31,6 +31,7 @@ private
       govuk_content_id:,
       slug:,
       name: organisation_data[:title],
+      closed: organisation_data[:details][:govuk_status] == "closed",
     }
 
     organisation.update!(update_data)

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -1,6 +1,3 @@
-require_relative "../advisory_lock"
-require_relative "../organisations_fetcher"
-
 namespace :organisations do
   desc "Update organisations table using data from GOV.UK"
   task fetch: :environment do

--- a/spec/lib/organisations_fetcher_spec.rb
+++ b/spec/lib/organisations_fetcher_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe OrganisationsFetcher do
+  subject(:organisations_fetcher) { described_class.new }
+
+  def stub_organisation_api_has_organisations_with_bodies(organisation_bodies)
+    stub_request(:get, "https://www.gov.uk/api/organisations")
+      .to_return_json(body: { results: organisation_bodies })
+  end
+
+  def organisation_details_for_slug(slug, content_id = Faker::Internet.uuid)
+    {
+      details: { content_id:, slug: },
+      title: slug.titleize,
+    }
+  end
+
+  it "creates new organisations when none exist" do
+    stub_organisation_api_has_organisations_with_bodies([
+      organisation_details_for_slug("department-for-tests"),
+      organisation_details_for_slug("ministry-of-tests"),
+    ])
+
+    expect {
+      organisations_fetcher.call
+    }.to change(Organisation, :count).by(2)
+
+    expect(Organisation.find_by(slug: "department-for-tests")).to be_persisted
+    expect(Organisation.find_by(slug: "ministry-of-tests")).to be_persisted
+  end
+
+  it "updates an existing organisation when its slug changes" do
+    organisation = create :organisation, slug: "test-org", name: "Test Organisation"
+
+    stub_organisation_api_has_organisations_with_bodies([
+      organisation_details_for_slug("test-organisation", organisation.govuk_content_id),
+    ])
+
+    organisations_fetcher.call
+    organisation.reload
+
+    expect(organisation.slug).to eq "test-organisation"
+  end
+end

--- a/spec/lib/organisations_fetcher_spec.rb
+++ b/spec/lib/organisations_fetcher_spec.rb
@@ -41,4 +41,20 @@ RSpec.describe OrganisationsFetcher do
 
     expect(organisation.slug).to eq "test-organisation"
   end
+
+  it "updates an existing organisation when it is closed" do
+    organisation = create :organisation, slug: "test-org"
+
+    organisation_details = organisation_details_for_slug("test-organisation", organisation.govuk_content_id)
+    organisation_details[:details][:govuk_status] = "closed"
+
+    stub_organisation_api_has_organisations_with_bodies([
+      organisation_details,
+    ])
+
+    organisations_fetcher.call
+    organisation.reload
+
+    expect(organisation.closed).to be true
+  end
 end

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -52,4 +52,21 @@ RSpec.describe "organisations.rake" do
       end
     end
   end
+
+  describe "organisations:fetch" do
+    subject(:task) do
+      Rake::Task["organisations:fetch"]
+        .tap(&:reenable) # make sure task is invoked every time
+    end
+
+    it "fetches organisations" do
+      organisations_fetcher = instance_double(OrganisationsFetcher)
+      allow(organisations_fetcher).to receive(:call).and_return(nil)
+      allow(OrganisationsFetcher).to receive(:new).and_return(organisations_fetcher)
+
+      task.invoke
+
+      expect(organisations_fetcher).to have_received(:call).once
+    end
+  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -44,5 +44,14 @@ RSpec.describe Organisation, type: :model do
         expect(organisations_with_users).to eq([organisation1, organisation2])
       end
     end
+
+    describe ".not_closed" do
+      it "returns organisations which are not closed" do
+        organisation = create :organisation
+        create :organisation, slug: "closed-org", closed: true
+
+        expect(described_class.not_closed).to eq [organisation]
+      end
+    end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/sLRD2UNh/1434-update-the-database-of-organisations-so-users-can-select-from-a-shorter-list <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to make it easier for users to choose the right organisation. Our list of organisations includes lots of departments and whatnots that no longer exist for various reasons; this information is recorded in the GOV.UK organisation API, but we previously we haven't been recording that information in our own database.

This PR adds a `closed` column to the organisation table that indicates whether an organisation is no longer extant.

I've called this status field `closed` even though this is a negative because it most closely matches what's in the [GOV.UK Signon codebase][1], and I thought it would be useful for our codebase to hew closely to theirs; if people find the default double negative too heinous though I'll change it!

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?