### PR TITLE
Add feature flag for groups

### DIFF
--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -62,7 +62,7 @@ module Forms
     end
 
     def delete_form(form)
-      success_url = form.group.present? ? group_path(form.group) : root_path
+      success_url = FeatureService.enabled?(:groups) && form.group.present? ? group_path(form.group) : root_path
 
       authorize form, :can_view_form?
       if form.destroy

--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -1,4 +1,5 @@
 class GroupFormsController < ApplicationController
+  before_action :feature_enabled
   before_action :set_group
   after_action :verify_authorized
 
@@ -29,6 +30,10 @@ class GroupFormsController < ApplicationController
   end
 
 private
+
+  def feature_enabled
+    raise ActionController::RoutingError, "Groups feature is not enabled" unless FeatureService.enabled?(:groups)
+  end
 
   def set_group
     @group = Group.find_by!(external_id: params[:group_id])

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -1,4 +1,5 @@
 class GroupMembersController < ApplicationController
+  before_action :feature_enabled
   before_action :set_group
   after_action :verify_authorized
 
@@ -25,6 +26,10 @@ class GroupMembersController < ApplicationController
   end
 
 private
+
+  def feature_enabled
+    raise ActionController::RoutingError, "Groups feature not enabled" unless FeatureService.enabled?(:groups)
+  end
 
   def set_group
     @group = Group.find_by!(external_id: params[:group_id])

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,5 @@
 class GroupsController < ApplicationController
+  before_action :feature_enabled
   before_action :set_group, except: %i[index new create]
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
@@ -104,6 +105,10 @@ class GroupsController < ApplicationController
   end
 
 private
+
+  def feature_enabled
+    raise ActionController::RoutingError, "Groups feature not enabled" unless FeatureService.enabled?(:groups)
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_group

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -34,10 +34,12 @@ class FormPolicy
 
   def can_view_form?
     return true if user.super_admin?
-    if form.group.present?
+
+    if FeatureService.enabled?(:groups) && form.group.present?
       return user.groups.include?(form.group) || user.is_organisations_admin?(form.group.organisation)
     end
 
+    # TODO: Remove these checks in cleanup after groups feature
     if user.trial?
       user_is_form_creator
     else

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -1,6 +1,6 @@
 <% set_page_title(form.name) %>
 
-<% if form.group.present? %>
+<% if FeatureService.enabled?(:groups) && form.group.present? %>
   <% content_for :back_link, govuk_back_link_to(group_path(form.group), t("back_link.group", group_name: form.group.name)) %>
 <% else %>
   <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -4,7 +4,7 @@
   <% content_for :back_link, govuk_back_link_to(live_form_path(current_form.id), t("back_link.form_view")) %>
 <% elsif current_form.is_archived? %>
   <% content_for :back_link, govuk_back_link_to(archived_form_path(current_form.id), t("back_link.form_view")) %>
-<% elsif current_form.group.present? %>
+<% elsif FeatureService.enabled?(:groups) && current_form.group.present? %>
   <% content_for :back_link, govuk_back_link_to(group_path(current_form.group), t("back_link.group", group_name: current_form.group.name)) %>
 <% else %>
   <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,7 @@ features:
   metrics_for_form_creators_enabled: false
   notify_original_submission_email_of_change: false
   check_your_question_enabled: false
+  groups: false
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,7 +52,10 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create_list :user, 3, :with_trial_role, :with_no_org, :with_no_name
 
   # create some test groups
-  FactoryBot.create :group, name: "Test Group", organisation: gds, creator: default_user
+  test_group = FactoryBot.create :group, name: "Test Group", organisation: gds, creator: default_user
   FactoryBot.create :group, name: "Ministry of Tests forms", organisation: test_org, creator: default_user
   FactoryBot.create :group, name: "Ministry of Tests forms - secret!", organisation: test_org, creator: default_user
+
+  # add a form to a test group (assumes database seed being used for forms-api)
+  GroupForm.create! group: test_group, form_id: 1
 end

--- a/spec/features/form/create_or_edit_a_form_spec.rb
+++ b/spec/features/form/create_or_edit_a_form_spec.rb
@@ -19,7 +19,7 @@ feature "Create or edit a form", type: :feature do
       end
     end
 
