### PR TITLE
Update change link hidden text

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -7,7 +7,7 @@
                  visually_hidden_text: t("page_settings_summary.answer_type")
       ) end %>
 
-  <% if @draft_question.answer_type == "selection" %>
+  <% if show_selection_settings_summary %>
     <%= summary_list.with_row do |row|
           row.with_key(text: t("page_settings_summary.selection.options"))
           row.with_value(text: show_selection_options)
@@ -28,7 +28,7 @@
                     visually_hidden_text: t("page_settings_summary.selection.include_none_of_the_above")) end %>
   <% end %>
 
-  <% if @draft_question.answer_type == "text" && answer_settings.present? && answer_settings[:input_type] %>
+  <% if show_text_settings_summary %>
     <%= summary_list.with_row do |row|
           row.with_key(text: t("page_settings_summary.text.length"))
           row.with_value(text: t("helpers.label.page.text_settings_options.names.#{answer_settings[:input_type]}"))
@@ -37,7 +37,7 @@
                     visually_hidden_text: t("page_settings_summary.text.length")) end %>
   <% end %>
 
-  <% if @draft_question.answer_type == "date" && answer_settings.present? && answer_settings[:input_type]%>
+  <% if show_date_settings_summary%>
     <%= summary_list.with_row do |row|
           row.with_key(text: t("page_settings_summary.date.date_of_birth"))
           row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{answer_settings[:input_type]}"))
@@ -46,7 +46,7 @@
                     visually_hidden_text: t("page_settings_summary.date.date_of_birth")) end %>
   <% end %>
 
-  <% if @draft_question.answer_type == "address" && answer_settings.present? && answer_settings[:input_type] %>
+  <% if show_address_settings_summary %>
     <%= summary_list.with_row do |row|
           row.with_key(text: t("page_settings_summary.address.address_type"))
           row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
@@ -55,7 +55,7 @@
                      visually_hidden_text: t("page_settings_summary.address.address_type")) end %>
   <% end %>
 
-  <% if @draft_question.answer_type == "name" && answer_settings.present? && answer_settings[:input_type] %>
+  <% if show_name_settings_summary %>
     <%= summary_list.with_row do |row|
           row.with_key(text: t("page_settings_summary.name.name_fields"))
           row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:input_type]}"))

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -1,72 +1,73 @@
 <%= govuk_summary_list do |summary_list| %>
   <%= summary_list.with_row do |row|
-      row.with_key(text: "Answer type")
+      row.with_key(text: t("page_settings_summary.answer_type"))
       row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}"))
-      row.with_action(text: "Change",
+      row.with_action(text: t("page_settings_summary.change"),
                  href: @change_answer_type_path,
-                 visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}")
+                 visually_hidden_text: t("page_settings_summary.answer_type") + " " + t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}")
       ) end %>
 
   <% if @draft_question.answer_type == "selection" %>
     <%= summary_list.with_row do |row|
-          row.with_key(text: "Options")
+          row.with_key(text: t("page_settings_summary.selection.options"))
           row.with_value(text: show_selection_options)
-          row.with_action(text: "Change",
+          row.with_action(text: t("page_settings_summary.change"),
                     href: @change_selections_settings_path,
-                    visually_hidden_text: "Options") end %>
+                    visually_hidden_text: t("page_settings_summary.selection.options")) end %>
     <%= summary_list.with_row do |row|
