### PR TITLE
Implement archive form journey

### DIFF
--- a/app/controllers/forms/archive_form_controller.rb
+++ b/app/controllers/forms/archive_form_controller.rb
@@ -1,0 +1,46 @@
+module Forms
+  class ArchiveFormController < ApplicationController
+    before_action :check_user_has_permission
+    after_action :verify_authorized
+
+    def archive
+      return redirect_to path_to_form unless current_form.is_live?
+
+      @confirm_archive_form = ConfirmArchiveForm.new(form: current_form)
+    end
+
+    def update
+      return redirect_to path_to_form unless current_form.is_live?
+
+      @confirm_archive_form = ConfirmArchiveForm.new(confirm_archive_form_params)
+
+      return render :archive unless @confirm_archive_form.valid?
+      return redirect_to live_form_path(current_form) unless user_wants_to_archive_form
+
+      current_form.archive!
+      redirect_to archive_form_confirmation_path(current_form)
+    end
+
+    def confirmation
+      render :confirmation, locals: { form: current_form }
+    end
+
+  private
+
+    def check_user_has_permission
+      authorize current_form, :can_view_form?
+    end
+
+    def path_to_form
+      FormService.new(current_form).path_for_state
+    end
+
+    def confirm_archive_form_params
+      params.require(:forms_confirm_archive_form).permit(:confirm_archive).merge(form: current_form)
+    end
+
+    def user_wants_to_archive_form
+      @confirm_archive_form.archive?
+    end
+  end
+end

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -1,6 +1,7 @@
 module Forms
   class LiveController < ApplicationController
     after_action :verify_authorized
+
     def show_form
       authorize current_form, :can_view_form?
       render :show_form, locals: { form_metadata: current_form, form: current_live_form }
@@ -10,6 +11,8 @@ module Forms
       authorize current_form, :can_view_form?
       render :show_pages, locals: { form: current_live_form }
     end
+
+  private
 
     def current_live_form
       @current_live_form ||= Form.find_live(params[:form_id])

--- a/app/form_objects/forms/confirm_archive_form.rb
+++ b/app/form_objects/forms/confirm_archive_form.rb
@@ -1,0 +1,15 @@
+class Forms::ConfirmArchiveForm < BaseForm
+  attr_accessor :form, :confirm_archive
+
+  CONFIRM_ARCHIVE_VALUES = { archive: "archive", do_not_archive: "do_not_archive" }.freeze
+
+  validates :confirm_archive, presence: true, inclusion: { in: CONFIRM_ARCHIVE_VALUES.values }
+
+  def archive?
+    confirm_archive == CONFIRM_ARCHIVE_VALUES[:archive]
+  end
+
+  def values
+    CONFIRM_ARCHIVE_VALUES.keys
+  end
+end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -30,6 +30,10 @@ class Form < ActiveResource::Base
     has_live_version ? :live : :draft
   end
 
+  def is_live?
+    state.to_sym.in?(%i[live live_with_draft])
+  end
+
   def is_archived?
     state.to_sym.in?(%i[archived archived_with_draft])
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -55,6 +55,10 @@ class Form < ActiveResource::Base
     post "make-live"
   end
 
+  def archive!
+    post "archive"
+  end
+
   def self.update_organisation_for_creator(creator_id, organisation_id)
     if creator_id.present? && organisation_id.present?
       patch("update-organisation-for-creator", creator_id:, organisation_id:)

--- a/app/service/form_list_service.rb
+++ b/app/service/form_list_service.rb
@@ -59,10 +59,7 @@ private
   end
 
   def form_name_link(form)
-    return govuk_link_to(form.name, live_form_path(form.id)) if form.has_live_version
-    return govuk_link_to(form.name, archived_form_path(form.id)) if form.is_archived?
-
-    govuk_link_to(form.name, form_path(form.id))
+    govuk_link_to(form.name, FormService.new(form).path_for_state)
   end
 
   def form_status_tags(form)

