### PR TITLE
Add group new member

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -6,7 +6,9 @@ class GroupMembersController < ApplicationController
     authorize @group, :show?
   end
 
-  def new; end
+  def new
+    @group_member_form = GroupMemberForm.new
+  end
 
 private
 

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -1,5 +1,5 @@
 class GroupMembersController < ApplicationController
-  before_action :set_group, :authorize_group_members
+  before_action :set_group
   after_action :verify_authorized
 
   def index
@@ -7,10 +7,13 @@ class GroupMembersController < ApplicationController
   end
 
   def new
+    authorize @group, :add_editor?
     @group_member_form = GroupMemberForm.new
   end
 
   def create
+    authorize @group, :add_editor?
+
     @group_member_form = GroupMemberForm.new(group_member_params)
     if @group_member_form.save
       redirect_to group_members_path(@group.external_id)
@@ -23,10 +26,6 @@ private
 
   def set_group
     @group = Group.find_by(external_id: params[:group_id])
-  end
-
-  def group_member_params
-    params.require(:group_member_form).permit(:member_email_address).merge(group: @group, creator: current_user)
   end
 
   def group_member_params

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -4,6 +4,8 @@ class GroupMembersController < ApplicationController
 
   def index; end
 
+  def new; end
+
 private
 
   def set_group

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -10,10 +10,23 @@ class GroupMembersController < ApplicationController
     @group_member_form = GroupMemberForm.new
   end
 
+  def create
+    @group_member_form = GroupMemberForm.new(group_member_params)
+    if @group_member_form.save
+      redirect_to group_members_path(@group.external_id)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
 private
 
   def set_group
     @group = Group.find_by(external_id: params[:group_id])
+  end
+
+  def group_member_params
+    params.require(:group_member_form).permit(:member_email_address).merge(group: @group, creator: current_user)
   end
 
   def group_member_params

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -2,7 +2,9 @@ class GroupMembersController < ApplicationController
   before_action :set_group, :authorize_group_members
   after_action :verify_authorized
 
-  def index; end
+  def index
+    authorize @group, :show?
+  end
 
   def new; end
 
@@ -12,7 +14,7 @@ private
     @group = Group.find_by(external_id: params[:group_id])
   end
 
-  def authorize_group_members
-    authorize @group, :show?
+  def group_member_params
+    params.require(:group_member_form).permit(:member_email_address).merge(group: @group, creator: current_user)
   end
 end

--- a/app/form_objects/group_member_form.rb
+++ b/app/form_objects/group_member_form.rb
@@ -1,0 +1,48 @@
+class GroupMemberForm < BaseForm
+  include ActiveModel::Validations::Callbacks
+
+  attr_accessor :member_email_address, :group, :creator
+
+  EMAIL_REGEX = /.*@.*/
+
+  validates :member_email_address, presence: true
+  validates :member_email_address, format: { with: EMAIL_REGEX, message: :invalid_email }
+  validate :invited_user_has_account, if: -> { member_email_address.present? }
+
+  before_validation :strip_whitespace
+
+  def save
+    if invalid? || new_membership.invalid?
+      copy_membership_errors
+      return false
+    end
+
+    new_membership.save!
+  end
+
+private
+
+  def invited_user
+    @invited_user ||= User.find_by(email: member_email_address)
+  end
+
+  def new_membership
+    @new_membership ||= group.memberships.new(user: invited_user, role: :editor, added_by: creator)
+  end
+
+  def invited_user_has_account
+    return if invited_user.present?
+
+    errors.add(:member_email_address, :not_forms_user)
+  end
+
+  def copy_membership_errors
+    new_membership.errors.each do |err|
+      errors.add(:member_email_address, err.type)
+    end
+  end
+
+  def strip_whitespace
+    member_email_address&.strip!
+  end
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -22,6 +22,6 @@ private
     return if user.nil? || group.nil?
     return if user.organisation == group.organisation
 
-    errors.add :base, "User and group must have the same organisation"
+    errors.add(:base, :user_in_other_org, message: "User and group must have the same organisation")
   end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -10,6 +10,10 @@ class GroupPolicy < ApplicationPolicy
   alias_method :edit?, :show?
   alias_method :update?, :show?
 
