### PR TITLE
Admin: Ask user for name and org

### DIFF
--- a/app/controllers/account/names_controller.rb
+++ b/app/controllers/account/names_controller.rb
@@ -12,7 +12,7 @@ module Account
       if @name_form.submit
         redirect_to root_path
       else
-        render :edit
+        render :edit, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/account/names_controller.rb
+++ b/app/controllers/account/names_controller.rb
@@ -1,0 +1,29 @@
+module Account
+  class NamesController < ApplicationController
+    before_action :redirect_if_name_exists
+
+    def edit
+      @name_form = NameForm.new(user: current_user).assign_form_values
+    end
+
+    def update
+      @name_form = NameForm.new(account_name_form_params(current_user))
+
+      if @name_form.submit
+        redirect_to root_path
+      else
+        render :edit
+      end
+    end
+
+    def account_name_form_params(user)
+      params.require(:account_name_form).permit(:name).merge(user:)
+    end
+
+  private
+
+    def redirect_if_name_exists
+      redirect_to root_path if current_user.name.present?
+    end
+  end
+end

--- a/app/controllers/account/organisations_controller.rb
+++ b/app/controllers/account/organisations_controller.rb
@@ -1,0 +1,29 @@
+module Account
+  class OrganisationsController < ApplicationController
+    before_action :redirect_if_organisation_exists
+
+    def edit
+      @organisation_form = OrganisationForm.new(user: current_user).assign_form_values
+    end
+
+    def update
+      @organisation_form = OrganisationForm.new(account_organisation_form_params(current_user))
+
+      if @organisation_form.submit
+        redirect_to root_path
+      else
+        render :edit
+      end
+    end
+
+    def account_organisation_form_params(user)
+      params.require(:account_organisation_form).permit(:organisation_id).merge(user:)
+    end
+
+  private
+
+    def redirect_if_organisation_exists
+      redirect_to root_path if current_user.organisation.present?
+    end
+  end
+end

--- a/app/controllers/account/organisations_controller.rb
+++ b/app/controllers/account/organisations_controller.rb
@@ -12,7 +12,7 @@ module Account
       if @organisation_form.submit
         redirect_to root_path
       else
-        render :edit
+        render :edit, status: :unprocessable_entity
       end
     end
 

--- a/app/form_objects/account/name_form.rb
+++ b/app/form_objects/account/name_form.rb
@@ -1,0 +1,17 @@
+class Account::NameForm < BaseForm
+  attr_accessor :user, :name
+
+  validates :name, presence: true
+
+  def submit
+    return false if invalid?
+
+    user.name = name
+    user.save!
+  end
+
+  def assign_form_values
+    self.name = user.name
+    self
+  end
+end

--- a/app/form_objects/account/organisation_form.rb
+++ b/app/form_objects/account/organisation_form.rb
@@ -1,0 +1,17 @@
+class Account::OrganisationForm < BaseForm
+  attr_accessor :user, :organisation_id
+
+  validates :organisation_id, presence: true
+
+  def submit
+    return false if invalid?
+
+    user.organisation_id = organisation_id
+    user.save!
+  end
+
+  def assign_form_values
+    self.organisation_id = user.organisation_id
+    self
+  end
+end

--- a/app/form_objects/account/organisation_form.rb
+++ b/app/form_objects/account/organisation_form.rb
@@ -7,11 +7,25 @@ class Account::OrganisationForm < BaseForm
     return false if invalid?
 
     user.organisation_id = organisation_id
-    user.save!
+
+    if user.save!
+      log_organisation_chosen_event
+      true
+    end
   end
 
   def assign_form_values
     self.organisation_id = user.organisation_id
     self
+  end
+
+private
+
+  def log_organisation_chosen_event
+    EventLogger.log({
+      event: "organisation_chosen",
+      user_id: user.id,
+      organisation_id:,
+    })
   end
 end

