### PR TITLE
Enable the groups feature flag for e2e test org

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,7 +2,7 @@ features:
   groups:
     enabled: false
     organisations:
-      government_digital_service: false
+      gov-uk-forms-end-to-end-tests: true
 
 # Use real authentication
 auth_provider: gds_sso


### PR DESCRIPTION
The end to end tests will move to another organisation to keep them separate from the GDS org.

This commit enables the groups feature for the new organisation.

We no longer need to specify GDS in the groups feature, so it's removed.

### What problem does this pull request solve?

Trello card: https://trello.com/c/quDifeT4/1550-migration-ensure-the-end-to-end-tests-pass-with-groups-feature-both-enabled-and-disabled

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
