### PR TITLE
Restrict upgrade routes

### DIFF
--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -16,10 +16,12 @@ class GroupPolicy < ApplicationPolicy
   alias_method :add_editor?, :edit?
 
   def upgrade?
-    organisation_admin_or_super_admin?
+    organisation_admin_or_super_admin? && record.organisation.mou_signatures.present?
   end
 
-  alias_method :add_group_admin?, :upgrade?
+  def add_group_admin?
+    organisation_admin_or_super_admin?
+  end
 
   def request_upgrade?
     group_admin? && !record.active? && record.organisation.admin_users.present?

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -22,7 +22,7 @@ class GroupPolicy < ApplicationPolicy
   alias_method :add_group_admin?, :upgrade?
 
   def request_upgrade?
-    group_admin? && !record.active?
+    group_admin? && !record.active? && record.organisation.admin_users.present?
   end
 
   def review_upgrade?

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -13,6 +13,9 @@
           <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
           <%= t("groups.show.trial_banner.upgrade.body_html") %>
           <%= govuk_link_to t("groups.show.trial_banner.upgrade.link"), upgrade_group_path(@group) %>
+        <% elsif @current_user.super_admin? %>
+          <% nb.with_heading(text: t("groups.index.no_mou_banner.heading"), tag: "h3") %>
+          <%= t("groups.index.no_mou_banner.body_html", contact_link: contact_link) %>
         <% elsif policy(@group).request_upgrade? %>
           <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
           <%= t("groups.show.trial_banner.request_upgrade.body_html") %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -5,28 +5,35 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |nb| %>
-        <% if policy(@group).review_upgrade? %>
-          <% nb.with_heading(text: t("groups.show.trial_banner.review_upgrade.heading"), tag: "h3") %>
-          <%= t("groups.show.trial_banner.review_upgrade.body_html", upgrade_requester_name: @group.upgrade_requester.name) %>
-          <%= govuk_link_to t("groups.show.trial_banner.review_upgrade.link"), review_upgrade_group_path(@group) %>
-        <% elsif policy(@group).upgrade? %>
-          <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
-          <%= t("groups.show.trial_banner.upgrade.body_html") %>
-          <%= govuk_link_to t("groups.show.trial_banner.upgrade.link"), upgrade_group_path(@group) %>
-        <% elsif @current_user.super_admin? %>
-          <% nb.with_heading(text: t("groups.index.no_mou_banner.heading"), tag: "h3") %>
-          <%= t("groups.index.no_mou_banner.body_html", contact_link: contact_link) %>
-        <% elsif policy(@group).request_upgrade? %>
-          <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
-          <%= t("groups.show.trial_banner.request_upgrade.body_html") %>
-          <% if @group.organisation.mou_signatures.present? %>
+        <% if @group.organisation.mou_signatures.present? %>
+          <% if policy(@group).review_upgrade? %>
+            <% nb.with_heading(text: t("groups.show.trial_banner.review_upgrade.heading"), tag: "h3") %>
+            <%= t("groups.show.trial_banner.review_upgrade.body_html", upgrade_requester_name: @group.upgrade_requester.name) %>
+            <%= govuk_link_to t("groups.show.trial_banner.review_upgrade.link"), review_upgrade_group_path(@group) %>
+          <% elsif policy(@group).upgrade? %>
+            <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
+            <%= t("groups.show.trial_banner.upgrade.body_html") %>
+            <%= govuk_link_to t("groups.show.trial_banner.upgrade.link"), upgrade_group_path(@group) %>
+          <% elsif policy(@group).request_upgrade? %>
+            <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
+            <%= t("groups.show.trial_banner.request_upgrade.body_html") %>
             <%= govuk_link_to t("groups.show.trial_banner.request_upgrade.link"), request_upgrade_group_path(@group) %>
           <% else %>
