### PR TITLE
Show how many trial user forms are not in groups in trial_groups:summary

### DIFF
--- a/lib/tasks/trial_users.rake
+++ b/lib/tasks/trial_users.rake
@@ -16,14 +16,17 @@ class Summarizer
     total_trial_user_groups = 0
     total_trial_users_with_groups = 0
     total_trial_user_groups_to_create = 0
+    total_trial_users_with_forms = 0
     total_trial_users_with_org_name_and_forms = 0
     total_trial_users_with_default_group = 0
     total_trial_user_forms_in_groups = 0
+    total_trial_user_forms_not_in_group = 0
     trial_user_forms_not_in_default_group = Set.new
 
     group_form_ids = Set.new(GroupForm.pluck(:form_id))
 
-    trial_users_with_org_and_name.find_each do |trial_user|
+    User.trial.find_each do |trial_user|
+      with_org_and_name = trial_user.organisation.present? && trial_user.name.present?
       forms = Form.where(creator_id: trial_user.id)
       trial_user_form_ids = Set.new(forms.map(&:id))
       default_group = Group.find_by(creator: trial_user, name: "#{trial_user.name}’s trial group", status: :trial)
@@ -31,11 +34,13 @@ class Summarizer
 
       forms_without_group = trial_user_form_ids - group_form_ids
 
-      total_trial_user_groups_to_create += 1 if forms_without_group.present?
-      total_trial_users_with_org_name_and_forms += 1 if forms.present?
+      total_trial_users_with_forms += 1 if forms.present?
+      total_trial_user_groups_to_create += 1 if with_org_and_name && forms_without_group.present?
+      total_trial_users_with_org_name_and_forms += 1 if with_org_and_name && forms.present?
       total_trial_users_with_default_group += 1 if default_group.present?
-      total_forms_to_add_to_groups += forms_without_group.count
+      total_forms_to_add_to_groups += forms_without_group.count if with_org_and_name
       total_trial_user_forms_in_groups += (trial_user_form_ids.count - forms_without_group.count)
+      total_trial_user_forms_not_in_group += forms_without_group.count
       trial_user_forms_not_in_default_group += (trial_user_form_ids - forms_without_group - default_group_form_ids)
 
       total_trial_user_groups += Group.where(creator_id: trial_user.id).count
@@ -45,9 +50,11 @@ class Summarizer
     {
       total_forms_to_add_to_groups:,
       total_trial_user_forms_in_groups:,
+      total_trial_user_forms_not_in_group:,
       total_trial_user_groups:,
       total_trial_user_groups_to_create:,
       total_trial_users:,
+      total_trial_users_with_forms:,
       total_trial_users_with_groups:,
       total_trial_users_with_org_and_name:,
       total_trial_users_with_org_name_and_forms:,

--- a/spec/lib/tasks/trial_users.rake_spec.rb
+++ b/spec/lib/tasks/trial_users.rake_spec.rb
@@ -23,13 +23,15 @@ RSpec.describe "trial_users.rake" do
       user = create :user, name: "A User"
       another_user_with_forms = create :user
       user_without_forms = create :user
+      user_with_form_but_no_org_or_name = create :user, :with_no_name, :with_no_org
+      user_with_no_org_and_no_forms = create :user, :with_no_org
       create :editor_user
-      create :user, :with_no_org
 
       form = build :form, id: 1, creator_id: user.id
       another_form = build :form, id: 2, creator_id: user.id
       form_in_group = build :form, id: 3, creator_id: user.id
       form_in_default_group = build :form, id: 4, creator_id: user.id
+      old_form = build :form, id: 5, creator_id: user_with_form_but_no_org_or_name
       another_user_with_forms_forms = build_list(:form, 3) do |f, i|
         f.id = 10 + i
         f.creator_id = another_user_with_forms.id
@@ -44,14 +46,17 @@ RSpec.describe "trial_users.rake" do
         mock.get "/api/v1/forms?creator_id=#{user.id}", headers, [form, another_form, form_in_group, form_in_default_group].to_json, 200
         mock.get "/api/v1/forms?creator_id=#{user_without_forms.id}", headers, [].to_json, 200
         mock.get "/api/v1/forms?creator_id=#{another_user_with_forms.id}", headers, another_user_with_forms_forms.to_json, 200
+        mock.get "/api/v1/forms?creator_id=#{user_with_form_but_no_org_or_name.id}", headers, [old_form].to_json, 200
+        mock.get "/api/v1/forms?creator_id=#{user_with_no_org_and_no_forms.id}", headers, [].to_json, 200
       end
     end
 
     it "returns the right output" do
       expect(Summarizer.new.summarize).to eq({
-        total_trial_users: 4,
+        total_trial_users: 5,
+        total_trial_users_with_forms: 3,
         total_trial_users_with_org_and_name: 3,
-        total_trial_users_without_org_or_name: 1,
+        total_trial_users_without_org_or_name: 2,
         total_trial_user_forms_in_groups: 2,
         total_forms_to_add_to_groups: 5,
         total_trial_user_groups_to_create: 2,
@@ -59,6 +64,7 @@ RSpec.describe "trial_users.rake" do
         total_trial_users_with_org_name_and_forms: 2,
         total_trial_users_with_groups: 1,
         trial_user_forms_not_in_default_group: [3],
+        total_trial_user_forms_not_in_group: 6,
       })
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/t4bUdTbz/1555-migration-create-a-default-group-for-each-trial-user <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

It would be helpful to know how many trial users have created forms but have not set their organisation and/or name.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?