### PR TITLE
Fix record not found for groups routes

### DIFF
--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -31,7 +31,7 @@ class GroupFormsController < ApplicationController
 private
 
   def set_group
-    @group = Group.find_by(external_id: params[:group_id])
+    @group = Group.find_by!(external_id: params[:group_id])
   end
 
   def name_input_params(form)

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -27,7 +27,7 @@ class GroupMembersController < ApplicationController
 private
 
   def set_group
-    @group = Group.find_by(external_id: params[:group_id])
+    @group = Group.find_by!(external_id: params[:group_id])
   end
 
   def group_member_params

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -107,7 +107,7 @@ private
 
   # Use callbacks to share common setup or constraints between actions.
   def set_group
-    @group = Group.find_by(external_id: params[:id])
+    @group = Group.find_by!(external_id: params[:id])
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/policies/group_form_policy.rb
+++ b/app/policies/group_form_policy.rb
@@ -1,6 +1,6 @@
 class GroupFormPolicy < ApplicationPolicy
   def new?
-    record.group && Pundit.policy!(user, record.group).show?
+    Pundit.policy!(user, record.group).show?
   end
   alias_method :create?, :new?
 end

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "/groups/:group_id/forms", type: :request do
   let(:group) { create :group }
+  let(:nonexistent_group) { "foobar" }
 
   let(:valid_attributes) do
     { name: "Test form" }
@@ -46,10 +47,10 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
     end
 
     context "when the group does not exist" do
-      it "returns a forbidden status code" do
-        get new_group_form_url("nonsense")
+      it "renders a 404 not found response" do
+        get new_group_form_url(nonexistent_group)
 
-        expect(response).to have_http_status :forbidden
+        expect(response).to have_http_status :not_found
       end
     end
   end
@@ -124,10 +125,10 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
     end
 
     context "when the group does not exist" do
-      it "returns a forbidden status code" do
-        post group_forms_url("nonsense"), params: { forms_name_input: valid_attributes }
+      it "renders a 404 not found response" do
+        post group_forms_url(nonexistent_group), params: { forms_name_input: valid_attributes }
 
-        expect(response).to have_http_status :forbidden
+        expect(response).to have_http_status :not_found
       end
     end
   end

--- a/spec/requests/group_members_controller_spec.rb
+++ b/spec/requests/group_members_controller_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "/groups/:group_id/members", type: :request do
   let(:role) { :group_admin }
   let(:current_user) { editor_user }
 
+  let(:nonexistent_group) { "foobar" }
+
   before do
     create(:membership, user: current_user, group:, role:)
     login_as current_user
@@ -25,6 +27,13 @@ RSpec.describe "/groups/:group_id/members", type: :request do
         expect(response).to have_http_status :forbidden
       end
     end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        get group_members_url(nonexistent_group)
+        expect(response).to have_http_status :not_found
+      end
+    end
   end
 
   describe "GET /groups/:group_id/members/new" do
@@ -41,12 +50,19 @@ RSpec.describe "/groups/:group_id/members", type: :request do
         expect(response).to have_http_status :forbidden
       end
     end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        get new_group_member_url(nonexistent_group)
+        expect(response).to have_http_status :not_found
+      end
+    end
   end
 
   describe "POST /groups/:group_id/members" do
-    context "with valid parameters" do
-      let(:user) { create :user, organisation: editor_user.organisation }
+    let(:user) { create :user, organisation: editor_user.organisation }
 
