### PR TITLE
Add ability to enable groups feature flag for individual organisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,18 @@ features:
 
 And check with `FeatureService.enabled?("some.nested_feature")`.
 
+You can also set a feature for users from a specific organisation:
+
+```yaml
+features:
+  some_feature:
+    enabled: false
+    organisations:
+      some_organisation: true
+```
+
+The `features.some_features.enabled` key sets the default for the flag, and then you can override for an organisation by adding a key for the organisation slug (with underscores instead of dashes). And then check the flag for a user with `FeatureService.new(user).enabled?(:some_feature)`.
+
 ### Testing with features
 
 You can also tag RSpec tests with `feature_{name}: true`. This will turn that feature on just for the duration of that test.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,6 +95,10 @@ class ApplicationController < ActionController::Base
     @current_form ||= Form.find(params[:form_id])
   end
 
+  def groups_enabled
+    @groups_enabled ||= current_user.present? && FeatureService.new(current_user).enabled?(:groups)
+  end
+
 private
 
   def authenticate_and_check_access

--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -62,7 +62,7 @@ module Forms
     end
 
     def delete_form(form)
-      success_url = FeatureService.enabled?(:groups) && form.group.present? ? group_path(form.group) : root_path
+      success_url = groups_enabled && form.group.present? ? group_path(form.group) : root_path
 
       authorize form, :can_view_form?
       if form.destroy

--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -32,7 +32,7 @@ class GroupFormsController < ApplicationController
 private
 
   def feature_enabled
-    raise ActionController::RoutingError, "Groups feature is not enabled" unless FeatureService.enabled?(:groups)
+    raise ActionController::RoutingError, "Groups feature is not enabled" unless groups_enabled
   end
 
   def set_group

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -28,7 +28,7 @@ class GroupMembersController < ApplicationController
 private
 
   def feature_enabled
-    raise ActionController::RoutingError, "Groups feature not enabled" unless FeatureService.enabled?(:groups)
+    raise ActionController::RoutingError, "Groups feature not enabled" unless groups_enabled
   end
 
   def set_group

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -107,7 +107,7 @@ class GroupsController < ApplicationController
 private
 
   def feature_enabled
-    raise ActionController::RoutingError, "Groups feature not enabled" unless FeatureService.enabled?(:groups)
+    raise ActionController::RoutingError, "Groups feature not enabled" unless groups_enabled
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,6 +1,6 @@
 class HomepageController < ApplicationController
   def index
-    if FeatureService.enabled? :groups
+    if groups_enabled
       redirect_to groups_path
     else
       FormsController.dispatch(:index, request, response)

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -35,7 +35,7 @@ class FormPolicy
   def can_view_form?
     return true if user.super_admin?
 
-    if FeatureService.enabled?(:groups) && form.group.present?
+    if FeatureService.new(user).enabled?(:groups) && form.group.present?
       return user.groups.include?(form.group) || user.is_organisations_admin?(form.group.organisation)
     end
 

--- a/app/service/feature_service.rb
+++ b/app/service/feature_service.rb
@@ -1,10 +1,33 @@
 class FeatureService
-  class << self
-    def enabled?(feature_name)
-      return false if Settings.features.blank?
+  class UserRequiredError < StandardError; end
 
-      segments = feature_name.to_s.split(".")
-      segments.reduce(Settings.features) { |config, segment| config[segment] }
+  class << self
+    def enabled?(...)
+      FeatureService.new(nil).enabled?(...)
     end
+  end
+
+  def initialize(user)
+    @user = user
+  end
+
+  def enabled?(feature_name)
+    return false if Settings.features.blank?
+
+    segments = feature_name.to_s.split(".")
+    feature = Settings.features.dig(*segments)
+
+    return feature unless feature.is_a? Config::Options
+
+    if feature.organisations.present?
+      raise UserRequiredError, "Feature #{feature_name} requires user to be provided" if @user.blank?
+
+      if @user.organisation.present?
+        organisation_key = @user.organisation.slug.underscore.to_sym
+        return feature.organisations[organisation_key] if feature.organisations.key?(organisation_key)
+      end
+    end
+
+    feature.enabled
   end
 end

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -1,6 +1,6 @@
 <% set_page_title(form.name) %>
 
-<% if FeatureService.enabled?(:groups) && form.group.present? %>
+<% if FeatureService.new(@current_user).enabled?(:groups) && form.group.present? %>
   <% content_for :back_link, govuk_back_link_to(group_path(form.group), t("back_link.group", group_name: form.group.name)) %>
 <% else %>
   <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -4,7 +4,7 @@
   <% content_for :back_link, govuk_back_link_to(live_form_path(current_form.id), t("back_link.form_view")) %>
 <% elsif current_form.is_archived? %>
   <% content_for :back_link, govuk_back_link_to(archived_form_path(current_form.id), t("back_link.form_view")) %>
-<% elsif FeatureService.enabled?(:groups) && current_form.group.present? %>
+<% elsif FeatureService.new(@current_user).enabled?(:groups) && current_form.group.present? %>
   <% content_for :back_link, govuk_back_link_to(group_path(current_form.group), t("back_link.group", group_name: current_form.group.name)) %>
 <% else %>
   <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,9 @@
+features:
+  groups:
+    enabled: false
+    organisations:
+      government_digital_service: false
+
 # Use real authentication
 auth_provider: gds_sso
 