--- a/app/service/form_service.rb
+++ b/app/service/form_service.rb
@@ -1,0 +1,14 @@
+class FormService
+  include Rails.application.routes.url_helpers
+
+  def initialize(form)
+    @form = form
+  end
+
+  def path_for_state
+    return live_form_path(@form.id) if @form.is_live?
+    return archived_form_path(@form.id) if @form.is_archived?
+
+    form_path(@form.id)
+  end
+end

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -72,9 +72,11 @@
       <%# i18n-tasks-use t('made_live_form.draft_create') %>
       <%# i18n-tasks-use t('made_live_form.draft_edit') %>
       <%= govuk_button_link_to t("made_live_form.draft_#{ form_metadata.has_draft_version ? 'edit': 'create'}"), form_path(form.id) %>
-      <% if status == :archived %>
+      <% if status == :live && FeatureService.enabled?(:archive_enabled) %>
+        <%= govuk_button_link_to t("made_live_form.archive_this_form"), archive_form_path(form.id), warning: true %>
+      <% elsif status == :archived %>
         <%= govuk_button_link_to t("made_live_form.make_this_form_live"), unarchive_path(form.id), secondary: true %>
       <% end %>
-    </p>
+    </div>
   </div>
 </div>

--- a/app/views/forms/archive_form/archive.html.erb
+++ b/app/views/forms/archive_form/archive.html.erb
@@ -1,0 +1,27 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.archive_form_confirm'), @confirm_archive_form.errors.any?)) %>
+
+<% content_for :back_link, govuk_back_link_to(live_form_path(@confirm_archive_form.form.id), t('back_link.form_view')) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @confirm_archive_form, url: archive_form_update_path(@confirm_archive_form.form.id)) do |f| %>
+      <% if @confirm_archive_form&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @confirm_archive_form.form.name %></span>
+        <%= t('page_titles.archive_form_confirm') %>
+      </h1>
+
+      <%= t('archive_form.confirm.body_html') %>
+
+      <%= f.govuk_collection_radio_buttons :confirm_archive,
+                                           @confirm_archive_form.values, ->(option) { option }, ->(option) { t('helpers.label.forms_confirm_archive_form.options.' + "#{option}") },
+                                           legend: { text: t('archive_form.confirm.radios_legend'), size: 'm' },
+                                           inline: true %>
+
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/forms/archive_form/confirmation.erb
+++ b/app/views/forms/archive_form/confirmation.erb
@@ -1,0 +1,19 @@
+<% set_page_title(t("page_titles.archive_form_confirmation")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(title_text: t("page_titles.archive_form_confirmation")) %>
+
+    <h2 class="govuk-heading-m"><%= t('archive_form.confirmation.form_name_heading') %></h2>
+
+    <p><%= form.name %></p>
+
+    <h2 class="govuk-heading-m"><%= t("archive_form.confirmation.links_will_no_longer_work_heading") %></h2>
+
+    <p><%= t("archive_form.confirmation.links_will_no_longer_work_body") %></p>
+
+    <p>
+      <%= govuk_link_to t("archive_form.confirmation.continue_link"), archived_form_path(form.id) %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -482,6 +482,7 @@ en:
       immediately.
     notification_title: Important
   made_live_form:
+    archive_this_form: Archive this form
     contact_details: Your form’s contact details for support
     declaration: Declaration
     declaration_description: Your form’s declaration is shown to people when they have answered all the questions, just before they submit the form.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,21 @@ en:
               blank: Select a role for the user
   address_settings:
     hint: Select all that apply
+  archive_form:
+    confirm:
+      body_html: |
+        <p>When you archive this form:<p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>links to the form will no longer work - make sure any links to the form have been removed</li>
+          <li>anyone who is part way through completing the form will lose their progress and get an error page</li>
+        </ul>
+        <p>You will still be able to preview the form and see its information and settings. You can also make a new draft of the form and make it live again if you need to.</p>
+      radios_legend: Are you sure you want to archive this form?
+    confirmation:
+      continue_link: Continue to form details
+      form_name_heading: Form name
+      links_will_no_longer_work_body: People who go to the form’s URL will get an error page. Make sure any links to the form are removed.
+      links_will_no_longer_work_heading: Links to this form will no longer work
   back_link:
     form_create: Back to create your form
     form_edit: Back to edit your form
@@ -673,6 +688,8 @@ en:
     account_organisation: Select your organisation
     add_guidance: Add guidance
     address_settings: What kind of addresses do you expect to receive?
+    archive_form_confirm: Archive this form
+    archive_form_confirmation: Your form has been archived
     change_name_form: Name your form
     confirm_email_form: Enter the confirmation code
     confirm_email_success: Email address confirmed

--- a/config/locales/forms/confirm_archive.yml
+++ b/config/locales/forms/confirm_archive.yml
@@ -1,0 +1,14 @@
+en:
+  helpers:
+    label:
+      forms_confirm_archive_form:
+        options:
+          archive: "Yes"
+          do_not_archive: "No"
+  activemodel:
+    errors:
+      models:
+        forms/confirm_archive_form:
+          attributes:
+            confirm_archive:
+              blank: Select yes if you want to archive this form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,9 @@ Rails.application.routes.draw do
 
     get "/delete" => "forms/delete_confirmation#delete", as: :delete_form
     delete "/delete" => "forms/delete_confirmation#destroy", as: :destroy_form
+    get "/archive" => "forms/archive_form#archive", as: :archive_form
+    post "/archive" => "forms/archive_form#update", as: :archive_form_update
+    get "/archive-success" => "forms/archive_form#confirmation", as: :archive_form_confirmation
     get "/privacy-policy" => "forms/privacy_policy#new", as: :privacy_policy
     post "/privacy-policy" => "forms/privacy_policy#create"
     get "/make-live" => "forms/make_live#new", as: :make_live

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,7 @@ features:
   check_your_question_enabled: false
   payment_links: false
   reference_numbers_enabled: false
+  archive_enabled: false
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -25,6 +25,7 @@ describe "Settings" do
     include_examples expected_value_test, :metrics_for_form_creators_enabled, features, false
     include_examples expected_value_test, :notify_original_submission_email_of_change, features, false
     include_examples expected_value_test, :reference_numbers_enabled, features, false
+    include_examples expected_value_test, [:archive_enabled, features, false]
   end
 
   describe "forms_api" do

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -59,6 +59,12 @@ FactoryBot.define do
       state { :live }
     end
 
+    trait :live_with_draft do
+      live
+      state { :live_with_draft }
+      has_draft_version { true }
+    end
+
     trait :archived do
       live
       state { :archived }

--- a/spec/features/form/archive_a_form_spec.rb
+++ b/spec/features/form/archive_a_form_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+feature "Archive a form", type: :feature do
+  let(:form) { build(:form, :live, id: 1) }
+  let(:org_forms) { [form] }
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?organisation_id=1", headers, org_forms.to_json, 200
+      mock.get "/api/v1/forms/1", headers, form.to_json, 200
+      mock.get "/api/v1/forms/1/live", headers, form.to_json, 200
+      mock.get "/api/v1/forms/1/archived", headers, form.to_json, 200
+      mock.post "/api/v1/forms/1/archive", post_headers, {}, 200
+    end
+
+    login_as_editor_user
+  end
+
+  scenario "as a form editor", feature_archive_enabled: true do
+    visit root_path
+    expect(page.find("h1")).to have_text "GOV.UK Forms"
+    expect_page_to_have_no_axe_errors(page)
+
+    click_link form.name
+    expect(page.find("h1")).to have_text form.name
+    expect(page).to have_css ".govuk-tag.govuk-tag--turquoise", text: "Live"
+    expect_page_to_have_no_axe_errors(page)
+
+    click_link_or_button "Archive this form"
+    expect(page.find("h1")).to have_text "Archive this form"
+    expect(page).to have_text "Are you sure you want to archive this form?"
+    expect_page_to_have_no_axe_errors(page)
+
+    choose "Yes"
+    click_button "Save and continue"
+    expect(page.find("h1")).to have_text "Your form has been archived"
+    expect_page_to_have_no_axe_errors(page)
+
+    click_link_or_button "Continue to form details"
+    expect(page.find("h1")).to have_text form.name
+    expect(page).to have_css ".govuk-tag.govuk-tag--orange", text: "Archived"
+    expect_page_to_have_no_axe_errors(page)
+  end
+end

--- a/spec/form_objects/forms/confirm_archive_form_spec.rb
+++ b/spec/form_objects/forms/confirm_archive_form_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Forms::ConfirmArchiveForm, type: :model do
+  describe "Confirm archive form" do
+    it "is invalid if blank" do
+      confirm_archive_form = described_class.new(confirm_archive: "")
+      confirm_archive_form.validate(:confirm_archive)
+
+      expect(confirm_archive_form.errors.full_messages_for(:confirm_archive)).to include(
+        "Confirm archive Select yes if you want to archive this form",
+      )
+    end
+  end
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 describe Form, type: :model do
+  let(:id) { 1 }
   let(:organisation) { build :organisation, id: 1 }
-  let(:form) { described_class.new(id: 1, name: "Form 1", organisation:, submission_email: "") }
+  let(:form) { described_class.new(id:, name: "Form 1", organisation:, submission_email: "") }
 
   describe "validations" do
     it "does not require an org" do
@@ -343,6 +344,23 @@ describe Form, type: :model do
       it "returns nil" do
         expect(form.metrics_data).to eq(nil)
       end
+    end
+  end
+
+  describe "#is_live?" do
+    it "returns true if state live" do
+      form.state = :live
+      expect(form.is_live?).to be true
+    end
+
+    it "returns true if state live with draft" do
+      form.state = :live_with_draft
+      expect(form.is_live?).to be true
+    end
+
+    it "returns false if state draft" do
+      form.state = :draft
+      expect(form.is_live?).to be false
     end
   end
 

--- a/spec/requests/forms/archive_form_controller_spec.rb
+++ b/spec/requests/forms/archive_form_controller_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe Forms::ArchiveFormController, type: :request do
+  let(:id) { 2 }
+  let(:form) { build(:form, :live, id:) }
+
+  before do
+    login_as_editor_user
+  end
+
+  describe "#archive" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/#{id}", headers, form.to_json, 200
+      end
+
+      get archive_form_path(id)
+    end
+
+    it "reads the form from the APi" do
+      expect(form).to have_been_read
+    end
+
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders archive this form page" do
+      expect(response).to render_template(:archive)
+    end
+
+    context "when form is not live" do
+      let(:form) { build(:form, :archived, id:) }
+
+      it "redirects to archived form page" do
+        expect(response).to redirect_to(archived_form_path(id))
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:confirm_archive) { :archive }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/#{id}", headers, form.to_json, 200
+        mock.post "/api/v1/forms/#{id}/archive", post_headers
+      end
+
+      post archive_form_update_path(id), params: { forms_confirm_archive_form: { confirm_archive:, form: } }
+    end
+
+    context "when 'Yes' is selected" do
+      it "archives the form" do
+        archive_post = ActiveResource::Request.new(:post, "/api/v1/forms/#{id}/archive", {}, post_headers)
+        expect(ActiveResource::HttpMock.requests).to include archive_post
+      end
+
+      it "redirects to the success page" do
+        expect(response).to redirect_to(archive_form_confirmation_path(id))
+      end
+    end
+
+    context "when 'No' is selected" do
+      let(:confirm_archive) { :do_not_archive }
+
+      it "redirects to live form page" do
+        expect(response).to redirect_to(live_form_path(id))
+      end
+    end
+
+    context "when no option is selected" do
+      let(:confirm_archive) { nil }
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "re-renders the archive this form page with an error" do
+        expect(response).to render_template(:archive)
+        expect(response.body).to include("Select yes if you want to archive this form")
+      end
+    end
+
+    context "when form is not live" do
+      let(:form) { build(:form, :archived, id:) }
+
+      it "doesn't archive the form" do
+        archive_post = ActiveResource::Request.new(:post, "/api/v1/forms/#{id}/archive", {}, post_headers)
+        expect(ActiveResource::HttpMock.requests).not_to include archive_post
+      end
+
+      it "redirects to archived form page" do
+        expect(response).to redirect_to(archived_form_path(id))
+      end
+    end
+  end
+
+  describe "#confirmation" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/#{id}", headers, form.to_json, 200
+      end
+
+      get archive_form_confirmation_path(id)
+    end
+
+    it "renders the success template" do
+      expect(response).to render_template(:confirmation)
+    end
+  end
+end

