### PR TITLE
Add validation for org admin orgs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,7 @@ class User < ApplicationRecord
   validates :role, presence: true
   validates :organisation_id, presence: true, if: :requires_organisation?
   validates :has_access, inclusion: [true, false]
+  validates :role, exclusion: %w[organisation_admin], unless: :current_org_has_mou?
 
   before_create do
     self.has_access = false if organisation_restricted_access?
@@ -118,6 +119,10 @@ class User < ApplicationRecord
 
   def is_group_admin?(group)
     memberships.find_by(group:)&.group_admin?
+  end
+
+  def current_org_has_mou?
+    organisation&.mou_signatures.present?
   end
 
 private

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -8,6 +8,12 @@
         <%= f.govuk_error_summary %>
       <% end %>
 
+      <% unless @user.current_org_has_mou? %>
+        <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+          <%= t('users.edit.mou_banner') %>
+        <% end %>
+      <% end %>
+
       <h1 class="govuk-heading-l">
         <%= t("users.edit.title") %>
       </h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,7 @@ en:
               blank: Select the user’s organisation
             role:
               blank: Select a role for the user
+              exclusion: You cannot upgrade this user’s role until someone from their organisation agrees to the MOU
   address_settings:
     hint: Select all that apply
   archive_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1138,6 +1138,7 @@ en:
       access: Permission to access GOV.UK Forms
       caption: User details
       has_access: Access to GOV.UK Forms
+      mou_banner: You cannot upgrade this user’s role until someone from their organisation agrees to the MOU
       organisation: Organisation
       organisation_hint: The user will only be able to see their organisation’s forms
       organisation_prompt: Select an organisation

--- a/spec/factories/models/mou_signatures.rb
+++ b/spec/factories/models/mou_signatures.rb
@@ -2,5 +2,10 @@ FactoryBot.define do
   factory :mou_signature do
     user { create(:user) }
     organisation { user.organisation }
+
+    factory :mou_signature_for_organisation do
+      organisation
+      user { create(:user, organisation:) }
+    end
   end
 end

--- a/spec/factories/models/organisations.rb
+++ b/spec/factories/models/organisations.rb
@@ -8,5 +8,11 @@ FactoryBot.define do
     initialize_with do
       Organisation.create_with(govuk_content_id:, name:).find_or_initialize_by(slug:)
     end
+
+    trait :with_signed_mou do
+      after(:build) do |organisation|
+        organisation.mou_signatures << (create :mou_signature_for_organisation, organisation:)
+      end
+    end
   end
 end

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
 
     factory :organisation_admin_user do
       role { :organisation_admin }
+      org_has_signed_mou
     end
 
     trait :with_trial_role do
@@ -28,6 +29,10 @@ FactoryBot.define do
     end
 
     organisation { association :organisation, id: 1, slug: "test-org" }
+
+    trait :org_has_signed_mou do
+      organisation { association :organisation, :with_signed_mou, id: 1, slug: "test-org" }
+    end
 
     after(:build) do |user|
       if user.organisation.present?

--- a/spec/service/user_update_service_spec.rb
+++ b/spec/service/user_update_service_spec.rb
@@ -56,31 +56,29 @@ describe UserUpdateService do
         user_update_service.update_user
       end
 
-      User.roles.reject { |role| role == "trial" }.each_value do |role_value|
-        context "when the user is a trial user changing to #{role_value}" do
-          let(:organisation) { create(:organisation) }
-          let(:params) { { role: role_value, name: "name required", organisation: } }
+      context "when the user is a trial user changing to editor" do
+        let(:organisation) { create(:organisation) }
+        let(:params) { { role: "editor", name: "name required", organisation: } }
 
-          it "updates the user's params" do
-            expect(user.role).to eq(role_value)
-          end
-
-          it "calls update_organisation_for_creator" do
-            expect(Form).to have_received(:update_organisation_for_creator).with(user.id, user.organisation_id)
-          end
+        it "updates the user's params" do
+          expect(user.role).to eq("editor")
         end
 
-        context "when the user is a #{role_value} changing to editor" do
-          let(:user) { create :user, role: role_value }
-          let(:params) { { role: :editor } }
+        it "calls update_organisation_for_creator" do
+          expect(Form).to have_received(:update_organisation_for_creator).with(user.id, user.organisation_id)
+        end
+      end
 
-          it "updates the user's params" do
-            expect(user).to be_editor
-          end
+      context "when the user is a super_admin changing to editor" do
+        let(:user) { create :super_admin_user }
+        let(:params) { { role: :editor } }
 
-          it "calls update_organisation_for_creator" do
-            expect(Form).not_to have_received(:update_organisation_for_creator).with(user.id, user.organisation_id)
-          end
+        it "updates the user's params" do
+          expect(user).to be_editor
+        end
+
+        it "does not call update_organisation_for_creator" do
+          expect(Form).not_to have_received(:update_organisation_for_creator).with(user.id, user.organisation_id)
         end
       end
 

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -35,7 +35,7 @@ module AuthenticationFeatureHelpers
   end
 
   def test_org
-    @test_org ||= FactoryBot.create(:organisation, id: 1, slug: "test-org")
+    @test_org ||= FactoryBot.create(:organisation, :with_signed_mou, id: 1, slug: "test-org")
   end
 
   def super_admin_user

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -143,4 +143,18 @@ describe "users/edit.html.erb" do
       expect(rendered).to have_select("Organisation", with_options: ["Select an organisation"])
     end
   end
+
+  context "with a user where organisation has not signed MOU" do
+    it "shows MOU banner" do
+      expect(rendered).to have_text(I18n.t("users.edit.mou_banner"))
+    end
+  end
+
+  context "with a user where organisation has signed MOU" do
+    let(:user) { build :user, :org_has_signed_mou }
+
+    it "does not show MOU banner" do
+      expect(rendered).not_to have_text(I18n.t("users.edit.mou_banner"))
+    end
+  end
 end


### PR DESCRIPTION
Adds a validation to check that organisation_admins are part of an organisation.

We're not sure if there are any existing org admins that don't have an org, so would want to confirm that there aren't before adding this validation

We're also not sure if there are any better ways of using factories to build valid organisation_admin users, as it's a bit fiddly signing an mou for their org so that they're created in a valid state

### What problem does this pull request solve?

Trello card: https://trello.com/c/wgcwhH8p/1527-prevent-a-user-from-being-made-an-org-admin-if-their-organisation-hasnt-agreed-to-an-mou

![image](https://github.com/alphagov/forms-admin/assets/11035856/bb9b9c10-817d-44cc-b826-607d2473a331)


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