-            <%= t("groups.show.trial_banner.request_upgrade.without_mou_signature_html", contact_link: contact_link) %>
+            <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
+            <%= t("groups.show.trial_banner.editor.body_html") %>
           <% end %>
         <% else %>
-          <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
-          <%= t("groups.show.trial_banner.editor.body_html") %>
+          <% if @current_user.super_admin? %>
+            <% nb.with_heading(text: t("groups.index.no_mou_banner.heading"), tag: "h3") %>
+            <%= t("groups.index.no_mou_banner.body_html", contact_link: contact_link) %>
+          <% elsif policy(@group).request_upgrade? %>
+            <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
+            <%= t("groups.show.trial_banner.request_upgrade.body_html") %>
+            <%= t("groups.show.trial_banner.request_upgrade.without_mou_signature_html", contact_link: contact_link) %>
+          <% else %>
+            <% nb.with_heading(text: t("groups.show.trial_banner.heading"), tag: "h3") %>
+            <%= t("groups.show.trial_banner.editor.body_html") %>
+          <% end %>
         <% end %>
       <% end %>
     </div>

--- a/spec/factories/models/groups.rb
+++ b/spec/factories/models/groups.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     organisation { association :organisation, id: 1, slug: "test-org" }
     creator { association :user, organisation: }
     status { :trial }
+
+    trait :org_has_org_admin do
+      organisation { association :organisation, :with_org_admin, id: 1, slug: "test-org" }
+    end
   end
 end

--- a/spec/factories/models/organisations.rb
+++ b/spec/factories/models/organisations.rb
@@ -14,5 +14,13 @@ FactoryBot.define do
         organisation.mou_signatures << (create :mou_signature_for_organisation, organisation:)
       end
     end
+
+    trait :with_org_admin do
+      with_signed_mou
+
+      after(:build) do |organisation|
+        organisation.users << create(:organisation_admin_user, organisation:)
+      end
+    end
   end
 end

--- a/spec/features/groups/request_upgrade_spec.rb
+++ b/spec/features/groups/request_upgrade_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 
 feature "Request an upgrade for a group", type: :feature, feature_groups: true do
   let!(:group) do
-    create(:group, organisation: editor_user.organisation).tap do |group|
+    create(:group, :org_has_org_admin, organisation: editor_user.organisation).tap do |group|
       create(:membership, user: editor_user, group:, role: :group_admin)
+      create(:organisation_admin_user, organisation: editor_user.organisation)
     end
   end
 

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe GroupPolicy do
         expect(policy).to permit_action(:review_upgrade)
       end
     end
+
+    context "when the group organisation does not have an MOU" do
+      let(:group) { build(:group) }
+
+      it "forbids upgrade" do
+        expect(policy).to forbid_action(:upgrade)
+      end
+    end
   end
 
   context "when user is organisation_admin" do

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -114,6 +114,14 @@ RSpec.describe GroupPolicy do
           expect(policy).to permit_action(:request_upgrade)
         end
       end
+
+      context "when the group belongs to an organisation without an org admin" do
+        let(:group) { build :group }
+
+        it "forbids request_upgrade" do
+          expect(policy).to forbid_action(:request_upgrade)
+        end
+      end
     end
   end
 end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -459,7 +459,11 @@ RSpec.describe "/groups", type: :request, feature_groups: true do
   end
 
   describe "GET /request_upgrade" do
+    let(:org_has_admin_user) { true }
+
     before do
+      create(:organisation_admin_user, organisation: current_user.organisation) if org_has_admin_user
+
       get request_upgrade_group_url(member_group)
     end
 
@@ -472,6 +476,14 @@ RSpec.describe "/groups", type: :request, feature_groups: true do
 
       it "renders the confirm upgrade request view" do
         expect(response).to render_template(:confirm_upgrade_request)
+      end
+
+      context "and their organisation does not have an admin user" do
+        let(:org_has_admin_user) { false }
+
+        it "is forbidden" do
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
 
