### PR TITLE
Render separate view for making draft of archived form live

### DIFF
--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -1,6 +1,7 @@
 module Forms
   class MakeLiveController < ApplicationController
     after_action :verify_authorized
+
     def new
       authorize current_form, :can_make_form_live?
       @make_live_form = MakeLiveForm.new(form: current_form)
@@ -32,6 +33,8 @@ module Forms
     def render_new
       if current_form.is_live?
         render "make_your_changes_live", locals: { current_form: }
+      elsif current_form.is_archived?
+        render "make_archived_draft_live", locals: { current_form: }
       else
         render "make_your_form_live", locals: { current_form: }
       end

--- a/app/views/forms/make_live/make_archived_draft_live.html.erb
+++ b/app/views/forms/make_live/make_archived_draft_live.html.erb
@@ -1,0 +1,32 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.make_changes_live_form'), @make_live_form.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(form_path, t("back_link.form_edit")) %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @make_live_form, url: make_live_create_path) do |f| %>
+      <% if @make_live_form&.errors&.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @make_live_form.form.name %></span>
+        <%= t("page_titles.make_changes_live_form") %>
+      </h1>
+
+      <p>
+        <%= t("make_changes_live.warning") %>
+      </p>
+
+      <p>
+        <%= t("make_changes_live.url_will_remain_same") %>
+      </p>
+
+      <%= f.govuk_collection_radio_buttons :confirm_make_live,
+                                           @make_live_form.values, ->(option) { option }, ->(option) { t('helpers.label.forms_make_live_form.options.' + "#{option}") },
+                                           legend: { text: t('helpers.label.forms_make_changes_live_form.confirm_make_live'),
+                                                     size: 'm'}, inline: true %>
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -71,6 +71,22 @@ RSpec.describe Forms::MakeLiveController, type: :request do
       end
     end
 
+    context "when editing a draft of an archived form" do
+      let(:form) do
+        build(:form,
+              :archived_with_draft,
+              id: 2)
+      end
+
+      it "reads the form from the API" do
+        expect(form).to have_been_read
+      end
+
+      it "renders make your changes live" do
+        expect(response).to render_template("make_archived_draft_live")
+      end
+    end
+
     context "when current user has a trial account" do
       let(:user) { build :user, :with_trial_role }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UVCBeTs8/1433-allow-user-to-create-a-draft-for-an-archived-form

We will have different content for the confirm page for making the draft of an archived form live. Render a separate view for this - `make_archived_draft_live.html.erb`. This view currently duplicates the content for making the draft of a live form live, and the content will need to be updated when it is ready.

This will render the same content regardless of whether the form is in `archived` or `archived_with_draft` state. The form will only transition to `archived_with_draft` state if edits are made before making the draft live. We have a separate route and controller for making the form live again without making a draft, so the content for that is separate.

### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
