### PR TITLE
Delete members from groups

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -4,6 +4,7 @@ class GroupMembersController < ApplicationController
 
   def index
     authorize @group, :show?
+    @group_member_service = GroupMemberService.new(group: @group, current_user: @current_user)
   end
 
   def new

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,0 +1,13 @@
+class MembershipsController < ApplicationController
+  after_action :verify_authorized
+
+  def destroy
+    membership = Membership.find(params[:id])
+    authorize membership
+
+    membership.destroy!
+
+    success_message = t(".success", member_name: membership.user.name)
+    redirect_to group_members_path(membership.group), success: success_message
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,6 +116,10 @@ class User < ApplicationRecord
     organisation_admin? && organisation == org
   end
 
+  def is_group_admin?(group)
+    memberships.find_by(group:)&.group_admin?
+  end
+
 private
 
   def requires_name?

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -1,0 +1,19 @@
+class MembershipPolicy < ApplicationPolicy
+  def destroy?
+    user.super_admin? || organisation_admin? || (group_admin? && record.editor?)
+  end
+
+private
+
+  def group_admin?
+    user.is_group_admin?(record.group)
+  end
+
+  def organisation_admin?
+    user.is_organisations_admin?(organisation)
+  end
+
+  def organisation
+    record.group.organisation
+  end
+end

--- a/app/service/group_member_service.rb
+++ b/app/service/group_member_service.rb
@@ -15,7 +15,7 @@ class GroupMemberService
   end
 
   def show_actions?
-    current_user.super_admin? || current_user.is_organisations_admin?(group.organisation) || current_user.is_group_admin?(group)
+    @show_actions ||= current_user.super_admin? || current_user.is_organisations_admin?(group.organisation) || current_user.is_group_admin?(group)
   end
 
   def rows

--- a/app/service/group_member_service.rb
+++ b/app/service/group_member_service.rb
@@ -15,11 +15,11 @@ class GroupMemberService
   end
 
   def show_actions?
-    @show_actions ||= current_user.super_admin? || current_user.is_organisations_admin?(group.organisation) || current_user.is_group_admin?(group)
+    rows.any? { |row| row.actions.any? }
   end
 
   def rows
-    group.memberships.map(&method(:row))
+    @rows ||= group.memberships.map(&method(:row))
   end
 
 private

--- a/app/service/group_member_service.rb
+++ b/app/service/group_member_service.rb
@@ -1,0 +1,46 @@
+class GroupMemberService
+  Row = Struct.new(:name, :email, :role, :actions, :membership)
+
+  attr_reader :group, :current_user
+
+  class << self
+    def call(**args)
+      new(**args)
+    end
+  end
+
+  def initialize(group:, current_user:)
+    @group = group
+    @current_user = current_user
+  end
+
+  def show_actions?
+    current_user.super_admin? || current_user.is_organisations_admin?(group.organisation) || current_user.is_group_admin?(group)
+  end
+
+  def rows
+    group.memberships.map(&method(:row))
+  end
+
+private
+
+  def row(membership)
+    Row.new(
+      name: membership.user.name,
+      email: membership.user.email,
+      role: membership.role,
+      actions: actions(membership),
+      membership:,
+    )
+  end
+
+  def actions(membership)
+    actions = []
+
+    if Pundit.policy(current_user, membership).destroy?
+      actions << :delete
+    end
+
+    actions
+  end
+end

--- a/app/views/group_members/index.html.erb
+++ b/app/views/group_members/index.html.erb
@@ -7,28 +7,36 @@
   <%= t(".title") %>
 </h1>
 
-<% if @group.memberships.empty? %>
+<% if @group_member_service.rows.empty? %>
   <p class="govuk-body"><%= t(".no_members") %></p>
 <% else %>
-  <%= govuk_table do |table| %>
-    <%= table.with_head do |head|
+  <%= govuk_table do |table|
+    table.with_head do |head|
       head.with_row do |row|
         row.with_cell(text: t(".table_headings.name"))
         row.with_cell(text: t(".table_headings.email"))
         row.with_cell(text: t(".table_headings.role"))
+        row.with_cell(text: t(".table_headings.actions")) if @group_member_service.show_actions?
       end