--- a/app/views/account/names/edit.html.erb
+++ b/app/views/account/names/edit.html.erb
@@ -1,0 +1,16 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.account_name'), @name_form.errors.any?)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @name_form, url: account_name_path, method: :patch) do |f| %>
+      <% if @name_form &.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <%= f.govuk_text_field :name,
+        label: { size: 'xl', tag: 'h1' },
+        required: true %>
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/account/organisations/edit.html.erb
+++ b/app/views/account/organisations/edit.html.erb
@@ -1,0 +1,30 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.account_organisation'), @organisation_form.errors.any?)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @organisation_form , url: account_organisation_path, method: :patch) do |f| %>
+      <% if @organisation_form &.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <%= render DfE::Autocomplete::View.new(
+        f,
+        attribute_name: :organisation_id,
+        form_field: f.govuk_collection_select(:organisation_id,
+                                              Organisation.order(:slug),
+                                              :id,
+                                              :name,
+                                              class: ['govuk-!-width-three-quarters'],
+                                              options: { prompt: t('users.edit.organisation_prompt') },
+                                              label: { size: 'xl', tag: 'h1' },
+                                             ),
+      html_attributes: { 'data-show-all-values' => 'true'},
+      )%>
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+
+  <%= govuk_section_break(visible:true, size: "l") %>
+  <%= govuk_details(summary_text: t('account.organisation_details_summary'), text: t('account.organisation_text_html', contact_link: contact_link)) %>
+  </div>
+</div>
+
+<%= init_autocomplete_script(show_all_values: true, raw_attribute: false, source: false) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,17 @@
 ---
 en:
+  account:
+    organisation_details_summary: If your organisation is not listed
+    organisation_text_html: |
+      <p>If you're from a central government organisation that publishes content on the GOV.UK website but your organisation is not listed, please %{contact_link}.</p>
+      <p>If you’re from a public sector organisation that doesn’t publish content on GOV.UK you cannot use GOV.UK Forms yet. You can <a href="https://www.forms.service.gov.uk/forthcoming-features">read about our forthcoming features and sign up to our mailing list</a> for updates.</p>
   activemodel:
     errors:
       models:
+        account/organisation_form:
+          attributes:
+            organisation_id:
+              blank: Select your organisation
         page:
           attributes:
             hint_text:
@@ -292,6 +301,10 @@ en:
     users: Users
   helpers:
     hint:
+      account_name_form:
+        name: You do not need to include a title or any middle names.
+      account_organisation_form:
+        organisation_id: Currently, GOV.UK Forms is only available for central government organisations that publish content on the GOV.UK website.
       page:
         answer_type: The answer will be checked to make sure it’s in the selected format.
         hint_text:
@@ -327,6 +340,8 @@ en:
           radio: Ask the question the way you would in person. For example, ‘What country do you live in?’
           single_line: Ask the question the way you would in person. For example, ‘What’s your reference number?’
     label:
+      account_organisation_form:
+        organisation_id: Select your organisation
       forms_make_changes_live_form:
         confirm_make_live: Are you sure you want to make your draft live?
       forms_make_live_form:
@@ -647,6 +662,7 @@ en:
       only_one_option: Selection from a list, one option only.
   page_titles:
     access_denied: You do not have permission to access GOV.UK Forms
+    account_organisation: Select your organisation
     add_guidance: Add guidance
     address_settings: What kind of addresses do you expect to receive?
     change_name_form: Name your form

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,10 @@ en:
   activemodel:
     errors:
       models:
+        account/name_form:
+          attributes:
+            name:
+              blank: Enter your name
         account/organisation_form:
           attributes:
             organisation_id:
@@ -340,6 +344,8 @@ en:
           radio: Ask the question the way you would in person. For example, ‘What country do you live in?’
           single_line: Ask the question the way you would in person. For example, ‘What’s your reference number?’
     label:
+      account_name_form:
+        name: Enter your full name
       account_organisation_form:
         organisation_id: Select your organisation
       forms_make_changes_live_form:
