### PR TITLE
Add upgrade requests to group index

### DIFF
--- a/app/components/group_list_component/view.html.erb
+++ b/app/components/group_list_component/view.html.erb
@@ -1,11 +1,13 @@
 <% if @groups.empty? %>
-  <h2 class="govuk-heading-m">
-    <%= @title %>
-  </h2>
+  <% if @show_empty %>
+    <h2 class="govuk-heading-m">
+      <%= @title %>
+    </h2>
 
-  <p class="govuk-body">
-    <%= @empty_message %>
-  </p>
+    <p class="govuk-body">
+      <%= @empty_message %>
+    </p>
+  <% end %>
 <% else %>
   <%= govuk_table do |table| %>
     <%= table.with_caption(size: 'm', text: @title) %>

--- a/app/components/group_list_component/view.rb
+++ b/app/components/group_list_component/view.rb
@@ -1,10 +1,11 @@
 module GroupListComponent
   class View < ViewComponent::Base
-    def initialize(groups:, title:, empty_message:)
+    def initialize(groups:, title:, empty_message: "", show_empty: true)
       super
       @groups = groups
       @title = title
       @empty_message = empty_message
+      @show_empty = show_empty
     end
   end
 end

--- a/app/components/trial_role_warning_component/view.html.erb
+++ b/app/components/trial_role_warning_component/view.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_notification_banner(title_text: t("trial_role_warning.title")) do |banner| %>
+<%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
   <% banner.with_heading(text: t("trial_role_warning.heading"), tag: "h3") %>
   <%= t("trial_role_warning.content_html", link_url: link_url) %>
 <% end %>

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,6 +6,7 @@ class GroupsController < ApplicationController
   # GET /groups
   def index
     @active_groups = policy_scope(Group).active
+    @upgrade_requested_groups = policy_scope(Group).upgrade_requested
     @trial_groups = policy_scope(Group).trial
   end
 

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -18,8 +18,8 @@
     </h1>
 
     <%= render GroupListComponent::View.new(groups: @upgrade_requested_groups, title: t('groups.index.upgrade_requests_title'), show_empty: false) %>
-    <%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: "You're not in any active groups.") %>
-    <%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: "You're not in any trial groups.") %>
+    <%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: t('groups.index.active_empty_message')) %>
+    <%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: t('groups.index.trial_empty_message')) %>
 
     <%= govuk_button_link_to t("groups.index.create_group"), new_group_path, class:"govuk-!-margin-top-3" %>
   </div>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,11 +1,17 @@
 <% set_page_title(t("page_titles.group_index")) %>
 
+<% if @upgrade_requested_groups.present? && (@current_user.organisation_admin? || @current_user.super_admin?)  %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+        <% banner.with_heading(text: t("groups.index.upgrade_requests_banner_heading", count: @upgrade_requested_groups.length)) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-
-    <% content_for :notification_banner_content do %>
-      <%= notice %>
-    <% end%>
 
     <h1 class="govuk-heading-l">
       <%= t("page_titles.group_index") %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -11,6 +11,7 @@
       <%= t("page_titles.group_index") %>
     </h1>
 
+    <%= render GroupListComponent::View.new(groups: @upgrade_requested_groups, title: t('groups.index.upgrade_requests_title'), show_empty: false) %>
     <%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: "You're not in any active groups.") %>
     <%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: "You're not in any trial groups.") %>
 
@@ -23,9 +24,9 @@
     <%= govuk_details(summary_text: t("groups.index.group_explainer_title")) do
       if @current_user.organisation_admin? || @current_user.super_admin?
         t("groups.index.group_explainer_org_admin_body_html")
-      else 
+      else
         t("groups.index.group_explainer_body_html")
-      end 
+      end
     end %>
   </div>
 </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% unless @group.active? %>
-      <%= govuk_notification_banner(title_text: t("groups.show.trial_banner.title")) do |nb| %>
+      <%= govuk_notification_banner(title_text: t("banner.default.title")) do |nb| %>
         <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
         <% if policy(@group).upgrade? %>
           <%= t("groups.show.trial_banner.org_admin_body_html") %>

