### PR TITLE
Tweak MOU banner markup

### DIFF
--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -13,7 +13,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("groups.index.no_mou_banner.heading"), tag: "h3") %>
-        <% banner.with_heading(text: t("groups.index.no_mou_banner.body_html", contact_link: contact_link)) %>
+        <% t("groups.index.no_mou_banner.body_html", contact_link: contact_link) %>
       <% end %>
     </div>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -10,7 +10,7 @@
 
       <% unless @user.current_org_has_mou? %>
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
-          <%= t('users.edit.mou_banner') %>
+          <% banner.with_heading(text: t('users.edit.mou_banner'), tag: "p") %>
         <% end %>
       <% end %>
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

Tweaks the markup (specifically the usage of `.with_heading()`) on a couple of the new MOU banners to make them match the Design System guidance and the other uses of the component:

- the banner on the groups page was using `with_heading` twice, once for the heading and once for body text. I've updated it so that it's only used once
- the banner on the edit user page wasn't using the `with_heading` at all, which meant this banner wasn't getting the same styles as other banners. I've updated that so it is

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
