### PR TITLE
Add initial Group members screen

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -1,0 +1,11 @@
+class GroupMembersController < ApplicationController
+  before_action :set_group
+
+  def index; end
+
+private
+
+  def set_group
+    @group = Group.find_by(external_id: params[:group_id])
+  end
+end

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -1,5 +1,6 @@
 class GroupMembersController < ApplicationController
-  before_action :set_group
+  before_action :set_group, :authorize_group_members
+  after_action :verify_authorized
 
   def index; end
 
@@ -7,5 +8,9 @@ private
 
   def set_group
     @group = Group.find_by(external_id: params[:group_id])
+  end
+
+  def authorize_group_members
+    authorize @group, :index_users?
   end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -11,6 +11,7 @@ class GroupPolicy < ApplicationPolicy
   alias_method :edit?, :show?
   alias_method :update?, :edit?
   alias_method :destroy?, :edit?
+  alias_method :index_users?, :show?
 
   class Scope < ApplicationPolicy::Scope
     def resolve

--- a/app/views/group_members/index.html.erb
+++ b/app/views/group_members/index.html.erb
@@ -1,0 +1,38 @@
+<% set_page_title(t(".title")) %>
+<% content_for :back_link, govuk_back_link_to(@group, t("back_link.group", group_name: @group.name)) %>
+
+<h1 id="heading" class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @group.name %></span>
+  <span class="govuk-visually-hidden"> - </span>
+  <%= t(".title") %>
+</h1>
+
+<% if @group.memberships.empty? %>
+  <p class="govuk-body"><%= t(".no_members") %></p>
+<% else %>
+  <%= govuk_table do |table| %>
+    <%= table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: t(".table_headings.name"))
+        row.with_cell(text: t(".table_headings.email"))
+        row.with_cell(text: t(".table_headings.role"))
+      end
+    end %>
+
+    <%= table.with_body do |body|
+      @group.memberships.each do |membership|
+        body.with_row do |row|
+          row.with_cell { membership.user.name }
+          row.with_cell { membership.user.email }
+          row.with_cell { t(".roles.#{membership.role}.name") }
+        end
+      end
+    end %>
+  <% end %>
+<% end %>
+
+<div class="govuk-!-margin-top-3">
+  <%= govuk_details(summary_text: t(".details.summary_text")) do %>
+    <%= t(".details.summary_content_html") %>
+  <% end %>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -13,9 +13,10 @@
 
 <%= render @group %>
 
-<div class="govuk-button-group">
-  <%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %>
-</div>
+<ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-5">
+  <li><%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %></li>
+  <li><%= govuk_link_to(t(".edit_group_members"), group_members_path(@group)) %></li>
+</ul>
 
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_group_form_path(@group)) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -262,6 +262,25 @@ en:
     confirm_deletion_form: Are you sure you want to delete this draft?
     confirm_deletion_form_live_form: Deleting this draft will not remove the live form.
     confirm_deletion_page: Are you sure you want to delete this page?
+  group_members:
+    index:
+      details:
+        summary_content_html: |
+          <p>An editor can edit forms in a group but cannot make forms live.</p>
+          <p>A group admin can edit forms, make forms live and add editors to a group.</p>
+          <p>Only an organisation admin can add a group admin to a group.</p>
+        summary_text: What can ‘editors’ and ‘group admins’ do?
+      no_members: There are no members in this group.
+      roles:
+        editor:
+          name: Editor
+        group_admin:
+          name: Group Admin
+      table_headings:
+        email: Email
+        name: Name
+        role: Role
+      title: Members of this group
   groups:
     edit:
       title: Edit group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,7 +277,7 @@ en:
         group_admin:
           name: Group Admin
       table_headings:
-        email: Email
+        email: Email address
         name: Name
         role: Role
       title: Members of this group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,6 +302,7 @@ en:
     new:
       title: New group
     show:
+      edit_group_members: Edit members of this group
       edit_group_name: Change the name of this group
       trial_banner:
         body_html: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,7 @@ Rails.application.routes.draw do
 
   resources :groups, except: :destroy do
     resources :forms, controller: :group_forms, only: %i[new create]
+    resources :members, controller: :group_members, only: %i[index]
   end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page

--- a/spec/features/groups/manage_group_members_spec.rb
+++ b/spec/features/groups/manage_group_members_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+feature "Show members of a group", type: :feature do
+  let(:organisation) { editor_user.organisation }
+  let(:group) { create(:group, name: "Group 1", organisation:) }
+  let(:user1) { create(:user, organisation:) }
+  let(:user2) { create(:user, organisation:) }
+
+  before do
+    create(:membership, user: editor_user, group:, role: :editor)
+    create(:membership, user: user1, group:, role: :editor)
+    create(:membership, user: user2, group:, role: :group_admin)
+    login_as_editor_user
+  end
+
+  scenario "Group editor lists members of a group" do
+    when_i_visit_the_groups_page
+    and_i_click_the_group_link
+    and_i_click_the_edit_group_members_link
+    then_i_should_see_the_members_of_the_group
+  end
+
+  def when_i_visit_the_groups_page
+    visit groups_path
+  end
+
+  def and_i_click_the_group_link
+    click_link "Group 1"
+  end
+
+  def and_i_click_the_edit_group_members_link
+    click_link "Edit members of this group"
+  end
+
+  def then_i_should_see_the_members_of_the_group
+    expect(page.find("h1")).to have_text "Group 1"
+    expect(page).to have_text user1.name
+    expect(page).to have_text user1.email
+    expect(page).to have_text user2.name
+    expect(page).to have_text user2.email
+    expect_page_to_have_no_axe_errors(page)
+  end
+end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe GroupPolicy do
   context "when user is super_admin" do
     let(:user) { build :super_admin_user }
 