-    context "and in a group" do
+    context "when the groups feature is enabled", feature_groups: true do
       before do
         create(:membership, user: editor_user, group:)
       end
@@ -32,7 +32,7 @@ feature "Create or edit a form", type: :feature do
       end
     end
 
-    context "and not in a group" do
+    context "when the groups feature is not enabled", feature_groups: false do
       let(:org_forms) { [] }
 
       before do
@@ -69,7 +69,7 @@ feature "Create or edit a form", type: :feature do
       end
     end
 
-    context "and in a group" do
+    context "when the groups feature is enabled", feature_groups: true do
       before do
         create(:membership, user: editor_user, group:)
 
@@ -84,7 +84,7 @@ feature "Create or edit a form", type: :feature do
       end
     end
 
-    context "and not in a group" do
+    context "when the groups feature is not enabled", feature_groups: false do
       let(:org_forms) { [form] }
 
       before do

--- a/spec/features/groups/create_group_spec.rb
+++ b/spec/features/groups/create_group_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Create a new group", type: :feature do
+feature "Create a new group", type: :feature, feature_groups: true do
   before do
     login_as_editor_user
   end

--- a/spec/features/groups/manage_group_members_spec.rb
+++ b/spec/features/groups/manage_group_members_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Show members of a group", type: :feature do
+feature "Show members of a group", type: :feature, feature_groups: true do
   let(:organisation) { editor_user.organisation }
   let(:group) { create(:group, name: "Group 1", organisation:) }
   let(:user1) { create(:user, organisation:) }

--- a/spec/features/groups/request_upgrade_spec.rb
+++ b/spec/features/groups/request_upgrade_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Request an upgrade for a group", type: :feature do
+feature "Request an upgrade for a group", type: :feature, feature_groups: true do
   let!(:group) do
     create(:group, organisation: editor_user.organisation).tap do |group|
       create(:membership, user: editor_user, group:, role: :group_admin)

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe FormPolicy do
+describe FormPolicy, feature_groups: true do
   subject(:policy) { described_class.new(user, form) }
 
   let(:organisation) { build :organisation, id: 1, slug: "gds" }
@@ -81,9 +81,7 @@ describe FormPolicy do
       end
     end
 
-    context "when form is not in a group" do
-      let(:group) { nil }
-
+    shared_examples "without group" do
       context "with an editor role" do
         let(:user) { build :editor_user, organisation: }
 
@@ -124,13 +122,21 @@ describe FormPolicy do
         end
       end
     end
+
+    context "when a form is not in a group" do
+      let(:group) { nil }
+
+      include_examples "without group"
+    end
+
+    context "when the groups feature is not enabled", feature_groups: false do
+      include_examples "without group"
+    end
   end
 
   %i[can_change_form_submission_email can_make_form_live].each do |permission|
     describe "#{permission}?" do
-      context "when form is not in a group" do
-        let(:group) { nil }
-
+      shared_examples "without group" do
         context "with a form editor" do
           it { is_expected.to permit_actions(permission) }
 
@@ -164,6 +170,16 @@ describe FormPolicy do
             end
           end
         end
+      end
+
+      context "when a form is not in a group" do
+        let(:group) { nil }
+
+        include_examples "without group"
+      end
+
+      context "when the groups feature is not enabled", feature_groups: false do
+        include_examples "without group"
       end
     end
   end

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -7,20 +7,22 @@ describe FormPolicy do
   let(:form) { build :form, id: 1, organisation_id: 1, creator_id: 123 }
   let(:user) { build :editor_user, organisation: }
 
-  context "with no organisation set" do
-    context "with editor role" do
-      let(:user) { build :editor_user, :with_no_org }
+  describe "#initialize?" do
+    context "when user does not belong to an organisation" do
+      context "with editor role" do
+        let(:user) { build :editor_user, :with_no_org }
 
-      it "raises an error" do
-        expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+        it "raises an error" do
+          expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
+        end
       end
-    end
 
-    context "with trial role" do
-      let(:user) { build :user, :with_trial_role }
+      context "with trial role" do
+        let(:user) { build :user, :with_trial_role }
 
-      it "does not raise an error" do
-        expect { policy }.not_to raise_error
+        it "does not raise an error" do
+          expect { policy }.not_to raise_error
+        end
       end
     end
   end

--- a/spec/requests/forms/delete_confirmation_controller_spec.rb
+++ b/spec/requests/forms/delete_confirmation_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
     end
   end
 
