### PR TITLE
Add rake task to update the organisation for an MOU signature

### DIFF
--- a/lib/tasks/mou_signatures.rake
+++ b/lib/tasks/mou_signatures.rake
@@ -1,0 +1,22 @@
+namespace :mou_signatures do
+  desc "Update the organisation that an MOU was signed for"
+  task :update_organisation, %i[user_name current_organisation_name target_organisation_name] => :environment do |_, args|
+    usage_message = "usage: rake mou_signatures:update_organisation[<user_name>, <current_organisation_name>, <target_organisation_name>".freeze
+    abort usage_message if args[:user_name].blank? || args[:current_organisation_name].blank? || args[:target_organisation_name].blank?
+
+    user = User.find_by(name: args[:user_name])
+    abort "User with name: #{args[:user_name]} not found" unless user
+    current_organisation = Organisation.find_by(name: args[:current_organisation_name])
+    abort "Organisation with name: #{args[:current_organisation_name]} not found" unless current_organisation
+    target_organisation = Organisation.find_by(name: args[:target_organisation_name])
+    abort "Organisation with name: #{args[:target_organisation_name]} not found" unless target_organisation
+
+    mou_signature = MouSignature.find_by(user:, organisation: current_organisation)
+    abort "MOU signature for User: #{user.name} and Organisation: #{current_organisation.name} not found" unless mou_signature
+
+    mou_signature.organisation = target_organisation
+    mou_signature.save!
+
+    puts "Updated MOU signature for User: #{user.name} and Organisation: #{current_organisation.name} to be for #{target_organisation.name}"
+  end
+end

--- a/spec/lib/tasks/mou_signatures.rake_spec.rb
+++ b/spec/lib/tasks/mou_signatures.rake_spec.rb
@@ -1,0 +1,58 @@
+require "rake"
+
+require "rails_helper"
+
+RSpec.describe "mou_signatures.rake" do
+  before do
+    Rake.application.rake_require "tasks/mou_signatures"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "mou_signatures:update_organisation" do
+    subject(:task) do
+      Rake::Task["mou_signatures:update_organisation"]
+        .tap(&:reenable) # make sure task is invoked every time
+    end
+
+    let(:user) { create :user }
+    let(:current_organisation) { create :organisation, slug: "government-digital-service" }
+    let(:target_organisation) { create :organisation, slug: "cabinet-office" }
+    let(:mou_signature) { create :mou_signature, user:, organisation: current_organisation }
+
+    it "aborts when the user is not found" do
+      expect { task.invoke("John Doe", current_organisation.name, target_organisation.name) }
+        .to output(/User with name: John Doe not found/)
+              .to_stderr
+              .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+
+    it "aborts when the current organisation is not found" do
+      expect { task.invoke(user.name, "GDS", target_organisation.name) }
+        .to output(/Organisation with name: GDS not found/)
+              .to_stderr
+              .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+
+    it "aborts when the target organisation is not found" do
+      expect { task.invoke(user.name, current_organisation.name, "GDS") }
+        .to output(/Organisation with name: GDS not found/)
+              .to_stderr
+              .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+
+    it "aborts when an MOU signature is not found for the user and organisation" do
+      expect { task.invoke(user.name, target_organisation.name, current_organisation.name) }
+        .to output(/MOU signature for User:/)
+              .to_stderr
+              .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+
+    it "updates the organisation for an MOU" do
+      mou_signature
+      expect { task.invoke(user.name, current_organisation.name, target_organisation.name) }
+        .to change { mou_signature.reload.organisation }.to(target_organisation)
+        .and output(/Updated MOU signature/)
+              .to_stdout
+    end
+  end
+end

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 
 RSpec.describe "organisations.rake" do
   before do
-    # Rake.application.options.trace = true
-
     Rake.application.rake_require "tasks/organisations"
     Rake::Task.define_task(:environment)
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card:
https://trello.com/c/syeAKkzY/1535-manually-change-mou-agreement-from-dhsc-to-ohid
https://trello.com/c/vJsmEFPl/1534-manually-change-mou-agreement-from-home-office-to-cce

Adds a rake task that, given the User name and Organisation name for an MOU, will update the organisation for the MOU to the target organisation.

The primary intended use for this is when a user and their forms are moved to a sub-organisation and the MOU signature needs to be moved with them to the sub-organisation to reflect the organisation that the user agreed to the MOU for.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
