### PR TITLE
Add rake default_groups:create_dry_run

### DIFF
--- a/lib/tasks/default_groups.rake
+++ b/lib/tasks/default_groups.rake
@@ -1,35 +1,51 @@
 namespace :default_groups do
   desc "Create default groups for organisations"
   task create: :environment do
-    Organisation.joins(:users).where(users: { role: :editor }).distinct.each do |org|
-      Rails.logger.info "rake default_groups started"
-      Rails.logger.info "default_group: organisation #{org.name}"
-
-      if org.default_group.nil?
-        status = org.mou_signatures.present? ? :active : :trial
-        org.create_default_group!(name: "#{org.name} forms", organisation: org, status:)
-        org.save!
-        Rails.logger.info "default_group: created #{org.default_group.name}, with status #{org.default_group.status}"
-      end
-
-      org.users.editor.each do |editor|
-        org.default_group.memberships.find_or_create_by!(user: editor) do |membership|
-          membership.role = :editor
-          membership.added_by = editor
-          Rails.logger.info "default_group: added user #{editor.email}"
-        end
-      end
-
-      # Form is not an activerecord object so find_each is not right here
-      # rubocop:disable Rails/FindEach
-      Form.where(organisation_id: org.id).each do |form|
-        GroupForm.find_or_create_by!(form_id: form.id) do |group_form|
-          Rails.logger.info "default_group: added form to default group #{form.name}"
-          group_form.group = org.default_group
-        end
-      end
-      # rubocop:enable Rails/FindEach
+    Rails.logger.info "rake default_groups:create started"
+    ActiveRecord::Base.transaction do
+      create_default_groups
     end
+  end
+
+  desc "Create default groups for organisations but don't commit changes"
+  task create_dry_run: :environment do
+    Rails.logger.info "rake default_groups:create_dry_run started"
+    ActiveRecord::Base.transaction do
+      create_default_groups
+      Rails.logger.info "rake default_groups:create_dry_run rollback"
+      raise ActiveRecord::Rollback
+    end
+  end
+end
+
+def create_default_groups
+  Organisation.joins(:users).where(users: { role: :editor }).distinct.each do |org|
+    Rails.logger.info "default_group: organisation #{org.name}"
+
+    if org.default_group.nil?
+      status = org.mou_signatures.present? ? :active : :trial
+      org.create_default_group!(name: "#{org.name} forms", organisation: org, status:)
+      org.save!
+      Rails.logger.info "default_group: created #{org.default_group.name}, with status #{org.default_group.status}"
+    end
+
+    org.users.editor.each do |editor|
+      org.default_group.memberships.find_or_create_by!(user: editor) do |membership|
+        membership.role = :editor
+        membership.added_by = editor
+        Rails.logger.info "default_group: added user #{editor.email}"
+      end
+    end
+
+    # Form is not an activerecord object so find_each is not right here
+    # rubocop:disable Rails/FindEach
+    Form.where(organisation_id: org.id).each do |form|
+      GroupForm.find_or_create_by!(form_id: form.id) do |group_form|
+        Rails.logger.info "default_group: added form to default group #{form.name}"
+        group_form.group = org.default_group
+      end
+    end
+    # rubocop:enable Rails/FindEach
 
     Rails.logger.info "rake default_groups finished"
   end


### PR DESCRIPTION
Wrap the rake task for migrating existing forms and editor users into default groups in a transaction.

This prevents changes to the database being committed if an exception is raised when running.

For example, the task will try to create a default group for any organisation which doesn't have one. If that organisation already has a group with same name, an error will be thrown and the task aborted. This would leave the DB with some organisations having default groups and some without.

Using a transaction means that either all the changes will happen, or none of them.

This is used to create a dry_run version of the task. At the end of the dry run task, a Rollback exception is raised. This means no changes are committed to the database.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