-  describe "#destroy" do
+  describe "#destroy", feature_groups: true do
     describe "Given a valid form" do
       let(:group) { create :group, organisation_id: editor_user.organisation_id }
 
@@ -53,6 +53,12 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
       context "when the form is not in a group" do
         let(:group) { nil }
 
+        it "redirects to the home page" do
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context "when the groups feature is not enabled", feature_groups: false do
         it "redirects to the home page" do
           expect(response).to redirect_to(root_path)
         end

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "/groups/:group_id/forms", type: :request do
+RSpec.describe "/groups/:group_id/forms", type: :request, feature_groups: true do
   let(:group) { create :group }
   let(:nonexistent_group) { "foobar" }
 
@@ -51,6 +51,12 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
         get new_group_form_url(nonexistent_group)
 
         expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when the groups feature is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -129,6 +135,13 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
         post group_forms_url(nonexistent_group), params: { forms_name_input: valid_attributes }
 
         expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when the groups feature is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        post group_forms_url(group), params: { forms_name_input: valid_attributes }
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/group_members_controller_spec.rb
+++ b/spec/requests/group_members_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "/groups/:group_id/members", type: :request do
+RSpec.describe "/groups/:group_id/members", type: :request, feature_groups: true do
   let(:group) { create :group, organisation: current_user.organisation }
   let(:role) { :group_admin }
   let(:current_user) { editor_user }
@@ -34,6 +34,13 @@ RSpec.describe "/groups/:group_id/members", type: :request do
         expect(response).to have_http_status :not_found
       end
     end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        get group_members_url(group)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "GET /groups/:group_id/members/new" do
@@ -55,6 +62,13 @@ RSpec.describe "/groups/:group_id/members", type: :request do
       it "renders a 404 not found response" do
         get new_group_member_url(nonexistent_group)
         expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        get new_group_member_url(group)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -121,6 +135,13 @@ RSpec.describe "/groups/:group_id/members", type: :request do
       it "renders a 404 not found response" do
         post group_members_url(nonexistent_group), params: { group_member_input: { member_email_address: user.email } }
         expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        post group_members_url(group), params: { group_member_input: { member_email_address: user.email } }
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -12,7 +12,7 @@ require "rails_helper"
 # of tools you can use to make these specs even more expressive, but we're
 # sticking to rails and rspec-rails APIs to keep things simple and stable.
 
-RSpec.describe "/groups", type: :request do
+RSpec.describe "/groups", type: :request, feature_groups: true do
   let(:current_user) { editor_user }
   let(:role) { :editor }
   let(:status) { :trial }
@@ -96,6 +96,12 @@ RSpec.describe "/groups", type: :request do
         expect(assigns(:trial_groups)).to eq trial_groups + other_org_groups
       end
     end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "GET /show" do
@@ -153,12 +159,26 @@ RSpec.describe "/groups", type: :request do
         expect(response).to have_http_status :not_found
       end
     end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        get group_url(member_group)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "GET /new" do
     it "renders a successful response" do
       get new_group_url
       expect(response).to be_successful
+    end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        get new_group_url
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 
@@ -202,6 +222,13 @@ RSpec.describe "/groups", type: :request do
         expect(response).to have_http_status :not_found
       end
     end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        get edit_group_url(non_member_group)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "POST /create" do
