### PR TITLE
Add archive email

### DIFF
--- a/app/controllers/forms/archive_form_controller.rb
+++ b/app/controllers/forms/archive_form_controller.rb
@@ -14,7 +14,7 @@ module Forms
 
       @confirm_archive_input = ConfirmArchiveInput.new(confirm_archive_input_params)
 
-      return render :archive unless @confirm_archive_input.valid?
+      return render :archive, status: :unprocessable_entity unless @confirm_archive_input.valid?
       return redirect_to live_form_path(current_form) unless user_wants_to_archive_form
 
       ArchiveFormService.new(form: current_form, current_user: @current_user).archive

--- a/app/controllers/forms/archive_form_controller.rb
+++ b/app/controllers/forms/archive_form_controller.rb
@@ -17,7 +17,8 @@ module Forms
       return render :archive unless @confirm_archive_input.valid?
       return redirect_to live_form_path(current_form) unless user_wants_to_archive_form
 
-      current_form.archive!
+      ArchiveFormService.new(form: current_form, current_user: @current_user).archive
+
       redirect_to archive_form_confirmation_path(current_form)
     end
 

--- a/app/input_objects/forms/submission_email_input.rb
+++ b/app/input_objects/forms/submission_email_input.rb
@@ -27,7 +27,7 @@ class Forms::SubmissionEmailInput < BaseInput
     if form_processed && temporary_submission_email.present?
       # send notify email?
       Rails.logger.info "Email sent to #{temporary_submission_email} with code #{confirmation_code}"