@@ -662,6 +668,7 @@ en:
       only_one_option: Selection from a list, one option only.
   page_titles:
     access_denied: You do not have permission to access GOV.UK Forms
+    account_name: Enter your name
     account_organisation: Select your organisation
     add_guidance: Add guidance
     address_settings: What kind of addresses do you expect to receive?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
   account:
     organisation_details_summary: If your organisation is not listed
     organisation_text_html: |
-      <p>If you're from a central government organisation that publishes content on the GOV.UK website but your organisation is not listed, please %{contact_link}.</p>
+      <p>If you’re from a central government organisation that publishes content on the GOV.UK website but your organisation is not listed, please %{contact_link}.</p>
       <p>If you’re from a public sector organisation that doesn’t publish content on GOV.UK you cannot use GOV.UK Forms yet. You can <a href="https://www.forms.service.gov.uk/forthcoming-features">read about our forthcoming features and sign up to our mailing list</a> for updates.</p>
   activemodel:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
   end
 
   namespace :account do
+    resource :name, only: %i[edit update]
     resource :organisation, only: %i[edit update]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,10 @@ Rails.application.routes.draw do
     get "/requested", to: "user_upgrade_requests#confirmation", as: :confirmation
   end
 
+  namespace :account do
+    resource :organisation, only: %i[edit update]
+  end
+
   resources :mou_signatures, only: %i[index], path: "mous"
 
   resource :mou_signature, only: %i[new show create], path: "/memorandum-of-understanding" do

--- a/spec/features/account/add_account_org_spec.rb
+++ b/spec/features/account/add_account_org_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Add account organisation to user without organisation", type: :feature do
-  let(:user) { create :user, :with_no_org }
+  let(:user) { create :user, :with_no_org, name: nil }
   let!(:organisation) { create :organisation }
 
   before do
@@ -17,6 +17,12 @@ feature "Add account organisation to user without organisation", type: :feature 
     then_i_should_be_redirected_to_the_root_path
   end
 
+  scenario "when the does not have a name" do
+    when_i_visit_the_account_name_page
+    and_i_fill_in_my_name
+    then_i_should_be_redirected_to_the_root_path
+  end
+
 private
 
   def when_i_visit_the_account_organisation_page
@@ -26,6 +32,16 @@ private
 
   def and_i_select_an_organisation
     fill_in "Select your organisation", with: "#{organisation.name}\n"
+    click_button "Save and continue"
+  end
+
+  def when_i_visit_the_account_name_page
+    visit edit_account_name_path
+    expect(page).to have_content("Enter your full name")
+  end
+
+  def and_i_fill_in_my_name
+    fill_in "Enter your full name", with: "John Doe"
     click_button "Save and continue"
   end
 

--- a/spec/features/account/add_account_org_spec.rb
+++ b/spec/features/account/add_account_org_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+feature "Add account organisation to user without organisation", type: :feature do
+  let(:user) { create :user, :with_no_org }
+  let!(:organisation) { create :organisation }
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?creator_id=#{user.id}", headers, [].to_json, 200
+    end
+    login_as user
+  end
+
+  scenario "when the user does not have an organisation" do
+    when_i_visit_the_account_organisation_page
+    and_i_select_an_organisation
+    then_i_should_be_redirected_to_the_root_path
+  end
+
+private
+
+  def when_i_visit_the_account_organisation_page
+    visit edit_account_organisation_path
+    expect(page).to have_content("Select your organisation")
+  end
+
+  def and_i_select_an_organisation
+    fill_in "Select your organisation", with: "#{organisation.name}\n"
+    click_button "Save and continue"
+  end
+
+  def then_i_should_be_redirected_to_the_root_path
+    expect(page).to have_current_path(root_path)
+  end
+end

