### PR TITLE
Add setting for analytics

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -72,3 +72,5 @@ mailchimp:
   api_prefix: changeme
   active_users_list: changeme
   mou_signers_list: changeme
+
+analytics_enabled: false

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -63,4 +63,12 @@ describe "Settings" do
       expect(forms_env).to eq("local")
     end
   end
+
+  describe "analytics_enabled" do
+    it "has a default value" do
+      analytics_enabled = settings[:analytics_enabled]
+
+      expect(analytics_enabled).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/Meo1LbpG/1580-add-a-feature-flag-for-google-analytics-in-the-runner

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds a setting which controls whether analytics are enabled. This will be used to control the presence of the analytics snippet, so we can turn analytics off easily if we need to.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
