### PR TITLE
Refactor pundit stubs in request specs

### DIFF
--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe Forms::ChangeNameController, type: :request do
       mock.put "/api/v1/forms/2", post_headers
     end
 
-    allow(Pundit).to receive(:authorize).and_return(true)
-
     login_as user
   end
 

--- a/spec/requests/forms/contact_details_controller_spec.rb
+++ b/spec/requests/forms/contact_details_controller_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe Forms::ContactDetailsController, type: :request do
         mock.get "/api/v1/forms/2", headers, form.to_json, 200
       end
 
-      allow(Pundit).to receive(:authorize).and_return(true)
-
       post contact_details_create_path(form_id: 2), params:
     end
 

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe FormsController, type: :request do
 
   describe "Destroying an existing form" do
     describe "Given a valid form" do
-      let(:group) { create :group }
+      let(:group) { create :group, organisation_id: editor_user.organisation_id }
 
       before do
         ActiveResourceMock.mock_resource(form,
@@ -152,7 +152,11 @@ RSpec.describe FormsController, type: :request do
                                            delete: { response: {}, status: 200 },
                                          })
         GroupForm.create!(group:, form_id: form.id) if group.present?
-        allow(Pundit).to receive(:authorize).and_return(true)
+
+        if group.present?
+          create(:membership, user: editor_user, group:)
+        end
+
         delete destroy_form_path(form_id: 2, forms_delete_confirmation_input: { confirm: "yes" })
       end
 

--- a/spec/requests/memberships_controller_spec.rb
+++ b/spec/requests/memberships_controller_spec.rb
@@ -38,9 +38,10 @@ describe "/memberships", type: :request do
 
   describe "PUT #update" do
     let(:membership) { create(:membership, user:, group:) }
+    let(:current_user) { organisation_admin_user }
 
     before do
-      login_as_super_admin_user
+      login_as current_user
     end
 
     context "with valid parameters" do
@@ -79,9 +80,7 @@ describe "/memberships", type: :request do
     end
 
     context "when not authorized" do
-      before do
-        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
-      end
+      let(:current_user) { editor_user }
 
       it "redirects to the root path" do
         put membership_path(membership), params: { membership: { role: "group_admin" } }

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Pages::ConditionsController, type: :request do
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:organisation_id) { editor_user.organisation_id }
+  let(:other_organisation_id) { editor_user.organisation_id + 1 }
+  let(:form) { build :form, :ready_for_routing, id: 1, organisation_id: }
   let(:pages) { form.pages }
   let(:page) do
     pages.first.tap do |first_page|
@@ -17,8 +19,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
   let(:selected_page) { page }
 
   let(:submit_result) { true }
-
-  let(:expected_to_raise_error) { false }
 
   before do
     login_as_editor_user
@@ -54,12 +54,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages/1", headers, selected_page.to_json, 200
       end
 
-      if expected_to_raise_error
-        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
-      else
-        allow(Pundit).to receive(:authorize).and_return(true)
-      end
-
       post routing_page_path(form_id: 1, params:)
     end
 
@@ -72,7 +66,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when user should not be allowed to add routes to pages" do
-      let(:expected_to_raise_error) { true }
+      let(:organisation_id) { other_organisation_id }
 
       it "Renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")
@@ -105,12 +99,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages/1", headers, selected_page.to_json, 200
       end
 
-      if expected_to_raise_error
-        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
-      else
-        allow(Pundit).to receive(:authorize).and_return(true)
-      end
-
       get new_condition_path(form_id: 1, page_id: 1)
     end
 
@@ -123,7 +111,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when user should not be allowed to add routes to pages" do
-      let(:expected_to_raise_error) { true }
+      let(:form) { build :form, id: 1 }
+      let(:pages) { [build(:page)] }
 
       it "Renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")
@@ -142,12 +131,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
         mock.get "/api/v1/forms/1/pages/1", headers, selected_page.to_json, 200
