### PR TITLE
Fix page title on add and edit question page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
   end
 
   def set_page_title(title)
-    content_for(:title) { title.html_safe }
+    content_for(:title, title.html_safe)
   end
 
   def title_with_error_prefix(title, error)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def page_title(separator = " – ")
-    [content_for(:title), "GOV.UK Forms"].compact.join(separator)
+  def page_title
+    [content_for(:title), "GOV.UK Forms"].compact.join(I18n.t("page_titles.separator"))
   end
 
   def set_page_title(title)

--- a/app/views/mou_signatures/show.html.erb
+++ b/app/views/mou_signatures/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(page_title(t("page_titles.mou_signature_new"))) %>
+<% set_page_title(t("page_titles.mou_signature_new")) %>
 
 <% if @mou_signature.present? %>
   <%= govuk_notification_banner(title_text: "MOU Signature already complete") do |banner| %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(current_form.name) %>
+<% set_page_title(t("pages.index.title")) %>
 
 <% content_for :back_link, govuk_back_link_to(form_path(current_form), t("back_link.form_create")) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -760,6 +760,7 @@ en:
     routing_page_delete: Delete question %{question_position}’s route
     routing_page_edit: Edit question %{question_position}’s route
     routing_page_new: 'Add a question route: select answer and destination'
+    separator: " – "
     set_email_form: Set the email address for completed forms
     sign_in: Sign in
     sign_up: Sign up

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -236,4 +236,58 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#page_title" do
+    context "when no title content is present" do
+      it "returns the website name" do
+        expect(helper.page_title).to eq "GOV.UK Forms"
+      end
+    end
+
+    context "when title content is present" do
+      let(:title) { Faker::Lorem.sentence(word_count: 1, supplemental: true, random_words_to_add: 5) }
+
+      before do
+        helper.content_for(:title, title)
+      end
+
+      it "returns the title and website name separated by an en dash" do
+        expect(helper.page_title).to eq "#{title} – GOV.UK Forms"
+      end
+
+      context "when a custom separator is configured" do
+        let(:separator) { ", " }
+
+        it "returns the website name separated by the custom separator" do
+          expect(helper.page_title(separator)).to eq "#{title}, GOV.UK Forms"
+        end
+      end
+    end
+  end
+
+  describe "#set_page_title" do
+    let(:title) { Faker::Lorem.sentence(word_count: 1, supplemental: true, random_words_to_add: 5) }
+
+    it "sets the content_for for the title" do
+      allow(helper).to receive(:content_for)
+
+      helper.set_page_title(title)
+
+      expect(helper).to have_received(:content_for).with(:title, title.html_safe)
+    end
+  end
+
+  describe "setting and retrieving a page title" do
+    context "when the title contains special characters" do
+      let(:title) { "#{Faker::Lorem.sentence(word_count: 1, supplemental: true, random_words_to_add: 5)} ‘’&<script>alert('this string contains a script tag')</script>" }
+
+      before do
+        helper.set_page_title(title)
+      end
+
+      it "renders the special characters correctly" do
+        expect(helper.page_title).to eq "#{title} – GOV.UK Forms"
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -252,15 +252,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it "returns the title and website name separated by an en dash" do
-        expect(helper.page_title).to eq "#{title} – GOV.UK Forms"
-      end
-
-      context "when a custom separator is configured" do
-        let(:separator) { ", " }
-
-        it "returns the website name separated by the custom separator" do
-          expect(helper.page_title(separator)).to eq "#{title}, GOV.UK Forms"
-        end
+        expect(helper.page_title).to eq "#{title}#{I18n.t('page_titles.separator')}GOV.UK Forms"
       end
     end
   end
@@ -286,7 +278,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it "renders the special characters correctly" do
-        expect(helper.page_title).to eq "#{title} – GOV.UK Forms"
+        expect(helper.page_title).to eq "#{title}#{I18n.t('page_titles.separator')}GOV.UK Forms"
       end
     end
   end

--- a/spec/views/pages/index.html.erb_spec.rb
+++ b/spec/views/pages/index.html.erb_spec.rb
@@ -18,6 +18,10 @@ describe "pages/index.html.erb" do
     render template: "pages/index"
   end
 
+  it "has the correct title" do
+    expect(view.content_for(:title)).to eq I18n.t("pages.index.title")
+  end
+
   describe "when there are no pages to display" do
     it "allows the user to add a page" do
       expect(rendered).to have_link(I18n.t("pages.index.add_question"), href: start_new_question_path(form.id))


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/07ETWa8e/1473-form-task-list-and-questions-list-have-the-same-title

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
The form task list page (forms/index.html.erb) and the page index (pages/index.html.erb) previously had the same title (the form name).

This is a violation of WCAG 2.4.2: Page Titled - the identical titles are confusing, and at least one of them must not describe the page it's on meaningfully.

This PR changes the value in the page index to match the H1 on the page - i.e. 'Add and edit your questions'.

Also includes a bit of refactoring and some tests for the `page_title` and `set_page_title` fields. See individual commit messages for details.

### Screenshots
I think the only visible change should be the title on the page index:

![Screenshot of a the page index with the level one heading "Add and edit your questions". The browser console is open, showing that the page title is "Add and edit your questions – GOV.UK Forms"](https://github.com/alphagov/forms-admin/assets/5861235/831a7a1d-d929-4a9f-9742-af1ef0893b38)
 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
