### PR TITLE
Add banners org mou

### DIFF
--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -8,6 +8,15 @@
       <% end %>
     </div>
   </div>
+<% elsif @current_user.editor? && !@current_user.current_org_has_mou? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+        <% banner.with_heading(text: t("groups.index.no_mou_banner.heading"), tag: "h3") %>
+        <% banner.with_heading(text: t("groups.index.no_mou_banner.body_html", contact_link: contact_link)) %>
+      <% end %>
+    </div>
+  </div>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -16,7 +16,11 @@
         <% elsif policy(@group).request_upgrade? %>
           <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
           <%= t("groups.show.trial_banner.request_upgrade.body_html") %>
-          <%= govuk_link_to t("groups.show.trial_banner.request_upgrade.link"), request_upgrade_group_path(@group) %>
+          <% if @group.organisation.mou_signatures.present? %>
+            <%= govuk_link_to t("groups.show.trial_banner.request_upgrade.link"), request_upgrade_group_path(@group) %>
+          <% else %>
+            <%= t("groups.show.trial_banner.request_upgrade.without_mou_signature_html", contact_link: contact_link) %>
+          <% end %>
         <% else %>
           <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
           <%= t("groups.show.trial_banner.editor.body_html") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,6 +384,7 @@ en:
         request_upgrade:
           body_html: "<p>You can create forms in this group and test them, but you cannot make them live.</p>"
           link: Find out how to upgrade this group so you can make forms live
+          without_mou_signature_html: "<p>Speak to your organisation’s GOV.UK publishing team or %{contact_link} to find out how to make live forms.</p>"
         review_upgrade:
           body_html: "<p>%{upgrade_requester_name} has asked to upgrade this group so they can make forms live.</p>"
           heading: A group admin has asked to upgrade this group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,6 +351,12 @@ en:
         <p>When a group is first created it will be a ‘trial’ group. That means forms in the group cannot be made live.</p>
         <p>As an organisation admin, you can upgrade a trial group to an ‘active’ group so forms in that group can be made live. People will be able to send a request to you to ask for their trial group to be upgraded.</p>
       group_explainer_title: What is a ‘group’?
+      no_mou_banner:
+        body_html: |
+          <p>Someone from your organisation needs to agree to a ‘Memorandum of Understanding’ with GOV.UK Forms before your organisation can make any forms live.</p>
+          <p>Speak to your organisation’s GOV.UK publishing team or %{contact_link} to start this process.</p>
+          <p>In the meantime, you can try out making forms in a ‘trial’ group.</p>
+        heading: You cannot make any forms live yet
       trial_empty_message: You’re not in any trial groups.
       trial_title: Trial groups
       upgrade_requests_banner_heading:

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -34,17 +34,25 @@ RSpec.describe "groups/index", type: :view do
     expect(rendered).to have_link("Create a group", href: new_group_path)
   end
 
-  context "when the user is not an admin" do
+  context "when the user is an editor" do
     it "shows the details text for users who are not org/super admins" do
       expect(rendered).to have_content("If you need access to an existing form or group, ask someone who has access to that group to add you.")
     end
 
-    it "does not show a notification banner" do
-      expect(rendered).not_to have_css ".govuk-notification-banner"
+    it "shows a notification banner explaining forms cannot be made live" do
+      expect(rendered).to have_css ".govuk-notification-banner", text: "You cannot make any forms live yet"
+    end
+
+    context "and org has signed an MOU" do
+      let(:current_user) { build :editor_user, :org_has_signed_mou }
+
+      it "does not show a banner" do
+        expect(rendered).not_to have_css ".govuk-notification-banner"
+      end
     end
   end
 
-  context "when the user is an admin" do
+  context "when the user is an organisation admin" do
     let(:current_user) { build :organisation_admin_user }
 
     it "shows the details text for admins" do

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "groups/show", type: :view do
-  let(:current_user) { create :user }
+  let(:current_user) { create :user, :org_has_signed_mou }
   let(:forms) { [] }
   let(:group) { create :group, name: "My Group" }
   let(:upgrade?) { false }
@@ -148,6 +148,14 @@ RSpec.describe "groups/show", type: :view do
 
     it "has the trial group heading in the notification banner" do
       expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
+    end
+
+    context "and the org has not signed an MOU" do
+      let(:current_user) { create :user }
+
+      it "tells user to contact support to make forms live" do
+        expect(rendered).to have_text("Speak to your organisation’s GOV.UK publishing team or contact the GOV.UK Forms team to find out how to make live forms.")
+      end
     end
   end
 


### PR DESCRIPTION
## Change group banner content for organisations which have not signed the MOU

Trello card: https://trello.com/c/Gy7muhlE/1528-show-banners-for-users-that-are-in-orgs-that-havent-agreed-mou-dont-have-an-org-admin

Add new banners and change the existing text when a user belongs to an organisation which has not signed the MOU yet.

![image](https://github.com/alphagov/forms-admin/assets/11035856/d554fa06-a462-4d00-be0b-e34a86af3d10)

![image](https://github.com/alphagov/forms-admin/assets/11035856/0619bc5f-8d51-4c2b-95fb-1a0bbc98dcd9)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