--- a/spec/form_objects/account/name_form_spec.rb
+++ b/spec/form_objects/account/name_form_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe Account::NameForm do
+  subject(:name_form) { described_class.new(user:) }
+
+  let(:user) { create(:user) }
+
+  describe "validations" do
+    it "is valid with a name" do
+      name_form.name = "Test user"
+      expect(name_form).to be_valid
+    end
+
+    it "is invalid without a name" do
+      name_form.name = ""
+      error_message = I18n.t("activemodel.errors.models.account/name_form.attributes.name.blank")
+      expect(name_form).not_to be_valid
+      expect(name_form.errors[:name]).to include(error_message)
+    end
+  end
+
+  describe "#submit" do
+    context "with valid attributes" do
+      before do
+        name_form.name = "new name"
+      end
+
+      it "updates the user name" do
+        expect { name_form.submit }.to change { user.reload.name }.to("new name")
+      end
+
+      it "returns true" do
+        expect(name_form.submit).to be true
+      end
+    end
+
+    context "with invalid params" do
+      before do
+        name_form.name = ""
+      end
+
+      it "does not update the user name" do
+        expect { name_form.submit }.not_to(change { user.reload.name })
+      end
+
+      it "returns false" do
+        expect(name_form.submit).to be false
+      end
+    end
+  end
+
+  describe "#assign_form_values" do
+    it "assigns the user name to the form" do
+      expect { name_form.assign_form_values }.to change(name_form, :name).to(user.name)
+    end
+
+    it "returns the form object" do
+      expect(name_form.assign_form_values).to eq(name_form)
+    end
+  end
+end

--- a/spec/form_objects/account/organisation_form_spec.rb
+++ b/spec/form_objects/account/organisation_form_spec.rb
@@ -33,6 +33,15 @@ describe Account::OrganisationForm do
       it "returns true" do
         expect(organisation_form.submit).to be true
       end
+
+      it "logs the organisation_chosen event" do
+        expect(EventLogger).to receive(:log).with({
+          event: "organisation_chosen",
+          user_id: user.id,
+          organisation_id: organisation.id,
+        })
+        organisation_form.submit
+      end
     end
 
     context "with invalid attributes" do
@@ -46,6 +55,11 @@ describe Account::OrganisationForm do
 
       it "returns false" do
         expect(organisation_form.submit).to be false
+      end
+
+      it "does not log the organisation_chosen event" do
+        expect(EventLogger).not_to receive(:log)
+        organisation_form.submit
       end
     end
   end

--- a/spec/form_objects/account/organisation_form_spec.rb
+++ b/spec/form_objects/account/organisation_form_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe Account::OrganisationForm do
+  subject(:organisation_form) { described_class.new(user:) }
+
+  let(:user) { create(:user, :with_no_org) }
+  let(:organisation) { create(:organisation) }
+
+  describe "validations" do
+    it "is valid with a valid organisation_id" do
+      organisation_form.organisation_id = organisation.id
+      expect(organisation_form).to be_valid
+    end
+
+    it "is invalid without an organisation_id" do
+      organisation_form.organisation_id = nil
+      error_message = I18n.t("activemodel.errors.models.account/organisation_form.attributes.organisation_id.blank")
+      expect(organisation_form).to be_invalid
+      expect(organisation_form.errors[:organisation_id]).to include(error_message)
+    end
+  end
+
+  describe "#submit" do
+    context "with valid attributes" do
+      before do
+        organisation_form.organisation_id = organisation.id
+      end
+
+      it "updates the user organisation_id" do
+        expect { organisation_form.submit }.to change { user.reload.organisation_id }.to(organisation.id)
+      end
+
+      it "returns true" do
+        expect(organisation_form.submit).to be true
+      end
+    end
+
+    context "with invalid attributes" do
+      before do
+        organisation_form.organisation_id = nil
+      end
+
+      it "does not update the user organisation_id" do
+        expect { organisation_form.submit }.not_to(change { user.reload.organisation_id })
+      end
+
+      it "returns false" do
+        expect(organisation_form.submit).to be false
+      end
+    end
+  end
+
+  describe "#assign_form_values" do
+    let(:user) { create(:user) }
+
+    it "assigns the user organisation_id to the form" do
+      expect { organisation_form.assign_form_values }.to change(organisation_form, :organisation_id).to(user.organisation_id)
+    end
+
+    it "returns the form object" do
+      expect(organisation_form.assign_form_values).to eq(organisation_form)
+    end
+  end
+end

