### PR TITLE
Create a default group and add forms for trial users who set name and organisation

### DIFF
--- a/app/controllers/account/names_controller.rb
+++ b/app/controllers/account/names_controller.rb
@@ -13,6 +13,7 @@ module Account
       @name_input = NameInput.new(account_name_input_params(current_user))
 
       if @name_input.submit
+        DefaultGroupService.new.create_trial_user_default_group!(current_user)
         redirect_to next_path
       else
         render :edit, status: :unprocessable_entity

--- a/app/controllers/account/organisations_controller.rb
+++ b/app/controllers/account/organisations_controller.rb
@@ -13,6 +13,7 @@ module Account
       @organisation_input = OrganisationInput.new(account_organisation_input_params(current_user))
 
       if @organisation_input.submit
+        DefaultGroupService.new.create_trial_user_default_group!(current_user)
         redirect_to next_path
       else
         render :edit, status: :unprocessable_entity

--- a/app/service/default_group_service.rb
+++ b/app/service/default_group_service.rb
@@ -1,0 +1,45 @@
+class DefaultGroupService
+  def create_trial_user_default_group!(user)
+    return unless user.trial? && user.name.present? && user.organisation.present?
+
+    forms = Form.where(creator_id: user.id).to_h { [_1.id, _1] }
+    form_ids = forms.keys
+    group_form_ids = GroupForm.where(form_id: form_ids).pluck(:form_id)
+    not_group_form_ids = form_ids.to_set - group_form_ids
+
+    if not_group_form_ids.blank?
+      Rails.logger.info "DefaultGroupService: Trial user '#{user.name}' does not have any forms not in groups, skipping creating default group"
+      return
+    end
+
+    Rails.logger.info "DefaultGroupService: Trial user '#{user.name}' default group creation starting"
+
+    default_trial_group = Group.find_or_create_by!(
+      creator_id: user.id,
+      name: "#{user.name}’s trial group",
+      organisation_id: user.organisation_id,
+      status: :trial,
+    ) do |new_group|
+      Rails.logger.info "DefaultGroupService: Created default group '#{new_group.name}', with creator '#{new_group.creator.email}'"
+    end
+
+    default_trial_group.memberships.find_or_create_by!(
+      user:,
+      role: :group_admin,
+      added_by: user,
+    ) do |new_membership|
+      Rails.logger.info "DefaultGroupService: Added user '#{new_membership.user.email}' with '#{new_membership.role}' role to default group '#{default_trial_group.name}'"
+    end
+
+    not_group_form_ids.each do |form_id|
+      GroupForm.find_or_create_by!(form_id:) do |group_form|
+        Rails.logger.info "DefaultGroupService: Added form '#{forms[form_id].name}' to default group '#{default_trial_group.name}'"
+        group_form.group = default_trial_group
+      end
+    end
+
+    Rails.logger.info "DefaultGroupService: Trial user '#{user.name}' default group creation finished"
+
+    default_trial_group
+  end
+end

--- a/spec/requests/account/names_controller_spec.rb
+++ b/spec/requests/account/names_controller_spec.rb
@@ -33,11 +33,13 @@ describe Account::NamesController do
   describe "PUT #update" do
     context "with valid params" do
       let(:valid_params) { { account_name_input: { name: "John Doe" } } }
+      let(:default_group_service) { instance_spy(DefaultGroupService) }
 
       before do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(AfterSignInPathHelper).to receive(:after_sign_in_next_path).and_return("/next-path")
         # rubocop:enable RSpec/AnyInstance
+        allow(DefaultGroupService).to receive(:new).and_return(default_group_service)
       end
 
       it "updates the user's name" do
@@ -48,6 +50,11 @@ describe Account::NamesController do
       it "redirects to the root path" do
         put account_name_path, params: valid_params
         expect(response).to redirect_to("/next-path")
+      end
+
+      it "calls create_trial_user_default_group!" do
+        put account_name_path, params: valid_params
+        expect(default_group_service).to have_received(:create_trial_user_default_group!)
       end
     end
 

--- a/spec/requests/account/organisations_controller_spec.rb
+++ b/spec/requests/account/organisations_controller_spec.rb
@@ -34,11 +34,13 @@ describe Account::OrganisationsController do
     context "with valid parameters" do
       let(:organisation) { create(:organisation) }
       let(:valid_params) { { account_organisation_input: { organisation_id: organisation.id } } }
+      let(:default_group_service) { instance_spy(DefaultGroupService) }
 
       before do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(AfterSignInPathHelper).to receive(:after_sign_in_next_path).and_return("/next-path")
         # rubocop:enable RSpec/AnyInstance