--- a/spec/service/form_service_spec.rb
+++ b/spec/service/form_service_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe FormService do
+  subject(:form_service) do
+    described_class.new(form)
+  end
+
+  let(:id) { 1 }
+  let(:form) { build(:form, id:) }
+
+  describe "#path_for_state" do
+    context "when form is live" do
+      before do
+        form.state = :live
+      end
+
+      it "returns live form path" do
+        expect(form_service.path_for_state).to eq "/forms/#{id}/live"
+      end
+    end
+
+    context "when form is archived" do
+      before do
+        form.state = :archived
+      end
+
+      it "returns archived form path" do
+        expect(form_service.path_for_state).to eq "/forms/#{id}/archived"
+      end
+    end
+
+    context "when form is draft" do
+      before do
+        form.state = :draft
+      end
+
+      it "returns draft form path" do
+        expect(form_service.path_for_state).to eq "/forms/#{id}"
+      end
+    end
+  end
+end

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -185,6 +185,30 @@ describe "forms/_made_live_form.html.erb", feature_metrics_for_form_creators_ena
     end
   end
 
+  describe "the archive this form button" do
+    context "when the form is live" do
+      context "when the archive feature is enabled", feature_archive_enabled: true do
+        it "contains a link to archive the form" do
+          expect(rendered).to have_link("Archive this form")
+        end
+      end
+
+      context "when the archive feature is enabled", feature_archive_enabled: false do
+        it "does not contain a link to archive the form" do
+          expect(rendered).not_to have_link("Archive this form")
+        end
+      end
+    end
+
+    context "when the form is archived", feature_archive_enabled: true do
+      let(:status) { :archived }
+
+      it "does not contain a link to archive the form" do
+        expect(rendered).not_to have_link("Archive this form")
+      end
+    end
+  end
+
   context "when the metrics feature is enabled", feature_metrics_for_form_creators_enabled: true do
     let(:metrics_data) { { weekly_submissions: 125, weekly_starts: 256 } }
 

