### PR TITLE
Refactor group policy

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -11,6 +11,6 @@ private
   end
 
   def authorize_group_members
-    authorize @group, :index_users?
+    authorize @group, :show?
   end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -7,11 +7,8 @@ class GroupPolicy < ApplicationPolicy
   def show?
     user.super_admin? || user.is_organisations_admin?(record.organisation) || user.groups.include?(record)
   end
-
   alias_method :edit?, :show?
-  alias_method :update?, :edit?
-  alias_method :destroy?, :edit?
-  alias_method :index_users?, :show?
+  alias_method :update?, :show?
 
   class Scope < ApplicationPolicy::Scope
     def resolve

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -9,14 +9,8 @@ RSpec.describe GroupPolicy do
   context "when user is super_admin" do
     let(:user) { build :super_admin_user }
 
-    it { is_expected.to permit_actions(%i[create edit show destroy update index_users]) }
-
-    context "and user is not a member of the group" do
-      let(:group) { build :group, organisation_id: user.organisation_id + 1 }
-
-      it "allows show, edit, update or destroy" do
-        expect(policy).to permit_actions(%i[show edit update destroy index_users])
-      end
+    it "permits all actions" do
+      expect(policy).to permit_all_actions
     end
 
     it "scope resolves to all groups" do
@@ -27,23 +21,21 @@ RSpec.describe GroupPolicy do
   context "when user is organisation_admin" do
     let(:user) { build :organisation_admin_user }
 
-    it { is_expected.to permit_actions(%i[create edit show destroy update]) }
+    context "and in the same organisation as the group" do
+      it "permits all actions" do
+        expect(policy).to permit_all_actions
+      end
+    end
 
-    context "and not a member of the group" do
-      context "and in the same organisation as the group" do
-        let(:group) { create :group, organisation_id: user.organisation_id }
+    context "and not in the same organisation as the group" do
+      let(:group) { build :group, organisation_id: user.organisation_id + 1 }
 
-        it "allows show, edit, update or destroy" do
-          expect(policy).to permit_actions(%i[show edit update destroy])
-        end
+      it "permits new and create" do
+        expect(policy).to permit_only_actions(%i[new create])
       end
 
-      context "and not in the same organisation as the group" do
-        let(:group) { build :group, organisation_id: user.organisation_id + 1 }
-
-        it "forbids show, edit, update or destroy" do
-          expect(policy).to forbid_actions(%i[show edit update destroy])
-        end
+      it "forbids show, edit, and update" do
+        expect(policy).to forbid_only_actions(%i[show edit update])
       end
     end
 
@@ -53,19 +45,19 @@ RSpec.describe GroupPolicy do
   end
 
   context "when user is editor" do
-    it "allow creating new groups" do
-      expect(policy).to permit_actions(%i[new create])
+    it "permits new and create" do
+      expect(policy).to permit_only_actions(%i[new create])
     end
 
-    it "cannot view, list or modify group" do
-      expect(policy).to forbid_actions(%i[edit show destroy update index_users])
+    it "forbids show, edit, and update" do
+      expect(policy).to forbid_only_actions(%i[show edit update])
     end
 
     context "and user belongs to group" do
       before { user.groups << group }
 
-      it "allows view, list and modify group" do
-        expect(policy).to permit_actions(%i[edit show destroy update index_users])
+      it "permits group creation, viewing, and editing" do
+        expect(policy).to permit_only_actions(%i[show new edit create update])
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Simplify group policy method aliases, and refactor spec/policies/group_policy_spec.rb to use more specific pundit matchers

This was triggered by resolving some merge conflicts where it was unclear what an org admin should be permitted to do based on the specs.

### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
