### PR TITLE
Add upgrade request review

### DIFF
--- a/app/mailers/group_upgrade_mailer.rb
+++ b/app/mailers/group_upgrade_mailer.rb
@@ -1,5 +1,5 @@
 class GroupUpgradeMailer < GovukNotifyRails::Mailer
-  def group_upgraded_email(upgraded_by_name:, to_email:, group_name:, group_url:)
+  def upgraded_email(to_email:, upgraded_by_name:, group_name:, group_url:)
     set_template(Settings.govuk_notify.group_upgraded_template_id)
 
     set_email_reply_to(Settings.govuk_notify.zendesk_reply_to_id)
@@ -28,7 +28,7 @@ class GroupUpgradeMailer < GovukNotifyRails::Mailer
     mail(to: to_email)
   end
 
-  def group_upgrade_requested_email(requester_name:, requester_email_address:, to_email:, group_name:, view_request_url:)
+  def requested_email(to_email:, requester_name:, requester_email_address:, group_name:, view_request_url:)
     set_template(Settings.govuk_notify.group_upgrade_requested_template_id)
 
     set_email_reply_to(Settings.govuk_notify.zendesk_reply_to_id)

--- a/app/mailers/group_upgrade_mailer.rb
+++ b/app/mailers/group_upgrade_mailer.rb
@@ -13,6 +13,21 @@ class GroupUpgradeMailer < GovukNotifyRails::Mailer
     mail(to: to_email)
   end
 
+  def rejected_email(to_email:, rejected_by_name:, rejected_by_email:, group_name:, group_url:)
+    set_template(Settings.govuk_notify.group_upgrade_rejected_template_id)
+
+    set_email_reply_to(Settings.govuk_notify.zendesk_reply_to_id)
+
+    set_personalisation(
+      rejected_by_name:,
+      rejected_by_email:,
+      group_name:,
+      group_url:,
+    )
+
+    mail(to: to_email)
+  end
+
   def group_upgrade_requested_email(requester_name:, requester_email_address:, to_email:, group_name:, view_request_url:)
     set_template(Settings.govuk_notify.group_upgrade_requested_template_id)
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,6 +3,8 @@ class Group < ApplicationRecord
 
   belongs_to :creator, class_name: "User", optional: true
 
+  belongs_to :upgrade_requester, class_name: "User", optional: true
+
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
 

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -5,18 +5,18 @@ class GroupPolicy < ApplicationPolicy
   alias_method :create?, :new?
 
   def show?
-    user.super_admin? || user.is_organisations_admin?(record.organisation) || user.groups.include?(record)
+    organisation_admin_or_super_admin? || user.groups.include?(record)
   end
 
   def edit?
-    user.super_admin? || user.is_organisations_admin?(record.organisation) || group_admin?
+    organisation_admin_or_super_admin? || group_admin?
   end
 
   alias_method :update?, :edit?
   alias_method :add_editor?, :edit?
 
   def upgrade?
-    user.super_admin? || user.is_organisations_admin?(record.organisation)
+    organisation_admin_or_super_admin?
   end
 
   alias_method :add_group_admin?, :upgrade?
@@ -25,7 +25,15 @@ class GroupPolicy < ApplicationPolicy
     group_admin? && !record.active?
   end
 
+  def review_upgrade?
+    organisation_admin_or_super_admin? && record.upgrade_requested?
+  end
+
 private
+
+  def organisation_admin_or_super_admin?
+    user.super_admin? || user.is_organisations_admin?(record.organisation)
+  end
 
   def group_admin?
     record.memberships.find_by(user:)&.group_admin?

--- a/app/service/group_service.rb
+++ b/app/service/group_service.rb
@@ -12,6 +12,11 @@ class GroupService
     send_group_upgraded_emails
   end
 
+  def reject_upgrade
+    @group.trial!
+    send_upgrade_rejected_emails
+  end
+
   def request_upgrade
     @group.upgrade_requester = @current_user
     @group.upgrade_requested!
@@ -22,13 +27,19 @@ private
 
   def send_group_upgraded_emails
     @group.memberships.each do |membership|
-      send_group_updated_email(membership.user.email) if notify_member?(membership)
+      send_group_upgraded_email(membership.user.email) if notify_member?(membership)
+    end
+  end
+
+  def send_upgrade_rejected_emails
+    @group.memberships.each do |membership|
+      send_upgrade_rejected_email(membership.user.email) if notify_member?(membership)
     end
   end
 
   def send_group_upgrade_requested_emails
     @group.organisation.admin_users.each do |user|
-      send_group_update_requested_email(user.email)
+      send_group_upgrade_requested_email(user.email)
     end
   end
 
@@ -36,7 +47,7 @@ private
     membership.group_admin? && membership.user.id != @current_user.id
   end
 
-  def send_group_updated_email(to_email)
+  def send_group_upgraded_email(to_email)
     GroupUpgradeMailer.upgraded_email(
       to_email:,
       upgraded_by_name: @current_user.name,
@@ -45,7 +56,17 @@ private
     ).deliver_now
   end
 
