### PR TITLE
Put forms in default groups

### DIFF
--- a/app/controllers/forms/change_name_controller.rb
+++ b/app/controllers/forms/change_name_controller.rb
@@ -22,6 +22,7 @@ module Forms
       @name_input = NameInput.new(name_input_params(form))
 
       if @name_input.submit
+        FormService.new(form).add_to_default_group!(@current_user)
         redirect_to form_path(@name_input.form)
       else
         render :new

--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -16,7 +16,8 @@ class GroupFormsController < ApplicationController
     @group_form = GroupForm.new(group: @group)
     authorize @group_form
 
-    @form = Form.new(creator_id: @current_user.id)
+    @form = Form.new(creator_id: @current_user.id, organisation_id: @current_user.organisation_id)
+
     @name_input = Forms::NameInput.new(name_input_params(@form))
 
     if @name_input.submit

--- a/app/service/form_service.rb
+++ b/app/service/form_service.rb
@@ -11,4 +11,23 @@ class FormService
 
     form_path(@form.id)
   end
+
+  def add_to_default_group!(current_user)
+    return if current_user.trial?
+
+    org = current_user.organisation
+
+    if org.default_group.nil?
+      status = org.mou_signatures.present? ? :active : :trial
+      org.create_default_group!(name: "#{org.name} forms", organisation: org, status:)
+      org.save!
+    end
+
+    group_form = GroupForm.new(group: org.default_group)
+
+    group_form.form_id = @form.id
+    group_form.save!
+
+    org.default_group.memberships.find_or_create_by!(user: current_user, role: :editor, added_by: current_user)
+  end
 end

--- a/lib/tasks/default_groups.rake
+++ b/lib/tasks/default_groups.rake
@@ -1,0 +1,36 @@
+namespace :default_groups do
+  desc "Create default groups for organisations"
+  task create: :environment do
+    Organisation.joins(:users).where(users: { role: :editor }).distinct.each do |org|
+      Rails.logger.info "rake default_groups started"
+      Rails.logger.info "default_group: organisation #{org.name}"
+
+      if org.default_group.nil?
+        status = org.mou_signatures.present? ? :active : :trial
+        org.create_default_group!(name: "#{org.name} forms", organisation: org, status:)
+        org.save!
+        Rails.logger.info "default_group: created #{org.default_group.name}, with status #{org.default_group.status}"
+      end
+
+      org.users.editor.each do |editor|
+        org.default_group.memberships.find_or_create_by!(user: editor) do |membership|
+          membership.role = :editor
+          membership.added_by = editor
+          Rails.logger.info "default_group: added user #{editor.email}"
+        end
+      end
+
+      # Form is not an activerecord object so find_each is not right here
+      # rubocop:disable Rails/FindEach
+      Form.where(organisation_id: org.id).each do |form|
+        GroupForm.find_or_create_by!(form_id: form.id) do |group_form|
+          Rails.logger.info "default_group: added form to default group #{form.name}"
+          group_form.group = org.default_group
+        end
+      end
+      # rubocop:enable Rails/FindEach
+    end
+
+    Rails.logger.info "rake default_groups finished"
+  end
+end

--- a/spec/lib/tasks/default_groups.rake_spec.rb
+++ b/spec/lib/tasks/default_groups.rake_spec.rb
@@ -1,0 +1,111 @@
+require "rake"
+require "rails_helper"
+
+RSpec.describe "default_groups.rake" do
+  before do
+    Rake.application.rake_require "tasks/default_groups"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "default_groups:create" do
+    subject(:task) do
+      Rake::Task["default_groups:create"]
+        .tap(&:reenable)
+    end
+
+    let(:organisation) { create :organisation }
+    let!(:user) { create :editor_user, organisation: }
+    let!(:trial_user) { create :user, organisation: }
+    let(:forms_response) do
+      build_list(:form, 3) do |form, i|
+        form.id = i
+      end
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms?organisation_id=#{organisation.id}", headers, forms_response.to_json, 200
+      end
+    end
+
+    context "with the happy path" do
+      before do
+        task.invoke
+      end
+
+      it "creates a default group" do
+        expect(organisation.reload.default_group).not_to be_nil
+      end
+
+      it "adds user to group" do
+        expect(user.groups).to include(organisation.reload.default_group)
+      end
+
+      it "adds user to group as editor" do
+        expect(organisation.reload.default_group.memberships.find_by(user:)).to be_editor
+      end
+
+      it "does not add trial user to group" do
+        expect(trial_user.groups).not_to include(organisation.reload.default_group)
+      end
+
+      it "adds forms to group" do
+        expect(organisation.reload.default_group.group_forms.count).to eq 3
+      end
+
+      it "the default group has trial status" do
+        expect(organisation.reload.default_group).to be_trial
+      end
+    end
+
+    it "is idempotent" do
+      task.invoke
+
+      expect {
+        task.invoke
+      }.to change(Group, :count).by(0)
+        .and change(Membership, :count).by(0)
+        .and change(GroupForm, :count).by(0)
+    end
+
+    context "when the organisation has no users" do
+      let(:user) { nil }
+
+      it "does not create a default group" do
+        task.invoke
+        expect(organisation.reload.default_group).to be_nil
+      end
+    end
+
+    context "when the organisation has a signed MOU" do
+      let(:organisation) { create :organisation, :with_signed_mou }
+
+      it "the default group has active status" do
+        task.invoke
+        expect(organisation.reload.default_group).to be_active
+      end
+    end
+
+    context "when a default group already exists" do
+      let(:group) { create :group, organisation: }
+
+      it "does not create a new default group" do
+        organisation.default_group = group
+        organisation.save!
+        task.invoke
+        expect(organisation.reload.default_group).to eq group
+      end
+    end
+
+    context "when the form is already in a group" do
+      let(:group) { create(:group, organisation:) }
+
+      it "does not add it to the default group" do
+        group.group_forms.build(form_id: forms_response.first.id)
+        group.save!
+        task.invoke
+        expect(organisation.reload.default_group.group_forms.map(&:form_id)).not_to include forms_response.first.id
+      end
+    end
+  end
+end

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe Forms::ChangeNameController, type: :request do
       expect(form).to have_been_created
     end
 