@@ -497,6 +509,12 @@ RSpec.describe "/groups", type: :request, feature_groups: true do
   end
 
   describe "POST /request_upgrade" do
+    let(:org_has_admin_user) { true }
+
+    before do
+      create(:organisation_admin_user, organisation: current_user.organisation) if org_has_admin_user
+    end
+
     context "when user is a group admin" do
       let(:role) { :group_admin }
 
@@ -516,6 +534,16 @@ RSpec.describe "/groups", type: :request, feature_groups: true do
         post request_upgrade_group_url(member_group)
 
         expect(response).to render_template(:upgrade_requested)
+      end
+
+      context "when the organisation does not have an admin user" do
+        let(:org_has_admin_user) { false }
+
+        it "is forbidden" do
+          post request_upgrade_group_url(member_group)
+
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
 

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe "groups/show", type: :view do
         expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
       end
     end
+
+    context "when the user is a super admin" do
+      let(:current_user) { create(:super_admin_user) }
+
+      it "shows content for organisation requiring an MOU" do
+        expect(rendered).to have_text("Someone from your organisation needs to agree to a ‘Memorandum of Understanding’ with GOV.UK Forms before your organisation can make any forms live.")
+      end
+    end
   end
 
   context "and the user has permission to request an upgrade" do

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -117,59 +117,93 @@ RSpec.describe "groups/show", type: :view do
       expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
     end
 
-    context "when the user has permission to upgrade the group" do
-      let(:upgrade?) { true }
-      let(:request_upgrade?) { true }
+    context "when the group's organisation has signed an MOU" do
+      let(:current_user) { create :user, :org_has_signed_mou }
 
-      it "shows content for an organisation admin" do
-        expect(rendered).to have_text "Forms in this group cannot be made live unless the group is upgraded to an ‘active’ group."
+      context "and the user has permission to review upgrade requests" do
+        let(:review_upgrade?) { true }
+        let(:upgrade?) { true }
+        let(:request_upgrade?) { true }
+        let(:upgrade_requester) { create :user }
+        let(:group) { create :group, status: :upgrade_requested, upgrade_requester: }
+
+        it "has the heading in the notification banner for reviewing an upgrade request" do
+          expect(rendered).to have_css "h3", text: "A group admin has asked to upgrade this group"
+        end
+
+        it "has the content in the notification banner for reviewing an upgrade request" do
+          expect(rendered).to have_text "#{upgrade_requester.name} has asked to upgrade this group so they can make forms live."
+        end
+
+        it "shows a link to review the upgrade" do
+          expect(rendered).to have_link("Accept or reject this upgrade request", href: review_upgrade_group_path(group))
+        end
       end
 
-      it "shows a link to upgrade the group" do
-        expect(rendered).to have_link("Upgrade this group", href: upgrade_group_path(group))
+      context "when the user has permission to upgrade the group" do
+        let(:upgrade?) { true }
+        let(:request_upgrade?) { true }
+
+        it "shows content for an organisation admin" do
+          expect(rendered).to have_text "Forms in this group cannot be made live unless the group is upgraded to an ‘active’ group."
+        end
+
+        it "shows a link to upgrade the group" do
+          expect(rendered).to have_link("Upgrade this group", href: upgrade_group_path(group))
+        end
+
+        it "has the trial group heading in the notification banner" do
+          expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
+        end
       end
 
-      it "has the trial group heading in the notification banner" do
-        expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
+      context "and the user has permission to request an upgrade" do
+        let(:request_upgrade?) { true }
+
+        it "shows content for a group admin" do
+          expect(rendered).to have_text "You can create forms in this group and test them, but you cannot make them live."
+        end
+
+        it "shows a link to request an upgrade" do
+          expect(rendered).to have_link("Find out how to upgrade this group so you can make forms live", href: request_upgrade_group_path(group))
+        end
+
+        it "has the trial group heading in the notification banner" do
+          expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
+        end
       end
-    end
 