--- a/spec/views/forms/archive_form/confirm.html.erb_spec.rb
+++ b/spec/views/forms/archive_form/confirm.html.erb_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe "forms/archive_form/archive.html.erb" do
+  let(:id) { 2 }
+  let(:form) { build(:form, :live, id:) }
+  let(:confirm_archive_form) { Forms::ConfirmArchiveForm.new(form:) }
+
+  before do
+    assign(:confirm_archive_form, confirm_archive_form)
+  end
+
+  context "when there are no errors" do
+    before do
+      render
+    end
+
+    it "displays the form" do
+      expect(rendered).to have_selector("form[action='#{archive_form_update_path(id)}'][method='post']")
+      expect(rendered).to have_field("forms_confirm_archive_form[confirm_archive]")
+      expect(rendered).to have_button("Save and continue")
+    end
+  end
+
+  context "when there are errors" do
+    before do
+      confirm_archive_form.errors.add(:confirm_archive, "is required")
+      render
+    end
+
+    it "displays the error summary" do
+      expect(rendered).to have_selector(".govuk-error-summary")
+    end
+
+    it "sets the page title with error prefix" do
+      expect(view.content_for(:title)).to eq(title_with_error_prefix("Archive this form", true))
+    end
+  end
+end

--- a/spec/views/forms/archive_form/confirmation.html.erb_spec.rb
+++ b/spec/views/forms/archive_form/confirmation.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "forms/archive_form/confirmation.html.erb" do
+  let(:id) { 2 }
+  let(:form) { build(:form, :live, id:) }
+
+  before do
+    render(template: "forms/archive_form/confirmation", locals: { form: })
+  end
+
+  it "contains a confirmation panel with title" do
+    expect(rendered).to have_css(".govuk-panel--confirmation h1", text: "Your form has been archived")
+  end
+
+  it "has link to archived form" do
+    expect(rendered).to have_link("Continue to form details", href: archived_form_path(id))
+  end
+end

