### PR TITLE
Add new member emails

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -29,6 +29,7 @@ private
   end
 
   def group_member_params
-    params.require(:group_member_form).permit(:member_email_address).merge(group: @group, creator: current_user)
+    ## TODO: We are passing in host here because the admin doesn't know it's own URL to use in emails
+    params.require(:group_member_form).permit(:member_email_address).merge(group: @group, creator: current_user, host: request.host)
   end
 end

--- a/app/form_objects/group_member_form.rb
+++ b/app/form_objects/group_member_form.rb
@@ -18,10 +18,10 @@ class GroupMemberForm < BaseForm
       return false
     end
 
-    if new_membership.save
-      send_notification_email
-      true
-    end
+    new_membership.save!
+    send_notification_email
+
+    true
   end
 
 private

--- a/app/form_objects/group_member_form.rb
+++ b/app/form_objects/group_member_form.rb
@@ -1,7 +1,8 @@
 class GroupMemberForm < BaseForm
   include ActiveModel::Validations::Callbacks
+  include Rails.application.routes.url_helpers
 
-  attr_accessor :member_email_address, :group, :creator
+  attr_accessor :member_email_address, :group, :creator, :host
 
   EMAIL_REGEX = /.*@.*/
 
@@ -17,7 +18,10 @@ class GroupMemberForm < BaseForm
       return false
     end
 
-    new_membership.save!
+    if new_membership.save
+      send_notification_email
+      true
+    end
   end
 
 private
@@ -44,5 +48,9 @@ private
 
   def strip_whitespace
     member_email_address&.strip!
+  end
+
+  def send_notification_email
+    GroupMemberMailer.added_to_group(new_membership, group_url: group_url(group, host:)).deliver_now
   end
 end

--- a/app/mailers/group_member_mailer.rb
+++ b/app/mailers/group_member_mailer.rb
@@ -1,0 +1,28 @@
+class GroupMemberMailer < GovukNotifyRails::Mailer
+  def added_to_group(membership, group_url:)
+    set_template(Settings.govuk_notify.group_member_added_to_group_id)
+    set_email_reply_to(Settings.govuk_notify.zendesk_reply_to_id)
+
+    set_personalisation(
+      added_by_name: membership.added_by.name,
+      added_by_email: membership.added_by.email,
+      group_url:,
+      group_name: membership.group.name,
+      **role_template_conditions(membership),
+    )
+
+    mail(to: membership.user.email)
+  end
+
+private
+
+  def role_template_conditions(membership)
+    roles = {
+      editor: "no",
+      group_admin: "no",
+    }
+
+    roles[membership.role.to_sym] = "yes"
+    roles
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,7 @@ govuk_notify:
   live_submission_email_of_no_further_form_submissions: a8c43931-af3d-48ff-b5b2-dbc444796dec
   user_upgrade_template_id: 5ec25494-c045-4cf6-9009-2f122e3339f4
   zendesk_reply_to_id: 0acefa17-04b5-4614-a2ad-6c7f17dd26ab
+  group_member_added_to_group_id: d1fc7267-7e27-4e6c-aa30-523b8be3d637
 
 # When set to true, any capybara tests will run chrome normally rather than in headless mode.
 show_browser_during_tests: false

--- a/spec/form_objects/group_member_form_spec.rb
+++ b/spec/form_objects/group_member_form_spec.rb
@@ -66,6 +66,27 @@ describe GroupMemberForm do
           expect(group_member_form.errors[:member_email_address]).to include(error_message)
         end
       end
+
+      context "when the new Membership is valid" do
+        let(:group_member_form) { described_class.new }
+
+        before do
+          group_member_form.group = group
+          group_member_form.member_email_address = user.email
+          group_member_form.creator = user
+          group_member_form.host = "example.net"
+
+          delivery = double
+          allow(GroupMemberMailer).to receive(:added_to_group).with(an_instance_of(Membership), group_url: group_url(group, host: "example.net")).and_return(delivery)
+          allow(delivery).to receive(:deliver_now).with(no_args)
+        end
+
+        it "creates a new Membership" do
+          expect(group_member_form.save).to be true
+          expect(group_member_form).to be_valid
+          expect(GroupMemberMailer).to have_received(:added_to_group).with(an_instance_of(Membership), group_url: group_url(group, host: "example.net"))
+        end
+      end
     end
   end
 end

--- a/spec/mailers/group_member_mailer_spec.rb
+++ b/spec/mailers/group_member_mailer_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe GroupMemberMailer, type: :mailer do
+  describe "#added_to_group" do
+    subject(:mail) do
+      described_class.added_to_group(membership, group_url:)
+    end
+
+    let(:role) { :editor }
+    let(:membership) { create(:membership, role:) }
+    let(:group_url) { "group-dot-com" }
+
+    describe "sending an email to a given submission email to check its correct and receiving emails" do
+      it "sends an email with the correct template" do
+        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.group_member_added_to_group_id)
+      end
+
+      it "sends an email to the new member" do
+        expect(mail.to).to eq([membership.user.email])
+      end
+
+      it "includes the group path" do
+        expect(mail.govuk_notify_personalisation[:group_url]).to eq(group_url)
+      end
+
+      it "includes the name of the person who added the new member" do
+        expect(mail.govuk_notify_personalisation[:added_by_name]).to eq(membership.added_by.name)
+      end
+
+      it "includes the email of the person who added the new member" do
+        expect(mail.govuk_notify_personalisation[:added_by_email]).to eq(membership.added_by.email)
+      end
+
+      it "includes the group name" do
+        expect(mail.govuk_notify_personalisation[:group_name]).to eq(membership.group.name)
+      end
+
+      Membership.roles.each_key do |role|
+        context "when the role is a #{role}" do
+          let(:role) { role }
+
+          it "current role is passed with yes" do
+            expect(mail.govuk_notify_personalisation[role.to_sym]).to eq("yes")
+          end
+
+          (Membership.roles.keys - [role]).each do |other_role|
+            it "#{other_role} are all set to no" do
+              expect(mail.govuk_notify_personalisation[other_role.to_sym]).to eq("no")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,4 +82,5 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
   config.include Sentry::TestHelper
+  config.include Rails.application.routes.url_helpers
 end


### PR DESCRIPTION
### Send notification emails when a user is added to a group

Trello card: https://trello.com/c/o7SAFAWi/1401-add-screens-for-managing-existing-users-in-groups

When a user is added to a group, they should receive an email notifying them.

This PR adds a new mailer which is used when a new membership is created. A new template has been added to notify with conditional text for the two cases: a new editor or a new group admin.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
The design:
![image](https://github.com/alphagov/forms-admin/assets/11035856/db17fff1-7967-4422-8770-6daec09bedf4)

A sample email sent when joining a group (it's not shown in this image but the template is now "an editor" not "a editor")
![image](https://github.com/alphagov/forms-admin/assets/11035856/1e1e904b-589e-4b20-9ec9-cebd39545586)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
