### PR TITLE
Remove link to request upgrade when org has no org admins

### DIFF
--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -139,6 +139,7 @@ private
   end
 
   def inactive_group_message
+    return I18n.t("forms.task_list_create.make_form_live_section.group_not_active.no_org_admin") if @form.group.organisation.admin_users.blank?
     return I18n.t("forms.task_list_create.make_form_live_section.group_not_active.group_admin.body_text", upgrade_path: group_upgrade_url) if Pundit.policy(@current_user, @form).can_administer_group?
 
     I18n.t("forms.task_list_create.make_form_live_section.group_not_active.group_editor.body_text", group_members_path: group_members_path(@form.group))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,6 +255,7 @@ en:
               This form cannot be made live because it’s in a ‘trial’ group.
 
               A group admin can request to upgrade the group so forms can be made live. You can <a href="%{group_members_path}">view the members of the group</a> to find a group admin.
+          no_org_admin: You cannot make this form live because it’s in a ‘trial’ group.
         if_not_permitted:
           body_text: You cannot make a form live with a trial account.
         make_live: Make your form live

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -343,40 +343,42 @@ describe FormTaskListService do
             expect(section).not_to include(:rows)
           end
 
-          context "when the user is an editor" do
-            let(:group_role) { :editor }
-
-            it "has text explaining that the group must be upgraded, with a link to the group members page" do
+          context "when the organisation has no organisation admins" do
+            it "has text explaining that the form cannot be made live because it is in a trial group, with no link to request an upgrade" do
               expect(section[:body_text])
-                .to eq I18n.t(
-                  "forms.task_list_create.make_form_live_section.group_not_active.group_editor.body_text", group_members_path: group_members_path(group)
-                )
+                .to eq I18n.t("forms.task_list_create.make_form_live_section.group_not_active.no_org_admin")
             end
           end
 
-          context "when the user is a group admin" do
-            let(:group_role) { :group_admin }
-
-            it "has text explaining that the group must be upgraded, with a link to the upgrade request page" do
-              expect(section[:body_text])
-                .to eq I18n.t(
-                  "forms.task_list_create.make_form_live_section.group_not_active.group_admin.body_text", upgrade_path: request_upgrade_group_path(group)
-                )
-            end
-          end
-
-          context "when the user is an organisation admin" do
-            let(:current_user) { create :user, :organisation_admin, organisation: }
-
-            it "has text explaining that forms need to be in an active group to be made live" do
-              expect(section[:body_text])
-                .to eq I18n.t(
-                  "forms.task_list_create.make_form_live_section.group_not_active.group_admin.body_text", upgrade_path: group_path(group)
-                )
+          context "when the organisation has an organisation admin" do
+            before do
+              create(:user, organisation:, role: :organisation_admin)
             end
 
-            context "when the user is also a group admin" do
+            context "when the user is an editor" do
+              let(:group_role) { :editor }
+
+              it "has text explaining that the group must be upgraded, with a link to the group members page" do
+                expect(section[:body_text])
+                  .to eq I18n.t(
+                    "forms.task_list_create.make_form_live_section.group_not_active.group_editor.body_text", group_members_path: group_members_path(group)
+                  )
+              end
+            end
+
+            context "when the user is a group admin" do
               let(:group_role) { :group_admin }
+
+              it "has text explaining that the group must be upgraded, with a link to the upgrade request page" do
+                expect(section[:body_text])
+                  .to eq I18n.t(
+                    "forms.task_list_create.make_form_live_section.group_not_active.group_admin.body_text", upgrade_path: request_upgrade_group_path(group)
+                  )
+              end
+            end
+
+            context "when the user is an organisation admin" do
+              let(:current_user) { create :user, :organisation_admin, organisation: }
 
               it "has text explaining that forms need to be in an active group to be made live" do
                 expect(section[:body_text])
@@ -384,17 +386,28 @@ describe FormTaskListService do
                     "forms.task_list_create.make_form_live_section.group_not_active.group_admin.body_text", upgrade_path: group_path(group)
                   )
               end
+
+              context "when the user is also a group admin" do
+                let(:group_role) { :group_admin }
+
+                it "has text explaining that forms need to be in an active group to be made live" do
+                  expect(section[:body_text])
+                    .to eq I18n.t(
+                      "forms.task_list_create.make_form_live_section.group_not_active.group_admin.body_text", upgrade_path: group_path(group)
+                    )
+                end
+              end
             end
-          end
 
-          context "when the user is a super admin" do
-            let(:current_user) { build :user, :super_admin, organisation: }
+            context "when the user is a super admin" do
+              let(:current_user) { build :user, :super_admin, organisation: }
 
-            it "has text explaining that forms need to be in an active group to be made live" do
-              expect(section[:body_text])
-                .to eq I18n.t(
-                  "forms.task_list_create.make_form_live_section.group_not_active.group_admin.body_text", upgrade_path: group_path(group)
-                )
+              it "has text explaining that forms need to be in an active group to be made live" do
+                expect(section[:body_text])
+                  .to eq I18n.t(
+                    "forms.task_list_create.make_form_live_section.group_not_active.group_admin.body_text", upgrade_path: group_path(group)
+                  )
+              end
             end
           end
         end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/slE3Jq7H/1569-remove-link-to-request-an-upgrade-from-task-list-for-trial-groups-with-no-org-admin

Don't display the link to request a group upgrade in the "Make your form live" section for a form if the organisation that the group belongs to does not have any organisation admins. This is because there will be nobody to request an upgrade from.

Instead, rely on the user seeing the various other banners that will tell them what to do to make their group active.

<img width="562" alt="Screenshot 2024-06-03 at 15 29 12" src="https://github.com/alphagov/forms-admin/assets/5648592/4837fde0-4864-447a-b2a3-123a4f96933b">

### Things to consider when reviewing

It might be easier to hide whitespace changes in the diff when reviewing, as I added some extra contexts that changed indentation.

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