--- a/app/views/pages/selections_settings.html.erb
+++ b/app/views/pages/selections_settings.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @page.present? && @page.conditions.any? %>
-      <%= govuk_notification_banner(title_text: t("selections_settings.routing_warning_notification_title")) do |banner| %>
+      <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("selections_settings.routing_warning_about_change_only_one_option_heading"), tag: "h3") %>
         <%= t("selections_settings.routing_warning_about_change_only_one_option_html", pages_link_url: form_pages_path(current_form)) %>
       <% end %>

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @page.present? && @page.conditions.any?  %>
-      <%= govuk_notification_banner(title_text: t("type_of_answer.routing_warning_notification_title")) do |banner| %>
+      <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("type_of_answer.routing_warning_about_change_answer_type_heading"), tag: "h3") %>
         <%= t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(current_form)) %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,6 +342,7 @@ en:
         <p>As an organisation admin, you can upgrade a trial group to an ‘active’ group so forms in that group can be made live. People will be able to send a request to you to ask for their trial group to be upgraded.</p>
       group_explainer_title: What is a ‘group’?
       trial_title: Trial groups
+      upgrade_requests_title: Upgrade requests
     new:
       title: New group
     show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,6 +330,7 @@ en:
       created_by_unknown: Unknown
       name: Group name
     index:
+      active_empty_message: You’re not in any active groups.
       active_title: Active groups
       create_group: Create a group
       group_explainer_body_html: |
@@ -343,6 +344,7 @@ en:
         <p>When a group is first created it will be a ‘trial’ group. That means forms in the group cannot be made live.</p>
         <p>As an organisation admin, you can upgrade a trial group to an ‘active’ group so forms in that group can be made live. People will be able to send a request to you to ask for their trial group to be upgraded.</p>
       group_explainer_title: What is a ‘group’?
+      trial_empty_message: You’re not in any trial groups.
       trial_title: Trial groups
       upgrade_requests_banner_heading:
         one: You have one request to upgrade a trial group.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -362,7 +362,6 @@ en:
         heading: This is a ‘trial’ group
         org_admin_body_html: "<p>Forms in this group cannot be made live unless the group is upgraded to an ‘active’ group.</p>"
         request_upgrade: Find out how to upgrade this group so you can make forms live
-        title: Important
         upgrade_group: Upgrade this group
     status_caption:
       active: Active group
@@ -1012,7 +1011,6 @@ en:
       <p>
         If you do not want to lose your question route you can cancel this change by using the back button or <a href="%{pages_link_url}">go to your questions</a>.
       </p>
-    routing_warning_notification_title: Important
     'yes': 'Yes'
   set_email:
     new:
@@ -1051,7 +1049,6 @@ en:
         <a href="%{link_url}">Find out if you can upgrade to an editor account</a>
       </p>
     heading: You have a trial account
-    title: Important
   type_of_answer:
     routing_warning_about_change_answer_type_heading: Your existing question route may be deleted
     routing_warning_about_change_answer_type_html: |
@@ -1061,7 +1058,6 @@ en:
       <p>
         If you do not want to lose your question route you can cancel this change by using the back button or <a href="%{pages_link_url}">go to your questions</a>.
       </p>
-    routing_warning_notification_title: Important
   unarchive:
     new:
       body_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,8 @@ en:
     group: Back to %{group_name}
     groups: Back to your groups
   banner:
+    default:
+      title: Important
     success:
       form:
         change_name: Your form name has been saved
@@ -342,6 +344,9 @@ en:
         <p>As an organisation admin, you can upgrade a trial group to an ‘active’ group so forms in that group can be made live. People will be able to send a request to you to ask for their trial group to be upgraded.</p>
       group_explainer_title: What is a ‘group’?
       trial_title: Trial groups
+      upgrade_requests_banner_heading:
+        one: You have one request to upgrade a trial group.
+        other: You have %{count} requests to upgrade a trial group.
       upgrade_requests_title: Upgrade requests
     new:
       title: New group

--- a/spec/components/group_list_component/view_spec.rb
+++ b/spec/components/group_list_component/view_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe GroupListComponent::View, type: :component do
-  subject(:group_list) { described_class.new(groups:, title:, empty_message:) }
+  subject(:group_list) { described_class.new(groups:, title:, empty_message:, show_empty:) }
 
   let(:groups) { create_list(:group, 3) }
   let(:title) { "Your Groups" }
   let(:empty_message) { "There are no groups to display" }
+  let(:show_empty) { true }
 
   describe "rendering component" do
     before do
