### PR TITLE
Fix database seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,7 +49,7 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create :user, :with_no_org
 
   # create some trial users
-  FactoryBot.create_list :user, 3, :with_trial_role
+  FactoryBot.create_list :user, 3, :with_trial_role, :with_no_org, :with_no_name
 
   # create some test groups
   FactoryBot.create :group, name: "Test Group", organisation: gds, creator: default_user


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Commit bb70aa192 changed the trial user factory to set an organisation and name for the user; unfortunately this caused the database seed to fail with an error about duplicate keys:

```
Created database 'forms_admin_development'
bin/rails aborted!
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "organisations_pkey" (ActiveRecord::RecordNotUnique)
DETAIL:  Key (id)=(1) already exists.
/app/spec/factories/models/users.rb:30:in `block (3 levels) in <main>'
/app/db/seeds.rb:52:in `<main>'

Caused by:
PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "organisations_pkey" (PG::UniqueViolation)
DETAIL:  Key (id)=(1) already exists.
/app/spec/factories/models/users.rb:30:in `block (3 levels) in <main>'
/app/db/seeds.rb:52:in `<main>'
Tasks: TOP => db:prepare
```

Restoring the original behaviour (just for the seed) fixes things.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?