-  def send_group_update_requested_email(to_email)
+  def send_upgrade_rejected_email(to_email)
+    GroupUpgradeMailer.rejected_email(
+      to_email:,
+      rejected_by_name: @current_user.name,
+      rejected_by_email: @current_user.email,
+      group_name: @group.name,
+      group_url: group_url(@group, host: @host),
+    ).deliver_now
+  end
+
+  def send_group_upgrade_requested_email(to_email)
     GroupUpgradeMailer.requested_email(
       to_email:,
       requester_name: @current_user.name,

--- a/app/service/group_service.rb
+++ b/app/service/group_service.rb
@@ -37,19 +37,19 @@ private
   end
 
   def send_group_updated_email(to_email)
-    GroupUpgradeMailer.group_upgraded_email(
-      upgraded_by_name: @current_user.name,
+    GroupUpgradeMailer.upgraded_email(
       to_email:,
+      upgraded_by_name: @current_user.name,
       group_name: @group.name,
       group_url: group_url(@group, host: @host),
     ).deliver_now
   end
 
   def send_group_update_requested_email(to_email)
-    GroupUpgradeMailer.group_upgrade_requested_email(
+    GroupUpgradeMailer.requested_email(
+      to_email:,
       requester_name: @current_user.name,
       requester_email_address: @current_user.email,
-      to_email:,
       group_name: @group.name,
       view_request_url: group_url(@group, host: @host),
     ).deliver_now

--- a/app/service/group_service.rb
+++ b/app/service/group_service.rb
@@ -13,6 +13,7 @@ class GroupService
   end
 
   def request_upgrade
+    @group.upgrade_requester = @current_user
     @group.upgrade_requested!
     send_group_upgrade_requested_emails
   end

--- a/app/views/groups/review_upgrade.html.erb
+++ b/app/views/groups/review_upgrade.html.erb
@@ -1,0 +1,26 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.group_review_upgrade'), @confirm_upgrade_input.errors.any?)) %>
+
+<% content_for :back_link, govuk_back_link_to(@group, t("back_link.group", group_name: @group.name)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @confirm_upgrade_input, url: review_upgrade_group_path(@group)) do |f| %>
+      <% if @confirm_upgrade_input&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <%= t('page_titles.group_review_upgrade') %>
+      </h1>
+
+      <%= t('groups.review_upgrade.body_html', upgrade_requester_name: @group.upgrade_requester.name) %>
+
+      <%= f.govuk_collection_radio_buttons :confirm,
+                                           @confirm_upgrade_input.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_action_input.options.' + "#{option}") },
+                                           legend: { text: t('groups.review_upgrade.radios_legend'), size: 'm' },
+                                           inline: true %>
+
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,24 +1,30 @@
 <% set_page_title(@group.name) %>
 <% content_for :back_link, govuk_back_link_to(groups_path, t("back_link.groups")) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% unless @group.active? %>
+<% unless @group.active? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |nb| %>
-        <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
-        <% if policy(@group).upgrade? %>
-          <%= t("groups.show.trial_banner.org_admin_body_html") %>
-          <%= govuk_link_to t("groups.show.trial_banner.upgrade_group"), upgrade_group_path(@group) %>
+        <% if policy(@group).review_upgrade? %>
+          <% nb.with_heading(text: t("groups.show.trial_banner.review_upgrade.heading"), tag: "h3") %>
+          <%= t("groups.show.trial_banner.review_upgrade.body_html", upgrade_requester_name: @group.upgrade_requester.name) %>
+          <%= govuk_link_to t("groups.show.trial_banner.review_upgrade.link"), review_upgrade_group_path(@group) %>
+        <% elsif policy(@group).upgrade? %>
+          <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
+          <%= t("groups.show.trial_banner.upgrade.body_html") %>
+          <%= govuk_link_to t("groups.show.trial_banner.upgrade.link"), upgrade_group_path(@group) %>
         <% elsif policy(@group).request_upgrade? %>
-          <%= t("groups.show.trial_banner.group_admin_body_html") %>
-          <%= govuk_link_to t("groups.show.trial_banner.request_upgrade"), request_upgrade_group_path(@group) %>
+          <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
+          <%= t("groups.show.trial_banner.request_upgrade.body_html") %>
+          <%= govuk_link_to t("groups.show.trial_banner.request_upgrade.link"), request_upgrade_group_path(@group) %>
         <% else %>
-          <%= t("groups.show.trial_banner.editor_body_html") %>
+          <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
+          <%= t("groups.show.trial_banner.editor.body_html") %>
         <% end %>
       <% end %>
-    <% end %>
+    </div>
   </div>
-</div>
+<% end %>
 
 <%= render @group %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,14 +369,21 @@ en:
       edit_group_name: Change the name of this group
       review_group_members: Review members of this group
       trial_banner:
-        editor_body_html: |
-          <p>You can create a form, preview and test it.</p>
-          <p>Forms in this group cannot be made live unless the group is upgraded. Only a group admin can request for a group to be upgraded.</p>
-        group_admin_body_html: "<p>You can create forms in this group and test them, but you cannot make them live.</p>"
+        editor:
+          body_html: |
+            <p>You can create a form, preview and test it.</p>
+            <p>Forms in this group cannot be made live unless the group is upgraded. Only a group admin can request for a group to be upgraded.</p>
         heading: This is a ‘trial’ group
-        org_admin_body_html: "<p>Forms in this group cannot be made live unless the group is upgraded to an ‘active’ group.</p>"
-        request_upgrade: Find out how to upgrade this group so you can make forms live
-        upgrade_group: Upgrade this group
+        request_upgrade:
+          body_html: "<p>You can create forms in this group and test them, but you cannot make them live.</p>"
+          link: Find out how to upgrade this group so you can make forms live
+        review_upgrade:
+          body_html: "<p>%{upgrade_requester_name} has asked to upgrade this group so they can make forms live.</p>"
+          heading: A group admin has asked to upgrade this group
+          link: Accept or reject this upgrade request
+        upgrade:
+          body_html: "<p>Forms in this group cannot be made live unless the group is upgraded to an ‘active’ group.</p>"
+          link: Upgrade this group
     status_caption:
       active: Active group
       trial: Trial group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -358,6 +358,12 @@ en:
       upgrade_requests_title: Upgrade requests
     new:
       title: New group
+    review_upgrade:
+      body_html: |
+        <p>%{upgrade_requester_name} has asked to upgrade this group to an ‘active’ group.</p>
+        <p>If you upgrade this group, any group admins in it will be able to make forms live.</p>
+        <p>We’ll send an email to the group admins to let them know your response to the upgrade request.</p>
+      radios_legend: Do you want to upgrade this group?
     show:
       edit_group_members: Edit members of this group
       edit_group_name: Change the name of this group
@@ -844,6 +850,7 @@ en:
     forbidden: You cannot view this page
     group_confirm_upgrade_request: Request to upgrade this trial group
     group_index: Your groups
+    group_review_upgrade: Upgrade this group
     group_upgrade: Upgrade this group
     group_upgrade_requested: Your upgrade request has been sent
     home: Home

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,8 @@ Rails.application.routes.draw do
 
       get "request_upgrade", to: "groups#confirm_upgrade_request"
       post "request_upgrade", to: "groups#request_upgrade"
+      get "review_upgrade", to: "groups#review_upgrade"
+      post "review_upgrade", to: "groups#submit_review_upgrade"
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,6 +29,7 @@ govuk_notify:
   group_member_added_to_group_id: d1fc7267-7e27-4e6c-aa30-523b8be3d637
   group_upgraded_template_id: b5d0d3d4-fc24-403e-aba6-b421fdcebd55
   group_upgrade_requested_template_id: e2251c92-9365-429a-9857-56780263718f
+  group_upgrade_rejected_template_id: f494999a-1a38-4b01-a3c8-dbb2d60e6e5f
 
 # When set to true, any capybara tests will run chrome normally rather than in headless mode.
 show_browser_during_tests: false

--- a/db/migrate/20240509160514_add_upgrade_requester_to_group.rb
+++ b/db/migrate/20240509160514_add_upgrade_requester_to_group.rb
@@ -1,0 +1,5 @@
+class AddUpgradeRequesterToGroup < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :groups, :upgrade_requester, null: true, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_27_090626) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_09_160514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,9 +52,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_27_090626) do
     t.bigint "organisation_id"
     t.string "status", default: "trial"
     t.bigint "creator_id"
+    t.bigint "upgrade_requester_id"
     t.index ["creator_id"], name: "index_groups_on_creator_id"
     t.index ["external_id"], name: "index_groups_on_external_id", unique: true
     t.index ["organisation_id"], name: "index_groups_on_organisation_id"
+    t.index ["upgrade_requester_id"], name: "index_groups_on_upgrade_requester_id"
   end
 
   create_table "groups_form_ids", id: false, force: :cascade do |t|
@@ -131,6 +133,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_27_090626) do
 
   add_foreign_key "draft_questions", "users"
   add_foreign_key "groups", "users", column: "creator_id"
