### PR TITLE
Prevent editors from editing groups

### DIFF
--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -7,12 +7,12 @@ class GroupPolicy < ApplicationPolicy
   def show?
     user.super_admin? || user.is_organisations_admin?(record.organisation) || user.groups.include?(record)
   end
-  alias_method :edit?, :show?
-  alias_method :update?, :show?
 
-  def add_editor?
+  def edit?
     user.super_admin? || user.is_organisations_admin?(record.organisation) || record.memberships.find_by(user:)&.group_admin?
   end
+  alias_method :update?, :edit?
+  alias_method :add_editor?, :edit?
 
   def upgrade?
     user.super_admin? || user.is_organisations_admin?(record.organisation)

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -18,7 +18,9 @@
 <%= render @group %>
 
 <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-5">
-  <li><%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %></li>
+  <% if policy(@group).edit? %>
+    <li><%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %></li>
+  <% end %>
   <li><%= govuk_link_to(t(".edit_group_members"), group_members_path(@group)) %></li>
 </ul>
 

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -20,8 +20,10 @@
 <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-5">
   <% if policy(@group).edit? %>
     <li><%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %></li>
+    <li><%= govuk_link_to(t(".edit_group_members"), group_members_path(@group)) %></li>
+  <% else %>
+    <li><%= govuk_link_to(t(".review_group_members"), group_members_path(@group)) %></li>
   <% end %>
-  <li><%= govuk_link_to(t(".edit_group_members"), group_members_path(@group)) %></li>
 </ul>
 
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_group_form_path(@group)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,6 +340,7 @@ en:
     show:
       edit_group_members: Edit members of this group
       edit_group_name: Change the name of this group
+      review_group_members: Review members of this group
       trial_banner:
         body_html: "<p>You can create forms in this group and test them, but you cannot make them live.</p>"
         heading: This is a ‘trial’ group

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe GroupPolicy do
       end
 
       it "permits group creation, viewing, and editing" do
-        expect(policy).to permit_only_actions(%i[show new edit create update])
+        expect(policy).to permit_only_actions(%i[show new create])
       end
 
-      it "does not allow add_editor or upgrade" do
-        expect(policy).to forbid_only_actions(%i[add_editor upgrade])
+      it "does not allow add_editor, rename or upgrade" do
+        expect(policy).to forbid_only_actions(%i[add_editor edit update upgrade])
       end
     end
 

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -31,16 +31,20 @@ RSpec.describe "groups/show", type: :view do
     expect(rendered).to have_link "Change the name of this group", href: edit_group_path(group)
   end
 
+  it "has a link to the edit members page" do
+    expect(rendered).to have_link "Edit members of this group", href: group_members_path(group)
+  end
+
   context "when the user does not have permission to edit the group" do
     let(:edit?) { false }
 
     it "does not have a link to the change group name page" do
       expect(rendered).not_to have_link "Change the name of this group", href: edit_group_path(group)
     end
-  end
 
-  it "has a link to the edit members page" do
-    expect(rendered).to have_link "Edit members of this group", href: group_members_path(group)
+    it "has a link to the review members page" do
+      expect(rendered).to have_link "Review members of this group", href: group_members_path(group)
+    end
   end
 
   context "when the group has no forms" do

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "groups/show", type: :view do
   let(:forms) { [] }
   let(:group) { create :group, name: "My Group" }
   let(:upgrade?) { false }
+  let(:edit?) { true }
 
   before do
     assign(:current_user, current_user)
@@ -12,7 +13,7 @@ RSpec.describe "groups/show", type: :view do
     assign(:forms, forms)
 
     without_partial_double_verification do
-      allow(view).to receive(:policy).and_return(instance_double(GroupPolicy, upgrade?: upgrade?))
+      allow(view).to receive(:policy).and_return(instance_double(GroupPolicy, upgrade?: upgrade?, edit?: edit?))
     end
 
     render
@@ -28,6 +29,14 @@ RSpec.describe "groups/show", type: :view do
 
   it "has a link to the change group name page" do
     expect(rendered).to have_link "Change the name of this group", href: edit_group_path(group)
+  end
+
+  context "when the user does not have permission to edit the group" do
+    let(:edit?) { false }
+
+    it "does not have a link to the change group name page" do
+      expect(rendered).not_to have_link "Change the name of this group", href: edit_group_path(group)
+    end
   end
 
   it "has a link to the edit members page" do


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/5iV1sCvx/1504-prevent-editors-from-changing-the-group-name-and-the-members

This removes the link from a group for changing the name of the group for editor users. 
It also changes the text for the link to the group members page for editors. 
Under the hood, editors have been restricted from the group `edit` and `update` policy, as there weren't any use cases for them.

See comparisons:

### Previous page / current page for non-editors
![image](https://github.com/alphagov/forms-admin/assets/25597009/ee4f84aa-a7a2-4972-85c1-970b641de9db)

### New version for editor members

![image](https://github.com/alphagov/forms-admin/assets/25597009/0e2f3072-7dee-4508-8626-5b31572a98d6)
