### PR TITLE
Restrict making group forms live

### DIFF
--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -66,6 +66,10 @@ class FormPolicy
     false
   end
 
+  def can_administer_group?
+    user.super_admin? || user.is_organisations_admin?(form.group.organisation) || user.is_group_admin?(form.group)
+  end
+
 private
 
   def user_is_form_creator
@@ -74,9 +78,5 @@ private
 
   def users_organisation_owns_form
     user.organisation.present? ? user.organisation_id == form.organisation_id : false
-  end
-
-  def can_administer_group?
-    user.super_admin? || user.is_organisations_admin?(form.group.organisation) || user.is_group_admin?(form.group)
   end
 end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -58,7 +58,13 @@ class FormPolicy
     form_has_two_or_more_pages && form_has_qualifying_pages
   end
 
-  alias_method :can_make_form_live?, :can_change_form_submission_email?
+  def can_make_form_live?
+    # TODO: we should remove the check the form is within a group when we remove the feature flag
+    return can_change_form_submission_email? unless FeatureService.new(user).enabled?(:groups) && form.group.present?
+    return can_change_form_submission_email? if form.group.active? && can_administer_group?
+
+    false
+  end
 
 private
 
@@ -68,5 +74,9 @@ private
 
   def users_organisation_owns_form
     user.organisation.present? ? user.organisation_id == form.organisation_id : false
+  end
+
+  def can_administer_group?
+    user.super_admin? || user.is_organisations_admin?(form.group.organisation) || user.is_group_admin?(form.group)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -240,10 +240,26 @@ en:
             Editor accounts can change the email address completed forms are sent to.
         title: Set email address for completed forms
       make_form_live_section:
+        group_not_active:
+          group_admin:
+            body_text: |
+              You cannot make this form live because it’s in a ‘trial’ group.
+
+              <a href="%{upgrade_path}">Find out how to upgrade the group</a> so you can make forms live.
+          group_editor:
+            body_text: |
+              This form cannot be made live because it’s in a ‘trial’ group.
+
+              A group admin can request to upgrade the group so forms can be made live. You can <a href="%{group_members_path}">view the members of the group</a> to find a group admin.
         if_not_permitted:
           body_text: You cannot make a form live with a trial account.
         make_live: Make your form live
         title: Make your form live
+        user_cannot_administer:
+          body_text: |
+            Only a group admin can make a form live.
+
+            <a href="%{group_members_path}">View the members of the group</a> to find a group admin.
       payment_link_subsection:
         payment_link: Add a link to a payment page on GOV.UK Pay
         title: Optional tasks

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe FormPolicy, feature_groups: true do
   subject(:policy) { described_class.new(user, form) }
 
-  let(:organisation) { build :organisation, :with_signed_mou, id: 1, slug: "gds" }
+  let(:organisation) { build :organisation, :with_signed_mou, id: 1 }
   let(:form) { build :form, id: 1, organisation_id: 1, creator_id: 123 }
   let(:group) { create(:group, name: "Group 1", organisation:, status: group_status) }
   let(:group_status) { :trial }
@@ -304,6 +304,37 @@ describe FormPolicy, feature_groups: true do
           it { is_expected.to permit_actions(%i[can_add_page_routing_conditions]) }
         end
       end
+    end
+  end
+
+  describe "#can_administer_group?" do
+    let(:group) { create(:group, name: "Group 1", organisation:) }
+    let(:group_role) { :editor }
+
+    before do
+      Membership.create!(user:, group:, added_by: user, role: group_role)
+    end
+
+    context "when the user is a super admin" do
+      let(:user) { build :super_admin_user }
+
+      it { is_expected.to permit_action(:can_administer_group) }
+    end
+
+    context "when the user is an organisation admin" do
+      let(:user) { build :organisation_admin_user }
+
+      it { is_expected.to permit_action(:can_administer_group) }
+    end
+
+    context "when the user is a group admin" do
+      let(:group_role) { :group_admin }
+
+      it { is_expected.to permit_action(:can_administer_group) }
+    end
+
+    context "when the user is an editor" do
+      it { is_expected.to forbid_action(:can_administer_group) }
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?
This PR prevent forms within groups from being made live if the group is not active, or if the user doesn't have permission to administer the group (group, org, and super admins). 

It also includes changes to the task list, to indicate to the user why the form cannot be made live, and point them in the direction of a group admin or the group page as appropriate.

Trello card: https://trello.com/c/6nLLXGzi

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Screenshots
#### Inactive group, editor user
![image](https://github.com/alphagov/forms-admin/assets/5861235/91b5046f-1ef8-400b-bd69-5334a8e20b13)

#### Inactive group, admin users
![image](https://github.com/alphagov/forms-admin/assets/5861235/52c36531-c0ac-479c-ab6a-6bbdc45f6dfe)

For group admins, the link will go directly to the request upgrade page. For org and super admins, it'll go to the group page.

#### Active group, editor user
![image](https://github.com/alphagov/forms-admin/assets/5861235/cc56848b-c552-422e-b55d-6a32219f5bcf)

#### Active group, admin user
![image](https://github.com/alphagov/forms-admin/assets/5861235/2230d1d3-e8ea-4931-ae0e-c9dc338d9bc1)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
