### PR TITLE
Refactor input object submit methods

### DIFF
--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -13,15 +13,13 @@ module Forms
 
       @make_live_input = MakeLiveInput.new(**make_live_input_params)
 
-      return redirect_to form_path(@make_live_input.form) unless @make_live_input.user_wants_to_make_form_live
+      return render_new(status: :unprocessable_entity) unless @make_live_input.valid?
+      return redirect_to form_path(@make_live_input.form) unless @make_live_input.confirmed?
 
       @make_form_live_service = MakeFormLiveService.call(current_form:, current_user:)
+      @make_form_live_service.make_live
 
-      if @make_live_input.make_form_live(@make_form_live_service)
-        render "confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title }
-      else
-        render_new
-      end
+      render "confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title }
     end
 
   private
@@ -30,13 +28,13 @@ module Forms
       params.require(:forms_make_live_input).permit(:confirm).merge(form: current_form)
     end
 
-    def render_new
+    def render_new(status: :ok)
       if current_form.is_live?
-        render "make_your_changes_live", locals: { current_form: }
+        render "make_your_changes_live", status:, locals: { current_form: }
       elsif current_form.is_archived?
-        render "make_archived_draft_live", locals: { current_form: }
+        render "make_archived_draft_live", status:, locals: { current_form: }
       else
-        render "make_your_form_live", locals: { current_form: }
+        render "make_your_form_live", status:, locals: { current_form: }
       end
     end
   end

--- a/app/controllers/forms/unarchive_controller.rb
+++ b/app/controllers/forms/unarchive_controller.rb
@@ -13,15 +13,13 @@ module Forms
 
       @make_live_input = MakeLiveInput.new(**unarchive_form_params)
 
-      return redirect_to archived_form_path(current_form) unless @make_live_input.user_wants_to_make_form_live
+      return render "unarchive_form", status: :unprocessable_entity, locals: { current_form: } unless @make_live_input.valid?
+      return redirect_to archived_form_path(current_form) unless @make_live_input.confirmed?
 
       @make_form_live_service = MakeFormLiveService.call(current_form:, current_user:)
+      @make_form_live_service.make_live
 
-      if @make_live_input.make_form_live(@make_form_live_service)
-        render "forms/make_live/confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title }
-      else
-        render "unarchive_form", status: :unprocessable_entity, locals: { current_form: }
-      end
+      render "forms/make_live/confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title }
     end
 
   private

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -25,7 +25,7 @@ class FormsController < ApplicationController
     @pages = current_form.pages
     @mark_complete_input = Forms::MarkCompleteInput.new(mark_complete_input_params)
 
-    if @mark_complete_input.mark_section
+    if @mark_complete_input.submit
       success_message = if @mark_complete_input.mark_complete == "true"
                           t("banner.success.form.pages_saved_and_section_completed")
                         else

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -16,7 +16,7 @@ class GroupMembersController < ApplicationController
     authorize @group, :add_editor?
 
     @group_member_input = GroupMemberInput.new(group_member_params)
-    if @group_member_input.save
+    if @group_member_input.submit
       redirect_to group_members_path(@group.external_id)
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -72,7 +72,7 @@ class Pages::ConditionsController < PagesController
 
     delete_condition_input = Pages::DeleteConditionInput.new(form_params)
 
-    if delete_condition_input.delete
+    if delete_condition_input.submit
       if delete_condition_input.confirmed?
         redirect_to form_pages_path(current_form.id, page.id), success: t("banner.success.route_deleted", question_position: delete_condition_input.page.position)
       else

--- a/app/input_objects/forms/make_live_input.rb
+++ b/app/input_objects/forms/make_live_input.rb
@@ -3,14 +3,6 @@ class Forms::MakeLiveInput < ConfirmActionInput
 
   validate :required_parts_of_form_completed
 
-  def user_wants_to_make_form_live
-    valid? && confirmed?
-  end
-
-  def make_form_live(service)
-    valid? && service.make_live
-  end
-
 private
 
   def required_parts_of_form_completed