-          row.with_key(text: t("selections_settings.only_one_option"))
+          row.with_key(text: t("page_settings_summary.selection.only_one_option"))
           row.with_value(text: answer_settings[:only_one_option] == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
-          row.with_action(text: "Change",
+          row.with_action(text: t("page_settings_summary.change"),
                     href: @change_selections_settings_path,
-                    visually_hidden_text: t("selections_settings.only_one_option")) end %>
+                    visually_hidden_text: t("page_settings_summary.selection.only_one_option")) end %>
     <%= summary_list.with_row do |row|
-          row.with_key(text: t("selections_settings.include_none_of_the_above"))
+          row.with_key(text: t("page_settings_summary.selection.include_none_of_the_above"))
           row.with_value(text: @draft_question.is_optional ? t("selections_settings.yes") : t("selections_settings.no"))
-          row.with_action(text: "Change",
+          row.with_action(text: t("page_settings_summary.change"),
                     href: @change_selections_settings_path,
-                    visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
+                    visually_hidden_text: t("page_settings_summary.selection.include_none_of_the_above")) end %>
   <% end %>
+
   <% if @draft_question.answer_type == "text" && answer_settings.present? && answer_settings[:input_type] %>
     <%= summary_list.with_row do |row|
-          row.with_key(text: "Length")
+          row.with_key(text: t("page_settings_summary.text.length"))
           row.with_value(text: t("helpers.label.page.text_settings_options.names.#{answer_settings[:input_type]}"))
-          row.with_action(text: "Change",
+          row.with_action(text: t("page_settings_summary.change"),
                     href: @change_text_settings_path,
-                    visually_hidden_text: "length") end %>
+                    visually_hidden_text: t("page_settings_summary.text.length")) end %>
   <% end %>
 
   <% if @draft_question.answer_type == "date" && answer_settings.present? && answer_settings[:input_type]%>
     <%= summary_list.with_row do |row|
-          row.with_key(text: "Date of birth")
+          row.with_key(text: t("page_settings_summary.date.date_of_birth"))
           row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{answer_settings[:input_type]}"))
-          row.with_action(text: "Change",
+          row.with_action(text: t("page_settings_summary.change"),
                     href: @change_date_settings_path,
-                    visually_hidden_text: "date of birth") end %>
+                    visually_hidden_text: t("page_settings_summary.date.date_of_birth")) end %>
   <% end %>
 
   <% if @draft_question.answer_type == "address" && answer_settings.present? && answer_settings[:input_type] %>
     <%= summary_list.with_row do |row|
-          row.with_key(text: "Address type")
+          row.with_key(text: t("page_settings_summary.address.address_type"))
           row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
-          row.with_action(text: "Change",
+          row.with_action(text: t("page_settings_summary.change"),
                      href: @change_address_settings_path,
-                     visually_hidden_text: "address type") end %>
+                     visually_hidden_text: t("page_settings_summary.address.address_type")) end %>
   <% end %>
 
   <% if @draft_question.answer_type == "name" && answer_settings.present? && answer_settings[:input_type] %>
     <%= summary_list.with_row do |row|
-          row.with_key(text: "Name fields")
+          row.with_key(text: t("page_settings_summary.name.name_fields"))
           row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:input_type]}"))
-          row.with_action(text: "Change",
+          row.with_action(text: t("page_settings_summary.change"),
                      href: @change_name_settings_path,
-                     visually_hidden_text: "name fields") end %>
+                     visually_hidden_text: t("page_settings_summary.name.name_fields")) end %>
 
     <%= summary_list.with_row do |row|
-          row.with_key(text: "Title needed")
+          row.with_key(text: t("page_settings_summary.name.title_needed"))
           row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:title_needed]}"))
-          row.with_action(text: "Change",
+          row.with_action(text: t("page_settings_summary.change"),
                      href: @change_name_settings_path,
-                     visually_hidden_text: "title needed") end %>
+                     visually_hidden_text: t("page_settings_summary.name.title_needed")) end %>
   <% end %>
 <% end %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_summary_list do |summary_list| %>
-    <%= summary_list.with_row do |row|
+  <%= summary_list.with_row do |row|
       row.with_key(text: "Answer type")
       row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}"))
       row.with_action(text: "Change",
@@ -7,66 +7,66 @@
                  visually_hidden_text: "Answer type " + t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}")
       ) end %>
 
-      <% if @draft_question.answer_type == "selection" %>
-        <%= summary_list.with_row do |row|
+  <% if @draft_question.answer_type == "selection" %>
+    <%= summary_list.with_row do |row|
           row.with_key(text: "Options")
           row.with_value(text: show_selection_options)
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: "Options") end %>
-        <%= summary_list.with_row do |row|
+    <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.only_one_option"))
           row.with_value(text: answer_settings[:only_one_option] == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.only_one_option")) end %>
-        <%= summary_list.with_row do |row|
+    <%= summary_list.with_row do |row|
           row.with_key(text: t("selections_settings.include_none_of_the_above"))
           row.with_value(text: @draft_question.is_optional ? t("selections_settings.yes") : t("selections_settings.no"))
           row.with_action(text: "Change",
                     href: @change_selections_settings_path,
                     visually_hidden_text: t("selections_settings.include_none_of_the_above")) end %>
-      <% end %>
-      <% if @draft_question.answer_type == "text" && answer_settings.present? && answer_settings[:input_type] %>
-        <%= summary_list.with_row do |row|
+  <% end %>
+  <% if @draft_question.answer_type == "text" && answer_settings.present? && answer_settings[:input_type] %>
+    <%= summary_list.with_row do |row|
           row.with_key(text: "Length")
           row.with_value(text: t("helpers.label.page.text_settings_options.names.#{answer_settings[:input_type]}"))
           row.with_action(text: "Change",
                     href: @change_text_settings_path,
-                    visually_hidden_text: "input type") end %>
-      <% end %>
+                    visually_hidden_text: "length") end %>
+  <% end %>
 
