### PR TITLE
Display correct title and back link for archive draft

### DIFF
--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -2,6 +2,8 @@
 
 <% if current_form.is_live? %>
   <% content_for :back_link, govuk_back_link_to(live_form_path(current_form.id), t("back_link.form_view")) %>
+<% elsif current_form.is_archived? %>
+  <% content_for :back_link, govuk_back_link_to(archived_form_path(current_form.id), t("back_link.form_view")) %>
 <% elsif current_form.group.present? %>
   <% content_for :back_link, govuk_back_link_to(group_path(current_form.group), t("back_link.group", group_name: current_form.group.name)) %>
 <% else %>
@@ -14,7 +16,7 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       <span class="govuk-caption-l"><%= current_form.name %></span><span class="govuk-visually-hidden"> - </span>
-      <%= current_form.is_live? ? t("forms.form_overview.title_edit") : t("forms.form_overview.title_create") %>
+      <%= current_form.state.to_sym == :draft ? t("forms.form_overview.title_create") : t("forms.form_overview.title_edit") %>
     </h1>
 
     <%= render FormStatusTagDescriptionComponent::View.new(status: :draft) %>

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -61,6 +61,10 @@ describe "forms/show.html.erb" do
       expect(view.content_for(:back_link)).to have_link("Back", href: "/forms/2/live")
     end
 
+    it "has the heading 'Edit your form'" do
+      expect(rendered).to have_css("h1.govuk-heading-l", text: /Edit your form/)
+    end
+
     it "rendered draft tag" do
       expect(rendered).to have_css(".govuk-tag.govuk-tag--yellow", text: "Draft")
     end
@@ -80,6 +84,18 @@ describe "forms/show.html.erb" do
 
   context "when form state is archived" do
     let(:form) { build :form, :archived, id: 2 }
+
+    it "has a back link to the archived form page" do
+      expect(view.content_for(:back_link)).to have_link("Back", href: "/forms/2/archived")
+    end
+
+    it "has the heading 'Edit your form'" do
+      expect(rendered).to have_css("h1.govuk-heading-l", text: /Edit your form/)
+    end
+
+    it "rendered draft tag" do
+      expect(rendered).to have_css(".govuk-tag.govuk-tag--yellow", text: "Draft")
+    end
 
     it "does not contain a link to delete the form" do
       expect(rendered).not_to have_link("Delete draft form", href: delete_form_path(2))


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UVCBeTs8/1433-allow-user-to-create-a-draft-for-an-archived-form

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