--- a/app/input_objects/forms/make_live_input.rb
+++ b/app/input_objects/forms/make_live_input.rb
@@ -11,7 +11,7 @@ private
     return if form.all_ready_for_live?
 
     form.all_incomplete_tasks.each do |section|
-      errors.add(:confirm, section)
+      errors.add(:confirm, section.to_sym)
     end
 
     errors.empty?

--- a/app/input_objects/forms/mark_complete_input.rb
+++ b/app/input_objects/forms/mark_complete_input.rb
@@ -4,7 +4,7 @@ class Forms::MarkCompleteInput < BaseInput
   validates :mark_complete, presence: true
   validate :has_routing_errors, if: :marked_complete?
 
-  def mark_section
+  def submit
     return false if invalid?
 
     form.question_section_completed = mark_complete

--- a/app/input_objects/group_member_input.rb
+++ b/app/input_objects/group_member_input.rb
@@ -12,7 +12,7 @@ class GroupMemberInput < BaseInput
 
   before_validation :strip_whitespace
 
-  def save
+  def submit
     if invalid? || new_membership.invalid?
       copy_membership_errors
       return false

--- a/app/input_objects/pages/delete_condition_input.rb
+++ b/app/input_objects/pages/delete_condition_input.rb
@@ -1,7 +1,7 @@
 class Pages::DeleteConditionInput < ConfirmActionInput
   attr_accessor :form, :page, :check_page_id, :routing_page_id, :answer_value, :goto_page_id, :record
 
-  def delete
+  def submit
     return false if invalid?
 
     result = true

--- a/app/service/make_form_live_service.rb
+++ b/app/service/make_form_live_service.rb
@@ -22,8 +22,6 @@ class MakeFormLiveService
         creator_email: @current_user.email,
       ).deliver_now
     end
-
-    true
   end
 
   def page_title

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -105,5 +105,9 @@ FactoryBot.define do
         Array.new(pages_count) { association(:page, :with_selections_settings) }
       end
     end
+
+    trait :missing_pages do
+      incomplete_tasks { %i[missing_pages] }
+    end
   end
 end

--- a/spec/input_objects/forms/make_live_input_spec.rb
+++ b/spec/input_objects/forms/make_live_input_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Forms::MakeLiveInput, type: :model do
   let(:error_message) { I18n.t("activemodel.errors.models.forms/make_live_input.attributes.confirm.blank") }
 
-  describe "Make Live Form" do
+  describe "validations" do
     it "is invalid if blank" do
       make_live_input = described_class.new(confirm: "")
       make_live_input.validate(:confirm)
@@ -27,50 +27,6 @@ RSpec.describe Forms::MakeLiveInput, type: :model do
 
         expect(make_live_input).not_to be_valid
         expect(make_live_input.errors.full_messages_for(:confirm)).to include("Confirm #{I18n.t('activemodel.errors.models.forms/make_live_input.attributes.confirm.missing_submission_email')}")
-      end
-    end
-  end
-
-  describe "#user_wants_to_make_form_live" do
-    [
-      { valid: true, confirmed: true },
-      { valid: true, confirmed: false },
-      { valid: false, confirmed: true },
-      { valid: false, confirmed: false },
-    ].each do |scenario|
-      context "when valid? returns #{scenario[:valid]} and confirmed? returns #{scenario[:confirmed]}" do
-        let(:make_live_input) { described_class.new(confirm: "") }
-
-        before do
-          allow(make_live_input).to receive(:valid?).and_return(scenario[:valid])
-          allow(make_live_input).to receive(:confirmed?).and_return(scenario[:confirmed])
-        end
-
-        it "returns #{scenario[:valid] && scenario[:confirmed]}" do
-          expect(make_live_input.user_wants_to_make_form_live).to eq scenario[:valid] && scenario[:confirmed]
-        end
-      end
-    end
-  end
-
-  describe "#make_form_live" do
-    [
-      { valid: true, make_live: true },
-      { valid: true, make_live: false },
-      { valid: false, make_live: true },
-      { valid: false, make_live: false },
-    ].each do |scenario|
-      context "when valid? returns #{scenario[:valid]} and make_live? returns #{scenario[:make_live]}" do
-        let(:make_live_input) { described_class.new(confirm: "") }
-        let(:make_form_live_service) { OpenStruct.new(make_live: scenario[:make_live]) }
-
-        before do
-          allow(make_live_input).to receive(:valid?).and_return(scenario[:valid])
-        end
-
-        it "returns #{scenario[:valid] && scenario[:make_live]}" do
-          expect(make_live_input.make_form_live(make_form_live_service)).to eq scenario[:valid] && scenario[:make_live]
-        end
       end
     end
   end

