### PR TITLE
Always log to STDOUT in production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,12 +47,6 @@ module FormsAdmin
     # logging use the Logger::Formatter.new.
     config.log_formatter = JsonLogFormatter.new
 
-    if ENV["RAILS_LOG_TO_STDOUT"].present?
-      config.logger = ActiveSupport::Logger.new($stdout)
-      config.logger.formatter = config.log_formatter
-
-    end
-
     # Lograge is used to format the standard HTTP request logging
     config.lograge.enabled = true
     config.lograge.formatter = Lograge::Formatters::Json.new

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,11 +46,11 @@ Rails.application.configure do
   config.force_ssl = true
 
   # Log to STDOUT by default
-  # config.logger = ActiveSupport::Logger.new($stdout)
-  #   .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-  #   .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-  #
-  # # Prepend all log lines with the following tags.
+  config.logger = ActiveSupport::Logger.new($stdout)
+    .tap { |logger| logger.formatter = config.log_formatter }
+
+  # Do not enable log_tags because it interferes with our JSON log formatting.
+  # The request_id is already being logged by Lograge.
   # config.log_tags = [:request_id]
 
   # "info" includes generic and useful information about system operation, but avoids logging too much


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We always want to log to standard out in production, instead of relying on the `RAILS_LOG_TO_STDOUT` environment variable. As well as allowing us to simplify our app configuration in forms-deploy [[1]] it also brings our app configuration closer in line with the Rails 7.1 defaults [[2]] and our other apps [[3], [4]].

[1]: https://github.com/alphagov/forms-deploy/blob/96cab32c19ab68515c357d6de7c9d3f801022ee8/infra/modules/forms-admin/main.tf#L106
[2]: https://github.com/rails/rails/blob/v7.1.2/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L62-L65
[3]: https://github.com/alphagov/forms-api/blob/88a0ad5818a1b626cd494fd8bfccb2392bccc66d/config/environments/production.rb#L47-L49
[4]: https://github.com/alphagov/forms-api/blob/88a0ad5818a1b626cd494fd8bfccb2392bccc66d/config/environments/production.rb#L47-L49

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?