-    context "when the user is a super admin" do
-      let(:current_user) { create(:super_admin_user) }
-
-      it "shows content for organisation requiring an MOU" do
-        expect(rendered).to have_text("Someone from your organisation needs to agree to a ‘Memorandum of Understanding’ with GOV.UK Forms before your organisation can make any forms live.")
+      context "and the user has no permissions relating to upgrading groups" do
+        it "shows content for an editor" do
+          expect(rendered).to have_text "You can create a form, preview and test it."
+        end
       end
-    end
-  end
-
-  context "and the user has permission to request an upgrade" do
-    let(:request_upgrade?) { true }
-
-    it "shows content for a group admin" do
-      expect(rendered).to have_text "You can create forms in this group and test them, but you cannot make them live."
-    end
-
-    it "shows a link to request an upgrade" do
-      expect(rendered).to have_link("Find out how to upgrade this group so you can make forms live", href: request_upgrade_group_path(group))
-    end
-
-    it "has the trial group heading in the notification banner" do
-      expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
     end
 
     context "and the org has not signed an MOU" do
       let(:current_user) { create :user }
 
-      it "tells user to contact support to make forms live" do
-        expect(rendered).to have_text("Speak to your organisation’s GOV.UK publishing team or contact the GOV.UK Forms team to find out how to make live forms.")
-      end
-    end
-  end
+      context "when the user is a super admin" do
+        let(:current_user) { create :super_admin_user }
 
-  context "and the user has no permissions relating to upgrading groups" do
-    it "shows content for an editor" do
-      expect(rendered).to have_text "You can create a form, preview and test it."
+        it "shows content for organisation requiring an MOU" do
+          expect(rendered).to have_text("Someone from your organisation needs to agree to a ‘Memorandum of Understanding’ with GOV.UK Forms before your organisation can make any forms live.")
+        end
+      end
+
+      context "and the user has permission to request an upgrade" do
+        let(:request_upgrade?) { true }
+
+        it "tells user to contact support to make forms live" do
+          expect(rendered).to have_text("Speak to your organisation’s GOV.UK publishing team or contact the GOV.UK Forms team to find out how to make live forms.")
+        end
+      end
+
+      context "and the user has no permissions relating to upgrading groups" do
+        it "shows content for an editor" do
+          expect(rendered).to have_text "You can create a form, preview and test it."
+        end
+      end
     end
   end
 
@@ -186,26 +220,6 @@ RSpec.describe "groups/show", type: :view do
 
     it "has the trial group heading in the notification banner" do
       expect(rendered).to have_css "h3", text: "This is a ‘trial’ group"
-    end
-
-    context "when the user has permission to review upgrade requests" do
-      let(:review_upgrade?) { true }
-      let(:upgrade?) { true }
-      let(:request_upgrade?) { true }
-      let(:upgrade_requester) { create :user }
-      let(:group) { create :group, status: :upgrade_requested, upgrade_requester: }
-
-      it "has the heading in the notification banner for reviewing an upgrade request" do
-        expect(rendered).to have_css "h3", text: "A group admin has asked to upgrade this group"
-      end
-
-      it "has the content in the notification banner for reviewing an upgrade request" do
-        expect(rendered).to have_text "#{upgrade_requester.name} has asked to upgrade this group so they can make forms live."
-      end
-
-      it "shows a link to review the upgrade" do
-        expect(rendered).to have_link("Accept or reject this upgrade request", href: review_upgrade_group_path(group))
-      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/dvoXCPwg/1538-stop-group-upgrades-when-an-organisation-doesnt-have-an-mou-org-admins

Forbids group upgrades when a group's organisation has not signed an MOU
Forbids group admins from requesting an upgrade when a group's organisation does not have any organisation admins.

Also added some extra content for when a super admin views a trial group that can't be upgraded.

![image](https://github.com/alphagov/forms-admin/assets/25597009/d8544881-3b60-4d34-b21b-bf8f9494d697)