--- a/spec/requests/account/names_controller_spec.rb
+++ b/spec/requests/account/names_controller_spec.rb
@@ -55,6 +55,7 @@ describe Account::NamesController do
 
       it "renders the edit template" do
         put account_name_path, params: invalid_params
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/requests/account/names_controller_spec.rb
+++ b/spec/requests/account/names_controller_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe Account::NamesController do
+  let(:user) { create(:user, name: nil) }
+
+  before do
+    login_as user
+  end
+
+  describe "GET #edit" do
+    context "when user does not have a name" do
+      it "renders the edit template" do
+        get edit_account_name_path
+        expect(response).to render_template(:edit)
+      end
+
+      it "assigns a new NameForm to @name_form" do
+        get edit_account_name_path
+        expect(assigns(:name_form)).to be_a(Account::NameForm)
+      end
+    end
+
+    context "when the user already has a name" do
+      let(:user) { create(:user, name: "John Smith") }
+
+      it "redirects to the root path" do
+        get edit_account_name_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    context "with valid params" do
+      let(:valid_params) { { account_name_form: { name: "John Doe" } } }
+
+      it "updates the user's name" do
+        put account_name_path, params: valid_params
+        expect(user.reload.name).to eq("John Doe")
+      end
+
+      it "redirects to the root path" do
+        put account_name_path, params: valid_params
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "with invalid params" do
+      let(:invalid_params) { { account_name_form: { name: "" } } }
+
+      it "does not update the user's name" do
+        put account_name_path, params: invalid_params
+        expect(user.reload.name).to be_nil
+      end
+
+      it "renders the edit template" do
+        put account_name_path, params: invalid_params
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/requests/account/organisations_controller_spec.rb
+++ b/spec/requests/account/organisations_controller_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe Account::OrganisationsController do
+  let(:user) { create(:user, :with_no_org) }
+
+  before do
+    login_as user
+  end
+
+  describe "GET #edit" do
+    context "when the user does not have an organisation" do
+      it "renders the edit template" do
+        get edit_account_organisation_path
+        expect(response).to render_template(:edit)
+      end
+
+      it "assigns a new OrganisationForm to @organisation_form" do
+        get edit_account_organisation_path
+        expect(assigns(:organisation_form)).to be_a(Account::OrganisationForm)
+      end
+    end
+
+    context "when the user already has an organisation" do
+      let(:user) { create(:user) }
+
+      it "redirects to the root path" do
+        get edit_account_organisation_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    context "with valid parameters" do
+      let(:organisation) { create(:organisation) }
+      let(:valid_params) { { account_organisation_form: { organisation_id: organisation.id } } }
+
+      it "updates the user's organisation" do
+        put account_organisation_path, params: valid_params
+        expect(user.reload.organisation).to eq(organisation)
+      end
+
+      it "redirects to the root path" do
+        put account_organisation_path, params: valid_params
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_params) { { account_organisation_form: { organisation_id: nil } } }
+
+      it "does not update the user's organisation" do
+        expect {
+          put account_organisation_path, params: invalid_params
+        }.not_to(change { user.reload.organisation })
+      end
+
+      it "re-renders the edit template" do
+        put account_organisation_path, params: invalid_params
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/requests/account/organisations_controller_spec.rb
+++ b/spec/requests/account/organisations_controller_spec.rb
@@ -57,6 +57,7 @@ describe Account::OrganisationsController do
 
       it "re-renders the edit template" do
         put account_organisation_path, params: invalid_params
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/views/account/names/edit.html.erb_spec.rb
+++ b/spec/views/account/names/edit.html.erb_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe "account/names/edit.html.erb" do
+  let(:name_form) { Account::NameForm.new(name: "John Smith") }
+
+  before do
+    assign(:name_form, name_form)
+  end
+
+  context "when there are no errors" do
+    before do
+      render
+    end
+
+    it "displays the form" do
+      expect(rendered).to have_selector('form[action="/account/name"][method="post"]')
+      expect(rendered).to have_field("_method", with: "patch", type: :hidden)
+      expect(rendered).to have_field("account_name_form[name]", with: "John Smith")
+      expect(rendered).to have_button(I18n.t("save_and_continue"))
+    end
+
+    it "sets the page title" do
+      expect(view.content_for(:title)).to eq(t("page_titles.account_name"))
+    end
+  end
+
+  context "when there are errors" do
+    before do
+      name_form.errors.add(:name, "is required")
+      render
+    end
+
+    it "displays the error summary" do
+      expect(rendered).to have_selector(".govuk-error-summary")
+    end
+
+    it "sets the page title with error prefix" do
+      expect(view.content_for(:title)).to eq(title_with_error_prefix(t("page_titles.account_name"), true))
+    end
+  end
+end