-      SubmissionEmailMailer.confirmation_code_email(
+      SubmissionEmailMailer.send_confirmation_code(
         new_submission_email: temporary_submission_email,
         form_name: form.name,
         confirmation_code:,

--- a/app/mailers/submission_email_mailer.rb
+++ b/app/mailers/submission_email_mailer.rb
@@ -25,4 +25,16 @@ class SubmissionEmailMailer < GovukNotifyRails::Mailer
 
     mail(to: live_email)
   end
+
+  def alert_processor_form_archive(processor_email:, form_name:, archived_by_name:, archived_by_email:)
+    set_template(Settings.govuk_notify.alert_processor_form_archive_template_id)
+
+    set_personalisation(
+      archived_by_name:,
+      archived_by_email:,
+      form_name:,
+    )
+
+    mail(to: processor_email)
+  end
 end

--- a/app/mailers/submission_email_mailer.rb
+++ b/app/mailers/submission_email_mailer.rb
@@ -1,5 +1,5 @@
 class SubmissionEmailMailer < GovukNotifyRails::Mailer
-  def confirmation_code_email(new_submission_email:, form_name:, confirmation_code:, notify_response_id:, current_user:)
+  def send_confirmation_code(new_submission_email:, form_name:, confirmation_code:, notify_response_id:, current_user:)
     set_template(Settings.govuk_notify.submission_email_confirmation_code_email_template_id)
 
     set_personalisation(
@@ -14,7 +14,7 @@ class SubmissionEmailMailer < GovukNotifyRails::Mailer
     mail(to: new_submission_email)
   end
 
-  def notify_submission_email_has_changed(live_email:, form_name:, current_user:)
+  def alert_email_change(live_email:, form_name:, current_user:)
     set_template(Settings.govuk_notify.live_submission_email_of_no_further_form_submissions)
 
     set_personalisation(

--- a/app/mailers/submission_email_mailer.rb
+++ b/app/mailers/submission_email_mailer.rb
@@ -14,12 +14,12 @@ class SubmissionEmailMailer < GovukNotifyRails::Mailer
     mail(to: new_submission_email)
   end
 
-  def alert_email_change(live_email:, form_name:, current_user:)
-    set_template(Settings.govuk_notify.live_submission_email_of_no_further_form_submissions)
+  def alert_email_change(live_email:, form_name:, creator_name:, creator_email:)
+    set_template(Settings.govuk_notify.live_submission_email_of_no_further_form_submissions_template_id)
 
     set_personalisation(
-      form_creator_name: current_user.name,
-      form_creator_email: current_user.email,
+      form_creator_name: creator_name,
+      form_creator_email: creator_email,
       form_name:,
     )
 

--- a/app/service/archive_form_service.rb
+++ b/app/service/archive_form_service.rb
@@ -1,0 +1,14 @@
+class ArchiveFormService
+  def initialize(form:, current_user:)
+    @form = form
+    @current_user = current_user
+  end
+
+  def archive
+    @form.archive!
+    SubmissionEmailMailer.alert_processor_form_archive(processor_email: @form.submission_email,
+                                                       form_name: @form.name,
+                                                       archived_by_name: @current_user.name,
+                                                       archived_by_email: @current_user.email).deliver_now
+  end
+end

--- a/app/service/make_form_live_service.rb
+++ b/app/service/make_form_live_service.rb
@@ -15,7 +15,7 @@ class MakeFormLiveService
     @current_form.make_live!
 
     if FeatureService.enabled?(:notify_original_submission_email_of_change) && live_form_submission_email_has_changed
-      SubmissionEmailMailer.notify_submission_email_has_changed(
+      SubmissionEmailMailer.alert_email_change(
         live_email: @current_live_form.submission_email,
         form_name: @current_live_form.name,
         current_user: @current_user,

--- a/app/service/make_form_live_service.rb
+++ b/app/service/make_form_live_service.rb
@@ -18,7 +18,8 @@ class MakeFormLiveService
       SubmissionEmailMailer.alert_email_change(
         live_email: @current_live_form.submission_email,
         form_name: @current_live_form.name,
-        current_user: @current_user,
+        creator_name: @current_user.name,
+        creator_email: @current_user.email,
       ).deliver_now
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,7 @@ forms_product_page:
 # Settings for GOV.UK Notify api & email templates
 govuk_notify:
   api_key: changeme
+  alert_processor_form_archive_template_id: 22fe5aae-a695-42a2-81e8-1d9ec4bab7ad
   submission_email_confirmation_code_email_template_id: ce2638ab-754c-416d-8df6-c0ccb5e1a688
   live_submission_email_of_no_further_form_submissions: a8c43931-af3d-48ff-b5b2-dbc444796dec
   user_upgrade_template_id: 5ec25494-c045-4cf6-9009-2f122e3339f4

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,7 +26,7 @@ govuk_notify:
   api_key: changeme
   alert_processor_form_archive_template_id: 22fe5aae-a695-42a2-81e8-1d9ec4bab7ad
   submission_email_confirmation_code_email_template_id: ce2638ab-754c-416d-8df6-c0ccb5e1a688
-  live_submission_email_of_no_further_form_submissions: a8c43931-af3d-48ff-b5b2-dbc444796dec
+  live_submission_email_of_no_further_form_submissions_template_id: a8c43931-af3d-48ff-b5b2-dbc444796dec
   user_upgrade_template_id: 5ec25494-c045-4cf6-9009-2f122e3339f4
   zendesk_reply_to_id: 0acefa17-04b5-4614-a2ad-6c7f17dd26ab
   group_member_added_to_group_id: d1fc7267-7e27-4e6c-aa30-523b8be3d637

--- a/spec/input_objects/forms/submission_email_input_spec.rb
+++ b/spec/input_objects/forms/submission_email_input_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Forms::SubmissionEmailInput, type: :model do
 
         allow(submission_email_input_with_user).to receive(:generate_confirmation_code).and_return("123456")
 
-        allow(SubmissionEmailMailer).to receive(:confirmation_code_email)
+        allow(SubmissionEmailMailer).to receive(:send_confirmation_code)
                                           .with(
                                             new_submission_email: submission_email_input_with_user.temporary_submission_email,
                                             form_name: form.name,
@@ -121,7 +121,7 @@ RSpec.describe Forms::SubmissionEmailInput, type: :model do
 
         allow(submission_email_input_with_user).to receive(:generate_confirmation_code).and_return("123456")
 
-        allow(SubmissionEmailMailer).to receive(:confirmation_code_email)
+        allow(SubmissionEmailMailer).to receive(:send_confirmation_code)
                                           .with(
                                             new_submission_email: submission_email_input_with_user.temporary_submission_email,
                                             form_name: form.name,
@@ -180,7 +180,7 @@ RSpec.describe Forms::SubmissionEmailInput, type: :model do
 
         allow(submission_email_input_with_user).to receive(:generate_confirmation_code).and_return("123456")
 
-        allow(SubmissionEmailMailer).to receive(:confirmation_code_email)
+        allow(SubmissionEmailMailer).to receive(:send_confirmation_code)
                                           .with(
                                             new_submission_email: submission_email_input_with_user.temporary_submission_email,
                                             form_name: form.name,
@@ -208,7 +208,7 @@ RSpec.describe Forms::SubmissionEmailInput, type: :model do
 
         allow(submission_email_input_with_user).to receive(:generate_confirmation_code).and_return("123456")
 
-        allow(SubmissionEmailMailer).to receive(:confirmation_code_email)
+        allow(SubmissionEmailMailer).to receive(:send_confirmation_code)
                                           .with(
                                             new_submission_email: submission_email_input_with_user.temporary_submission_email,
                                             form_name: form.name,

--- a/spec/mailers/previews/submission_email_mailer_preview.rb
+++ b/spec/mailers/previews/submission_email_mailer_preview.rb
@@ -9,11 +9,12 @@ class SubmissionEmailMailerPreview < ActionMailer::Preview
     )
   end
 
-  def notify_submission_email_has_changed
+  def alert_email_change
     SubmissionEmailMailer.alert_email_change(
       live_email: "testing@example.com",
       form_name: "My fantastic form",
-      current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com"),
+      creator_name: "Joe Bloggs",
+      creator_email: "example@example.com",
     )
   end
 

--- a/spec/mailers/previews/submission_email_mailer_preview.rb
+++ b/spec/mailers/previews/submission_email_mailer_preview.rb
@@ -16,4 +16,13 @@ class SubmissionEmailMailerPreview < ActionMailer::Preview
       current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com"),
     )
   end
+
+  def alert_processor_form_archive
+    SubmissionEmailMailer.alert_processor_form_archive(
+      processor_email: "testing@example.com",
+      form_name: "My fantastic form",
+      creator_name: "Joe Bloggs",
+      creator_email: "example@example.com",
+    )
+  end
 end

--- a/spec/mailers/previews/submission_email_mailer_preview.rb
+++ b/spec/mailers/previews/submission_email_mailer_preview.rb
@@ -1,6 +1,6 @@
 class SubmissionEmailMailerPreview < ActionMailer::Preview
   def confirmation_code_email
-    SubmissionEmailMailer.confirmation_code_email(
+    SubmissionEmailMailer.send_confirmation_code(
       new_submission_email: "testing@example.com",
       form_name: "My fantastic form",
       confirmation_code: "12345",
@@ -10,7 +10,7 @@ class SubmissionEmailMailerPreview < ActionMailer::Preview
   end
 
   def notify_submission_email_has_changed
-    SubmissionEmailMailer.notify_submission_email_has_changed(
+    SubmissionEmailMailer.alert_email_change(
       live_email: "testing@example.com",
       form_name: "My fantastic form",
       current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com"),

--- a/spec/mailers/submission_email_mailer_spec.rb
+++ b/spec/mailers/submission_email_mailer_spec.rb
@@ -40,16 +40,17 @@ describe SubmissionEmailMailer, type: :mailer do
     end
   end
 
-  describe "#notify_submission_email_has_changed" do
+  describe "#alert_email_change" do
     let(:mail) do
       described_class.alert_email_change(live_email: "test@example.com",
                                          form_name: "Testing API",
-                                         current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com"))
+                                         creator_name: "Joe Bloggs",
+                                         creator_email: "example@example.com")
     end
 
     describe "sending an email to notify confirmed submission email not to expect future form submissions" do
       it "sends an email with the correct template" do
-        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.live_submission_email_of_no_further_form_submissions)
+        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.live_submission_email_of_no_further_form_submissions_template_id)
       end
 
       it "sends an email to the live submission email address" do

--- a/spec/mailers/submission_email_mailer_spec.rb
+++ b/spec/mailers/submission_email_mailer_spec.rb
@@ -66,4 +66,25 @@ describe SubmissionEmailMailer, type: :mailer do
       end
     end
   end
+
+  describe "#alert_archive" do
+    let(:mail) do
+      described_class.alert_processor_form_archive(processor_email: "test@example.com",
+                                                   form_name: "Testing API",
+                                                   archived_by_name: "Joe Bloggs",
+                                                   archived_by_email: "example@example.com")
+    end
+
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.alert_processor_form_archive_template_id)
+    end
+
+    it "sends an email to the live submission email address" do
+      expect(mail.to).to eq(["test@example.com"])
+    end
+
+    it "includes the form name" do
+      expect(mail.govuk_notify_personalisation[:form_name]).to eq("Testing API")
+    end
+  end
 end

--- a/spec/mailers/submission_email_mailer_spec.rb
+++ b/spec/mailers/submission_email_mailer_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe SubmissionEmailMailer, type: :mailer do
-  describe "#confirmation_code_email" do
+  describe "#send_confirmation_code" do
     let(:mail) do
-      described_class.confirmation_code_email(
+      described_class.send_confirmation_code(
         new_submission_email: "test@example.com",
         form_name: "Testing API",
         confirmation_code: "654321",
@@ -42,9 +42,9 @@ describe SubmissionEmailMailer, type: :mailer do
 
   describe "#notify_submission_email_has_changed" do
     let(:mail) do
-      described_class.notify_submission_email_has_changed(live_email: "test@example.com",
-                                                          form_name: "Testing API",
-                                                          current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com"))
+      described_class.alert_email_change(live_email: "test@example.com",
+                                         form_name: "Testing API",
+                                         current_user: OpenStruct.new(name: "Joe Bloggs", email: "example@example.com"))
     end
 
     describe "sending an email to notify confirmed submission email not to expect future form submissions" do

--- a/spec/requests/forms/archive_form_controller_spec.rb
+++ b/spec/requests/forms/archive_form_controller_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe Forms::ArchiveFormController, type: :request do
     context "when no option is selected" do
       let(:confirm) { nil }
 
-      it "returns 200" do
-        expect(response).to have_http_status(:ok)
+      it "returns 422" do
+        expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it "re-renders the archive this form page with an error" do

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     let(:temporary_submission_email) { user.email }
 
     before do
-      allow(submission_email_mailer_spy).to receive(:confirmation_code_email)
+      allow(submission_email_mailer_spy).to receive(:send_confirmation_code)
 
       post(
         submission_email_path(form.id),

--- a/spec/service/archive_form_service_spec.rb
+++ b/spec/service/archive_form_service_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe ArchiveFormService do
+  subject(:archive_form_service) do
+    described_class.new(form:, current_user:)
+  end
+
+  let(:submission_email) { "submission@example.gov.uk" }
+  let(:form) { build(:form, submission_email:) }
+  let(:current_user) { build(:user) }
+  let(:delivery) { double }
+
+  describe "#archive" do
+    before do
+      allow(form).to receive(:archive!)
+      allow(SubmissionEmailMailer).to receive(:alert_processor_form_archive)
+                                        .with(anything)
+                                        .and_return(delivery)
+      allow(delivery).to receive(:deliver_now).with(no_args)
+    end
+
+    it "calls archive! on the form" do
+      expect(form).to receive(:archive!)
+      archive_form_service.archive
+    end
+
+    it "sends an email to the submission email address" do
+      expect(SubmissionEmailMailer).to receive(:alert_processor_form_archive)
+                                         .with(processor_email: submission_email,
+                                               form_name: form.name,
+                                               archived_by_name: current_user.name,
+                                               archived_by_email: current_user.email)
+      expect(delivery).to receive(:deliver_now).with(no_args)
+      archive_form_service.archive
+    end
+  end
+end

--- a/spec/service/make_form_live_service_spec.rb
+++ b/spec/service/make_form_live_service_spec.rb
@@ -57,7 +57,8 @@ describe MakeFormLiveService do
             expect(SubmissionEmailMailer).to receive(:alert_email_change).with(
               live_email: live_form.submission_email,
               form_name: live_form.name,
-              current_user:,
+              creator_name: current_user.name,
+              creator_email: current_user.email,
             ).and_call_original
 
             make_form_live_service.make_live

--- a/spec/service/make_form_live_service_spec.rb
+++ b/spec/service/make_form_live_service_spec.rb
@@ -17,7 +17,7 @@ describe MakeFormLiveService do
     end
 
     it "does not call the SubmissionEmailMailer" do
-      expect(SubmissionEmailMailer).not_to receive(:notify_submission_email_has_changed)
+      expect(SubmissionEmailMailer).not_to receive(:alert_email_change)
       make_form_live_service.make_live
     end
 
@@ -35,7 +35,7 @@ describe MakeFormLiveService do
 
       context "when submission email has not been changed" do
         it "does not call the SubmissionEmailMailer" do
-          expect(SubmissionEmailMailer).not_to receive(:notify_submission_email_has_changed)
+          expect(SubmissionEmailMailer).not_to receive(:alert_email_change)
 
           make_form_live_service.make_live
         end
@@ -47,14 +47,14 @@ describe MakeFormLiveService do
         end
 
         it "does not call the SubmissionEmailMailer" do
-          expect(SubmissionEmailMailer).not_to receive(:notify_submission_email_has_changed)
+          expect(SubmissionEmailMailer).not_to receive(:alert_email_change)
 
           make_form_live_service.make_live
         end
 
         context "when notify_original_submission_email_of_change feature is enabled", feature_notify_original_submission_email_of_change: true do
           it "calls the SubmissionEmailMailer" do
-            expect(SubmissionEmailMailer).to receive(:notify_submission_email_has_changed).with(
+            expect(SubmissionEmailMailer).to receive(:alert_email_change).with(
               live_email: live_form.submission_email,
               form_name: live_form.name,
               current_user:,


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/RzPVKyp0/1490-add-sending-an-email-to-submission-processor-when-form-is-archived

Sends an email to the submission email for a form when it is archived.

<img width="1153" alt="Screenshot 2024-04-30 at 15 27 58" src="https://github.com/alphagov/forms-admin/assets/5648592/eed4b313-0cb5-4cda-9ae1-62cd89811bf5">


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
