### PR TITLE
Add new group member role

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -10,6 +10,7 @@ class GroupMembersController < ApplicationController
   def new
     authorize @group, :add_editor?
     @group_member_input = GroupMemberInput.new
+    render locals: { show_role_options: show_role_options? }
   end
 
   def create
@@ -19,7 +20,7 @@ class GroupMembersController < ApplicationController
     if @group_member_input.submit
       redirect_to group_members_path(@group.external_id)
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity, locals: { show_role_options: show_role_options? }
     end
   end
 
@@ -31,10 +32,22 @@ private
 
   def group_member_params
     ## TODO: We are passing in host here because the admin doesn't know it's own URL to use in emails
-    params.require(:group_member_input).permit(:member_email_address).merge(group: @group, creator: current_user, host: request.host)
+    params.require(:group_member_input).permit(:member_email_address).merge(role: new_member_role, group: @group, creator: current_user, host: request.host)
+  end
+
+  def new_member_role
+    if policy(@group).add_group_admin?
+      params.require(:group_member_input).permit(:role)[:role]
+    else
+      Membership.roles[:editor]
+    end
   end
 
   def show_actions?
     @group.memberships.any? { |membership| policy(membership).update? || policy(membership).destroy? }
+  end
+
+  def show_role_options?
+    policy(@group).add_group_admin?
   end
 end

--- a/app/input_objects/group_member_input.rb
+++ b/app/input_objects/group_member_input.rb
@@ -2,11 +2,12 @@ class GroupMemberInput < BaseInput
   include ActiveModel::Validations::Callbacks
   include Rails.application.routes.url_helpers
 
-  attr_accessor :member_email_address, :group, :creator, :host
+  attr_accessor :member_email_address, :group, :creator, :host, :role
 
   EMAIL_REGEX = /.*@.*/
 
   validates :member_email_address, presence: true
+  validates :role, presence: true
   validates :member_email_address, format: { with: EMAIL_REGEX, message: :invalid_email }
   validate :invited_user_has_account, if: -> { member_email_address.present? }
 
@@ -24,6 +25,10 @@ class GroupMemberInput < BaseInput
     true
   end
 
+  def role_options
+    Membership.roles.keys.map { |role| [I18n.t("membership.roles.#{role}"), role] }
+  end
+
 private
 
   def invited_user
@@ -31,7 +36,7 @@ private
   end
 
   def new_membership
-    @new_membership ||= group.memberships.new(user: invited_user, role: :editor, added_by: creator)
+    @new_membership ||= group.memberships.new(user: invited_user, role:, added_by: creator)
   end
 
   def invited_user_has_account

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -19,6 +19,8 @@ class GroupPolicy < ApplicationPolicy
     user.super_admin? || user.is_organisations_admin?(record.organisation)
   end
 
+  alias_method :add_group_admin?, :upgrade?
+
   def request_upgrade?
     group_admin? && !record.active?
   end

--- a/app/views/group_members/index.html.erb
+++ b/app/views/group_members/index.html.erb
@@ -51,8 +51,10 @@
 <% end %>
 <% end %>
 
-<% if Pundit.policy(@current_user, @group).edit? %>
+<% if policy(@group).add_group_admin? %>
   <%= govuk_link_to(t(".add_member"), new_group_member_path(@group), class: "govuk-button") %>
+<% elsif policy(@group).add_editor? %>
+  <%= govuk_link_to(t(".add_editor"), new_group_member_path(@group), class: "govuk-button") %>
 <% end %>
 
 <div class="govuk-!-margin-top-3">

--- a/app/views/group_members/new.html.erb
+++ b/app/views/group_members/new.html.erb
@@ -1,4 +1,8 @@
-<% set_page_title(t(".title")) %>
+<% if show_role_options %>
+  <% set_page_title(t(".title_show_role_options")) %>
+<% else %>
+  <% set_page_title(t(".title")) %>
+<% end %>
 <% content_for :back_link, govuk_back_link_to(group_members_path(@group)) %>
 
 <div class="govuk-grid-row">
@@ -6,7 +10,11 @@
     <h1 id="heading" class="govuk-heading-l">
       <span class="govuk-caption-l"><%= @group.name %></span>
       <span class="govuk-visually-hidden"> - </span>
-      <%= t(".title") %>
+      <% if show_role_options %>
+        <%= t(".title_show_role_options") %>
+      <% else %>
+        <%= t(".title") %>
+      <% end %>
     </h1>
 
     <%= t(".body_html") %>
@@ -17,6 +25,17 @@
       <% end %>
 
       <%= f.govuk_text_field :member_email_address, label: {  tag: 'h2', size: 'm' } %>
+
+      <% if show_role_options %>
+        <%= f.govuk_collection_radio_buttons(
+              :role,
+              Membership.roles.keys.sort,
+              ->(option) { option },
+              ->(option) { t("helpers.label.group_member_input.roles.#{option}.name") },
+              ->(option) { t("helpers.label.group_member_input.roles.#{option}.description") },
+              legend: { text: t('helpers.label.group_member_input.role'), size: 'm', tag: 'h2' },
+            )  %>
+      <% end %>
       <%= f.govuk_submit t(".submit") %>
     <% end %>
   </div>