-    end %>
+    end
 
-    <%= table.with_body do |body|
-      @group.memberships.each do |membership|
+    table.with_body do |body|
+      @group_member_service.rows.each do |member|
         body.with_row do |row|
-          row.with_cell { membership.user.name }
-          row.with_cell { membership.user.email }
-          row.with_cell { t(".roles.#{membership.role}.name") }
+          row.with_cell { member.name }
+          row.with_cell { member.email }
+          row.with_cell { t("group_members.index.roles.#{member.role}.name") }
+          if @group_member_service.show_actions?
+            row.with_cell do
+              if member.actions.include?(:delete)
+                govuk_button_to(t(".remove_member"), membership_path(member.membership), method: :delete, secondary: true)
+              end
+            end
+          end
         end
       end
-    end %>
-  <% end %>
+    end
+  end %>
 <% end %>
 
 <% if Pundit.policy(@current_user, @group).add_editor? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -665,6 +665,9 @@ en:
       numbered_list: Add a numbered list
     update_preview: Update preview
     write_tab_text: Write
+  memberships:
+    destroy:
+      success: "%{member_name} has been removed from this group"
   metrics_summary:
     completion_rate: Completion rate
     date_range: "%{start_date} to %{end_date}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,12 +281,14 @@ en:
           <p>Only an organisation admin can add a group admin to a group.</p>
         summary_text: What can ‘editors’ and ‘group admins’ do?
       no_members: There are no members in this group.
+      remove_member: Remove
       roles:
         editor:
           name: Editor
         group_admin:
           name: Group Admin
       table_headings:
+        actions: Action
         email: Email address
         name: Name
         role: Role

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :memberships, only: %i[destroy]
+
   get "/maintenance" => "errors#maintenance", as: :maintenance_page
   match "/403", to: "errors#forbidden", as: :error_403, via: :all
   match "/404", to: "errors#not_found", as: :error_404, via: :all

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -396,4 +396,24 @@ describe User, type: :model do
       end
     end
   end
+
+  describe "is_group_admin?" do
+    let(:user) { create(:user, organisation:) }
+    let(:organisation) { create(:organisation) }
+    let(:group) { create(:group, organisation:) }
+
+    it "returns falsey when user is not in group" do
+      expect(user).not_to be_is_group_admin(group)
+    end
+
+    it "returns falsey when a user is an editor of the group" do
+      create(:membership, user:, group:, role: :editor)
+      expect(user).not_to be_is_group_admin(group)
+    end
+
+    it "returns true when user is a group admin of the group" do
+      create(:membership, user: user, group: group, role: :group_admin)
+      expect(user.is_group_admin?(group)).to eq(true)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -399,7 +399,7 @@ describe User, type: :model do
 
   describe "is_group_admin?" do
     let(:user) { create(:user, organisation:) }
-    let(:organisation) { create(:organisation) }
+    let(:organisation) { create(:organisation, slug: "org") }
     let(:group) { create(:group, organisation:) }
 
     it "returns falsey when user is not in group" do
@@ -412,7 +412,7 @@ describe User, type: :model do
     end
 
     it "returns true when user is a group admin of the group" do
-      create(:membership, user: user, group: group, role: :group_admin)
+      create(:membership, user:, group:, role: :group_admin)
       expect(user.is_group_admin?(group)).to eq(true)
     end
   end