+  add_foreign_key "groups", "users", column: "upgrade_requester_id"
   add_foreign_key "memberships", "groups"
   add_foreign_key "memberships", "users"
   add_foreign_key "memberships", "users", column: "added_by_id"

--- a/spec/features/groups/request_upgrade_spec.rb
+++ b/spec/features/groups/request_upgrade_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+feature "Request an upgrade for a group", type: :feature do
+  let!(:group) do
+    create(:group, organisation: editor_user.organisation).tap do |group|
+      create(:membership, user: editor_user, group:, role: :group_admin)
+    end
+  end
+
+  scenario "a group admin requests an upgrade that is approved by an admin user" do
+    login_as_editor_user
+
+    visit groups_path
+    expect(page.find("h1")).to have_text "Your groups"
+    expect_page_to_have_no_axe_errors(page)
+
+    click_link group.name
+    expect(page.find("h1")).to have_text group.name
+    expect(page).to have_css ".govuk-caption-l", text: "Trial group"
+    expect_page_to_have_no_axe_errors(page)
+
+    click_link "Find out how to upgrade this group so you can make forms live"
+    expect(page.find("h1")).to have_text "Request to upgrade this trial group"
+    expect_page_to_have_no_axe_errors(page)
+
+    click_link_or_button "Send request to upgrade"
+    expect(page.find("h1")).to have_text "Your upgrade request has been sent"
+    expect_page_to_have_no_axe_errors(page)
+
+    login_as_organisation_admin_user
+
+    visit groups_path
+    expect(page).to have_css ".govuk-notification-banner", text: "You have one request to upgrade a trial group."
+    expect_page_to_have_no_axe_errors(page)
+
+    click_link group.name
+    expect(page.find("h3")).to have_text "A group admin has asked to upgrade this group"
+    expect(page).to have_css ".govuk-notification-banner", text: "#{editor_user.name} has asked to upgrade this group so they can make forms live."
+    expect_page_to_have_no_axe_errors(page)
+
+    click_link "Accept or reject this upgrade request"
+    expect(page).to have_text "#{editor_user.name} has asked to upgrade this group to an ‘active’ group."
+    expect(page.find("h1")).to have_text "Upgrade this group"
+    expect_page_to_have_no_axe_errors(page)
+
+    choose "Yes"
+    click_button "Save and continue"
+    expect(page).to have_css ".govuk-notification-banner--success", text: "This group is now active"
+    expect(page).to have_css ".govuk-caption-l", text: "Active group"
+    expect_page_to_have_no_axe_errors(page)
+  end
+end