+        allow(DefaultGroupService).to receive(:new).and_return(default_group_service)
       end
 
       it "updates the user's organisation" do
@@ -49,6 +51,11 @@ describe Account::OrganisationsController do
       it "redirects to the root path" do
         put account_organisation_path, params: valid_params
         expect(response).to redirect_to("/next-path")
+      end
+
+      it "calls create_trial_user_default_group!" do
+        put account_organisation_path, params: valid_params
+        expect(default_group_service).to have_received(:create_trial_user_default_group!)
       end
     end
 

--- a/spec/service/default_group_service_spec.rb
+++ b/spec/service/default_group_service_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+RSpec.describe DefaultGroupService do
+  subject(:default_group_service) do
+    described_class.new
+  end
+
+  describe "#create_trial_user_default_group!" do
+    let(:user) { create :user, name: "Batman" }
+    let(:form) { build :form, id: 1 }
+    let(:forms_response) do
+      [form]
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms?creator_id=#{user.id}", headers, forms_response.to_json, 200
+      end
+    end
+
+    context "when the user has the trial role" do
+      context "when the user does not already have a trial group" do
+        it "creates a group" do
+          expect {
+            default_group_service.create_trial_user_default_group!(user)
+          }.to change(Group, :count).by(1)
+
+          expect(Group.last).to have_attributes(
+            creator: user,
+            name: "Batman’s trial group",
+            organisation: user.organisation,
+          )
+          expect(Group.last).to be_trial
+          expect(Group.last.users).to eq [user]
+          expect(Group.last.users.group_admins).to eq [user]
+        end
+
+        it "adds their trial forms to the group" do
+          expect {
+            default_group_service.create_trial_user_default_group!(user)
+          }.to change(GroupForm, :count).by(1)
+
+          expect(GroupForm.last).to have_attributes(form_id: form.id)
+        end
+
+        context "when the user does not have a name" do
+          let(:user) { create :user, name: "" }
+
+          it "returns nil" do
+            expect(
+              default_group_service.create_trial_user_default_group!(user),
+            ).to be_nil
+          end
+        end
+
+        context "when the user does not have an organisation" do
+          let(:user) { create :user, :with_no_org }
+
+          it "returns nil" do
+            expect(
+              default_group_service.create_trial_user_default_group!(user),
+            ).to be_nil
+          end
+        end
+
+        context "when the user doesn't have any forms" do
+          let(:forms_response) do
+            []
+          end
+
+          it "returns nil" do
+            expect(
+              default_group_service.create_trial_user_default_group!(user),
+            ).to be_nil
+          end
+        end
+      end
+
+      context "when the user already has a group" do
+        context "and the group status is 'trial'" do
+          it "does not create a group " do
+            group = create :group, creator: user, organisation: user.organisation, name: "Batman’s trial group", status: :trial
+
+            expect {
+              default_group_service.create_trial_user_default_group!(user)
+            }.not_to change(Group, :count)
+            expect(group).to be_trial
+            expect(group.users).to include user
+            expect(Group.last.users.group_admins).to include user
+          end
+        end
+
+        context "and the group status is 'active'" do
+          it "raises an exception" do
+            create :group, creator: user, organisation: user.organisation, name: "Batman’s trial group", status: :active
+
+            expect {
+              default_group_service.create_trial_user_default_group!(user)
+            }.to raise_error(ActiveRecord::RecordInvalid)
+          end
+        end
+      end
+
+      context "when the user's forms are already in a group" do
+        it "returns nil" do
+          group = create :group, creator: user, organisation: user.organisation
+          GroupForm.create!(form_id: form.id, group_id: group.id)
+
+          expect(
+            default_group_service.create_trial_user_default_group!(user),
+          ).to be_nil
+        end
+      end
+    end
+
+    context "when the user does not have the trial role" do
+      let(:user) { create :user, name: "Batman", role: :editor }
+
+      it "returns nil" do
+        expect(
+          default_group_service.create_trial_user_default_group!(user),
+        ).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Create a default group and add forms for trial users who set name and organisation

Trello card: https://trello.com/c/t4bUdTbz/1555-migration-create-a-default-group-for-each-trial-user

We have not migrated the forms owned by trial users who do not have name or organisation set into groups.

This PR adds code which runs when a user sets name or org. It checks that they are a trial user and creates a new default group if required, adds the user as group admin and adds any forms owned by the user which are not already in groups.

As this only happens when a trial user signs in to the service, it will take a while for all forms to be added to groups.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
