### PR TITLE
Make the create_group button primary

### DIFF
--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -11,7 +11,7 @@
 <%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: "You're not in any active groups.") %>
 <%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: "You're not in any trial groups.") %>
 
-<%= govuk_button_link_to t("groups.index.create_group"), new_group_path, class:"govuk-!-margin-top-3", secondary: true %>
+<%= govuk_button_link_to t("groups.index.create_group"), new_group_path, class:"govuk-!-margin-top-3" %>
 
 <div class="govuk-!-margin-top-3">
   <%= govuk_details(summary_text: t("groups.index.group_explainer_title")) do %>


### PR DESCRIPTION
The button was secondary but it's the call to action. The design in figma has been updated.

This commit changes the styling to make the button primary and green.

Trello card: https://trello.com/c/EWnpyXt3/1487-change-create-a-group-buttons-to-primary-cta-on-group-org-admin-group-landing-pages

Now:
![image](https://github.com/alphagov/forms-admin/assets/11035856/a81289ac-4f3a-4c8e-8510-9d67185fa872)

Then:
![image](https://github.com/alphagov/forms-admin/assets/11035856/4a47bcbf-56f6-4b61-8dcd-5cc7f595aa83)

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