--- a/spec/views/forms/index.html.erb_spec.rb
+++ b/spec/views/forms/index.html.erb_spec.rb
@@ -23,9 +23,9 @@ describe "forms/index.html.erb" do
   describe "when there are one or more forms to display" do
     let(:forms) do
       [
-        OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", has_draft_version: true, has_live_version: false),
-        OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2", has_draft_version: false, has_live_version: true),
-        OpenStruct.new(id: 3, name: "Form 3", form_slug: "form-3", has_draft_version: true, has_live_version: true),
+        build(:form, id: 1, name: "Form 1", form_slug: "form-1"),
+        build(:form, :live, id: 2, name: "Form 2", form_slug: "form-2"),
+        build(:form, :live_with_draft, id: 3, name: "Form 3", form_slug: "form-3"),
       ]
     end
 
@@ -83,7 +83,12 @@ describe "forms/index.html.erb" do
     end
 
     context "when a form is live renders link to 'live' form readonly view" do
-      let(:forms) { [OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1", status: "draft", has_live_version: false), OpenStruct.new(id: 2, name: "Form 2", form_slug: "form-2", status: "live", has_live_version: true)] }
+      let(:forms) do
+        [
+          build(:form, id: 1, name: "Form 1", form_slug: "form-1"),
+          build(:form, :live, id: 2, name: "Form 2", form_slug: "form-2"),
+        ]
+      end
 
       it "allows the user to create a new form" do
         expect(rendered).to have_link("Create a form", href: forms_new_path)

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe "groups/show", type: :view do
   context "when the group has one of more forms" do
     let(:forms) do
       [
-        build(:form, id: 1, name: "Form 1", has_draft_version: true, has_live_version: false),
-        build(:form, id: 2, name: "Form 2", has_draft_version: false, has_live_version: true),
-        build(:form, id: 3, name: "Form 3", has_draft_version: true, has_live_version: true),
+        build(:form, id: 1, name: "Form 1"),
+        build(:form, :live, id: 2, name: "Form 2"),
+        build(:form, :live_with_draft, id: 3, name: "Form 3"),
       ]
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UyRNXHGh/1330-implement-archive-a-form-journey

This PR implements the journey to archive a live form.

The "Archive this form" button only appears on the live form page if the `archive_enabled` feature flag is set to `true`.

**There is a button to archive on the live form page, if `archive_enabled=true`**

<img width="992" alt="Screenshot 2024-03-28 at 14 58 40" src="https://github.com/alphagov/forms-admin/assets/5648592/24ec32d3-1bc3-4c15-a667-66d8c7ed7fe8">

**Clicking button shows a confirm page**

<img width="1015" alt="Screenshot 2024-03-27 at 14 14 25" src="https://github.com/alphagov/forms-admin/assets/5648592/f7ae8648-b57d-48b1-84fa-3a18b4e6cee5">

**If an option isn't selected, an error is shown**

<img width="1015" alt="Screenshot 2024-03-27 at 14 14 41" src="https://github.com/alphagov/forms-admin/assets/5648592/07accddc-b59f-487a-ba9c-5fc5decbf73b">

**When "Yes" is selected, a success page is shown**

<img width="1015" alt="Screenshot 2024-03-27 at 14 14 50" src="https://github.com/alphagov/forms-admin/assets/5648592/cb415d11-0447-4e1b-b0f2-7ef2e635fb25">

**When "Continue to form details" is clicked, the archived form is shown**

<img width="1015" alt="Screenshot 2024-03-27 at 14 14 58" src="https://github.com/alphagov/forms-admin/assets/5648592/8094cbaf-9309-43e1-9786-4cd5767e443b">

### Things to consider when reviewing

1. I've added a `path_to_form` method to the form model - I'm not sure whether this was the right place for this.
2. Is the feature flag configuration all correct?

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
