### PR TITLE
Remove success banners for trial groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -37,7 +37,7 @@ class GroupsController < ApplicationController
     authorize @group
 
     if @group.save
-      redirect_to @group, success: t("groups.success_messages.create")
+      redirect_to @group
     else
       render :new, status: :unprocessable_entity
     end
@@ -47,7 +47,8 @@ class GroupsController < ApplicationController
   def update
     authorize @group
     if @group.update(group_params)
-      redirect_to @group, success: t("groups.success_messages.update"), status: :see_other
+      success_message = @group.active? ? t("groups.success_messages.update") : nil
+      redirect_to @group, success: success_message, status: :see_other
     else
       render :edit, status: :unprocessable_entity
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -432,8 +432,7 @@ en:
       trial: Trial group
       upgrade_requested: Trial group
     success_messages:
-      create: Group was successfully created.
-      update: Group was successfully updated.
+      update: The name of this group has been changed
       upgrade: This group is now active
     upgrade_requested:
       what_happens_next:

--- a/spec/factories/models/groups.rb
+++ b/spec/factories/models/groups.rb
@@ -9,4 +9,8 @@ FactoryBot.define do
       organisation { association :organisation, :with_org_admin, id: 1, slug: "test-org" }
     end
   end
+
+  trait :active do
+    status { :live }
+  end
 end

--- a/spec/factories/models/groups.rb
+++ b/spec/factories/models/groups.rb
@@ -9,8 +9,4 @@ FactoryBot.define do
       organisation { association :organisation, :with_org_admin, id: 1, slug: "test-org" }
     end
   end
-
-  trait :active do
-    status { :live }
-  end
 end


### PR DESCRIPTION
We don't want to show success banners for trial groups, as we already display a notification banner when a group is in trial mode and we do not multiple banners. So:

- don't display a banner when a group is created
- only display a banner when the group's name is changed if the group is active.

Updated the content for success banner when the name is changed.

### What problem does this pull request solve?

Trello card: https://trello.com/c/KUmN1mEt/1695-update-new-group-page-and-edit-group-name-page-to-match-designs

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