--- a/spec/input_objects/forms/mark_complete_input_spec.rb
+++ b/spec/input_objects/forms/mark_complete_input_spec.rb
@@ -62,11 +62,11 @@ RSpec.describe Forms::MarkCompleteInput, type: :model do
       end
 
       it "returns true if valid and form is updated" do
-        expect(mark_complete_input.mark_section).to eq true
+        expect(mark_complete_input.submit).to eq true
       end
 
       it "sets the forms question section completed" do
-        mark_complete_input.mark_section
+        mark_complete_input.submit
         expect(mark_complete_input.form.question_section_completed).to eq mark_complete_input.mark_complete
       end
     end
@@ -77,11 +77,11 @@ RSpec.describe Forms::MarkCompleteInput, type: :model do
       end
 
       it "returns false if invalid" do
-        expect(mark_complete_input.mark_section).to eq false
+        expect(mark_complete_input.submit).to eq false
       end
 
       it "does not set the forms question section completed" do
-        mark_complete_input.mark_section
+        mark_complete_input.submit
         expect(mark_complete_input.form.question_section_completed).not_to eq mark_complete_input.mark_complete
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe Forms::MarkCompleteInput, type: :model do
       allow(mark_complete_input).to receive(:invalid?).and_return(false)
       allow(form).to receive(:save!).and_return(true)
       allow(mark_complete_input).to receive(:form).and_return(form)
-      expect(mark_complete_input.mark_section).to eq true
+      expect(mark_complete_input.submit).to eq true
     end
 
     context "when mark_complete_input form does not save" do
@@ -101,7 +101,7 @@ RSpec.describe Forms::MarkCompleteInput, type: :model do
       end
 
       it "returns false if invalid" do
-        expect(mark_complete_input.mark_section).to eq false
+        expect(mark_complete_input.submit).to eq false
       end
     end
   end

--- a/spec/input_objects/group_member_input_spec.rb
+++ b/spec/input_objects/group_member_input_spec.rb
@@ -39,7 +39,7 @@ describe GroupMemberInput do
       expect(group_member_input).to be_valid
     end
 
-    describe "#save" do
+    describe "#submit" do
       context "when the new Membership has errors" do
         let(:group_member_input) { described_class.new }
 
@@ -62,7 +62,7 @@ describe GroupMemberInput do
 
         it "adds the appropriate error message to member_email_address" do
           error_message = I18n.t("activemodel.errors.models.group_member_input.attributes.member_email_address.user_in_other_org")
-          expect(group_member_input.save).to be false
+          expect(group_member_input.submit).to be false
           expect(group_member_input.errors[:member_email_address]).to include(error_message)
         end
       end
@@ -82,7 +82,7 @@ describe GroupMemberInput do
         end
 
         it "creates a new Membership" do
-          expect(group_member_input.save).to be true
+          expect(group_member_input.submit).to be true
           expect(group_member_input).to be_valid
           expect(GroupMemberMailer).to have_received(:added_to_group).with(an_instance_of(Membership), group_url: group_url(group, host: "example.net"))
         end

--- a/spec/input_objects/pages/delete_condition_input_spec.rb
+++ b/spec/input_objects/pages/delete_condition_input_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe Pages::DeleteConditionInput, type: :model do
 
         delete_condition_input.confirm = "yes"
 
