### PR TITLE
Handle paginated Mailchimp API response

### DIFF
--- a/spec/lib/tasks/mailchimp.rake_spec.rb
+++ b/spec/lib/tasks/mailchimp.rake_spec.rb
@@ -17,6 +17,44 @@ RSpec.describe "mailchimp.rake" do
       instance_double("MailchimpMarketing::ListsApi")
     end
 
+    let(:list_1) do
+      {
+        "name" => "List 1",
+        "stats" => {
+          "member_count" => 3,
+        },
+      }
+    end
+
+    let(:list_2) do
+      {
+        "name" => "List 2",
+        "stats" => {
+          "member_count" => 3,
+        },
+      }
+    end
+
+    let(:list_1_members_info) do
+      {
+        "members" => [
+          { "email_address" => "keep@domain.org" },
+          { "email_address" => "remove@domain.org" },
+          { "email_address" => "retireduser@domain.org" },
+        ],
+      }
+    end
+
+    let(:list_2_members_info) do
+      {
+        "members" => [
+          { "email_address" => "keep@domain.org" },
+          { "email_address" => "remove@domain.org" },
+          { "email_address" => "retireduser@domain.org" },
+        ],
+      }
+    end
+
     before do
       # Rake.application.options.trace = true
 
@@ -39,19 +77,9 @@ RSpec.describe "mailchimp.rake" do
       allow(mailchimp_client_lists).to receive(:get_list) do |list_id|
         case list_id
         when "list-1"
-          {
-            "name" => "List 1",
-            "stats" => {
-              "member_count" => 3,
-            },
-          }
+          list_1
         when "list-2"
-          {
-            "name" => "List 2",
-            "stats" => {
-              "member_count" => 3,
-            },
-          }
+          list_2
         else
           raise "Unknown list id"
         end
@@ -60,21 +88,9 @@ RSpec.describe "mailchimp.rake" do
       allow(mailchimp_client_lists).to receive(:get_list_members_info) do |list_id|
         case list_id
         when "list-1"
-          {
-            "members" => [
-              { "email_address" => "keep@domain.org" },
-              { "email_address" => "remove@domain.org" },
-              { "email_address" => "retireduser@domain.org" },
-            ],
-          }
+          list_1_members_info
         when "list-2"
-          {
-            "members" => [
-              { "email_address" => "keep@domain.org" },
-              { "email_address" => "remove@domain.org" },
-              { "email_address" => "retireduser@domain.org" },
-            ],
-          }
+          list_2_members_info
         else
           raise "Unknown list id"
         end

--- a/spec/lib/tasks/mailchimp.rake_spec.rb
+++ b/spec/lib/tasks/mailchimp.rake_spec.rb
@@ -160,5 +160,29 @@ RSpec.describe "mailchimp.rake" do
 
       expect { task.invoke }.to output.to_stdout
     end
+
+    context "when the mailing list has more than 1000 members" do
+      let(:list_1) do
+        {
+          "name" => "List 1",
+          "stats" => {
+            "member_count" => 1001,
+          },
+        }
+      end
+
+      let(:list_1_members_info) do
+        {
+          "members" =>
+          1001.times.map { { "email_address" => Faker::Internet.email } },
+        }
+      end
+
+      it "handles all of the results" do
+        expect(mailchimp_client_lists).to receive(:delete_list_member_permanent).with("list-1", anything).exactly(1001).times
+
+        expect { task.invoke }.to output.to_stdout
+      end
+    end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/1B4eVcBh/1466-fix-the-updates-for-platform-users-mailchimp-mailing-list-so-denied-users-are-unsubscribed-automatically

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We had some issues with the Mailchimp task failing to unsubscribe people from the mailing lists when they weren't active users in the database. The cause for this is that the Mailchimp API paginates its response when requesting a list of subscribers. By default it will only return 10 results. This means the comparisons of existing members vs users in the database in our rake task didn't actually return the right results - we were comparing the list of users in the database against the first 10 subscribers of each Mailchimp list.

This PR adds some logic to handle the pagination, and requests the maximum page size (1000 results) in each request.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