--- a/spec/policies/membership_policy_spec.rb
+++ b/spec/policies/membership_policy_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe MembershipPolicy do
+  subject(:policy) { described_class.new(user, membership) }
+
+  let(:organisation) { create :organisation, slug: "an organisation" }
+  let(:user) { create :editor_user, organisation: }
+  let(:group) { build :group, organisation: }
+  let(:membership) { build :membership, user:, group:, role: }
+  let(:role) { :editor }
+
+  context "when user is super_admin" do
+    let(:user) { build :super_admin_user }
+
+    it "permits all actions" do
+      expect(policy).to permit_all_actions
+    end
+  end
+
+  context "when user is organisation_admin" do
+    let(:user) { build :organisation_admin_user, organisation: }
+
+    context "and in the same organisation as the group" do
+      it "permits all actions" do
+        expect(policy).to permit_all_actions
+      end
+    end
+
+    context "and not in the same organisation as the group" do
+      let(:group) { build :group, organisation_id: user.organisation_id + 1 }
+
+      it "forbids all actions" do
+        expect(policy).to forbid_all_actions
+      end
+    end
+  end
+
+  context "when the user is a group admin" do
+    before do
+      create :membership, user:, group:, role: :group_admin
+    end
+
+    context "and the membership role is editor" do
+      let(:role) { :editor }
+
+      it "permits destroy" do
+        expect(policy).to permit_only_actions(%i[destroy])
+      end
+    end
+
+    context "and the membership role is group_admin" do
+      let(:role) { :group_admin }
+
+      it "forbids destroy" do
+        expect(policy).to forbid_only_actions(%i[destroy])
+      end
+    end
+  end
+
+  context "when the user is an editor" do
+    it "forbids all actions" do
+      expect(policy).to forbid_all_actions
+    end
+  end
+end

--- a/spec/requests/memberships_controller_spec.rb
+++ b/spec/requests/memberships_controller_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 describe "/memberships", type: :request do
   let(:user) { create(:user) }
   let(:group) { create(:group) }
-  let(:role) { :group_admin }
+  let(:logged_in_user_role) { :group_admin }
 
   before do
-    create(:membership, user: editor_user, group:, role:)
+    create(:membership, user: editor_user, group:, role: logged_in_user_role)
     login_as_editor_user
   end
 
@@ -21,8 +21,8 @@ describe "/memberships", type: :request do
       expect(response).to redirect_to(group_members_path(group.external_id))
     end
 
-    context "when user is not a group admin" do
-      let(:role) { :editor }
+    context "when logged in user is not a group admin" do
+      let(:logged_in_user_role) { :editor }
 
       it "does not delete a membership" do
         membership = create(:membership, user:, group:, added_by: editor_user)

--- a/spec/requests/memberships_controller_spec.rb
+++ b/spec/requests/memberships_controller_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe "/memberships", type: :request do
+  let(:user) { create(:user) }
+  let(:group) { create(:group) }
+  let(:role) { :group_admin }
+
+  before do
+    create(:membership, user: editor_user, group:, role:)
+    login_as_editor_user
+  end
+
+  describe "#destroy" do
+    it "deletes a membership" do
+      membership = create(:membership, user:, group:, added_by: editor_user)
+
+      expect {
+        delete membership_path(membership)
+      }.to change(Membership, :count).by(-1)
+
+      expect(response).to redirect_to(group_members_path(group.external_id))
+    end
+
+    context "when user is not a group admin" do
+      let(:role) { :editor }
+
+      it "does not delete a membership" do
+        membership = create(:membership, user:, group:, added_by: editor_user)
+
+        expect {
+          delete membership_path(membership)
+        }.not_to change(Membership, :count)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/service/group_member_service_spec.rb
+++ b/spec/service/group_member_service_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+describe GroupMemberService do
+  let(:group) { create(:group) }
+  let(:current_user) { create(:user) }
+  let(:membership1) { create(:membership, group:, user: create(:user), role: "editor") }
+  let(:membership2) { create(:membership, group:, user: create(:user), role: "group_admin") }
+
+  describe ".call" do
+    it "creates a new instance of GroupMemberService" do
+      service = described_class.call(group:, current_user:)
+      expect(service).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe "#show_actions?" do
+    context "when current user is a super admin" do
+      let(:current_user) { create(:user, role: "super_admin") }
+
+      it "returns true" do
+        service = described_class.new(group:, current_user:)
+        expect(service.show_actions?).to be true
+      end
+    end
+
+    context "when current user is an organisation admin" do
+      before do
+        allow(current_user).to receive(:is_organisations_admin?).and_return(true)
+      end
+
+      it "returns true" do
+        service = described_class.new(group:, current_user:)
+        expect(service.show_actions?).to be true
+      end
+    end
+
+    context "when current user is a group admin" do
+      before do
+        allow(current_user).to receive(:is_group_admin?).and_return(true)
+      end
+
+      it "returns true" do
+        service = described_class.new(group:, current_user:)
+        expect(service.show_actions?).to be true
+      end
+    end
+
+    context "when current user is a regular user" do
+      it "returns false" do
+        service = described_class.new(group:, current_user:)
+        expect(service).not_to be_show_actions
+      end
+    end
+  end
+
+  describe "#rows" do
+    before do
+      membership1
+      membership2
+    end
+
+    it "returns an array of Row structs" do
+      service = described_class.new(group:, current_user:)
+      rows = service.rows
+
+      expect(rows).to be_an(Array)
+      expect(rows.first).to be_an_instance_of(GroupMemberService::Row)
+    end
+
+    it "includes the correct data in each row" do
+      service = described_class.new(group:, current_user:)
+      rows = service.rows
+
+      expect(rows.first.name).to eq(membership1.user.name)
+      expect(rows.first.email).to eq(membership1.user.email)
+      expect(rows.first.role).to eq(membership1.role)
+      expect(rows.first.membership).to eq(membership1)
+    end
+  end
+
+  describe "#actions" do
+    context "when current user can destroy the membership" do
+      before do
+        allow(Pundit).to receive(:policy).and_return(instance_double(MembershipPolicy, destroy?: true))
+      end
+
+      it "includes the delete action" do
+        service = described_class.new(group:, current_user:)
+        actions = service.send(:actions, membership1)
+
+        expect(actions).to include(:delete)
+      end
+    end
+
+    context "when current user cannot destroy the membership" do
+      before do
+        allow(Pundit).to receive(:policy).and_return(instance_double(MembershipPolicy, destroy?: false))
+      end
+
+      it "does not include the delete action" do
+        service = described_class.new(group:, current_user:)
+        actions = service.send(:actions, membership1)
+
+        expect(actions).not_to include(:delete)
+      end
+    end
+  end
+end

