### PR TITLE
Add alternate 'what is a group?' details component for org admins

### DIFF
--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,20 +1,27 @@
 <% set_page_title(t("page_titles.group_index")) %>
 
-<% content_for :notification_banner_content do %>
-  <%= notice %>
-<% end%>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
 
-<h1 class="govuk-heading-l">
-  <%= t("page_titles.group_index") %>
-</h1>
+    <% content_for :notification_banner_content do %>
+      <%= notice %>
+    <% end%>
 
-<%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: "You're not in any active groups.") %>
-<%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: "You're not in any trial groups.") %>
+    <h1 class="govuk-heading-l">
+      <%= t("page_titles.group_index") %>
+    </h1>
 
-<%= govuk_button_link_to t("groups.index.create_group"), new_group_path, class:"govuk-!-margin-top-3" %>
+    <%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: "You're not in any active groups.") %>
+    <%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: "You're not in any trial groups.") %>
 
-<div class="govuk-!-margin-top-3">
+    <%= govuk_button_link_to t("groups.index.create_group"), new_group_path, class:"govuk-!-margin-top-3" %>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-top-3">
+  <div class="govuk-grid-column-two-thirds">
   <%= govuk_details(summary_text: t("groups.index.group_explainer_title")) do %>
     <%= t("groups.index.group_explainer_body_html") %>
   <% end %>
+  </div>
 </div>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -20,8 +20,12 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-3">
   <div class="govuk-grid-column-two-thirds">
-  <%= govuk_details(summary_text: t("groups.index.group_explainer_title")) do %>
-    <%= t("groups.index.group_explainer_body_html") %>
-  <% end %>
+    <%= govuk_details(summary_text: t("groups.index.group_explainer_title")) do
+      if @current_user.organisation_admin? || @current_user.super_admin?
+        t("groups.index.group_explainer_org_admin_body_html")
+      else 
+        t("groups.index.group_explainer_body_html")
+      end 
+    end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,6 +318,11 @@ en:
         <p>If you need access to an existing form or group, ask someone who has access to that group to invite you.</p>
         <p>When a group is first created it will be a ‘trial’ group. That means you cannot make any forms in the group live. You can request for a group to be upgraded to an ‘active’ group if you need to make forms live.</p>
         <p>If you’re not sure if you should make a new group, speak with your organisation’s GOV.UK publishing team.</p>
+      group_explainer_org_admin_body_html: |
+        <p>Each form is created inside a group. Anyone with a GOV.UK Forms account can make a group. They can add people from their organisation to that group to view, create and edit forms in it.</p>
+        <p>Because you’re an organisation admin, you can access all the groups in your organisation. </p>
+        <p>When a group is first created it will be a ‘trial’ group. That means forms in the group cannot be made live.</p>
+        <p>As an organisation admin, you can upgrade a trial group to an ‘active’ group so forms in that group can be made live. People will be able to send a request to you to ask for their trial group to be upgraded.</p>
       group_explainer_title: What is a ‘group’?
       trial_title: Trial groups
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -314,8 +314,8 @@ en:
       active_title: Active groups
       create_group: Create a group
       group_explainer_body_html: |
-        <p>Each form is created inside a group. People can be invited to a group to create and edit forms in it.</p>
-        <p>If you need access to an existing form or group, ask someone who has access to that group to invite you.</p>
+        <p>Each form is created inside a group. People can be added to a group to create and edit forms in it.</p>
+        <p>If you need access to an existing form or group, ask someone who has access to that group to add you.</p>
         <p>When a group is first created it will be a ‘trial’ group. That means you cannot make any forms in the group live. You can request for a group to be upgraded to an ‘active’ group if you need to make forms live.</p>
         <p>If you’re not sure if you should make a new group, speak with your organisation’s GOV.UK publishing team.</p>
       group_explainer_org_admin_body_html: |

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -3,10 +3,13 @@ require "rails_helper"
 RSpec.describe "groups/index", type: :view do
   let(:trial_groups) { create_list :group, 2 }
   let(:active_groups) { create_list :group, 2, status: :active }
+  let(:current_user) { build :editor_user }
 
   before do
     assign(:trial_groups, trial_groups)
     assign(:active_groups, active_groups)
+
+    assign(:current_user, current_user)
 
     render
   end
@@ -23,5 +26,17 @@ RSpec.describe "groups/index", type: :view do
 
   it "shows a create group button" do
     expect(rendered).to have_link("Create a group", href: new_group_path)
+  end
+
+  it "shows the details text for users who are not org/super admins" do
+    expect(rendered).to have_content("If you need access to an existing form or group, ask someone who has access to that group to invite you.")
+  end
+
+  context "when the user is an admin" do
+    let(:current_user) { build :organisation_admin_user }
+
+    it "shows the details text for admins" do
+      expect(rendered).to have_content("Because you’re an organisation admin, you can access all the groups in your organisation.")
+    end
   end
 end

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "groups/index", type: :view do
   end
 
   it "shows the details text for users who are not org/super admins" do
-    expect(rendered).to have_content("If you need access to an existing form or group, ask someone who has access to that group to invite you.")
+    expect(rendered).to have_content("If you need access to an existing form or group, ask someone who has access to that group to add you.")
   end
 
   context "when the user is an admin" do


### PR DESCRIPTION
### Add alternate 'what is a group?' details component for org admins

Trello card: https://trello.com/c/Wj6x9vPd/1460-add-alternate-what-is-a-group-details-component-for-org-admins

- Change the content describing groups when the user is a organisation_admin or super_admin.

- Change the layout of the page so that the details component is kept to 2/3rds. I've also wrapped the stuff above in a full width column because I think it's clearer.

As a group_admin or editor:
![image](https://github.com/alphagov/forms-admin/assets/11035856/0f549d59-ef59-4119-bb98-85bf8b08f5e5)

As an organisation admin or super admin:
![image](https://github.com/alphagov/forms-admin/assets/11035856/008df096-847b-4468-9306-2245d770fc9d)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