@@ -24,12 +25,26 @@ RSpec.describe GroupListComponent::View, type: :component do
     context "when there are no groups" do
       let(:groups) { [] }
 
-      it "renders a message" do
-        expect(page).to have_css("p", text: empty_message)
+      context "and show_empty is true" do
+        it "shows a message" do
+          expect(page).to have_css("p", text: empty_message)
+        end
+
+        it "shows the title as a heading" do
+          expect(page).to have_css("h2", text: title)
+        end
       end
 
-      it "shows the title as a heading" do
-        expect(page).to have_css("h2", text: title)
+      context "and show_empty is false" do
+        let(:show_empty) { false }
+
+        it "does not show a message" do
+          expect(page).not_to have_css("p", text: empty_message)
+        end
+
+        it "does not show the title as a heading" do
+          expect(page).not_to have_css("h2", text: title)
+        end
       end
     end
 

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -34,8 +34,14 @@ RSpec.describe "groups/index", type: :view do
     expect(rendered).to have_link("Create a group", href: new_group_path)
   end
 
-  it "shows the details text for users who are not org/super admins" do
-    expect(rendered).to have_content("If you need access to an existing form or group, ask someone who has access to that group to add you.")
+  context "when the user is not an admin" do
+    it "shows the details text for users who are not org/super admins" do
+      expect(rendered).to have_content("If you need access to an existing form or group, ask someone who has access to that group to add you.")
+    end
+
+    it "does not show a notification banner" do
+      expect(rendered).not_to have_css ".govuk-notification-banner"
+    end
   end
 
   context "when the user is an admin" do
@@ -43,6 +49,30 @@ RSpec.describe "groups/index", type: :view do
 
     it "shows the details text for admins" do
       expect(rendered).to have_content("Because you’re an organisation admin, you can access all the groups in your organisation.")
+    end
+
+    context "when there is a single group with an upgrade requested" do
+      let(:upgrade_requested_groups) { create_list :group, 1, status: :upgrade_requested }
+
+      it "shows a notification banner" do
+        expect(rendered).to have_css ".govuk-notification-banner", text: "You have one request to upgrade a trial group."
+      end
+    end
+
+    context "when there is more than one group with an upgrade requested" do
+      let(:upgrade_requested_groups) { create_list :group, 2, status: :upgrade_requested }
+
+      it "shows a notification banner with pluralized message" do
+        expect(rendered).to have_css ".govuk-notification-banner", text: "You have 2 requests to upgrade a trial group."
+      end
+    end
+
+    context "when there are no groups with an upgrade requested" do
+      let(:upgrade_requested_groups) { [] }
+
+      it "does not show a notification banner" do
+        expect(rendered).not_to have_css ".govuk-notification-banner"
+      end
     end
   end
 end

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -2,11 +2,13 @@ require "rails_helper"
 
 RSpec.describe "groups/index", type: :view do
   let(:trial_groups) { create_list :group, 2 }
+  let(:upgrade_requested_groups) { create_list :group, 2, status: :upgrade_requested }
   let(:active_groups) { create_list :group, 2, status: :active }
   let(:current_user) { build :editor_user }
 
   before do
     assign(:trial_groups, trial_groups)
+    assign(:upgrade_requested_groups, upgrade_requested_groups)
     assign(:active_groups, active_groups)
 
     assign(:current_user, current_user)
@@ -16,6 +18,10 @@ RSpec.describe "groups/index", type: :view do
 
   it "renders a list of groups" do
     trial_groups.each do |group|
+      expect(rendered).to have_link(group.name, href: group_path(group))
+    end
+
+    upgrade_requested_groups.each do |group|
       expect(rendered).to have_link(group.name, href: group_path(group))
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/4bS39P6Y/1485-request-group-upgrade-show-groups-which-have-requested-upgrade

Adds a section to the groups index page listing groups that an upgrade has been requested for. This section is only displayed if there are any upgrade requests.

For organisation admins and super admins, display a banner stating the number of upgrade requests.

<img width="872" alt="Screenshot 2024-05-09 at 16 00 54" src="https://github.com/alphagov/forms-admin/assets/5648592/8c9cb1e6-d620-4f5c-b1d5-0c07de31fadf">

<img width="872" alt="Screenshot 2024-05-09 at 16 02 03" src="https://github.com/alphagov/forms-admin/assets/5648592/62624ca1-b8a0-4167-a34d-c7ccac53a201">

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