--- a/spec/service/group_member_service_spec.rb
+++ b/spec/service/group_member_service_spec.rb
@@ -14,41 +14,25 @@ describe GroupMemberService do
   end
 
   describe "#show_actions?" do
-    context "when current user is a super admin" do
-      let(:current_user) { create(:user, role: "super_admin") }
+    context "when any row has actions" do
+      let(:row_with_actions) { instance_double(GroupMemberService::Row, actions: [:delete]) }
+      let(:rows) { [row_with_actions] }
 
       it "returns true" do
         service = described_class.new(group:, current_user:)
-        expect(service.show_actions?).to be true
+        allow(service).to receive(:rows).and_return(rows)
+        expect(service.show_actions?).to be(true)
       end
     end
 
-    context "when current user is an organisation admin" do
-      before do
-        allow(current_user).to receive(:is_organisations_admin?).and_return(true)
-      end
+    context "when no rows have actions" do
+      let(:row_without_actions) { instance_double(GroupMemberService::Row, actions: []) }
+      let(:rows) { [row_without_actions] }
 
-      it "returns true" do
-        service = described_class.new(group:, current_user:)
-        expect(service.show_actions?).to be true
-      end
-    end
-
-    context "when current user is a group admin" do
-      before do
-        allow(current_user).to receive(:is_group_admin?).and_return(true)
-      end
-
-      it "returns true" do
-        service = described_class.new(group:, current_user:)
-        expect(service.show_actions?).to be true
-      end
-    end
-
-    context "when current user is a regular user" do
       it "returns false" do
         service = described_class.new(group:, current_user:)
-        expect(service).not_to be_show_actions
+        allow(service).to receive(:rows).and_return(rows)
+        expect(service.show_actions?).to be(false)
       end
     end
   end

--- a/spec/views/group_members/index.html.erb_spec.rb
+++ b/spec/views/group_members/index.html.erb_spec.rb
@@ -2,25 +2,21 @@ require "rails_helper"
 
 RSpec.describe "group_members/index", type: :view do
   let(:organisation) { build(:organisation, slug: "Department for testing group members") }
-  let(:user1) { build(:user, organisation:) }
-  let(:user2) { build(:user, organisation:) }
   let(:group) { create(:group, name: "Group 1", organisation:) }
   let(:add_editor) { false }
 