+  def add_editor?
+    user.super_admin? || user.is_organisations_admin?(record.organisation) || record.memberships.find_by(user:)&.group_admin?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       if user.super_admin?

--- a/app/views/group_members/index.html.erb
+++ b/app/views/group_members/index.html.erb
@@ -31,6 +31,10 @@
   <% end %>
 <% end %>
 
+<% if Pundit.policy(@current_user, @group).add_editor? %>
+  <%= govuk_link_to(t(".add_member"), new_group_member_path(@group), class: "govuk-button") %>
+<% end %>
+
 <div class="govuk-!-margin-top-3">
   <%= govuk_details(summary_text: t(".details.summary_text")) do %>
     <%= t(".details.summary_content_html") %>

--- a/app/views/group_members/new.html.erb
+++ b/app/views/group_members/new.html.erb
@@ -10,5 +10,14 @@
     </h1>
 
     <%= t(".body_html") %>
+
+    <%= form_with(model: @group_member_form, url: group_members_path(@group)) do |f| %>
+      <% if @group_member_form&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <%= f.govuk_text_field :member_email_address, label: {  tag: 'h2', size: 'm' } %>
+      <%= f.govuk_submit t(".submit") %>
+    <% end %>
   </div>
 </div>

--- a/app/views/group_members/new.html.erb
+++ b/app/views/group_members/new.html.erb
@@ -1,0 +1,14 @@
+<% set_page_title(t(".title")) %>
+<% content_for :back_link, govuk_back_link_to(group_members_path(@group)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 id="heading" class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @group.name %></span>
+      <span class="govuk-visually-hidden"> - </span>
+      <%= t(".title") %>
+    </h1>
+
+    <%= t(".body_html") %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,6 +264,7 @@ en:
     confirm_deletion_page: Are you sure you want to delete this page?
   group_members:
     index:
+      add_member: Add an editor
       details:
         summary_content_html: |
           <p>An editor can edit forms in a group but cannot make forms live.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,14 @@ en:
           attributes:
             organisation_id:
               blank: Select your organisation
+        group_member_form:
+          attributes:
+            member_email_address:
+              blank: Enter an email address
+              invalid_email: Enter an email address in the correct format, like name@example.gov.uk
+              not_forms_user: This person does not have a GOV.UK Forms account
+              taken: This person is already a member of the group
+              user_in_other_org: This person has a different organisation set for their GOV.UK Forms account
         page:
           attributes:
             hint_text:
@@ -404,6 +412,8 @@ en:
         confirm_make_live: Are you sure you want to make your draft live?
       forms_make_live_form:
         confirm_make_live: Are you sure you want to make your form live?
+      group_member_form:
+        member_email_address: Enter the email address of the person you want to add
       mou_signature:
         agreed_options:
           '1': I agree to the MOU on behalf of my organisation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,6 +281,17 @@ en:
         name: Name
         role: Role
       title: Members of this group
+    new:
+      body_html: |
+        <p>You can add someone to create and edit forms in this group. They must:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>be from the same organisation as you</li>
+          <li>already have a GOV.UK Forms account</li>
+        </ul>
+
+        <p>You must use their government email address.</p>
+      submit: Add this person
+      title: Add an editor to this group
   groups:
     edit:
       title: Edit group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,7 +150,7 @@ Rails.application.routes.draw do
 
   resources :groups, except: :destroy do
     resources :forms, controller: :group_forms, only: %i[new create]
-    resources :members, controller: :group_members, only: %i[index new]
+    resources :members, controller: :group_members, only: %i[index new create]
   end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,7 +150,7 @@ Rails.application.routes.draw do
 
   resources :groups, except: :destroy do
     resources :forms, controller: :group_forms, only: %i[new create]
-    resources :members, controller: :group_members, only: %i[index]
+    resources :members, controller: :group_members, only: %i[index new]
   end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page

--- a/spec/features/groups/manage_group_members_spec.rb
+++ b/spec/features/groups/manage_group_members_spec.rb
@@ -5,9 +5,10 @@ feature "Show members of a group", type: :feature do
   let(:group) { create(:group, name: "Group 1", organisation:) }
   let(:user1) { create(:user, organisation:) }
   let(:user2) { create(:user, organisation:) }
+  let(:user3) { create(:user, organisation:) }
 
   before do
-    create(:membership, user: editor_user, group:, role: :editor)
+    create(:membership, user: editor_user, group:, role: :group_admin)
     create(:membership, user: user1, group:, role: :editor)
     create(:membership, user: user2, group:, role: :group_admin)
     login_as_editor_user
@@ -18,6 +19,10 @@ feature "Show members of a group", type: :feature do
     and_i_click_the_group_link
     and_i_click_the_edit_group_members_link
     then_i_should_see_the_members_of_the_group
+    when_i_click_add_editor
+    then_i_should_see_the_add_editor_form
+    when_i_fill_in_the_add_editor_form
+    then_i_should_see_the_new_editor_in_the_list
   end
 
   def when_i_visit_the_groups_page
@@ -39,5 +44,25 @@ feature "Show members of a group", type: :feature do
     expect(page).to have_text user2.name
     expect(page).to have_text user2.email
     expect_page_to_have_no_axe_errors(page)
+  end
+
+  def when_i_click_add_editor
+    click_link "Add an editor"
+  end
+
+  def then_i_should_see_the_add_editor_form
+    expect(page.find("h1")).to have_text "Add an editor to this group"
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def when_i_fill_in_the_add_editor_form
+    fill_in "Enter the email address of the person you want to add", with: user3.email
+    click_button "Add this person"
+  end
+
+  def then_i_should_see_the_new_editor_in_the_list
+    expect(page.find("h1")).to have_text "Group 1"
+    expect(page).to have_text user3.name
+    expect(page).to have_text user3.email
   end
 end

--- a/spec/form_objects/group_member_form_spec.rb
+++ b/spec/form_objects/group_member_form_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+describe GroupMemberForm do
+  subject(:group_member_form) { described_class.new }
+
+  let(:group) { create(:group) }
+  let(:user) { create(:user, organisation: group.organisation) }
+
+  describe "validations" do
+    it "is valid with an email address" do
+      group_member_form.member_email_address = user.email
+      expect(group_member_form).to be_valid
+    end
+
+    it "is invalid without an email address" do
+      group_member_form.member_email_address = ""
+      error_message = I18n.t("activemodel.errors.models.group_member_form.attributes.member_email_address.blank")
+      expect(group_member_form).not_to be_valid
+      expect(group_member_form.errors[:member_email_address]).to include(error_message)
+    end
+
+    it "is invalid with a invalid email address " do
+      group_member_form.member_email_address = "this isn't an email address"
+      error_message = I18n.t("activemodel.errors.models.group_member_form.attributes.member_email_address.invalid_email")
+      expect(group_member_form).not_to be_valid
+      expect(group_member_form.errors[:member_email_address]).to include(error_message)
+    end
+
+    it "is invalid with a email address that is not a GOV.UK forms user" do
+      group_member_form.member_email_address = "valid_but_not_user@email.gov.uk"
+      error_message = I18n.t("activemodel.errors.models.group_member_form.attributes.member_email_address.not_forms_user")
+      expect(group_member_form).not_to be_valid
+      expect(group_member_form.errors[:member_email_address]).to include(error_message)
+    end
+
+    it "is valid with a email address that is a GOV.UK forms user" do
+      user = create(:user)
+      group_member_form.member_email_address = user.email
+      expect(group_member_form).to be_valid
+    end
+
+    describe "#save" do
+      context "when the new Membership has errors" do
+        let(:group_member_form) { described_class.new }
+
+        before do
+          membership_errors = instance_double(ActiveModel::Errors)
+          error = instance_double(ActiveModel::Error, type: :user_in_other_org)
+          allow(membership_errors).to receive(:[]).with(:user_in_other_org).and_return(["User is already a member of another organization"])
+          allow(membership_errors).to receive(:each).and_yield(error)
+
+          new_membership = instance_double(Membership, invalid?: true, errors: membership_errors)
+
+          memberships_association = instance_double(ActiveRecord::Associations::CollectionProxy)
+          allow(memberships_association).to receive(:new).and_return(new_membership)
+
+          group = instance_double(Group, memberships: memberships_association)
+
+          group_member_form.group = group
+          group_member_form.member_email_address = user.email
+        end
+
+        it "adds the appropriate error message to member_email_address" do
+          error_message = I18n.t("activemodel.errors.models.group_member_form.attributes.member_email_address.user_in_other_org")
+          expect(group_member_form.save).to be false
+          expect(group_member_form.errors[:member_email_address]).to include(error_message)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/group_members_controller_spec.rb
+++ b/spec/requests/group_members_controller_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "/groups/:group_id/members", type: :request do
-  let(:group) { create :group }
+  let(:group) { create :group, organisation: editor_user.organisation }
+  let(:role) { :group_admin }
 
   before do
-    create(:membership, user: editor_user, group:)
+    create(:membership, user: editor_user, group:, role:)
     login_as_editor_user
   end
 
@@ -21,6 +22,59 @@ RSpec.describe "/groups/:group_id/members", type: :request do
         get group_members_url(other_group)
 
         expect(response).to have_http_status :forbidden
+      end
+    end
+  end
+
+  describe "GET /groups/:group_id/members/new" do
+    it "renders a successful response" do
+      get new_group_member_url(group)
+      expect(response).to be_successful
+    end
+
+    context "and I'm an editor" do
+      let(:role) { :editor }
+
+      it "denies access" do
+        get new_group_member_url(group)
+        expect(response).to have_http_status :forbidden
+      end
+    end
+  end
+
+  describe "POST /groups/:group_id/members" do
+    context "with valid parameters" do
+      let(:user) { create :user, organisation: editor_user.organisation }
+
+      it "creates a new membership" do
+        expect {
+          post group_members_url(group), params: { group_member_form: { member_email_address: user.email } }
+        }.to change(Membership, :count).by(1)
+
+        expect(response).to have_http_status :redirect
+      end
+
+      context "and I'm an editor" do
+        let(:role) { :editor }
+
+        it "denies access" do
+          expect {
+            post group_members_url(group), params: { group_member_form: { member_email_address: user.email } }
+          }.not_to change(Membership, :count)
+
+          expect(response).to have_http_status :forbidden
+        end
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not create a new membership" do
+        expect {
+          post group_members_url(group), params: { group_member_form: { member_email_address: "invalid" } }
+        }.not_to change(Membership, :count)
+
+        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to render_template :new
       end
     end
   end

--- a/spec/views/group_members/new.html.erb_spec.rb
+++ b/spec/views/group_members/new.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "group_members/new", type: :view do
+  let(:organisation) { build(:organisation, slug: "Department for testing new group members") }
+  let(:group) { create(:group, name: "Group 1", organisation:) }
+
+  before do
+    assign(:group, group)
+    render
+  end
+
+  it "displays the group name" do
+    expect(rendered).to have_selector("h1", text: group.name)
+  end
+
+  it "displays the page title" do
+    expect(rendered).to have_selector("h1", text: t("group_members.new.title"))
+  end
+
+  it "has a back link to group members page" do
+    expect(view.content_for(:back_link)).to have_link("Back", href: group_members_path(group))
+  end
+end

--- a/spec/views/group_members/new.html.erb_spec.rb
+++ b/spec/views/group_members/new.html.erb_spec.rb
@@ -3,9 +3,11 @@ require "rails_helper"
 RSpec.describe "group_members/new", type: :view do
   let(:organisation) { build(:organisation, slug: "Department for testing new group members") }
   let(:group) { create(:group, name: "Group 1", organisation:) }
+  let(:group_member_form) { GroupMemberForm.new }
 
   before do
     assign(:group, group)
+    assign(:group_member_form, group_member_form)
     render
   end
 


### PR DESCRIPTION
### Allow group_admins, org_admins and super_admins to add editors to groups

Trello card: https://trello.com/c/o7SAFAWi/1401-add-screens-for-managing-existing-users-in-groups

This PR gives group admins, org admins and super admins the ability to add new editors to groups.

It may require changes in the future to:
- change the way the policy works
- add email confirmations to new editors

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
