### PR TITLE
Change groups feature flag for e2e to underscores

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,7 +2,7 @@ features:
   groups:
     enabled: false
     organisations:
-      gov-uk-forms-end-to-end-tests: true
+      gov_uk_forms_end_to_end_tests: true
 
 # Use real authentication
 auth_provider: gds_sso


### PR DESCRIPTION
Underscores, not hyphens should be used when setting the groups feature flag for organisation slugs.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
