### PR TITLE
Add creator to group

### DIFF
--- a/app/components/group_list_component/view.html.erb
+++ b/app/components/group_list_component/view.html.erb
@@ -21,7 +21,7 @@
       @groups.each do |group|
         body.with_row do |row|
           row.with_cell { govuk_link_to(group.name, group) }
-          row.with_cell(numeric: true) { t('groups.group_list.created_by_unknown') }
+          row.with_cell(numeric: true) { group.creator&.name.presence || t('groups.group_list.created_by_unknown') }
         end
       end
     end %>

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -28,7 +28,7 @@ class GroupsController < ApplicationController
 
   # POST /groups
   def create
-    @group = Group.new(group_params)
+    @group = Group.new(group_params.merge({ creator: @current_user }))
     @group.organisation = current_user.organisation
     @group.memberships.build(user: current_user, added_by: current_user)
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,8 @@
 class Group < ApplicationRecord
   belongs_to :organisation
 
+  belongs_to :creator, class_name: "User", optional: true
+
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
 

--- a/db/migrate/20240325114214_add_creator_to_group.rb
+++ b/db/migrate/20240325114214_add_creator_to_group.rb
@@ -1,0 +1,5 @@
+class AddCreatorToGroup < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :groups, :creator, null: true, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_21_074041) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_25_114214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_074041) do
     t.text "external_id", null: false
     t.bigint "organisation_id"
     t.string "status", default: "trial"
+    t.bigint "creator_id"
+    t.index ["creator_id"], name: "index_groups_on_creator_id"
     t.index ["external_id"], name: "index_groups_on_external_id", unique: true
     t.index ["organisation_id"], name: "index_groups_on_organisation_id"
   end
@@ -127,6 +129,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_074041) do
   end
 
   add_foreign_key "draft_questions", "users"
+  add_foreign_key "groups", "users", column: "creator_id"
   add_foreign_key "memberships", "groups"
   add_foreign_key "memberships", "users"
   add_foreign_key "memberships", "users", column: "added_by_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,14 +18,14 @@ if HostingEnvironment.local_development? && User.none?
   )
 
   # Create default super-admin
-  User.create!({ email: "example@example.com",
-                 organisation_slug: "government-digital-service",
-                 organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
-                 organisation: gds,
-                 name: "A User",
-                 role: :super_admin,
-                 uid: "123456",
-                 provider: :mock_gds_sso })
+  default_user = User.create!({ email: "example@example.com",
+                                organisation_slug: "government-digital-service",
+                                organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+                                organisation: gds,
+                                name: "A User",
+                                role: :super_admin,
+                                uid: "123456",
+                                provider: :mock_gds_sso })
 
   # create extra organisations
   test_org = FactoryBot.create :organisation, slug: "test-org"
@@ -52,7 +52,7 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create_list :user, 3, :with_trial_role
 
   # create some test groups
-  FactoryBot.create :group, name: "Test Group", organisation: gds
-  FactoryBot.create :group, name: "Ministry of Tests forms", organisation: test_org
-  FactoryBot.create :group, name: "Ministry of Tests forms - secret!", organisation: test_org
+  FactoryBot.create :group, name: "Test Group", organisation: gds, creator: default_user
+  FactoryBot.create :group, name: "Ministry of Tests forms", organisation: test_org, creator: default_user
+  FactoryBot.create :group, name: "Ministry of Tests forms - secret!", organisation: test_org, creator: default_user
 end

--- a/spec/components/group_list_component/view_spec.rb
+++ b/spec/components/group_list_component/view_spec.rb
@@ -32,5 +32,22 @@ RSpec.describe GroupListComponent::View, type: :component do
         expect(page).to have_css("h2", text: title)
       end
     end
+
+    context "when the group creator is known" do
+      let(:user) { create :user }
+      let(:groups) { create_list(:group, 3, creator: user) }
+
+      it "renders the creator's name" do
+        expect(page).to have_css("tr", count: 3, text: user.name)
+      end
+    end
+
+    context "when the group creator is unknown" do
+      let(:groups) { create_list(:group, 3, creator: nil) }
+
+      it "renders the creator as unknown" do
+        expect(page).to have_css("tr", count: 3, text: "Unknown")
+      end
+    end
   end
 end

--- a/spec/factories/models/groups.rb
+++ b/spec/factories/models/groups.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :group do
     name { "My Group" }
     organisation { association :organisation, id: 1, slug: "test-org" }
+    creator { association :user, organisation: }
     status { :trial }
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Group, type: :model do
       group = build :group, status: nil
       expect(group).not_to be_valid
     end
+
+    it "is valid without a creator" do
+      group = build :group, creator: nil
+      expect(group).to be_valid
+    end
   end
 
   describe "before_create" do
@@ -59,6 +64,13 @@ RSpec.describe Group, type: :model do
       create(:membership, group:, user:, added_by:)
 
       expect { group.destroy }.to change(Membership, :count).by(-1)
+    end
+
+    it "does not destroy associated creator" do
+      user = create :user
+      group = create :group, creator: user
+
+      expect { group.destroy }.not_to change(User, :count)
     end
   end
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -158,6 +158,14 @@ RSpec.describe "/groups", type: :request do
         post groups_url, params: { group: valid_attributes }
         expect(response).to redirect_to(group_url(Group.last))
       end
+
+      it "records the creator" do
+        login_as_editor_user
+
+        post groups_url, params: { group: valid_attributes }
+
+        expect(Group.last.creator).to eq(editor_user)
+      end
     end
 
     context "with invalid parameters" do


### PR DESCRIPTION
### What problem does this pull request solve?

We want to be able to see who created each group, so that org and super admins can contact the correct person for initial group admin tasks.

This is done via a creator `belongs_to` association between the `Group` and `User` models. We then show the creator's name in the "Created by" column on the groups page.

Trello card: https://trello.com/c/KEYTEmgj

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