-        expect(delete_condition_input.delete).to be_truthy
+        expect(delete_condition_input.submit).to be_truthy
       end
     end
 
     context "when validations fail" do
       it "returns false" do
         invalid_delete_condition_input = described_class.new
-        expect(invalid_delete_condition_input.delete).to be false
+        expect(invalid_delete_condition_input.submit).to be false
         expect(invalid_delete_condition_input.errors.full_messages_for(:confirm)).to include(
           "Confirm Select yes if you want to delete this route",
         )

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -2,12 +2,8 @@ require "rails_helper"
 
 RSpec.describe Forms::MakeLiveController, type: :request do
   let(:user) { build :editor_user }
-
-  let(:form) do
-    build(:form,
-          :ready_for_live,
-          id: 2)
-  end
+  let(:id) { 2 }
+  let(:form) { build(:form, :ready_for_live, id:) }
 
   let(:updated_form) do
     build(:form,
@@ -157,6 +153,24 @@ RSpec.describe Forms::MakeLiveController, type: :request do
 
       it "redirects you to the form page" do
         expect(response).to redirect_to(form_path(2))
+      end
+    end
+
+    context "when all tasks are not complete" do
+      let(:form) { build(:form, :missing_pages, id:) }
+      let(:form_params) { { forms_make_live_input: { confirm: "yes", form: } } }
+
+      it "returns 422" do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "does not update the form on the API" do
+        expect(form).not_to have_been_updated
+      end
+
+      it "re-renders the page with an error" do
+        expect(response).to render_template("make_your_form_live")
+        expect(response.body).to include("You cannot make your form live because you have not finished adding questions.")
       end
     end
 

--- a/spec/requests/forms/unarchive_controller_spec.rb
+++ b/spec/requests/forms/unarchive_controller_spec.rb
@@ -112,6 +112,23 @@ RSpec.describe Forms::UnarchiveController, type: :request do
       end
     end
 
+    context "when no option is selected" do
+      let(:form_params) { { forms_make_live_input: { confirm: :"" } } }
+
+      it "returns 422" do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "does not update the form on the API" do
+        expect(form).not_to have_been_updated
+      end
+
+      it "re-renders the page with an error" do
+        expect(response).to render_template("unarchive_form")
+        expect(response.body).to include("You must choose an option")
+      end
+    end
+
     context "when current user has a trial account" do
       let(:user) { build :user, :with_trial_role }
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
   describe "#destroy" do
     let(:condition) { build :condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Wales", goto_page_id: pages.last.id }
     let(:confirm) { "yes" }
-    let(:delete_bool) { true }
+    let(:submit_bool) { true }
 
     before do
       selected_page.routing_conditions = [condition]
@@ -397,7 +397,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
       allow(delete_condition_input).to receive(:goto_page_question_text).and_return("What is your name?")
 
-      allow(delete_condition_input).to receive(:delete).and_return(delete_bool)
+      allow(delete_condition_input).to receive(:submit).and_return(submit_bool)
 
       allow(Pages::DeleteConditionInput).to receive(:new).and_return(delete_condition_input)
 
@@ -429,7 +429,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when the destroy fails" do
-      let(:delete_bool) { false }
+      let(:submit_bool) { false }
 
       it "return 422 error code" do
         expect(response).to have_http_status(:unprocessable_entity)
@@ -437,7 +437,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when form submit fails" do
-      let(:delete_bool) { false }
+      let(:submit_bool) { false }
       let(:confirm) { nil }
 
       it "return 422 error code" do


### PR DESCRIPTION
### What problem does this pull request solve?

We use input objects (previously referred to as form objects) to deserialize the input data for a form from the request body, validate the input, and also in many cases to perform actions with the input when the form is submitted.

We follow a general pattern where the method for performing the action when the form is submitted is named "submit". Change the places where it was named something else to follow this pattern.

As part of this, the submission for `make_live_controller` was fixed. This previously did not cause validation errors to be displayed when no option was selected for the "Yes"/"No" radio buttons on the "Make your form live" page, and when validation failed due to tasks not being completed the incorrect validation message was shown.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
