### PR TITLE
Cleanup default values for optional question

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -33,7 +33,7 @@ class Pages::QuestionsController < PagesController
     @question_input = Pages::QuestionInput.new(answer_type: draft_question.answer_type,
                                                question_text: draft_question.question_text,
                                                hint_text: draft_question.hint_text,
-                                               is_optional: draft_question.is_optional || false,
+                                               is_optional: draft_question.is_optional,
                                                answer_settings: draft_question.answer_settings)
     render :edit, locals: { current_form:, draft_question: }
   end

--- a/app/controllers/pages/selections_settings_controller.rb
+++ b/app/controllers/pages/selections_settings_controller.rb
@@ -1,6 +1,6 @@
 class Pages::SelectionsSettingsController < PagesController
   def new
-    @selections_settings_input = Pages::SelectionsSettingsInput.new(draft_question.answer_settings)
+    @selections_settings_input = Pages::SelectionsSettingsInput.new(**draft_question.answer_settings, include_none_of_the_above: draft_question.is_optional)
     @selections_settings_path = selections_settings_create_path(current_form)
     @back_link_url = question_text_new_path(current_form)
     render :selections_settings, locals: { current_form: }

--- a/spec/requests/pages/selections_settings_controller_spec.rb
+++ b/spec/requests/pages/selections_settings_controller_spec.rb
@@ -14,8 +14,7 @@ describe Pages::SelectionsSettingsController, type: :request do
            form_id: form.id,
            is_optional: false,
            answer_settings: { selection_options: [{ name: "" }, { name: "" }],
-                              only_one_option: false,
-                              include_none_of_the_above: false }
+                              only_one_option: false }
   end
   let(:page_id) { nil }
 
@@ -44,6 +43,27 @@ describe Pages::SelectionsSettingsController, type: :request do
 
     it "renders the template" do
       expect(response).to have_rendered("pages/selections_settings")
+    end
+
+    context "when draft question already contains selection settings" do
+      let(:draft_question) do
+        create :draft_question,
+               answer_type: "selection",
+               page_id:,
+               user: editor_user,
+               form_id: form.id,
+               is_optional: true,
+               answer_settings: { selection_options: [{ name: "Option 1" }, { name: "Option 2" }],
+                                  only_one_option: true }
+      end
+
+      it "returns the existing draft question answer settings" do
+        settings_form = assigns(:selections_settings_input)
+        draft_question_settings = draft_question.answer_settings
+        expect(settings_form.only_one_option).to eq draft_question_settings[:only_one_option]
+        expect(settings_form.selection_options.map { |option| { name: option[:name] } }).to eq(draft_question_settings[:selection_options].map { |option| { name: option[:name] } })
+        expect(settings_form.include_none_of_the_above).to eq draft_question.is_optional
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/WjhNHghp/1482-make-this-question-optional-checkbox-isnt-marked-as-optional

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Cleans up a null coalescing thing we don't need any more, since the `is_optional` value can now no longer be null (https://github.com/alphagov/forms-api/pull/480)

Includes a small fix for a bug I noticed while testing this - see the commit message for more details.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
