### PR TITLE
Remove archive_enabled feature flag

### DIFF
--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -72,7 +72,7 @@
       <%# i18n-tasks-use t('made_live_form.draft_create') %>
       <%# i18n-tasks-use t('made_live_form.draft_edit') %>
       <%= govuk_button_link_to t("made_live_form.draft_#{ form_metadata.has_draft_version ? 'edit': 'create'}"), form_path(form.id) %>
-      <% if status == :live && FeatureService.enabled?(:archive_enabled) %>
+      <% if status == :live %>
         <%= govuk_button_link_to t("made_live_form.archive_this_form"), archive_form_path(form.id), warning: true %>
       <% elsif status == :archived %>
         <%= govuk_button_link_to t("made_live_form.make_this_form_live"), unarchive_path(form.id), secondary: true %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,7 +5,6 @@ features:
   check_your_question_enabled: false
   payment_links: false
   reference_numbers_enabled: false
-  archive_enabled: false
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -25,7 +25,6 @@ describe "Settings" do
     include_examples expected_value_test, :metrics_for_form_creators_enabled, features, false
     include_examples expected_value_test, :notify_original_submission_email_of_change, features, false
     include_examples expected_value_test, :reference_numbers_enabled, features, false
-    include_examples expected_value_test, [:archive_enabled, features, false]
   end
 
   describe "forms_api" do

--- a/spec/features/form/archive_a_form_spec.rb
+++ b/spec/features/form/archive_a_form_spec.rb
@@ -16,7 +16,7 @@ feature "Archive a form", type: :feature do
     login_as_editor_user
   end
 
-  scenario "as a form editor", feature_archive_enabled: true do
+  scenario "as a form editor" do
     visit root_path
     expect(page.find("h1")).to have_text "GOV.UK Forms"
     expect_page_to_have_no_axe_errors(page)

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -187,20 +187,12 @@ describe "forms/_made_live_form.html.erb", feature_metrics_for_form_creators_ena
 
   describe "the archive this form button" do
     context "when the form is live" do
-      context "when the archive feature is enabled", feature_archive_enabled: true do
-        it "contains a link to archive the form" do
-          expect(rendered).to have_link("Archive this form")
-        end
-      end
-
-      context "when the archive feature is enabled", feature_archive_enabled: false do
-        it "does not contain a link to archive the form" do
-          expect(rendered).not_to have_link("Archive this form")
-        end
+      it "contains a link to archive the form" do
+        expect(rendered).to have_link("Archive this form")
       end
     end
 
-    context "when the form is archived", feature_archive_enabled: true do
+    context "when the form is archived" do
       let(:status) { :archived }
 
       it "does not contain a link to archive the form" do


### PR DESCRIPTION
Removing the archiving feature flag, as the feature has now been released.

### What problem does this pull request solve?

https://trello.com/c/wR1SpBpm/1519-extracting-the-archiving-feature-flag

