### PR TITLE
Fix question text page title

### DIFF
--- a/app/views/pages/question_text.html.erb
+++ b/app/views/pages/question_text.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(title_with_error_prefix(t("page_titles.date_settings"), @question_text_form.errors.any?)) %>
+<% set_page_title(title_with_error_prefix(t("page_titles.question_text"), @question_text_form.errors.any?)) %>
 <% content_for :back_link, govuk_back_link_to(@back_link_url) %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -719,6 +719,7 @@ en:
     not_found: Page not found
     payment_link_form: Add a link to a payment page on GOV.UK Pay
     privacy_policy_form: Provide a link to privacy information for this form
+    question_text: What’s your question?
     routing_page: Add a question route
     routing_page_delete: Delete question %{question_position}’s route
     routing_page_edit: Edit question %{question_position}’s route

--- a/spec/views/pages/question_text.html.erb_spec.rb
+++ b/spec/views/pages/question_text.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe "pages/question_text.html.erb" do
+  let(:form) { build :form, id: 1, pages: [] }
+  let(:question_text_form) { build :question_text_form }
+  let(:question_text_path) { "/forms/1/pages/new/question_text" }
+  let(:form_pages_path) { "/forms/1/pages/new/guidance" }
+  let(:back_link_url) { "/forms/1/pages/new/type-of-answer" }
+
+  before do
+    without_partial_double_verification do
+      allow(view).to receive(:form_pages_path).and_return(form_pages_path)
+      allow(view).to receive(:current_form).and_return(form)
+    end
+
+    # Assign instance variables so they can be accessed from views
+    assign(:question_text_form, question_text_form)
+    assign(:question_text_path, question_text_path)
+    assign(:back_link_url, back_link_url)
+
+    render template: "pages/question_text", locals: { current_form: form }
+  end
+
+  it "has the correct title" do
+    expect(view.content_for(:title)).to have_content(I18n.t("page_titles.question_text"))
+  end
+
+  it "has a back link to the type of answer page" do
+    expect(view.content_for(:back_link)).to have_link("Back", href: back_link_url)
+  end
+
+  it "has the correct heading" do
+    expect(rendered).to have_selector("h1", text: I18n.t("helpers.label.pages_question_text_form.question_text"))
+  end
+
+  it "includes a form field for entering your question text" do
+    expect(rendered).to have_field(I18n.t("helpers.label.pages_question_text_form.question_text"))
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/RkF3fgU1/1462-whats-your-question-page-has-the-wrong-title

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Previously this page had the same title as the date settings page (presumably some copy-pasted content that wasn't replaced). As well as being a bug this was a violation of WCAG 2.4.2 Page Titled, because the page title did not accurately describe the page.

This PR makes the title match the h1/form field text.

Also includes adding some view tests for this file.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
