### PR TITLE
Use email address as link text on list of MOUs

### DIFF
--- a/app/views/mou_signatures/index.html.erb
+++ b/app/views/mou_signatures/index.html.erb
@@ -19,10 +19,10 @@
     <%= table.with_body do |body|
       mou_signatures.each do |mou_signature|
         body.with_row do |row|
+          row.with_cell( text: mou_signature.user.name.presence || t("users.index.name_blank") )
           row.with_cell do
-            govuk_link_to(mou_signature.user.name.presence || t("users.index.name_blank"), edit_user_path(mou_signature.user))
+            govuk_link_to(mou_signature.user.email, edit_user_path(mou_signature.user))
           end
-          row.with_cell( text: mou_signature.user.email )
           row.with_cell( text: mou_signature.organisation&.name.presence || t("users.index.organisation_blank"))
           row.with_cell( text: l(mou_signature.created_at.to_date, :format => :long) )
         end
@@ -30,4 +30,3 @@
     end %>
   <% end %>
 <% end %>
-

--- a/spec/features/mou/upgrade_user_changes_mou_spec.rb
+++ b/spec/features/mou/upgrade_user_changes_mou_spec.rb
@@ -37,11 +37,12 @@ private
 
   def then_i_see_the_mou_with_no_organisation
     expect(page).to have_text mou_signature.user.name
+    expect(page).to have_text mou_signature.user.email
     expect(page).to have_text "No organisation"
   end
 
   def then_i_visit_the_users_page
-    click_link mou_signature.user.name
+    click_link mou_signature.user.email
   end
 
   def then_i_update_the_user_organisation

--- a/spec/features/mou/view_signed_mous_spec.rb
+++ b/spec/features/mou/view_signed_mous_spec.rb
@@ -28,13 +28,13 @@ private
 
   def then_i_can_see_the_mou_list
     expect(page).to have_text mou_signatures.first.organisation.name
-    expect(page).to have_text mou_signatures.first.user.email
-    expect(page).to have_link mou_signatures.first.user.name
+    expect(page).to have_link mou_signatures.first.user.email
+    expect(page).to have_text mou_signatures.first.user.name
     expect(page).to have_text "October 12, 2023"
 
     expect(page).to have_text mou_signatures.second.organisation.name
-    expect(page).to have_text mou_signatures.second.user.email
-    expect(page).to have_link mou_signatures.second.user.name
+    expect(page).to have_link mou_signatures.second.user.email
+    expect(page).to have_text mou_signatures.second.user.name
     expect(page).to have_text "September 01, 2023"
   end
 

--- a/spec/views/mou_signatures/index.html.erb_spec.rb
+++ b/spec/views/mou_signatures/index.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe "mou_signatures/index.html.erb" do
+  let(:mou_signatures) do
+    build_list(:mou_signature, 3) do |mou_signature|
+      mou_signature.created_at = Time.zone.parse("October 12, 2023")
+    end
+  end
+
+  before do
+    render template: "mou_signatures/index", locals: { mou_signatures: }
+  end
+
+  it "contains page heading" do
+    expect(rendered).to have_css("h1.govuk-heading-l", text: I18n.t("page_titles.mou_signatures"))
+  end
+
+  it "contains the user's name" do
+    expect(rendered).to have_text(mou_signatures.first.user.name)
+  end
+
+  it "contains the user's email as a link to the edit page" do
+    expect(rendered).to have_link(mou_signatures.first.user.email, href: edit_user_path(mou_signatures.first.user))
+  end
+
+  it "contains organisation name" do
+    expect(rendered).to have_text(mou_signatures.first.user.organisation.name)
+  end
+
+  it "contains the date the MOU was signed" do
+    expect(rendered).to have_text(I18n.l(mou_signatures.first.created_at.to_date, format: :long))
+  end
+
+  context "when there are no signed MOUs" do
+    let(:mou_signatures) { [] }
+
+    it "does not show the MOU table" do
+      expect(rendered).not_to have_text(I18n.t("mou_signatures.table_caption"))
+      expect(rendered).not_to have_css("table")
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/UOgSrjeL/1439-users-list-page-multiple-links-have-identical-link-text-and-context-no-name-set

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Previously on the MOUs page, we linked from the user's name to the edit user page. This failed guideline 2.4.4 of the Web Content Accessibility Guidelines, as it meant that when multiple users have the same name (either because their actual names are identical, or because they didn't have names set), there would be multiple links with the same link context.

This commit makes the user's email address the link instead of the user's name. This prevents the issue, as email addresses are unique in our service.

We did virtually the same thing for the users page in #1021 .

As part of this work we've also added tests for the view and updated the feature tests to account for this change.

### Screenshots
#### Before![Screenshot of a table with headings for name, email address, organisation, and 'agreed on' date. The entry for the name column is a hyperlink, the other columns are plain text.](https://github.com/alphagov/forms-admin/assets/5861235/0b5f8504-619f-4bc9-a98a-ed923c84a068)


#### After
![Screenshot of a table with headings for name, email address, organisation, and 'agreed on' date. The entry for the email address column is a hyperlink, the other columns are plain text.](https://github.com/alphagov/forms-admin/assets/5861235/0a6ae6ce-3216-4523-bcf8-30a7f970d612)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