--- a/spec/mailers/group_upgrade_mailer_spec.rb
+++ b/spec/mailers/group_upgrade_mailer_spec.rb
@@ -29,6 +29,37 @@ describe GroupUpgradeMailer, type: :mailer do
     end
   end
 
+  describe "#rejected_email" do
+    subject(:mail) do
+      described_class.rejected_email(
+        to_email:,
+        rejected_by_name: current_user.name,
+        rejected_by_email: current_user.email,
+        group_name: group.name,
+        group_url:,
+      )
+    end
+
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.group_upgrade_rejected_template_id)
+    end
+
+    it "sends an email with the correct reply-to value" do
+      expect(mail.govuk_notify_email_reply_to).to eq(Settings.govuk_notify.zendesk_reply_to_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq([to_email])
+    end
+
+    it "includes the personalisation" do
+      expect(mail.govuk_notify_personalisation[:rejected_by_name]).to eq(current_user.name)
+      expect(mail.govuk_notify_personalisation[:rejected_by_email]).to eq(current_user.email)
+      expect(mail.govuk_notify_personalisation[:group_name]).to eq(group.name)
+      expect(mail.govuk_notify_personalisation[:group_url]).to eq(group_url)
+    end
+  end
+
   describe "#group_upgrade_requested_email" do
     subject(:mail) do
       described_class.group_upgrade_requested_email(

--- a/spec/mailers/group_upgrade_mailer_spec.rb
+++ b/spec/mailers/group_upgrade_mailer_spec.rb
@@ -8,9 +8,9 @@ describe GroupUpgradeMailer, type: :mailer do
 
   describe "#group_upgraded_email" do
     subject(:mail) do
-      described_class.group_upgraded_email(
-        upgraded_by_name: current_user.name,
+      described_class.upgraded_email(
         to_email:,
+        upgraded_by_name: current_user.name,
         group_name: group.name,
         group_url:,
       )
@@ -62,11 +62,12 @@ describe GroupUpgradeMailer, type: :mailer do
 
   describe "#group_upgrade_requested_email" do
     subject(:mail) do
-      described_class.group_upgrade_requested_email(
+      described_class.requested_email(
+        to_email:,
         requester_name: current_user.name,
         requester_email_address: current_user.email,
-        to_email:, group_name: group.name,
-        view_request_url: group_url
+        group_name: group.name,
+        view_request_url: group_url,
       )
     end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe Group, type: :model do
       group = build :group, creator: nil
       expect(group).to be_valid
     end
+
+    it "is valid without an upgrade requester" do
+      group = build :group, upgrade_requester: nil
+      expect(group).to be_valid
+    end
   end
 
   describe "before_create" do
@@ -69,6 +74,13 @@ RSpec.describe Group, type: :model do
     it "does not destroy associated creator" do
       user = create :user
       group = create :group, creator: user
+
+      expect { group.destroy }.not_to change(User, :count)
+    end
+
+    it "does not destroy associated upgrade requester" do
+      user = create :user
+      group = create :group, upgrade_requester: user
 
       expect { group.destroy }.not_to change(User, :count)
     end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -10,12 +10,20 @@ RSpec.describe GroupPolicy do
   context "when user is super_admin" do
     let(:user) { build :super_admin_user }
 
-    it "permits all actions" do
-      expect(policy).to forbid_only_actions(%i[request_upgrade])
+    it "forbids only request_upgrade and review_upgrade" do
+      expect(policy).to forbid_only_actions(%i[request_upgrade review_upgrade])
     end
 
     it "scope resolves to all groups" do
       expect(GroupPolicy::Scope.new(user, Group).resolve).to eq(Group.all)
+    end
+
+    context "when the group has status upgrade_requested" do
+      let(:group) { build :group, organisation:, status: :upgrade_requested }
+
+      it "permits review_upgrade" do
+        expect(policy).to permit_action(:review_upgrade)
+      end
     end
   end
 
@@ -23,8 +31,8 @@ RSpec.describe GroupPolicy do
     let(:user) { build :organisation_admin_user, organisation: }
 
     context "and in the same organisation as the group" do
-      it "permits all actions" do
-        expect(policy).to forbid_only_actions(%i[request_upgrade])
+      it "forbids only request_upgrade and review_upgrade" do
+        expect(policy).to forbid_only_actions(%i[request_upgrade review_upgrade])
       end
     end
 
@@ -33,6 +41,14 @@ RSpec.describe GroupPolicy do
 
       it "permits new and create only" do
         expect(policy).to permit_only_actions(%i[new create])
+      end
+    end
+
+    context "when the group has status upgrade_requested" do
+      let(:group) { build :group, organisation:, status: :upgrade_requested }
+
+      it "permits review_upgrade" do
+        expect(policy).to permit_action(:review_upgrade)
       end
     end
 
@@ -65,8 +81,8 @@ RSpec.describe GroupPolicy do
         create :membership, user:, group:, role: :group_admin
       end
 
-      it "forbids upgrade and add_group_admin" do
-        expect(policy).to forbid_only_actions(%i[upgrade add_group_admin])
+      it "forbids upgrade, add_group_admin and review_upgrade" do
+        expect(policy).to forbid_only_actions(%i[upgrade add_group_admin review_upgrade])
       end
 
       context "when the group status is active" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "/groups", type: :request do
 
       it "has a link to upgrade the trial group" do
         get group_url(member_group)
-        expect(response.body).to include(I18n.t("groups.show.trial_banner.upgrade_group"))
+        expect(response.body).to include(I18n.t("groups.show.trial_banner.upgrade.link"))
       end
     end
   end

--- a/spec/service/group_service_spec.rb
+++ b/spec/service/group_service_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe GroupService do
   end
 
   let(:group) { create :group }
-  let(:current_user) { create :user, email: "current_user@example.gov.uk" }
+  let(:current_user) { create :user }
   let(:host) { "example.net" }
 
   describe "#upgrade_group" do
-    let(:group_admin_user1) { create :user, email: "user1@example.gov.uk" }
-    let(:group_admin_user2) { create :user, email: "user2@example.gov.uk" }
-    let(:editor_user) { create :user, email: "user3@example.gov.uk" }
+    let(:group_admin_user1) { create :user }
+    let(:group_admin_user2) { create :user }
+    let(:editor_user) { create :user }
     let(:group) do
       create(:group).tap do |group|
         create(:membership, user: group_admin_user1, group:, role: :group_admin)
@@ -38,13 +38,13 @@ RSpec.describe GroupService do
       group_service.upgrade_group
       expect(delivery).to have_received(:deliver_now).with(no_args).exactly(2).times
       expect(GroupUpgradeMailer).to have_received(:upgraded_email).with(
-        to_email: "user1@example.gov.uk",
+        to_email: group_admin_user1.email,
         upgraded_by_name: current_user.name,
         group_name: group.name,
         group_url: group_url(group, host:),
       )
       expect(GroupUpgradeMailer).to have_received(:upgraded_email).with(
-        to_email: "user2@example.gov.uk",
+        to_email: group_admin_user2.email,
         upgraded_by_name: current_user.name,
         group_name: group.name,
         group_url: group_url(group, host:),
@@ -62,10 +62,66 @@ RSpec.describe GroupService do
     end
   end
 
+  describe "#reject_upgrade" do
+    let(:group_admin_user1) { create :user }
+    let(:group_admin_user2) { create :user }
+    let(:editor_user) { create :user }
+    let(:group) do
+      create(:group, status: :upgrade_requested).tap do |group|
+        create(:membership, user: group_admin_user1, group:, role: :group_admin)
+        create(:membership, user: group_admin_user2, group:, role: :group_admin)
+        create(:membership, user: editor_user, group:, role: :editor)
+        create(:membership, user: current_user, group:, role: :group_admin)
+      end
+    end
+    let(:delivery) { double }
+
+    before do
+      allow(GroupUpgradeMailer).to receive(:rejected_email).and_return(delivery)
+      allow(delivery).to receive(:deliver_now).with(no_args)
+    end
+
+    it "changes the group status to trial" do
+      expect {
+        group_service.reject_upgrade
+      }.to change(group, :status).to("trial")
+    end
+
+    it "sends an email to all group admins" do
+      group_service.reject_upgrade
+      expect(delivery).to have_received(:deliver_now).with(no_args).exactly(2).times
+      expect(GroupUpgradeMailer).to have_received(:rejected_email).with(
+        to_email: group_admin_user1.email,
+        rejected_by_name: current_user.name,
+        rejected_by_email: current_user.email,
+        group_name: group.name,
+        group_url: group_url(group, host:),
+      )
+      expect(GroupUpgradeMailer).to have_received(:rejected_email).with(
+        to_email: group_admin_user2.email,
+        rejected_by_name: current_user.name,
+        rejected_by_email: current_user.email,
+        group_name: group.name,
+        group_url: group_url(group, host:),
+      )
+    end
+
+    it "does not send an email to the logged in user that rejected the upgrade if they are a group admin" do
+      group_service.reject_upgrade
+      expect(GroupUpgradeMailer).not_to have_received(:rejected_email).with(
+        to_email: current_user.email,
+        rejected_by_name: current_user.name,
+        rejected_by_email: current_user.email,
+        group_name: group.name,
+        group_url: group_url(group, host:),
+      )
+    end
+  end
+
   describe "#request_upgrade" do
-    let!(:organisation_admin_user1) { create :organisation_admin_user, email: "user1@example.gov.uk" }
-    let!(:organisation_admin_user2) { create :organisation_admin_user, email: "user2@example.gov.uk" }
-    let(:editor_user) { create :user, email: "user3@example.gov.uk" }
+    let!(:organisation_admin_user1) { create :organisation_admin_user }
+    let!(:organisation_admin_user2) { create :organisation_admin_user }
+    let(:editor_user) { create :user }
     let(:group) do
       create(:group).tap do |group|
         create(:membership, user: editor_user, group:, role: :editor)

--- a/spec/service/group_service_spec.rb
+++ b/spec/service/group_service_spec.rb
@@ -64,7 +64,13 @@ RSpec.describe GroupService do
       allow(delivery).to receive(:deliver_now).with(no_args)
     end
 
-    it "upgrades the group to active" do
+    it "sets the upgrade_requester on the group" do
+      expect {
+        group_service.request_upgrade
+      }.to change(group, :upgrade_requester).to(current_user)
+    end
+
+    it "sets the group status to upgrade_requested" do
       expect {
         group_service.request_upgrade
       }.to change(group, :status).to("upgrade_requested")

--- a/spec/service/group_service_spec.rb
+++ b/spec/service/group_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GroupService do
     let(:delivery) { double }
 
     before do
-      allow(GroupUpgradeMailer).to receive(:group_upgraded_email).and_return(delivery)
+      allow(GroupUpgradeMailer).to receive(:upgraded_email).and_return(delivery)
       allow(delivery).to receive(:deliver_now).with(no_args)
     end
 
@@ -37,13 +37,28 @@ RSpec.describe GroupService do
     it "sends an email to all group admins" do
       group_service.upgrade_group
       expect(delivery).to have_received(:deliver_now).with(no_args).exactly(2).times
-      expect(GroupUpgradeMailer).to have_received(:group_upgraded_email).with(upgraded_by_name: current_user.name, to_email: "user1@example.gov.uk", group_name: group.name, group_url: group_url(group, host:))
-      expect(GroupUpgradeMailer).to have_received(:group_upgraded_email).with(upgraded_by_name: current_user.name, to_email: "user2@example.gov.uk", group_name: group.name, group_url: group_url(group, host:))
+      expect(GroupUpgradeMailer).to have_received(:upgraded_email).with(
+        to_email: "user1@example.gov.uk",
+        upgraded_by_name: current_user.name,
+        group_name: group.name,
+        group_url: group_url(group, host:),
+      )
+      expect(GroupUpgradeMailer).to have_received(:upgraded_email).with(
+        to_email: "user2@example.gov.uk",
+        upgraded_by_name: current_user.name,
+        group_name: group.name,
+        group_url: group_url(group, host:),
+      )
     end
 
     it "does not send an email to the logged in user that performed the upgrade if they are a group admin" do
       group_service.upgrade_group
-      expect(GroupUpgradeMailer).not_to have_received(:group_upgraded_email).with(upgraded_by_name: current_user.name, to_email: current_user.email, group_name: group.name, group_url: group_url(group, host:))
+      expect(GroupUpgradeMailer).not_to have_received(:upgraded_email).with(
+        to_email: current_user.email,
+        upgraded_by_name: current_user.name,
+        group_name: group.name,
+        group_url: group_url(group, host:),
+      )
     end
   end
 
@@ -60,7 +75,7 @@ RSpec.describe GroupService do
     let(:delivery) { double }
 
     before do
-      allow(GroupUpgradeMailer).to receive(:group_upgrade_requested_email).and_return(delivery)
+      allow(GroupUpgradeMailer).to receive(:requested_email).and_return(delivery)
       allow(delivery).to receive(:deliver_now).with(no_args)
     end
 
@@ -77,18 +92,18 @@ RSpec.describe GroupService do
     end
 
     it "sends an email to all organisation admins" do
-      expect(GroupUpgradeMailer).to receive(:group_upgrade_requested_email).with(
+      expect(GroupUpgradeMailer).to receive(:requested_email).with(
+        to_email: organisation_admin_user1.email,
         requester_name: current_user.name,
         requester_email_address: current_user.email,
-        to_email: organisation_admin_user1.email,
         group_name: group.name,
         view_request_url: group_url(group, host:),
       )
 
-      expect(GroupUpgradeMailer).to receive(:group_upgrade_requested_email).with(
+      expect(GroupUpgradeMailer).to receive(:requested_email).with(
+        to_email: organisation_admin_user2.email,
         requester_name: current_user.name,
         requester_email_address: current_user.email,
-        to_email: organisation_admin_user2.email,
         group_name: group.name,
         view_request_url: group_url(group, host:),
       )
@@ -98,10 +113,10 @@ RSpec.describe GroupService do
 
     it "does not send an email to a user without the organisation admin role" do
       group_service.request_upgrade
-      expect(GroupUpgradeMailer).not_to have_received(:group_upgrade_requested_email).with(
+      expect(GroupUpgradeMailer).not_to have_received(:requested_email).with(
+        to_email: editor_user.email,
         requester_name: current_user.name,
         requester_email_address: current_user.email,
-        to_email: editor_user.email,
         group_name: group.name,
         view_request_url: group_url(group, host:),
       )

--- a/spec/views/groups/review_upgrade.html.erb_spec.rb
+++ b/spec/views/groups/review_upgrade.html.erb_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe "groups/review_upgrade.html.erb" do
+  let(:current_user) { create(:user) }
+  let(:group) { create(:group, upgrade_requester: current_user) }
+  let(:confirm_upgrade_input) { Groups::ConfirmUpgradeInput.new }
+  let(:page) { Capybara.string(rendered.html) }
+
+  before do
+    assign(:confirm_upgrade_input, confirm_upgrade_input)
+    assign(:group, group)
+  end
+
+  context "when there are no errors" do
+    before do
+      render
+    end
+
+    it "has a back link to group page" do
+      expect(view.content_for(:back_link)).to have_link("Back", href: group_path(group))
+    end
+
+    it "has a form that will POST to the correct URL" do
+      expect(rendered).to have_css("form[action='#{review_upgrade_group_path(group)}'][method='post']")
+      expect(rendered).to have_field("groups_confirm_upgrade_input[confirm]")
+      expect(rendered).to have_button("Save and continue")
+    end
+
+    it "renders content containing the name of the user that requested an upgrade" do
+      expect(rendered).to have_text("#{current_user.name} has asked to upgrade this group to an ‘active’ group.")
+    end
+  end
+
+  context "when there are errors" do
+    before do
+      confirm_upgrade_input.errors.add(:confirm, "is required")
+      render
+    end
+
+    it "displays the error summary" do
+      expect(rendered).to have_selector(".govuk-error-summary")
+    end
+
+    it "displays an inline error message" do
+      expect(page.find("fieldset", text: "Do you want to upgrade this group?")).to have_selector(".govuk-error-message")
+    end
+
+    it "sets the page title with error prefix" do
+      expect(view.content_for(:title)).to eq(title_with_error_prefix("Upgrade this group", true))
+    end
+  end
+end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -107,50 +107,35 @@ RSpec.describe "groups/show", type: :view do
       expect(rendered).to have_css ".govuk-notification-banner"
     end
 
-    context "when the user has permission to upgrade the form" do
+    context "when the user has permission to upgrade the group" do
       let(:upgrade?) { true }
+      let(:request_upgrade?) { true }
 
-      context "and the user has permission to request an upgrade" do
-        let(:request_upgrade?) { true }
-
-        it "shows content for an organisation admin" do
-          expect(rendered).to have_text "Forms in this group cannot be made live unless the group is upgraded to an ‘active’ group."
-        end
-
-        it "shows a link to upgrade the group" do
-          expect(rendered).to have_link("Upgrade this group", href: upgrade_group_path(group))
-        end
+      it "shows content for an organisation admin" do
+        expect(rendered).to have_text "Forms in this group cannot be made live unless the group is upgraded to an ‘active’ group."
       end
 
-      context "and the user does not have permission to request an upgrade" do
-        it "shows content for an organisation admin" do
-          expect(rendered).to have_text "Forms in this group cannot be made live unless the group is upgraded to an ‘active’ group."
-        end
-
-        it "shows a link to upgrade the group" do
-          expect(rendered).to have_link("Upgrade this group", href: upgrade_group_path(group))
-        end
+      it "shows a link to upgrade the group" do
+        expect(rendered).to have_link("Upgrade this group", href: upgrade_group_path(group))
       end
     end
+  end
 
-    context "when the user does not have permission to upgrade the form" do
-      context "and the user has permission to request an upgrade" do
-        let(:request_upgrade?) { true }
+  context "and the user has permission to request an upgrade" do
+    let(:request_upgrade?) { true }
 
-        it "shows content for a group admin" do
-          expect(rendered).to have_text "You can create forms in this group and test them, but you cannot make them live."
-        end
+    it "shows content for a group admin" do
+      expect(rendered).to have_text "You can create forms in this group and test them, but you cannot make them live."
+    end
 
-        it "shows a link to request an upgrade" do
-          expect(rendered).to have_link("Find out how to upgrade this group so you can make forms live", href: request_upgrade_group_path(group))
-        end
-      end
+    it "shows a link to request an upgrade" do
+      expect(rendered).to have_link("Find out how to upgrade this group so you can make forms live", href: request_upgrade_group_path(group))
+    end
+  end
 
-      context "and the user does not have permission to request an upgrade" do
-        it "shows content for an editor" do
-          expect(rendered).to have_text "You can create a form, preview and test it."
-        end
-      end
+  context "and the user has no permissions relating to upgrading groups" do
+    it "shows content for an editor" do
+      expect(rendered).to have_text "You can create a form, preview and test it."
     end
   end
 

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "groups/show", type: :view do
   let(:upgrade?) { false }
   let(:edit?) { true }
   let(:request_upgrade?) { false }
+  let(:review_upgrade?) { false }
 
   before do
     assign(:current_user, current_user)
@@ -14,7 +15,12 @@ RSpec.describe "groups/show", type: :view do
     assign(:forms, forms)
 
     without_partial_double_verification do
-      allow(view).to receive(:policy).and_return(instance_double(GroupPolicy, upgrade?: upgrade?, edit?: edit?, request_upgrade?: request_upgrade?))
+      double = instance_double(GroupPolicy,
+                               upgrade?: upgrade?,
+                               edit?: edit?,
+                               request_upgrade?: request_upgrade?,
+                               review_upgrade?: review_upgrade?)
+      allow(view).to receive(:policy).and_return(double)
     end
 
     render
@@ -107,6 +113,10 @@ RSpec.describe "groups/show", type: :view do
       expect(rendered).to have_css ".govuk-notification-banner"
     end
 
+    it "has the trial group heading in the notification banner" do
+      expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
+    end
+
     context "when the user has permission to upgrade the group" do
       let(:upgrade?) { true }
       let(:request_upgrade?) { true }
@@ -117,6 +127,10 @@ RSpec.describe "groups/show", type: :view do
 
       it "shows a link to upgrade the group" do
         expect(rendered).to have_link("Upgrade this group", href: upgrade_group_path(group))
+      end
+
+      it "has the trial group heading in the notification banner" do
+        expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
       end
     end
   end
@@ -130,6 +144,10 @@ RSpec.describe "groups/show", type: :view do
 
     it "shows a link to request an upgrade" do
       expect(rendered).to have_link("Find out how to upgrade this group so you can make forms live", href: request_upgrade_group_path(group))
+    end
+
+    it "has the trial group heading in the notification banner" do
+      expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
     end
   end
 
@@ -148,6 +166,30 @@ RSpec.describe "groups/show", type: :view do
 
     it "shows a notification banner" do
       expect(rendered).to have_css ".govuk-notification-banner"
+    end
+
+    it "has the trial group heading in the notification banner" do
+      expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
+    end
+
+    context "when the user has permission to review upgrade requests" do
+      let(:review_upgrade?) { true }
+      let(:upgrade?) { true }
+      let(:request_upgrade?) { true }
+      let(:upgrade_requester) { create :user }
+      let(:group) { create :group, status: :upgrade_requested, upgrade_requester: }
+
+      it "has the heading in the notification banner for reviewing an upgrade request" do
+        expect(rendered).to have_css "h3", text: "A group admin has asked to upgrade this group"
+      end
+
+      it "has the content in the notification banner for reviewing an upgrade request" do
+        expect(rendered).to have_text "#{upgrade_requester.name} has asked to upgrade this group so they can make forms live."
+      end
+
+      it "shows a link to review the upgrade" do
+        expect(rendered).to have_link("Accept or reject this upgrade request", href: review_upgrade_group_path(group))
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UTcd8lwc/1486-request-group-upgrade-add-approve-request

When an upgrade has been requested for a group, display a notification banner for organisation/super admins to review the request:

<img width="872" alt="Screenshot 2024-05-13 at 18 15 57" src="https://github.com/alphagov/forms-admin/assets/5648592/e6e23309-9039-461f-8f0d-6323e17dfbe6">

When the link is clicked, a confirmation page is shown to accept or reject:

<img width="872" alt="Screenshot 2024-05-13 at 18 16 02" src="https://github.com/alphagov/forms-admin/assets/5648592/641e4711-61c6-4066-a224-96055a95915a">

If no option is chosen, an error message is shown:

<img width="872" alt="Screenshot 2024-05-13 at 18 16 07" src="https://github.com/alphagov/forms-admin/assets/5648592/54285805-ba2d-4f4a-9039-7b52a110315e">

When "Yes" is selected, the group is upgraded to `active` and the user is redirected to the group page with a success banner. The same email that is sent for when a group is upgraded without a request (already implemented) is sent to all group admins.

<img width="872" alt="Screenshot 2024-05-13 at 18 16 14" src="https://github.com/alphagov/forms-admin/assets/5648592/517a827a-5eaf-4fca-87a2-fe66821c6353">

When "No" is selected, the group status is changed back to `trial`. An email is sent to all group admins to tell them the request was rejected.

<img width="1184" alt="Screenshot 2024-05-14 at 15 36 38" src="https://github.com/alphagov/forms-admin/assets/5648592/b4ec6762-2b6a-4499-9166-b12723f2221f">

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
