### PR TITLE
Add end to end test group to database seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,6 +27,8 @@ if HostingEnvironment.local_development? && User.none?
                                 uid: "123456",
                                 provider: :mock_gds_sso })
 
+  FactoryBot.create :mou_signature_for_organisation, organisation: gds
+
   # create extra organisations
   test_org = FactoryBot.create :organisation, slug: "test-org"
   FactoryBot.create :organisation, slug: "ministry-of-tests"
@@ -55,6 +57,9 @@ if HostingEnvironment.local_development? && User.none?
   test_group = FactoryBot.create :group, name: "Test Group", organisation: gds, creator: default_user
   FactoryBot.create :group, name: "Ministry of Tests forms", organisation: test_org, creator: default_user
   FactoryBot.create :group, name: "Ministry of Tests forms - secret!", organisation: test_org, creator: default_user
+  end_to_end_group = FactoryBot.create :group, name: "End to end tests", organisation: gds, status: :active, creator: default_user
+
+  FactoryBot.create :membership, user: default_user, group: end_to_end_group, added_by: default_user, role: :group_admin
 
   # add a form to a test group (assumes database seed being used for forms-api)
   GroupForm.create! group: test_group, form_id: 1


### PR DESCRIPTION
To run the end to end tests locally, an active group must exist.

This commit changes the seed file to sign the MOU of the GDS organisation, create an active group and add the first user to it as group admin.


Trello card: https://trello.com/c/quDifeT4/1550-migration-ensure-the-end-to-end-tests-pass-with-groups-feature-both-enabled-and-disabled

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