@@ -240,6 +267,13 @@ RSpec.describe "/groups", type: :request do
       it "renders a response with 422 status (i.e. to display the 'new' template)" do
         post groups_url, params: { group: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        post groups_url, params: { group: valid_attributes }
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -304,15 +338,22 @@ RSpec.describe "/groups", type: :request do
         expect(response).to have_http_status :not_found
       end
     end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        patch group_url(member_group), params: { group: valid_attributes }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "GET /upgrade" do
+    before do
+      get upgrade_group_url(member_group)
+    end
+
     context "when user is an organisation admin" do
       let(:current_user) { organisation_admin_user }
-
-      before do
-        get upgrade_group_url(member_group)
-      end
 
       it "returns a successful response" do
         expect(response).to have_http_status(:ok)
@@ -325,7 +366,6 @@ RSpec.describe "/groups", type: :request do
 
     context "when user is not an organisation admin" do
       it "is forbidden" do
-        get upgrade_group_url(member_group)
         expect(response).to have_http_status(:forbidden)
       end
     end
@@ -334,6 +374,12 @@ RSpec.describe "/groups", type: :request do
       it "renders a 404 not found response" do
         get upgrade_group_url(nonexistent_group)
         expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -403,6 +449,13 @@ RSpec.describe "/groups", type: :request do
         expect(response).to have_http_status :not_found
       end
     end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        post upgrade_group_url(member_group), params: { groups_confirm_upgrade_input: { confirm: } }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "GET /request_upgrade" do
@@ -433,6 +486,12 @@ RSpec.describe "/groups", type: :request do
 
       it "renders a 404 not found response" do
         expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -476,18 +535,25 @@ RSpec.describe "/groups", type: :request do
         expect(response).to have_http_status :not_found
       end
     end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        post request_upgrade_group_url(member_group)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "GET /review_upgrade" do
     let(:status) { :upgrade_requested }
     let(:upgrade_requester) { create(:user) }
 
+    before do
+      get review_upgrade_group_url(member_group)
+    end
+
     context "when user is an organisation admin" do
       let(:current_user) { organisation_admin_user }
-
-      before do
-        get review_upgrade_group_url(member_group)
-      end
 
       it "returns a successful response" do
         expect(response).to have_http_status(:ok)
@@ -500,7 +566,6 @@ RSpec.describe "/groups", type: :request do
 
     context "when user is not an organisation admin" do
       it "is forbidden" do
-        get review_upgrade_group_url(member_group)
         expect(response).to have_http_status(:forbidden)
       end
     end
@@ -509,6 +574,12 @@ RSpec.describe "/groups", type: :request do
       it "renders a 404 not found response" do
         get review_upgrade_group_url(nonexistent_group)
         expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -588,6 +659,13 @@ RSpec.describe "/groups", type: :request do
       it "renders a 404 not found response" do
         post review_upgrade_group_url(nonexistent_group), params: { groups_confirm_upgrade_input: { confirm: } }
         expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when the groups feature flag is disabled", feature_groups: false do
+      it "returns a 404 response" do
+        post review_upgrade_group_url(member_group), params: { groups_confirm_upgrade_input: { confirm: } }
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "forms/_made_live_form.html.erb", feature_metrics_for_form_creators_enabled: false do
+describe "forms/_made_live_form.html.erb", feature_metrics_for_form_creators_enabled: false, feature_groups: true do
   let(:declaration) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:what_happens_next) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:form_metadata) { OpenStruct.new(has_draft_version: false) }
@@ -212,6 +212,12 @@ describe "forms/_made_live_form.html.erb", feature_metrics_for_form_creators_ena
   context "when form is not in a group" do
     let(:group) { nil }
 
+    it "back link is set to root" do
+      expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
+    end
+  end
+
+  context "when the groups feature is not enabled", feature_groups: false do
     it "back link is set to root" do
       expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
     end

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -36,7 +36,7 @@ describe "forms/show.html.erb" do
     expect(rendered).to have_selector(".app-task-list__summary", text: "You’ve completed 12 of 20 tasks.")
   end
 
-  context "when form state is draft" do
+  context "when form state is draft", feature_groups: true do
     it "rendered draft tag " do
       expect(rendered).to have_css(".govuk-tag.govuk-tag--yellow", text: "Draft")
     end
@@ -44,9 +44,15 @@ describe "forms/show.html.erb" do
     it "has a back link to the group page" do
       expect(view.content_for(:back_link)).to have_link("Back to Group 1", href: group_path(group))
     end
+
+    context "when the groups feature is not enabled", feature_groups: false do
+      it "has a back link to the forms page" do
+        expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
+      end
+    end
   end
 
-  context "when a form is not in a group" do
+  context "when a form is not in a group", feature_groups: true do
     let(:group) { nil }
 
     it "has a back link to the forms page" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/VTHtrbmn/1529-add-feature-flags-for-user-management-feature <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Put the groups feature behind a feature flag. When the feature flag is disabled:
- prevent access to all groups routes
- back links from forms will link to the root URL rather than the group URL, regardless of whether the form is in a group
- policies for forms will not look at the user's role in a group

In this PR, we have not yet made the feature flag configurable per organisation. This will come in a follow-up PR.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