--- a/app/views/group_members/new.html.erb
+++ b/app/views/group_members/new.html.erb
@@ -7,22 +7,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 id="heading" class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= @group.name %></span>
-      <span class="govuk-visually-hidden"> - </span>
-      <% if show_role_options %>
-        <%= t(".title_show_role_options") %>
-      <% else %>
-        <%= t(".title") %>
-      <% end %>
-    </h1>
-
-    <%= t(".body_html") %>
 
     <%= form_with(model: @group_member_input, url: group_members_path(@group)) do |f| %>
       <% if @group_member_input&.errors.any? %>
         <%= f.govuk_error_summary %>
       <% end %>
+
+      <h1 id="heading" class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @group.name %></span>
+        <span class="govuk-visually-hidden"> - </span>
+        <% if show_role_options %>
+          <%= t(".title_show_role_options") %>
+        <% else %>
+          <%= t(".title") %>
+        <% end %>
+      </h1>
+
+      <%= t(".body_html") %>
 
       <%= f.govuk_text_field :member_email_address, label: {  tag: 'h2', size: 'm' } %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
               not_forms_user: This person does not have a GOV.UK Forms account
               taken: This person is already a member of the group
               user_in_other_org: This person has a different organisation set for their GOV.UK Forms account
+            role:
+              blank: Select the role this person should have
         page:
           attributes:
             hint_text:
@@ -309,6 +311,7 @@ en:
         <p>You must use their government email address.</p>
       submit: Add this person
       title: Add an editor to this group
+      title_show_role_options: Add an editor or group admin to this group
   groups:
     confirm_upgrade:
       body_html: |
@@ -466,6 +469,14 @@ en:
         confirm: Are you sure you want to make your form live?
       group_member_input:
         member_email_address: Enter the email address of the person you want to add
+        role: What role should they have in this group?
+        roles:
+          editor:
+            description: They’ll be able to create and edit forms in this group.
+            name: Editor
+          group_admin:
+            description: They’ll be able to create and edit forms, make forms live and add editors to this group.
+            name: Group admin
       mou_signature:
         agreed_options:
           '1': I agree to the MOU on behalf of my organisation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,7 +278,8 @@ en:
     confirm_deletion_page: Are you sure you want to delete this page?
   group_members:
     index:
-      add_member: Add an editor
+      add_editor: Add an editor
+      add_member: Add an editor or group admin
       details:
         summary_content_html: |
           <p>An editor can edit forms in a group but cannot make forms live.</p>

--- a/spec/input_objects/group_member_input_spec.rb
+++ b/spec/input_objects/group_member_input_spec.rb
@@ -7,9 +7,15 @@ describe GroupMemberInput do
   let(:user) { create(:user, organisation: group.organisation) }
 
   describe "validations" do
-    it "is valid with an email address" do
+    it "is valid with an email address and role" do
       group_member_input.member_email_address = user.email
+      group_member_input.role = :editor
       expect(group_member_input).to be_valid
+    end
+
+    it "is invalid without a role" do
+      group_member_input.member_email_address = user.email
+      expect(group_member_input).not_to be_valid
     end
 
     it "is invalid without an email address" do
@@ -36,6 +42,7 @@ describe GroupMemberInput do
     it "is valid with a email address that is a GOV.UK forms user" do
       user = create(:user)
       group_member_input.member_email_address = user.email
+      group_member_input.role = :editor
       expect(group_member_input).to be_valid
     end
 
@@ -73,6 +80,7 @@ describe GroupMemberInput do
         before do
           group_member_input.group = group
           group_member_input.member_email_address = user.email
+          group_member_input.role = :editor
           group_member_input.creator = user
           group_member_input.host = "example.net"
 

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe GroupPolicy do
         create :membership, user:, group:, role: :group_admin
       end
 
-      it "forbids upgrade" do
-        expect(policy).to forbid_only_actions(%i[upgrade])
+      it "forbids upgrade and add_group_admin" do
+        expect(policy).to forbid_only_actions(%i[upgrade add_group_admin])
       end
 
       context "when the group status is active" do

--- a/spec/views/group_members/new.html.erb_spec.rb
+++ b/spec/views/group_members/new.html.erb_spec.rb
@@ -4,11 +4,12 @@ RSpec.describe "group_members/new", type: :view do
   let(:organisation) { build(:organisation, slug: "Department for testing new group members") }
   let(:group) { create(:group, name: "Group 1", organisation:) }
   let(:group_member_input) { GroupMemberInput.new }
+  let(:show_role_options) { false }
 
   before do
     assign(:group, group)
     assign(:group_member_input, group_member_input)
-    render
+    render locals: { show_role_options: }
   end
 
   it "displays the group name" do
@@ -21,5 +22,19 @@ RSpec.describe "group_members/new", type: :view do
 
   it "has a back link to group members page" do
     expect(view.content_for(:back_link)).to have_link("Back", href: group_members_path(group))
+  end
+
+  context "when show_role_options is true" do
+    let(:show_role_options) { true }
+
+    it "shows radio buttons for role" do
+      Membership.roles.each_key do |role|
+        expect(rendered).to have_field("group_member_input[role]", with: role)
+      end
+    end
+
+    it "displays the correct page title" do
+      expect(rendered).to have_selector("h1", text: t("group_members.new.title_show_role_options"))
+    end
   end
 end


### PR DESCRIPTION
### Add members to groups with role

Trello card: https://trello.com/c/ICk5nthH/1517-allow-organisation-admins-to-manage-group-admins

Allow super admins and organisation admins to add members to a group as either editors or group admins.

<img width="719" alt="image" src="https://github.com/alphagov/forms-admin/assets/11035856/33b3a137-88f2-4461-89df-80b2e3ceec24">


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