+    context "with valid parameters" do
       it "creates a new membership" do
         expect {
           post group_members_url(group), params: { group_member_input: { member_email_address: user.email } }
@@ -98,6 +114,13 @@ RSpec.describe "/groups/:group_id/members", type: :request do
 
         expect(response).to have_http_status :unprocessable_entity
         expect(response).to render_template :new
+      end
+    end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        post group_members_url(nonexistent_group), params: { group_member_input: { member_email_address: user.email } }
+        expect(response).to have_http_status :not_found
       end
     end
   end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe "/groups", type: :request do
     create :group
   end
 
+  let(:nonexistent_group) do
+    "foobar"
+  end
+
   # This should return the minimal set of attributes required to create a valid
   # Group. As you add validations to Group, be sure to
   # adjust the attributes here as well.
@@ -142,6 +146,13 @@ RSpec.describe "/groups", type: :request do
         expect(response.body).to include(I18n.t("groups.show.trial_banner.upgrade.link"))
       end
     end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        get group_url(nonexistent_group)
+        expect(response).to have_http_status :not_found
+      end
+    end
   end
 
   describe "GET /new" do
@@ -182,6 +193,13 @@ RSpec.describe "/groups", type: :request do
           get edit_group_url(non_member_group)
           expect(response).to be_successful
         end
+      end
+    end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        get edit_group_url(nonexistent_group)
+        expect(response).to have_http_status :not_found
       end
     end
   end
@@ -279,6 +297,13 @@ RSpec.describe "/groups", type: :request do
         end
       end
     end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        patch group_url(nonexistent_group), params: { group: valid_attributes }
+        expect(response).to have_http_status :not_found
+      end
+    end
   end
 
   describe "GET /upgrade" do
@@ -302,6 +327,13 @@ RSpec.describe "/groups", type: :request do
       it "is forbidden" do
         get upgrade_group_url(member_group)
         expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        get upgrade_group_url(nonexistent_group)
+        expect(response).to have_http_status :not_found
       end
     end
   end
@@ -364,6 +396,13 @@ RSpec.describe "/groups", type: :request do
         expect(response).to have_http_status(:forbidden)
       end
     end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        post upgrade_group_url(nonexistent_group), params: { groups_confirm_upgrade_input: { confirm: } }
+        expect(response).to have_http_status :not_found
+      end
+    end
   end
 
   describe "GET /request_upgrade" do
@@ -386,6 +425,14 @@ RSpec.describe "/groups", type: :request do
     context "when the user is not a group admin" do
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when there is no group with the given ID" do
+      let(:member_group) { nonexistent_group }
+
+      it "renders a 404 not found response" do
+        expect(response).to have_http_status :not_found
       end
     end
   end
@@ -422,6 +469,13 @@ RSpec.describe "/groups", type: :request do
         expect(response).to have_http_status(:forbidden)
       end
     end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        post request_upgrade_group_url(nonexistent_group)
+        expect(response).to have_http_status :not_found
+      end
+    end
   end
 
   describe "GET /review_upgrade" do
@@ -448,6 +502,13 @@ RSpec.describe "/groups", type: :request do
       it "is forbidden" do
         get review_upgrade_group_url(member_group)
         expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        get review_upgrade_group_url(nonexistent_group)
+        expect(response).to have_http_status :not_found
       end
     end
   end
@@ -520,6 +581,13 @@ RSpec.describe "/groups", type: :request do
       it "is forbidden" do
         post review_upgrade_group_url(member_group), params: { groups_confirm_upgrade_input: { confirm: } }
         expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when there is no group with the given ID" do
+      it "renders a 404 not found response" do
+        post review_upgrade_group_url(nonexistent_group), params: { groups_confirm_upgrade_input: { confirm: } }
+        expect(response).to have_http_status :not_found
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Requests to any URLs with an invalid group_id (such as `/groups/foobar`) currently result in a 500 error instead of a 404 error.

The 500 is caused when the method `set_group` assigns the instance variable `@group` is assigned to `nil`, leading Pundit to explode with the error:

```
unable to find policy `NilClassPolicy` for `nil`
```

This bug was introduced multiple times, whenever we used the Rails controller scaffold generator. We thought that the files created by the `rails generate scaffold` tool would follow best practice, however by failing to use `find!` (note the exclamation mark) in the template the generated controller would not raise a 404 as expected. This bug was then propagated by us and not caught even as we modified the code.

We also weren't testing this unhappy path because the template from the RSpec generator only covers the happy paths, and we missed this at review time.

This bug may be present in other places in our codebase, but for now I'm just focusing on places related to the groups feature.

[1]: https://github.com/rails/rails/blob/747a03ba7722b6f0a7ce42e86cea83cf07a2e6ef/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt#L52
[2]: https://github.com/rspec/rspec-rails/blob/4ab08fa954fe4e0ae6f2302fa7201dcad3f11521/lib/generators/rspec/scaffold/templates/request_spec.rb

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?