### PR TITLE
Update content for unarchiving a form

### DIFF
--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -32,7 +32,10 @@ class FormTaskListService
 private
 
   def create_or_edit
-    @form.is_live? ? "edit" : "create"
+    return "edit" if @form.is_live?
+    return "edit" if @form.is_archived?
+
+    "create"
   end
 
   def create_form_section
@@ -116,7 +119,7 @@ private
 
   def make_form_live_section
     section = {
-      title: I18n.t("forms.task_list_#{create_or_edit}.make_form_live_section.title"),
+      title: live_title_name,
       section_number: 4,
       subsection: false,
     }
@@ -132,11 +135,29 @@ private
 
   def make_form_live_section_tasks
     [{
-      task_name: I18n.t("forms.task_list_#{create_or_edit}.make_form_live_section.make_live"),
-      path: @form.all_ready_for_live? ? make_live_path(@form.id) : "",
+      task_name: live_task_name,
+      path: live_path,
       status: @task_statuses[:make_live_status],
       active: @form.all_ready_for_live?,
     }]
+  end
+
+  def live_title_name
+    return I18n.t("forms.task_list_create.make_form_live_section.title") if @form.is_archived?
+
+    I18n.t("forms.task_list_#{create_or_edit}.make_form_live_section.title")
+  end
+
+  def live_task_name
+    return I18n.t("forms.task_list_create.make_form_live_section.make_live") if @form.is_archived?
+
+    I18n.t("forms.task_list_#{create_or_edit}.make_form_live_section.make_live")
+  end
+
+  def live_path
+    return "" unless @form.all_ready_for_live?
+
+    make_live_path(@form.id)
   end
 
   def statuses_by_user

--- a/app/views/forms/archive_form/archive.html.erb
+++ b/app/views/forms/archive_form/archive.html.erb
@@ -14,7 +14,7 @@
         <%= t('page_titles.archive_form_confirm') %>
       </h1>
 
-      <%= t('archive_form.confirm.body_html') %>
+      <%= t('archive_form.confirm.body_html', submission_email: @confirm_archive_form.form.submission_email) %>
 
       <%= f.govuk_collection_radio_buttons :confirm,
                                            @confirm_archive_form.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_action_form.options.' + "#{option}") },

--- a/app/views/forms/make_live/make_archived_draft_live.html.erb
+++ b/app/views/forms/make_live/make_archived_draft_live.html.erb
@@ -1,6 +1,5 @@
-<% set_page_title(title_with_error_prefix(t('page_titles.make_changes_live_form'), @make_live_form.errors.any?)) %>
+<% set_page_title(title_with_error_prefix(t('page_titles.unarchive_form'), @make_live_form.errors.any?)) %>
 <% content_for :back_link, govuk_back_link_to(form_path, t("back_link.form_edit")) %>
-
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -11,16 +10,10 @@
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= @make_live_form.form.name %></span>
-        <%= t("page_titles.make_changes_live_form") %>
+        <%= t("page_titles.make_archived_draft_live") %>
       </h1>
 
-      <p>
-        <%= t("make_changes_live.warning") %>
-      </p>
-
-      <p>
-        <%= t("make_changes_live.url_will_remain_same") %>
-      </p>
+      <%= t("make_archived_draft_live.new.body_html", submission_email: @make_live_form.form.submission_email) %>
 
       <%= f.govuk_collection_radio_buttons :confirm,
                                            @make_live_form.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_action_form.options.' + "#{option}") },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
         <ul class="govuk-list govuk-list--bullet">
           <li>links to the form will no longer work - make sure any links to the form have been removed</li>
           <li>anyone who is part way through completing the form will lose their progress and get an error page</li>
+          <li>we’ll send an email to %{submission_email} to let them know the form has been archived</li>
         </ul>
         <p>You will still be able to preview the form and see its information and settings. You can also make a new draft of the form and make it live again if you need to.</p>
       radios_legend: Are you sure you want to archive this form?
@@ -545,6 +546,17 @@ en:
       <p>You’ll be able to use the service later.</p>
       <p>If you need urgent help with your forms you can %{link}.</p>
     title: Sorry, the service is unavailable
+  make_archived_draft_live:
+    new:
+      body_html: |
+        <p>
+          The form will not be indexed by search engines, so people will not be able to find it easily.
+          Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
+        </p>
+
+        <p>
+          After you have made your form live, completed forms will be sent to %{submission_email}.
+        </p>
   make_changes_live:
     url_will_remain_same: Links to the form will still work, even if you’ve changed the form’s name.
     warning: |
@@ -757,6 +769,7 @@ en:
     home: Home
     internal_server_error: Sorry, there is a problem with the service
     maintenance: Sorry, the service is unavailable
+    make_archived_draft_live: Make your form live again
     make_changes_live_form: Make your changes live
     make_live_form: Make your form live
     mou_signature_confirmation: You've agreed to the MOU
@@ -996,9 +1009,9 @@ en:
     new:
       body_html: |
         <p>
-          When you make your form live again you’ll get a URL for the form. The form
-          will not be indexed by search engines, so people will not be able to
-          find it easily. Contact your GOV.UK publishing team to publish a link to
+          The form will not be indexed by search engines,
+          so people will not be able to find it easily.
+          Contact your GOV.UK publishing team to publish a link to
           your form on GOV.UK so people can find it.
         </p>
 

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -323,6 +323,15 @@ describe FormTaskListService do
         end
       end
 
+      context "when the form is archived" do
+        let(:form) { build(:form, :archived, id: 1) }
+
+        it "has link to make the form live" do
+          expect(section_rows.first[:task_name]).to eq "Make your form live"
+          expect(section_rows.first[:path]).to eq "/forms/1/make-live"
+        end
+      end
+
       context "when current user has a trial account" do
         let(:current_user) { build :user, :with_trial_role }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Content that was added as part of the unarchiving journey was (quite pragmatically) added by devs as placeholder. We now have the proper content from our Content Designer and this PR updates to that.

[Trello card](https://trello.com/c/K2gHWdLY)

## Screenshots

<details>
<summary>When making an archived form live again (without making a draft first)</summary>

![localhost_3000_forms_4_unarchive](https://github.com/alphagov/forms-admin/assets/424772/7a0c16cf-67da-47c6-b878-f9a467e47965)
</details>

<details>
<summary>When making a draft of an archived form live</summary>

![localhost_3000_forms_1_make-live (1)](https://github.com/alphagov/forms-admin/assets/424772/fa57fe9a-de29-4ae5-a32e-06ca092bc80f)


![localhost_3000_forms_4_make-live (1)](https://github.com/alphagov/forms-admin/assets/424772/7e03a848-d86d-45c1-a757-eed889a44180)

</details>

<details>

<summary>For the draft of an archived form task list page</summary>

![localhost_3000_forms_9](https://github.com/alphagov/forms-admin/assets/424772/046c1b61-5dcc-4087-8ee2-e23651ac9616)


</details>

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
