### PR TITLE
Remove full stop from upgrade banner

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -376,8 +376,8 @@ en:
       trial_empty_message: You’re not in any trial groups.
       trial_title: Trial groups
       upgrade_requests_banner_heading:
-        one: You have one request to upgrade a trial group.
-        other: You have %{count} requests to upgrade a trial group.
+        one: You have one request to upgrade a trial group
+        other: You have %{count} requests to upgrade a trial group
       upgrade_requests_title: Upgrade requests
     new:
       title: New group

--- a/spec/features/groups/request_upgrade_spec.rb
+++ b/spec/features/groups/request_upgrade_spec.rb
@@ -69,7 +69,7 @@ feature "Request an upgrade for a group", type: :feature, feature_groups: true d
   end
 
   def then_i_see_a_notification_banner_stating_there_are_upgrade_requests
-    expect(page).to have_css ".govuk-notification-banner", text: "You have one request to upgrade a trial group."
+    expect(page).to have_css ".govuk-notification-banner", text: "You have one request to upgrade a trial group"
     expect_page_to_have_no_axe_errors(page)
   end
 

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "groups/index", type: :view do
       let(:upgrade_requested_groups) { create_list :group, 1, status: :upgrade_requested }
 
       it "shows a notification banner" do
-        expect(rendered).to have_css ".govuk-notification-banner", text: "You have one request to upgrade a trial group."
+        expect(rendered).to have_css ".govuk-notification-banner", text: "You have one request to upgrade a trial group"
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe "groups/index", type: :view do
       let(:upgrade_requested_groups) { create_list :group, 2, status: :upgrade_requested }
 
       it "shows a notification banner with pluralized message" do
-        expect(rendered).to have_css ".govuk-notification-banner", text: "You have 2 requests to upgrade a trial group."
+        expect(rendered).to have_css ".govuk-notification-banner", text: "You have 2 requests to upgrade a trial group"
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Just removing a rogue full-stop that was erroneously in the designs. Silly content designer (me). This is part of our review of all the content for user management. 

Trello card:https://trello.com/c/RHC9XKps/1531-content-review-of-user-management-so-far-to-identify-anything-that-need-changing

### Things to consider when reviewing

- Did Hannah break anything or miss anything? 