### PR TITLE
Update root path to depend on groups feature flag

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,0 +1,9 @@
+class HomepageController < ApplicationController
+  def index
+    if FeatureService.enabled? :groups
+      redirect_to groups_path
+    else
+      FormsController.dispatch(:index, request, response)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   # TODO: Remove once infrastructure has been updated to use /up
   get :ping, controller: :heartbeat
 
-  root "forms#index"
+  root "homepage#index"
 
   get "/sign-up" => "authentication#sign_up", as: :sign_up
   get "/sign-out" => "authentication#sign_out", as: :sign_out

--- a/spec/requests/homepage_controller_spec.rb
+++ b/spec/requests/homepage_controller_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe HomepageController, type: :request do
+  before do
+    login_as_editor_user
+  end
+
+  context "when the groups feature flag is enabled", feature_groups: true do
+    before do
+      get root_path
+    end
+
+    it "redirects to the groups index page" do
+      expect(response).to redirect_to groups_path
+    end
+  end
+
+  context "when the groups feature flag is disabled", feature_groups: false do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms?organisation_id=1", headers, {}.to_json, 200
+      end
+      get root_path
+    end
+
+    it "returns a 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the forms index page" do
+      expect(response).to render_template("forms/index")
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/VTHtrbmn/1529-add-feature-flags-for-user-management-feature

Add a new HomepageController with an index action that is called when the root path is visited.

If the groups feature flag is enabled, redirect to the groups index page.

If the groups feature flag is disabled, directly call the Forms controller index action. We're doing this rather than redirecting because we don't want to add a new route for the Forms controller index action, which will be removed soon anyway.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