+  let(:rows) { [OpenStruct.new({ name: "user1", email: "user1@gov.uk", role: :editor, actions: [] })] }
+
   before do
     assign(:group, group)
+    assign(:group_member_service, instance_double(GroupMemberService, rows:, show_actions?: true))
 
     allow(Pundit).to receive(:policy).and_return(instance_double(GroupPolicy, add_editor?: add_editor))
+
+    render
   end
 
   context "when there are members of a group" do
-    before do
-      create(:membership, user: user1, group:, role: :editor)
-      create(:membership, user: user2, group:, role: :group_admin)
-
-      render
-    end
-
     it "displays the group name" do
       expect(rendered).to have_selector("h1", text: group.name)
     end
@@ -30,9 +26,9 @@ RSpec.describe "group_members/index", type: :view do
     end
 
     it "displays a table of group memberships" do
-      group.memberships.each do |membership|
-        expect(rendered).to have_selector("table td", text: membership.user.name)
-        expect(rendered).to have_selector("table td", text: membership.user.email)
+      rows.each do |membership|
+        expect(rendered).to have_selector("table td", text: membership.name)
+        expect(rendered).to have_selector("table td", text: membership.email)
         expect(rendered).to have_selector("table td", text: t("group_members.index.roles.#{membership.role}.name"))
       end
     end
@@ -55,9 +51,7 @@ RSpec.describe "group_members/index", type: :view do
   end
 
   context "when there are no members of a group" do
-    before do
-      render
-    end
+    let(:rows) { [] }
 
     it "displays a message" do
       expect(rendered).to have_text(t("group_members.index.no_members"))

--- a/spec/views/group_members/index.html.erb_spec.rb
+++ b/spec/views/group_members/index.html.erb_spec.rb
@@ -1,11 +1,16 @@
 require "rails_helper"
 
-RSpec.describe "group_members/index", type: :view do
+describe "group_members/index", type: :view do
   let(:organisation) { build(:organisation, slug: "Department for testing group members") }
   let(:group) { create(:group, name: "Group 1", organisation:) }
   let(:add_editor) { false }
 
-  let(:rows) { [OpenStruct.new({ name: "user1", email: "user1@gov.uk", role: :editor, actions: [] })] }
+  let(:rows) do
+    [
+      OpenStruct.new({ name: "user1", email: "user1@gov.uk", role: :editor, actions: [], membership: { id: 1 } }),
+      OpenStruct.new({ name: "user2", email: "user2@gov.uk", role: :group_admin, actions: [:delete], membership: { id: 1 } }),
+    ]
+  end
 
   before do
     assign(:group, group)
@@ -26,11 +31,13 @@ RSpec.describe "group_members/index", type: :view do
     end
 
     it "displays a table of group memberships" do
-      rows.each do |membership|
-        expect(rendered).to have_selector("table td", text: membership.name)
-        expect(rendered).to have_selector("table td", text: membership.email)
-        expect(rendered).to have_selector("table td", text: t("group_members.index.roles.#{membership.role}.name"))
+      rows.each do |row|
+        expect(rendered).to have_selector("td", text: row.name)
+        expect(rendered).to have_selector("td", text: row.email)
+        expect(rendered).to have_selector("td", text: t("group_members.index.roles.#{row.role}.name"))
       end
+
+      expect(rendered).to have_button(t("group_members.index.remove_member"), count: 1)
     end
 
     it "has a back link to the group page" do


### PR DESCRIPTION
### Allow group admins to remove editors from groups

Trello card: https://trello.com/c/o7SAFAWi/1401-add-screens-for-managing-existing-users-in-groups

We add a new membership controller to avoid adding too many routes to the nested resource group_member. There is a new policy to permit "admins" to remove members and a new service to avoid sticking too much logic into the view.

As a group admin:

![image](https://github.com/alphagov/forms-admin/assets/11035856/e5697040-88ed-446c-a3bc-59d2cc2d28cb)

The designs:
![image](https://github.com/alphagov/forms-admin/assets/11035856/ad897ddb-7dce-4533-abbf-ac80ede33a26)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