-      <% if @draft_question.answer_type == "date" && answer_settings.present? && answer_settings[:input_type]%>
-        <%= summary_list.with_row do |row|
+  <% if @draft_question.answer_type == "date" && answer_settings.present? && answer_settings[:input_type]%>
+    <%= summary_list.with_row do |row|
           row.with_key(text: "Date of birth")
           row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{answer_settings[:input_type]}"))
           row.with_action(text: "Change",
                     href: @change_date_settings_path,
-                    visually_hidden_text: "input type") end %>
-      <% end %>
+                    visually_hidden_text: "date of birth") end %>
+  <% end %>
 
-      <% if @draft_question.answer_type == "address" && answer_settings.present? && answer_settings[:input_type] %>
-        <%= summary_list.with_row do |row|
+  <% if @draft_question.answer_type == "address" && answer_settings.present? && answer_settings[:input_type] %>
+    <%= summary_list.with_row do |row|
           row.with_key(text: "Address type")
           row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
           row.with_action(text: "Change",
                      href: @change_address_settings_path,
-                     visually_hidden_text: "input type") end %>
-      <% end %>
+                     visually_hidden_text: "address type") end %>
+  <% end %>
 
-      <% if @draft_question.answer_type == "name" && answer_settings.present? && answer_settings[:input_type] %>
-        <%= summary_list.with_row do |row|
+  <% if @draft_question.answer_type == "name" && answer_settings.present? && answer_settings[:input_type] %>
+    <%= summary_list.with_row do |row|
           row.with_key(text: "Name fields")
           row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:input_type]}"))
           row.with_action(text: "Change",
                      href: @change_name_settings_path,
-                     visually_hidden_text: "input type") end %>
+                     visually_hidden_text: "name fields") end %>
 
-        <%= summary_list.with_row do |row|
+    <%= summary_list.with_row do |row|
           row.with_key(text: "Title needed")
           row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:title_needed]}"))
           row.with_action(text: "Change",
                      href: @change_name_settings_path,
                      visually_hidden_text: "title needed") end %>
-      <% end %>
   <% end %>
+<% end %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -4,7 +4,7 @@
       row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}"))
       row.with_action(text: t("page_settings_summary.change"),
                  href: @change_answer_type_path,
-                 visually_hidden_text: t("page_settings_summary.answer_type") + " " + t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}")
+                 visually_hidden_text: t("page_settings_summary.answer_type")
       ) end %>
 
   <% if @draft_question.answer_type == "selection" %>

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -102,5 +102,25 @@ module PageSettingsSummaryComponent
     def is_new_question?
       @draft_question.page_id.nil?
     end
+
+    def show_selection_settings_summary
+      @draft_question.answer_type == "selection"
+    end
+
+    def show_text_settings_summary
+      @draft_question.answer_type == "text" && answer_settings.present? && answer_settings[:input_type]
+    end
+
+    def show_date_settings_summary
+      @draft_question.answer_type == "date" && answer_settings.present? && answer_settings[:input_type]
+    end
+
+    def show_address_settings_summary
+      @draft_question.answer_type == "address" && answer_settings.present? && answer_settings[:input_type]
+    end
+
+    def show_name_settings_summary
+      @draft_question.answer_type == "name" && answer_settings.present? && answer_settings[:input_type]
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -708,6 +708,22 @@ en:
       default: Selection from a list
       none_of_the_above: None of the above
       only_one_option: Selection from a list, one option only.
+  page_settings_summary:
+    address:
+      address_type: Address type
+    answer_type: Answer type
+    change: Change
+    date:
+      date_of_birth: Date of birth
+    name:
+      name_fields: Name fields
+      title_needed: Title needed
+    selection:
+      include_none_of_the_above: Include an option for ‘None of the above’
+      only_one_option: People can only select one option
+      options: Options
+    text:
+      length: Length
   page_titles:
     access_denied: You do not have permission to access GOV.UK Forms
     account_name: Enter your name

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has links to change the text selections" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change input type", href: edit_text_setting_path)
+      expect(page).to have_link("Change length", href: edit_text_setting_path)
     end
 
     it "renders the input type" do
