### PR TITLE
Add role to group membership

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -30,7 +30,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params.merge({ creator: @current_user }))
     @group.organisation = current_user.organisation
-    @group.memberships.build(user: current_user, added_by: current_user)
+    @group.memberships.build(user: current_user, added_by: current_user, role: :group_admin)
 
     authorize @group
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,6 +4,7 @@ class Membership < ApplicationRecord
   belongs_to :added_by, class_name: "User"
 
   enum :role, {
+    group_admin: "group_admin",
     editor: "editor",
   }
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -3,8 +3,13 @@ class Membership < ApplicationRecord
   belongs_to :group
   belongs_to :added_by, class_name: "User"
 
+  enum :role, {
+    editor: "editor",
+  }
+
   validate :user_and_group_in_same_organisation
   validates :user, uniqueness: { scope: :group }
+  validates :role, presence: true
 
   def self.destroy_invalid_organisation_memberships(user)
     Membership.joins(:group).where(user:).where.not(groups: { organisation_id: user.organisation_id }).destroy_all

--- a/db/migrate/20240327090626_add_role_to_memberships.rb
+++ b/db/migrate/20240327090626_add_role_to_memberships.rb
@@ -1,0 +1,5 @@
+class AddRoleToMemberships < ActiveRecord::Migration[7.1]
+  def change
+    add_column :memberships, :role, :string, default: "editor"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_25_114214) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_27_090626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_25_114214) do
     t.bigint "added_by_id", null: false, comment: "The user who created the membership"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "role", default: "editor"
     t.index ["added_by_id"], name: "index_memberships_on_added_by_id"
     t.index ["user_id", "group_id"], name: "index_memberships_on_user_id_and_group_id", unique: true, comment: "Ensure that a user can only be a member of a group once"
   end

--- a/spec/factories/models/memberships.rb
+++ b/spec/factories/models/memberships.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     user
     group
     added_by { association :user }
+    role { :editor }
   end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -96,5 +96,10 @@ RSpec.describe Membership, type: :model do
       membership = build :membership
       expect(membership.role).to eq("editor")
     end
+
+    it "can be set to group_admin" do
+      membership = build :membership, role: :group_admin
+      expect(membership).to be_valid
+    end
   end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe Membership, type: :model do
     expect(membership).not_to be_valid
   end
 
+  it "is invalid without a role" do
+    membership = build :membership, role: nil
+    expect(membership).not_to be_valid
+  end
+
   it "is invalid if the user and group are not in the same organisation" do
     org1 = create :organisation, id: 1, slug: "test-org"
     org2 = create :organisation, id: 2, slug: "ministry-of-testing"
@@ -83,6 +88,13 @@ RSpec.describe Membership, type: :model do
 
       described_class.destroy_invalid_organisation_memberships(user1)
       expect(described_class.exists?(membership2.id)).to be true
+    end
+  end
+
+  describe "role" do
+    it "has a default role of editor" do
+      membership = build :membership
+      expect(membership.role).to eq("editor")
     end
   end
 end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -166,6 +166,14 @@ RSpec.describe "/groups", type: :request do
 
         expect(Group.last.creator).to eq(editor_user)
       end
+
+      it "gives the creator the group admin role" do
+        login_as_editor_user
+
+        post groups_url, params: { group: valid_attributes }
+
+        expect(Membership.last).to have_attributes user: editor_user, role: "group_admin"
+      end
     end
 
     context "with invalid parameters" do


### PR DESCRIPTION
### What problem does this pull request solve?

We want to use role based access control for actions that can be taken at the group level, e.g. manage users, make forms live. But first, we need the roles!

This PR adds the editor and group admin roles to group memberships, so that each user can have a role for each group they are a member of. We also give the creator of a group the group admin role. Restricting what each role can do will come later.

Trello card: https://trello.com/c/YuTJjp3p

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
