### PR TITLE
Fix Editing Multiple Forms

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,8 +11,6 @@ class ApplicationController < ActionController::Base
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
-  before_action :clear_draft_questions_data
-
   add_flash_types :success
 
   rescue_from ActiveResource::ResourceNotFound do
@@ -55,10 +53,6 @@ class ApplicationController < ActionController::Base
     payload[:page_id] = params[:page_id] if params[:page_id].present?
     payload[:session_id_hash] = Digest::SHA256.hexdigest session.id.to_s if session.exists?
     payload[:trace_id] = request.env["HTTP_X_AMZN_TRACE_ID"].presence
-  end
-
-  def clear_draft_questions_data
-    current_user.draft_questions.destroy_all if current_user.present?
   end
 
   def set_request_id

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,5 +1,5 @@
 class HeartbeatController < ApplicationController
-  skip_before_action :authenticate_and_check_access, :check_maintenance_mode_is_enabled, :clear_draft_questions_data, :redirect_if_account_not_completed
+  skip_before_action :authenticate_and_check_access, :check_maintenance_mode_is_enabled, :redirect_if_account_not_completed
 
   def ping
     render(body: "PONG")

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   before_action :check_user_has_permission
-  skip_before_action :clear_draft_questions_data, except: %i[index move_page]
+  before_action :clear_draft_questions_data, only: %i[index move_page]
   after_action :verify_authorized
 
   def index
@@ -29,6 +29,10 @@ class PagesController < ApplicationController
   end
 
 private
+
+  def clear_draft_questions_data
+    DraftQuestion.destroy_by(form_id: current_form.id, user_id: current_user.id) if current_user.present? && current_form.present?
+  end
 
   def check_user_has_permission
     authorize current_form, :can_view_form?

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -63,23 +63,6 @@ describe ApplicationController, type: :controller do
     end
   end
 
-  describe "#clear_draft_questions_data" do
-    let(:user) { create(:user) }
-
-    it "destroys draft questions when user is present" do
-      allow(controller).to receive(:current_user).and_return(user)
-      create_list(:draft_question, 3, user:)
-
-      controller.send(:clear_draft_questions_data)
-
-      expect(user.draft_questions.count).to eq(0)
-    end
-
-    it "does not raise an error when draft question and user are not present" do
-      expect { controller.send(:clear_draft_questions_data) }.not_to raise_exception
-    end
-  end
-
   describe "#current_form" do
     it "returns the current form" do
       params = ActionController::Parameters.new(form_id: id)

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -66,11 +66,17 @@ RSpec.describe PagesController, type: :request do
       end
     end
 
-    it "clears draft questions data for current_user" do
+    it "clears draft questions data for current user and form" do
       original_draft_question # Setup initial draft question which will clear
       expect {
         get start_new_question_path(form_id: current_form.id)
-      }.to change { DraftQuestion.exists?({ user: editor_user }) }.from(true).to(false)
+      }.to change { DraftQuestion.exists?({ form_id: current_form.id, user: editor_user }) }.from(true).to(false)
+    end
+
+    it "does not clear draft questions data for a different form" do
+      create :draft_question, form_id: 99, user: editor_user # Setup initial draft question which should not clear
+      get start_new_question_path(form_id: current_form.id)
+      expect(DraftQuestion.exists?({ form_id: 99, user: editor_user })).to be true
     end
 
     it "redirects to type_of_answer_create_path" do


### PR DESCRIPTION
When draft questions are created they are separated by their form_id and user_id. The `clear_draft_questions_data` was originally deleting all draft forms for the user regardless of the form they were associated with. This commit:
1. when clearing draft forms it clears them for the current form and user only.
2. moves the `clear_draft_questions_data` function and the `before_action` call into the PagesController to which it is more closely related. This should help future understanding and avoids users inadvertently clearing draft questions when visiting other pages unrelated to draft questions in another tab.

The above is done in a single commit. Attempting to introduce the form_id into the condition of `clear_draft_question_data` whilst it remains in the `ApplicationController` would require wide spread changes to tests to mock the active resource for getting the form. It doesn't seem valuable to do this when the intention is to move it to the PagesController immediately afterwards.

### What problem does this pull request solve?

Trello card: https://trello.com/c/ELMRrABD/382-end-to-end-test-locking
https://trello.com/c/EVSrkyxX/1518-fix-parallel-end-to-end-tests

**First problem:** Allows the same user to edit multiple forms by clearing draft questions by user and form id. Essentially the problem was:
1. Add a question to form 1
2. In another tab add a question to form 2. this invoked `clear_draft_question_data` clearing all draft questions for the user, including the draft question above for form 1 because it didn't consider the form_id.
4. Go back to the first tab and the state has been lost, so attempting to progress throws various errors depending on the next page but one of them is `No answer type set for draft question (RuntimeError)`

**Second problem:** Allows users to visit non PageController pages without inadvertently clearing draft questions. This is achieved by moving the `clear_draft_question_data` into the PagesController rather than it being invoked in the ApplicationController on almost all pages. I also believe this helps with comprehension since the clearing draft questions is the responsibility of the PagesController.
1. Add a question to form 1
2. In another tab visit almost any other page which invoked `clear_draft_question_data`
3. Go back to the first tab and the state has been lost, so attempting to progress throws various errors depending on the next page but one of them is `No answer type set for draft question (RuntimeError)`

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing
I've tested this locally and deployed to dev whilst running multiple e2e tests at once (previous to this change those tests threw the errors seen during deployments).

![image](https://github.com/alphagov/forms-admin/assets/31340341/a385408f-214e-4da1-8eb8-7be109fbd0a2)

I don't think there is ever a need to clear all draft questions without knowing the form so I have not kept that but I'm open to opinions; I don't think you can get the pages controller without being signed in and referencing a particular form. **Are there any nasty edge cases lurking here?**

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