-      end
-
-      if expected_to_raise_error
-        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
-      else
-        allow(Pundit).to receive(:authorize).and_return(true)
       end
 
       conditional_form = Pages::ConditionsInput.new(form:, page: selected_page, answer_value: "Yes", goto_page_id: 3)
@@ -185,7 +168,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when user should not be allowed to add routes to pages" do
-      let(:expected_to_raise_error) { true }
+      let(:form) { build :form, id: 1 }
+      let(:pages) { [build(:page)] }
 
       it "Renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")
@@ -209,12 +193,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, condition.to_json, 200
-      end
-
-      if expected_to_raise_error
-        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
-      else
-        allow(Pundit).to receive(:authorize).and_return(true)
       end
 
       allow(Pages::ConditionsInput).to receive(:new).and_return(conditions_input)
@@ -241,7 +219,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when user should not be allowed to add routes to pages" do
-      let(:expected_to_raise_error) { true }
+      let(:organisation_id) { other_organisation_id }
 
       it "Renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")
@@ -264,12 +242,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, condition.to_json, 200
-      end
-
-      if expected_to_raise_error
-        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
-      else
-        allow(Pundit).to receive(:authorize).and_return(true)
       end
 
       conditional_form = Pages::ConditionsInput.new(form:, page: selected_page, record: condition, answer_value: "Yes", goto_page_id: 3)
@@ -310,7 +282,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when user should not be allowed to add routes to pages" do
-      let(:expected_to_raise_error) { true }
+      let(:organisation_id) { other_organisation_id }
 
       it "Renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")
@@ -335,12 +307,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, condition.to_json, 200
       end
 
-      if expected_to_raise_error
-        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
-      else
-        allow(Pundit).to receive(:authorize).and_return(true)
-      end
-
       delete_condition_input = Pages::DeleteConditionInput.new(form:, page: selected_page, record: condition, answer_value: "Yes", goto_page_id: 3)
 
       allow(delete_condition_input).to receive(:goto_page_question_text).and_return("What is your name?")
@@ -359,7 +325,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when user should not be allowed to add routes to pages" do
-      let(:expected_to_raise_error) { true }
+      let(:organisation_id) { other_organisation_id }
 
       it "Renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")
@@ -385,12 +351,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, condition.to_json, 200
         mock.delete "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, nil, 204
-      end
-
-      if expected_to_raise_error
-        allow(Pundit).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
-      else
-        allow(Pundit).to receive(:authorize).and_return(true)
       end
 
       delete_condition_input = Pages::DeleteConditionInput.new(form:, page: selected_page, record: condition, answer_value: "Wales", goto_page_id: 3, confirm:)
@@ -450,7 +410,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when user should not be allowed to add routes to pages" do
-      let(:expected_to_raise_error) { true }
+      let(:organisation_id) { other_organisation_id }
 
       it "Renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")


### PR DESCRIPTION
### Remove Pundit stubs in request specs

A recent update to Pundit, the gem we use for authorisation, means our request tests no longer pass.

This is because the way we were stubbing calls to Pundit no longer works. See this [dependabot PR](https://github.com/alphagov/forms-admin/pull/1140) for more details.

After [some discussion with the technical team](https://docs.google.com/document/d/1iHfUoCzgg-2Mk9wbi5o46fFVRak_R6nNQ2m8OqSz_hs/edit#heading=h.c0rqps9ls6o) we decided that request specs should not stub Pundit but arrange the tests so that the authorisation is tested and passes the tests too.

This PR works through the request specs and removes the stubs to Pundit. Instead the setup has been modified so that the tests pass. Some Pundit stubs were not doing anything and so could be removed without changing the test behaviour.

This PR doesn't do the Pundit update. Rebasing the dependabot PR when this is merged should allow them to pass.

There are other Pundit stubs within our code which don't need to change. This are stubbing the policy object within views, which the Pundit update doesn't break.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