@@ -132,7 +132,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has links to change the text settings" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change input type", href: edit_text_setting_path)
+        expect(page).to have_link("Change length", href: edit_text_setting_path)
       end
 
       it "renders the input type" do
@@ -152,7 +152,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has links to change the text selections" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change input type", href: new_text_setting_path)
+        expect(page).to have_link("Change length", href: new_text_setting_path)
       end
     end
   end
@@ -167,7 +167,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has a link to change the input type" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change input type", href: edit_date_setting_path)
+      expect(page).to have_link("Change date of birth", href: edit_date_setting_path)
     end
 
     it "renders the input type" do
@@ -193,9 +193,9 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         expect(page).to have_link("Change Answer type Date", href: new_answer_type_path)
       end
 
-      it "has links to change the text selections" do
+      it "has links to change the date of birth setting" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change input type", href: new_date_setting_path)
+        expect(page).to have_link("Change date of birth", href: new_date_setting_path)
       end
     end
   end
@@ -212,7 +212,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has links to change the answer settings" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change input type", href: edit_address_setting_path)
+      expect(page).to have_link("Change address type", href: edit_address_setting_path)
     end
 
     it "renders the input type" do
@@ -249,9 +249,9 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         expect(page).to have_link("Change Answer type Address", href: new_answer_type_path)
       end
 
-      it "has links to change the text selections" do
+      it "has a link to change the address type" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change input type", href: new_address_setting_path)
+        expect(page).to have_link("Change address type", href: new_address_setting_path)
       end
     end
   end
@@ -268,7 +268,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has links to change the answer settings" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change input type", href: edit_name_setting_path)
+      expect(page).to have_link("Change name fields", href: edit_name_setting_path)
       expect(page).to have_link("Change title needed", href: edit_name_setting_path)
     end
 
@@ -292,9 +292,9 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         expect(page).to have_link("Change Answer type Person’s name", href: new_answer_type_path)
       end
 
-      it "has links to change the text selections" do
+      it "has a link to change the name fields" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change input type", href: new_name_setting_path)
+        expect(page).to have_link("Change name fields", href: new_name_setting_path)
       end
     end
   end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has links to change the text selections" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change length", href: edit_text_setting_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.text.length')}", href: edit_text_setting_path)
     end
 
     it "renders the input type" do
@@ -132,7 +132,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has links to change the text settings" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change length", href: edit_text_setting_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.text.length')}", href: edit_text_setting_path)
       end
 
       it "renders the input type" do
@@ -152,7 +152,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has links to change the text selections" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change length", href: new_text_setting_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.text.length')}", href: new_text_setting_path)
       end
     end
   end
@@ -167,7 +167,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has a link to change the input type" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change date of birth", href: edit_date_setting_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.date.date_of_birth')}", href: edit_date_setting_path)
     end
 
     it "renders the input type" do
@@ -181,7 +181,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has no link to change the input type" do
         render_inline(described_class.new(draft_question))
-        expect(page).not_to have_link("Change input type", href: edit_date_setting_path)
+        expect(page).not_to have_link("Change #{I18n.t('page_settings_summary.date.date_of_birth')}", href: edit_date_setting_path)
       end
     end
 
@@ -195,7 +195,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has links to change the date of birth setting" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change date of birth", href: new_date_setting_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.date.date_of_birth')}", href: new_date_setting_path)
       end
     end
   end
@@ -212,7 +212,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has links to change the answer settings" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change address type", href: edit_address_setting_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.address.address_type')}", href: edit_address_setting_path)
     end
 
     it "renders the input type" do
@@ -251,7 +251,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has a link to change the address type" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change address type", href: new_address_setting_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.address.address_type')}", href: new_address_setting_path)
       end
     end
   end
@@ -268,8 +268,8 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has links to change the answer settings" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change name fields", href: edit_name_setting_path)
-      expect(page).to have_link("Change title needed", href: edit_name_setting_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.name.name_fields')}", href: edit_name_setting_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.name.title_needed')}", href: edit_name_setting_path)
     end
 
     it "renders the input type" do
@@ -294,7 +294,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has a link to change the name fields" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change name fields", href: new_name_setting_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.name.name_fields')}", href: new_name_setting_path)
       end
     end
   end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "does not have links to change the selection options" do
       render_inline(described_class.new(draft_question))
