### PR TITLE
Add group constraint for name and organisation

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -14,7 +14,7 @@ class Group < ApplicationRecord
 
   scope :for_organisation, ->(organisation) { where(organisation:) }
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: { scope: :organisation_id }
   before_create :set_external_id
 
   enum :status, { trial: "trial", active: "active", upgrade_requested: "upgrade_requested" }, validate: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
           attributes:
             name:
               blank: Enter a name for the group
+              taken: Your organisation already has a group with this name
         mou_signature:
           attributes:
             agreed:

--- a/db/migrate/20240603134957_add_group_constraints_by_name_and_organisation.rb
+++ b/db/migrate/20240603134957_add_group_constraints_by_name_and_organisation.rb
@@ -1,0 +1,5 @@
+class AddGroupConstraintsByNameAndOrganisation < ActiveRecord::Migration[7.1]
+  def change
+    add_index(:groups, %i[name organisation_id], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_09_160514) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_03_134957) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_09_160514) do
     t.bigint "upgrade_requester_id"
     t.index ["creator_id"], name: "index_groups_on_creator_id"
     t.index ["external_id"], name: "index_groups_on_external_id", unique: true
+    t.index ["name", "organisation_id"], name: "index_groups_on_name_and_organisation_id", unique: true
     t.index ["organisation_id"], name: "index_groups_on_organisation_id"
     t.index ["upgrade_requester_id"], name: "index_groups_on_upgrade_requester_id"
   end

--- a/spec/factories/models/groups.rb
+++ b/spec/factories/models/groups.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :group do
-    name { "My Group" }
+    sequence(:name) { |n| "Group #{n}" }
     organisation { association :organisation, id: 1, slug: "test-org" }
     creator { association :user, organisation: }
     status { :trial }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -36,6 +36,32 @@ RSpec.describe Group, type: :model do
       group = build :group, upgrade_requester: nil
       expect(group).to be_valid
     end
+
+    it "is invalid when a group already exists with the same name and organisation" do
+      organisation = create :organisation
+      create :group, organisation:, name: "Test group"
+      group = build :group, organisation:, name: "Test group"
+
+      expect(group).to be_invalid
+      expect(group.errors[:name]).to eq([I18n.t("activerecord.errors.models.group.attributes.name.taken")])
+    end
+
+    it "is valid when two groups have the same name but different organisations" do
+      organisation = create :organisation
+      other_organisation = create :organisation, name: "other organisation", slug: "other-organisation"
+      create :group, organisation:, name: "Test group"
+      group = build :group, organisation: other_organisation, name: "Test group"
+
+      expect(group).to be_valid
+    end
+
+    it "is valid when two groups have different names but the same organisation" do
+      organisation = create :organisation
+      create :group, organisation:, name: "Test group"
+      group = build :group, organisation:, name: "Other group"
+
+      expect(group).to be_valid
+    end
   end
 
   describe "before_create" do


### PR DESCRIPTION
Adds a index to the groups table on name and organisation.

Also adds validation to the group model to check that name and organisation are a unique combination.

### What problem does this pull request solve?

Trello card: https://trello.com/c/ZbW37yS5/1551-migration-create-a-default-group-for-each-organisation

*group name already exists error*
![image](https://github.com/alphagov/forms-admin/assets/25597009/299d5237-799b-41f4-b965-6decc745374d)