--- a/spec/views/account/organisations/edit.html.erb_spec.rb
+++ b/spec/views/account/organisations/edit.html.erb_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe "account/organisations/edit.html.erb" do
+  let(:organisation_form) { Account::OrganisationForm.new }
+  let!(:organisations) { create_list(:organisation, 3) }
+  let(:contact_href) { "https://example.com/contact" }
+
+  before do
+    assign(:organisation_form, organisation_form)
+    allow(view).to receive(:contact_link).and_return(contact_href)
+  end
+
+  context "when there are no errors" do
+    before do
+      render
+    end
+
+    it "displays the form" do
+      expect(rendered).to have_selector('form[action="/account/organisation"][method="post"]')
+      expect(rendered).to have_field("_method", with: "patch", type: :hidden)
+      expect(rendered).to have_button(I18n.t("save_and_continue"))
+    end
+
+    it "renders the organisation select field for autocomplete" do
+      expect(rendered).to have_selector('select[name="account_organisation_form[organisation_id]"]', visible: :all)
+      organisations.each do |organisation|
+        expect(rendered).to have_selector("option[value='#{organisation.id}']", text: organisation.name)
+      end
+    end
+
+    it "sets the page title" do
+      expect(view.content_for(:title)).to eq(t("page_titles.account_organisation"))
+    end
+  end
+
+  context "when there are errors" do
+    before do
+      organisation_form.errors.add(:base, "Some error")
+      render
+    end
+
+    it "displays the error summary" do
+      expect(rendered).to have_selector(".govuk-error-summary")
+    end
+
+    it "sets the page title with error prefix" do
+      expect(view.content_for(:title)).to eq(title_with_error_prefix(t("page_titles.account_organisation"), true))
+    end
+  end
+end


### PR DESCRIPTION
### Admin: Ask user for name and org

Trello card: https://trello.com/c/Apx9nwqS/1412-admin-ask-user-for-name-and-org-on-sign-in

This PR adds two new forms for capturing user organisation and name.

These will be used to ask the user for these values when we don't already have them on record. This PR only adds the forms, it does not show the user the screens unless they navigate directly to the URLs.

The forms are available to access for users who do not have name/org set. It is possible for them to directly access the forms and use them to update their own name and organisation. This isn't an issue, they are just doing it early, but worth pointing out.

### Organisation screen
![image](https://github.com/alphagov/forms-admin/assets/11035856/badd6007-a58f-45aa-987c-b441f69256b0)

### Name screen
![image](https://github.com/alphagov/forms-admin/assets/11035856/517ddedd-fdd2-48ec-be14-a60204fc50b8)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