-      expect(page).not_to have_link("Change Options", href: edit_selections_setting_path)
-      expect(page).not_to have_link("Change People can only select one option", href: edit_selections_setting_path)
-      expect(page).not_to have_link("Change Include an option for ‘None of the above’", href: edit_selections_setting_path)
+      expect(page).not_to have_link("Change #{I18n.t('page_settings_summary.selection.options')}", href: edit_selections_setting_path)
+      expect(page).not_to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: edit_selections_setting_path)
+      expect(page).not_to have_link("Change #{I18n.t('page_settings_summary.selection.include_none_of_the_above')}", href: edit_selections_setting_path)
     end
 
     it "does not render the selection settings" do
@@ -53,9 +53,9 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has links to change the selection options" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change Options", href: edit_selections_setting_path)
-      expect(page).to have_link("Change People can only select one option", href: edit_selections_setting_path)
-      expect(page).to have_link("Change Include an option for ‘None of the above’", href: edit_selections_setting_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.options')}", href: edit_selections_setting_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: edit_selections_setting_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.include_none_of_the_above')}", href: edit_selections_setting_path)
     end
 
     it "renders the selection settings" do
@@ -100,9 +100,9 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has links to change the selection options" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change Options", href: new_selections_setting_path)
-        expect(page).to have_link("Change People can only select one option", href: new_selections_setting_path)
-        expect(page).to have_link("Change Include an option for ‘None of the above’", href: new_selections_setting_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.options')}", href: new_selections_setting_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: new_selections_setting_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.include_none_of_the_above')}", href: new_selections_setting_path)
       end
     end
   end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
   context "when the page is not a selection page" do
     it "has a link to change the answer type" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change Answer type", href: edit_answer_type_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: edit_answer_type_path)
     end
 
     it "does not have links to change the selection options" do
@@ -48,7 +48,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has a link to change the answer type" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change Answer type Selection from a list", href: edit_answer_type_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: edit_answer_type_path)
     end
 
     it "has links to change the selection options" do
@@ -95,7 +95,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has a link to change the answer type" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change Answer type Selection from a list", href: new_answer_type_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: new_answer_type_path)
       end
 
       it "has links to change the selection options" do
@@ -113,7 +113,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has a link to change the answer type" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change Answer type Text", href: edit_answer_type_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: edit_answer_type_path)
     end
 
     it "has links to change the text selections" do
@@ -147,7 +147,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has a link to change the answer type" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change Answer type Text", href: new_answer_type_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: new_answer_type_path)
       end
 
       it "has links to change the text selections" do
@@ -162,7 +162,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has a link to change the answer type" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change Answer type Date", href: edit_answer_type_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: edit_answer_type_path)
     end
 
     it "has a link to change the input type" do
@@ -190,7 +190,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has a link to change the answer type" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change Answer type Date", href: new_answer_type_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: new_answer_type_path)
       end
 
       it "has links to change the date of birth setting" do
@@ -207,7 +207,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has a link to change the answer type" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change Answer type Address", href: edit_answer_type_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: edit_answer_type_path)
     end
 
     it "has links to change the answer settings" do
@@ -246,7 +246,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has a link to change the answer type" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change Answer type Address", href: new_answer_type_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: new_answer_type_path)
       end
 
       it "has a link to change the address type" do
@@ -263,7 +263,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
     it "has a link to change the answer type" do
       render_inline(described_class.new(draft_question))
-      expect(page).to have_link("Change Answer type Person’s name", href: edit_answer_type_path)
+      expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: edit_answer_type_path)
     end
 
     it "has links to change the answer settings" do
@@ -289,7 +289,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       it "has a link to change the answer type" do
         render_inline(described_class.new(draft_question))
-        expect(page).to have_link("Change Answer type Person’s name", href: new_answer_type_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: new_answer_type_path)
       end
 
       it "has a link to change the name fields" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/tJswYdpy/1471-page-settings-summary-change-link-accessible-name-does-not-match-the-visible-label

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
The main point to this PR is to update the change link visually hidden text in the page settings summary at the bottom of the edit question page.

As well as doing this, there are a few small refactors/cleanup jobs included, namely:
- Using translated values for these bits of text
- Changing the format of the 'Change answer type' link for consistency
- Some cleanup in the test files
- Moving some logic out of the view file

(see individual commit messages for details)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
