### PR TITLE
Stop adding users without access to mailing lists

### DIFF
--- a/lib/tasks/mailchimp.rake
+++ b/lib/tasks/mailchimp.rake
@@ -17,7 +17,7 @@ namespace :mailchimp do
       server: mailchimp_server_prefix,
     })
 
-    db_email_addresses = User.pluck(:email).to_set
+    db_email_addresses = User.where(has_access: true).pluck(:email).to_set
 
     puts "There are #{mailchimp_lists.length} lists to synchronize"
     mailchimp_lists.each do |list_id|


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/1B4eVcBh/1711-fix-the-updates-for-platform-users-mailchimp-mailing-list-so-denied-users-are-unsubscribed-automatically

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
This commit adds a `.where` to the database query which should stop users without access from being added to the mailing list. This means that users who no longer use the platform (e.g. people who've moved teams or people whose organisations can't use the platform) won't get emails which aren't relevant to them.

Also adds tests to make sure these users aren't added to the lists and that any existing users without access will be removed from the list.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