-    it { is_expected.to permit_actions(%i[create edit show destroy update]) }
+    it { is_expected.to permit_actions(%i[create edit show destroy update index_users]) }
 
     context "and user is not a member of the group" do
       let(:group) { build :group, organisation_id: user.organisation_id + 1 }
 
       it "allows show, edit, update or destroy" do
-        expect(policy).to permit_actions(%i[show edit update destroy])
+        expect(policy).to permit_actions(%i[show edit update destroy index_users])
       end
     end
 
@@ -30,14 +30,14 @@ RSpec.describe GroupPolicy do
     end
 
     it "cannot view, list or modify group" do
-      expect(policy).to forbid_actions(%i[edit show destroy update])
+      expect(policy).to forbid_actions(%i[edit show destroy update index_users])
     end
 
     context "and user belongs to group" do
       before { user.groups << group }
 
       it "allows view, list and modify group" do
-        expect(policy).to permit_actions(%i[edit show destroy update])
+        expect(policy).to permit_actions(%i[edit show destroy update index_users])
       end
     end
 

--- a/spec/requests/group_members_controller_spec.rb
+++ b/spec/requests/group_members_controller_spec.rb
@@ -13,5 +13,15 @@ RSpec.describe "/groups/:group_id/members", type: :request do
       get group_members_url(group)
       expect(response).to be_successful
     end
+
+    context "when the current user does not have access to the group" do
+      it "denies access" do
+        other_group = create :group
+
+        get group_members_url(other_group)
+
+        expect(response).to have_http_status :forbidden
+      end
     end
+  end
 end

--- a/spec/requests/group_members_controller_spec.rb
+++ b/spec/requests/group_members_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "/groups/:group_id/members", type: :request do
+  let(:group) { create :group }
+
+  before do
+    create(:membership, user: editor_user, group:)
+    login_as_editor_user
+  end
+
+  describe "GET /groups/:group_id/members" do
+    it "renders a successful response" do
+      get group_members_url(group)
+      expect(response).to be_successful
+    end
+    end
+end

--- a/spec/views/group_members/index.html.erb_spec.rb
+++ b/spec/views/group_members/index.html.erb_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "group_members/index", type: :view do
+  let(:organisation) { build(:organisation, slug: "Department for testing group members") }
+  let(:user1) { build(:user, organisation:) }
+  let(:user2) { build(:user, organisation:) }
+  let(:group) { build(:group, name: "Group 1", organisation:) }
+
+  context "when there are members of a group" do
+    before do
+      create(:membership, user: user1, group:, role: :editor)
+      create(:membership, user: user2, group:, role: :group_admin)
+
+      assign(:group, group)
+      render
+    end
+
+    it "displays the group name" do
+      expect(rendered).to have_selector("h1", text: group.name)
+    end
+
+    it "displays the page title" do
+      expect(rendered).to have_selector("h1", text: t("group_members.index.title"))
+    end
+
+    it "displays a table of group memberships" do
+      group.memberships.each do |membership|
+        expect(rendered).to have_selector("table td", text: membership.user.name)
+        expect(rendered).to have_selector("table td", text: membership.user.email)
+        expect(rendered).to have_selector("table td", text: t("group_members.index.roles.#{membership.role}.name"))
+      end
+    end
+
+    it "has a back link to the group page" do
+      expect(view.content_for(:back_link)).to have_link("Back to Group 1", href: group_path(group))
+    end
+  end
+
+  context "when there are no members of a group" do
+    before do
+      assign(:group, group)
+      render
+    end
+
+    it "displays a message" do
+      expect(rendered).to have_text(t("group_members.index.no_members"))
+    end
+  end
+end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe "groups/show", type: :view do
     expect(rendered).to have_link "Change the name of this group", href: edit_group_path(group)
   end
 
+  it "has a link to the edit members page" do
+    expect(rendered).to have_link "Edit members of this group", href: group_members_path(group)
+  end
+
   context "when the group has no forms" do
     let(:forms) { [] }
 


### PR DESCRIPTION
### Add new page to show members of a Group

Trello card: https://trello.com/c/o7SAFAWi/1401-add-screens-for-managing-existing-users-in-groups

This PR starts the work for managing members of a group.

It only tackles the basic journey of showing the members of a group. This is what members of a group with the role editor will see. Other members, group admins, org admins and super admins will all have options for adding and removing users fro the group.

<img width="1035" alt="image" src="https://github.com/alphagov/forms-admin/assets/11035856/7dbe25ab-9447-471b-a4db-1ae61d54aa40">

When the group doesn't have any members, I've added some new content (which can be changed). I think this screen won't happen often but super admins and org admins might see it if all members are removed from a group:
<img width="1035" alt="image" src="https://github.com/alphagov/forms-admin/assets/11035856/a1b6e0bd-046e-4561-8a6c-411eb6e05867">

Link from the group page:
<img width="1035" alt="image" src="https://github.com/alphagov/forms-admin/assets/11035856/882f2089-90be-4b7d-9615-75061446b566">


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