+    it "associates the new form with the organisations default group" do
+      expect(GroupForm.last).to have_attributes(group_id: user.organisation.default_group.id, form_id: 2)
+    end
+
     context "with a trial user" do
       let(:user) { build(:user, :with_trial_role, id: 1) }
       let(:form_data) do

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -75,7 +75,13 @@ RSpec.describe "/groups/:group_id/forms", type: :request, feature_groups: true d
         post group_forms_url(group), params: { forms_name_input: valid_attributes }
 
         expected_request = ActiveResource::Request.new(:post, "/api/v1/forms", nil, post_headers)
+
         expect(ActiveResource::HttpMock.requests).to include expected_request
+        expect(JSON(ActiveResource::HttpMock.requests.first.body, symbolize_names: true)).to eq({
+          name: "Test form",
+          creator_id: editor_user.id,
+          organisation_id: editor_user.organisation.id,
+        })
       end
 
       it "associates the new form with the group" do

--- a/spec/service/form_service_spec.rb
+++ b/spec/service/form_service_spec.rb
@@ -39,4 +39,78 @@ describe FormService do
       end
     end
   end
+
+  describe "#add_to_default_group" do
+    it "creates a default group in the users organisation if it doesn't exist" do
+      org = create :organisation
+      user = build :editor_user, organisation: org
+
+      expect {
+        form_service.add_to_default_group!(user)
+      }.to change(Group, :count).by(1)
+
+      expect(Group.last).to have_attributes(organisation_id: org.id, name: "Test Org forms")
+      expect(org.default_group_id).to eq Group.last.id
+    end
+
+    it "does not create a new default group if it already exists" do
+      org = create :organisation, default_group: (create :group)
+      user = build :editor_user, organisation: org
+
+      expect {
+        form_service.add_to_default_group!(user)
+      }.to change(Group, :count).by(0)
+    end
+
+    it "adds the current user to the default group" do
+      org = create :organisation
+      user = build :editor_user, organisation: org
+
+      form_service.add_to_default_group!(user)
+
+      expect(org.default_group.users).to include(user)
+    end
+
+    context "when the organisation has not signed an MOU" do
+      it "the default group will have trial status" do
+        org = create :organisation
+        user = build :editor_user, organisation: org
+
+        form_service.add_to_default_group!(user)
+
+        expect(org.default_group).to be_trial
+      end
+    end
+
+    context "when the organisation has signed an MOU" do
+      it "the default group will have active status" do
+        org = create :organisation, :with_signed_mou
+        user = build :editor_user, organisation: org
+
+        form_service.add_to_default_group!(user)
+
+        expect(org.default_group).to be_active
+      end
+    end
+
+    it "creates a new GroupForm" do
+      user = build :editor_user
+
+      expect {
+        form_service.add_to_default_group!(user)
+      }.to change(GroupForm, :count).by(1)
+
+      expect(GroupForm.last).to have_attributes(group_id: user.organisation.default_group.id, form_id: form.id)
+    end
+
+    it "does nothing if given a trial user" do
+      user = build :user
+      form_service.add_to_default_group!(user)
+
+      expect {
+        form_service.add_to_default_group!(user)
+      }.to change(Group, :count).by(0)
+      expect(user.organisation.default_group).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ZbW37yS5/1551-migration-create-a-default-group-for-each-organisation

This PR prepares for switching the groups feature flag on by creating default groups for forms created without the feature turned on.

It includes changes to the way forms are created to work both with and without the feature flag and a rake task to migrate existing forms.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
