### PR TITLE
Don't show delete button for archived form

### DIFF
--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -41,6 +41,6 @@
                                            sections: @task_list)
     %>
 
-    <%= govuk_button_link_to(t("forms.delete_form"), delete_form_path(current_form.id), warning: true) unless current_form.is_live?  %>
+    <%= govuk_button_link_to(t("forms.delete_form"), delete_form_path(current_form.id), warning: true) if current_form.state.to_sym == :draft %>
   </div>
 </div>

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -78,6 +78,22 @@ describe "forms/show.html.erb" do
     end
   end
 
+  context "when form state is archived" do
+    let(:form) { build :form, :archived, id: 2 }
+
+    it "does not contain a link to delete the form" do
+      expect(rendered).not_to have_link("Delete draft form", href: delete_form_path(2))
+    end
+  end
+
+  context "when form state is archived with draft" do
+    let(:form) { build :form, :archived_with_draft, id: 2 }
+
+    it "does not contain a link to delete the form" do
+      expect(rendered).not_to have_link("Delete draft form", href: delete_form_path(2))
+    end
+  end
+
   context "and a user has the trial role" do
     let(:user) { build :user, :with_trial_role }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UVCBeTs8/1433-allow-user-to-create-a-draft-for-an-archived-form

It should only be possible to delete a form if it is in draft state, so only show the button when a form is in this state.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
