### PR TITLE
Remove old feature flags

### DIFF
--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -24,10 +24,6 @@ module MetricsSummaryComponent
       end
     end
 
-    def render?
-      FeatureService.enabled?(:metrics_for_form_creators_enabled)
-    end
-
     def formatted_date_range
       start_date_format_string = start_date.year == end_date.year ? "%e %B" : "%e %B %Y"
       formatted_start_date = format_date(start_date.strftime(start_date_format_string))

--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -58,7 +58,7 @@ module Forms
     end
 
     def live_submission_email_updated?
-      return false unless FeatureService.enabled?(:notify_original_submission_email_of_change) && current_form.is_live?
+      return false unless current_form.is_live?
 
       current_live_form.submission_email != current_form.submission_email
     end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -92,7 +92,6 @@ class Form < ActiveResource::Base
   end
 
   def metrics_data
-    return nil unless FeatureService.enabled?(:metrics_for_form_creators_enabled)
     return nil if made_live_date.nil?
 
     # If the form went live today, there won't be any metrics to show

--- a/app/service/make_form_live_service.rb
+++ b/app/service/make_form_live_service.rb
@@ -14,7 +14,7 @@ class MakeFormLiveService
   def make_live
     @current_form.make_live!
 
-    if FeatureService.enabled?(:notify_original_submission_email_of_change) && live_form_submission_email_has_changed
+    if live_form_submission_email_has_changed
       SubmissionEmailMailer.alert_email_change(
         live_email: @current_live_form.submission_email,
         form_name: @current_live_form.name,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,5 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
-  check_your_question_enabled: false
   groups: false
 
 forms_api:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,6 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
   metrics_for_form_creators_enabled: false
-  notify_original_submission_email_of_change: false
   check_your_question_enabled: false
   groups: false
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,5 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
-  metrics_for_form_creators_enabled: false
   check_your_question_enabled: false
   groups: false
 

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe MetricsSummaryComponent::View, type: :component, feature_metrics_for_form_creators_enabled: true do
+RSpec.describe MetricsSummaryComponent::View, type: :component do
   let(:metrics_data) { nil }
   let(:form_live_date) { 7.days.ago.to_date }
   let(:metrics_summary) { described_class.new(form_live_date, metrics_data) }

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -21,7 +21,7 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    include_examples expected_value_test, :check_your_question_enabled, features, false
+    include_examples expected_value_test, :groups, features, false
   end
 
   describe "forms_api" do

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,7 +22,6 @@ describe "Settings" do
     features = settings[:features]
 
     include_examples expected_value_test, :check_your_question_enabled, features, false
-    include_examples expected_value_test, :metrics_for_form_creators_enabled, features, false
   end
 
   describe "forms_api" do

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -23,7 +23,6 @@ describe "Settings" do
 
     include_examples expected_value_test, :check_your_question_enabled, features, false
     include_examples expected_value_test, :metrics_for_form_creators_enabled, features, false
-    include_examples expected_value_test, :notify_original_submission_email_of_change, features, false
   end
 
   describe "forms_api" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -245,7 +245,7 @@ describe Form, type: :model do
     end
   end
 
-  describe "#metrics_data", feature_metrics_for_form_creators_enabled: true do
+  describe "#metrics_data" do
     let(:form) do
       described_class.new(id: 2, live_at: Time.zone.now - 1.day)
     end
@@ -319,12 +319,6 @@ describe Form, type: :model do
         described_class.new(id: 2, made_live_date: nil)
       end
 
-      it "returns nil" do
-        expect(form.metrics_data).to eq(nil)
-      end
-    end
-
-    context "when the metrics feature flag is off", feature_metrics_for_form_creators_enabled: false do
       it "returns nil" do
         expect(form.metrics_data).to eq(nil)
       end

--- a/spec/requests/forms/live_controller_spec.rb
+++ b/spec/requests/forms/live_controller_spec.rb
@@ -33,43 +33,21 @@ RSpec.describe Forms::LiveController, type: :request do
       expect(response).to render_template(:show_form)
     end
 
-    context "with metrics enabled", feature_metrics_for_form_creators_enabled: true do
-      context "when the form went live today" do
-        it "does not read the Cloudwatch API" do
-          expect(CloudWatchService).not_to have_received(:week_submissions)
-          expect(CloudWatchService).not_to have_received(:week_starts)
-        end
-      end
-
-      context "when the form went live before today" do
-        let(:form) do
-          build(:form, :live, id: 2, live_at: Time.zone.now - 1.day)
-        end
-
-        it "reads the Cloudwatch API" do
-          expect(CloudWatchService).to have_received(:week_submissions).once
-          expect(CloudWatchService).to have_received(:week_starts).once
-        end
+    context "when the form went live today" do
+      it "does not read the Cloudwatch API" do
+        expect(CloudWatchService).not_to have_received(:week_submissions)
+        expect(CloudWatchService).not_to have_received(:week_starts)
       end
     end
 
-    context "when the metrics feature flag is off", feature_metrics_for_form_creators_enabled: false do
-      context "when the form went live today" do
-        it "does not read the Cloudwatch API" do
-          expect(CloudWatchService).not_to have_received(:week_submissions)
-          expect(CloudWatchService).not_to have_received(:week_starts)
-        end
+    context "when the form went live before today" do
+      let(:form) do
+        build(:form, :live, id: 2, live_at: Time.zone.now - 1.day)
       end
 
-      context "when the form went live before today" do
-        let(:form) do
-          build(:form, :live, id: 2, live_at: Time.zone.now - 1.day)
-        end
-
-        it "does not read the Cloudwatch API" do
-          expect(CloudWatchService).not_to have_received(:week_submissions)
-          expect(CloudWatchService).not_to have_received(:week_starts)
-        end
+      it "reads the Cloudwatch API" do
+        expect(CloudWatchService).to have_received(:week_submissions).once
+        expect(CloudWatchService).to have_received(:week_starts).once
       end
     end
   end

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -269,14 +269,8 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
         get submission_email_confirmed_path(form.id)
       end
 
-      it "displays the default text" do
-        expect(response.body).to include(I18n.t("email_code_success.body_html", submission_email: form.submission_email))
-      end
-
-      context "when live_submission_email_changed_body_html is enabled", feature_notify_original_submission_email_of_change: true do
-        it "displays the default text and tells users we will email form processing team" do
-          expect(response.body).to include(simple_format(I18n.t("email_code_success.live_submission_email_changed_body_html", new_submission_email: form.submission_email)))
-        end
+      it "displays the default text and tells users we will email form processing team" do
+        expect(response.body).to include(simple_format(I18n.t("email_code_success.live_submission_email_changed_body_html", new_submission_email: form.submission_email)))
       end
     end
   end

--- a/spec/service/make_form_live_service_spec.rb
+++ b/spec/service/make_form_live_service_spec.rb
@@ -46,23 +46,15 @@ describe MakeFormLiveService do
           current_form.submission_email = "i-have-changed@example.com"
         end
 
-        it "does not call the SubmissionEmailMailer" do
-          expect(SubmissionEmailMailer).not_to receive(:alert_email_change)
+        it "calls the SubmissionEmailMailer" do
+          expect(SubmissionEmailMailer).to receive(:alert_email_change).with(
+            live_email: live_form.submission_email,
+            form_name: live_form.name,
+            creator_name: current_user.name,
+            creator_email: current_user.email,
+          ).and_call_original
 
           make_form_live_service.make_live
-        end
-
-        context "when notify_original_submission_email_of_change feature is enabled", feature_notify_original_submission_email_of_change: true do
-          it "calls the SubmissionEmailMailer" do
-            expect(SubmissionEmailMailer).to receive(:alert_email_change).with(
-              live_email: live_form.submission_email,
-              form_name: live_form.name,
-              creator_name: current_user.name,
-              creator_email: current_user.email,
-            ).and_call_original
-
-            make_form_live_service.make_live
-          end
         end
       end
     end

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
-describe "forms/_made_live_form.html.erb", feature_metrics_for_form_creators_enabled: false, feature_groups: true do
+describe "forms/_made_live_form.html.erb", feature_groups: true do
   let(:declaration) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
+  let(:metrics_data) { { weekly_submissions: 125, weekly_starts: 256 } }
   let(:what_happens_next) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:form_metadata) { OpenStruct.new(has_draft_version: false) }
   let(:form) { build(:form, :live, id: 2, declaration_text: declaration, what_happens_next_markdown: what_happens_next, live_at: 1.week.ago) }
   let(:group) { create(:group, name: "Group 1") }
