### PR TITLE
Add default group to organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -6,6 +6,8 @@ class Organisation < ApplicationRecord
 
   has_many :mou_signatures
 
+  belongs_to :default_group, class_name: "Group", optional: true
+
   scope :not_closed, -> { where(closed: false) }
   scope :with_users, -> { joins(:users).distinct.order(:name) }
 

--- a/db/migrate/20240603102551_add_default_group_to_organisation.rb
+++ b/db/migrate/20240603102551_add_default_group_to_organisation.rb
@@ -1,0 +1,5 @@
+class AddDefaultGroupToOrganisation < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :organisations, :default_group, null: true, foreign_key: { to_table: :groups }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,6 +97,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_03_134957) do
     t.datetime "updated_at", null: false
     t.boolean "closed", default: false
     t.string "abbreviation"
+    t.bigint "default_group_id"
+    t.index ["default_group_id"], name: "index_organisations_on_default_group_id"
     t.index ["govuk_content_id"], name: "index_organisations_on_govuk_content_id", unique: true
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
@@ -140,5 +142,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_03_134957) do
   add_foreign_key "memberships", "users", column: "added_by_id"
   add_foreign_key "mou_signatures", "organisations"
   add_foreign_key "mou_signatures", "users"
+  add_foreign_key "organisations", "groups", column: "default_group_id"
   add_foreign_key "users", "organisations"
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe Organisation, type: :model do
     end
   end
 
+  describe "associations" do
+    describe "default_group" do
+      it "does not have a default group by default" do
+        expect(described_class.new.default_group).to be_nil
+      end
+
+      it "returns the default group when assigned" do
+        organisation = described_class.create!(name: "test org", slug: "test-org")
+        group = create(:group, organisation:)
+        organisation.update!(default_group: group)
+
+        expect(organisation.default_group).to eq(group)
+      end
+    end
+  end
+
   describe "scopes" do
     describe ".with_users" do
       it "returns organisations with distinct users" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ZbW37yS5/1551-migration-create-a-default-group-for-each-organisation <!-- link -->

We want to keep track of which group has been assigned the default group for an organisation, at least until we have fully switched over to the new groups feature.

At some point we will want to revert this change (see https://trello.com/c/UJv8Cb1k/1642-cleanup-work-for-after-release-of-new-user-management-model)

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?