--- a/spec/service/feature_service_spec.rb
+++ b/spec/service/feature_service_spec.rb
@@ -1,52 +1,170 @@
 require "rails_helper"
 
 describe FeatureService do
-  describe ".enabled?" do
-    context "when eature is enabled" do
+  describe "#enabled?" do
+    subject :feature_service do
+      described_class.new(user)
+    end
+
+    let(:organisation) { build :organisation, id: 1, slug: "a-test-org" }
+    let(:user) { build :user, id: 1, organisation: }
+
+    context "when the feature key has a boolean value" do
+      context "when feature key has value true" do
+        before do
+          Settings.features[:some_feature] = true
+        end
+
+        it "is enabled" do
+          expect(feature_service).to be_enabled(:some_feature)
+        end
+      end
+
+      context "when feature key has value false" do
+        before do
+          Settings.features[:some_feature] = false
+        end
+
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature)
+        end
+      end
+
+      context "when empty features" do
+        before do
+          allow(Settings).to receive(:features).and_return(nil)
+        end
+
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature)
+        end
+      end
+
+      context "when nested features" do
+        before do
+          Settings.features[:some] = OpenStruct.new(nested_feature: true)
+        end
+
+        it "is enabled" do
+          expect(feature_service).to be_enabled("some.nested_feature")
+        end
+      end
+    end
+
+    context "when the feature key has an object value" do
+      context "when the enabled key exists and is set to true" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: true)
+        end
+
+        it "is enabled" do
+          expect(feature_service).to be_enabled(:some_feature)
+        end
+      end
+
+      context "when the enabled key exists and is set to false" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: false)
+        end
+
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature)
+        end
+      end
+
+      context "when the enabled key does not exist" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new
+        end
+
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature)
+        end
+      end
+
+      context "when a key exists for the organisation overriding the feature to be enabled" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: false, organisations: { a_test_org: true })
+        end
+
+        it "is enabled" do
+          expect(feature_service).to be_enabled(:some_feature)
+        end
+      end
+
+      context "when a key exists for the organisation overriding the feature to be disabled" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: true, organisations: { a_test_org: false })
+        end
+
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature)
+        end
+      end
+
+      context "when a key exists for the organisation overriding the feature and the user has not been provided to the service" do
+        let(:feature_service) { described_class.new(nil) }
+
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: false, organisations: { a_test_org: true })
+        end
+
+        it "raises an error" do
+          expect { feature_service.enabled?(:some_feature) }.to raise_error described_class::UserRequiredError
+        end
+      end
+
+      context "when a key exists for a different organisation" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: false, organisations: { 'another-org': true })
+        end
+
+        it "returns the value of the enabled flag" do
+          expect(feature_service).not_to be_enabled(:some_feature)
+        end
+      end
+
+      context "when the organisations object is empty" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: true, organisations: {})
+        end
+
+        it "returns the value of the enabled flag" do
+          expect(feature_service).to be_enabled(:some_feature)
+        end
+      end
+
+      context "when the user does not have an organisation set" do
+        before do
+          user.organisation = nil
+          Settings.features[:some_feature] = Config::Options.new(enabled: false, organisations: { a_test_org: true })
+        end
+
+        it "returns the value of the enabled flag" do
+          expect(feature_service).not_to be_enabled(:some_feature)
+        end
+      end
+    end
+  end
+
+  describe ".enabled" do
+    context "when the feature key has a boolean value" do
       before do
         Settings.features[:some_feature] = true
       end
 
-      it "returns true" do
-        response = described_class.enabled?(:some_feature)
-
-        expect(response).to be_truthy
+      it "resolves the boolean value of a feature" do
+        expect(described_class).to be_enabled(:some_feature)
       end
     end
 
-    context "when feature is disabled" do
+    context "when the feature key has an object value" do
       before do
-        Settings.features[:some_feature] = false
+        Settings.features[:some_feature] = Config::Options.new(enabled: true)
       end
 
-      it "returns false" do
-        response = described_class.enabled?(:some_feature)
-
-        expect(response).to be_falsey
-      end
-    end
-
-    context "when empty features" do
-      before do
-        allow(Settings).to receive(:features).and_return(nil)
-      end
-
-      it "returns false" do
-        response = described_class.enabled?(:some_feature)
-
-        expect(response).to be_falsey
-      end
-    end
-
-    context "when nested features" do
-      before do
-        Settings.features[:some] = OpenStruct.new(nested_feature: true)
-      end
-
-      it "returns true" do
-        response = described_class.enabled?("some.nested_feature")
-
-        expect(response).to be_truthy
+      it "resolves the value of the enabled flag" do
+        expect(described_class).to be_enabled(:some_feature)
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/VTHtrbmn/1529-add-feature-flags-for-user-management-feature

Allow specifying overrides for a feature flag per organisation by providing an object in the settings YAML file as the value for the feature, with optional keys matching the slugs for individual organisations (with underscores instead of dashes). If a key exists for the organisation for the logged in user, the value of this key is used over the value of the `enabled` key.

Example:

```
features:
  groups:
    enabled: false
    organisations:
      government_digital_service: true
```

Update where we check the groups feature flag to pass in the logged in user to the FeatureService so we check whether the feature flag has an override for the user's organisation.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