-  let(:metrics_data) { nil }
   let(:status) { :live }
   let(:preview_mode) { :preview_live }
   let(:questions_path) { Faker::Internet.url }
@@ -97,10 +97,6 @@ describe "forms/_made_live_form.html.erb", feature_metrics_for_form_creators_ena
 
   it "contains a link to view questions" do
     expect(rendered).to have_link("#{form.pages.count} questions", href: questions_path)
-  end
-
-  it "does not render the metrics summary component" do
-    expect(rendered).not_to have_text(I18n.t("metrics_summary.description"))
   end
 
   context "with only a single question" do
@@ -201,12 +197,8 @@ describe "forms/_made_live_form.html.erb", feature_metrics_for_form_creators_ena
     end
   end
 
-  context "when the metrics feature is enabled", feature_metrics_for_form_creators_enabled: true do
-    let(:metrics_data) { { weekly_submissions: 125, weekly_starts: 256 } }
-
-    it "renders the metrics summary component" do
-      expect(rendered).to have_text("If you want to track metrics over a longer period you'll need to make a note of these on the same day each week.")
-    end
+  it "renders the metrics summary component" do
+    expect(rendered).to have_text("If you want to track metrics over a longer period you'll need to make a note of these on the same day each week.")
   end
 
   context "when form is not in a group" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

We had two feature flags that have been hanging around for more than 6 months:
- `notify_original_submission_email_of_change` - controls whether we notify the old email address when a user changes a form's submission address.
- `metrics_for_form_creators_enabled` - controls whether users can see the metric feature on live forms.

These features have been around long enough that I think we can be confident that we won't turn the flags off, so this PR removes them.

We also had one flag which doesn't have any code attached to it, and isn't passed in by the terraform:
- `check_your_question_enabled` - intended to control the wizard-like 'Check your question' journey which we were going to implement (and still plan to at some point). 

It doesn't feel like there's much point having this flag at the moment, so I've removed it. We can readd it when we pick this feature up again.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
