### PR TITLE
Fix default_groups:create for organisations with only super admin users

### DIFF
--- a/lib/tasks/default_groups.rake
+++ b/lib/tasks/default_groups.rake
@@ -57,7 +57,7 @@ namespace :default_groups do
 end
 
 def create_organisation_default_groups
-  Organisation.joins(:users).where(users: { role: :editor }).distinct.each do |org|
+  Organisation.joins(:users).where.not(users: { role: :trial }).distinct.each do |org|
     Rails.logger.info "default_groups: organisation #{org.name}"
 
     if org.default_group.nil?

--- a/spec/lib/tasks/default_groups.rake_spec.rb
+++ b/spec/lib/tasks/default_groups.rake_spec.rb
@@ -107,6 +107,15 @@ RSpec.describe "default_groups.rake" do
         expect(organisation.reload.default_group.group_forms.map(&:form_id)).not_to include forms_response.first.id
       end
     end
+
+    context "when the organisation has only super admin users" do
+      let(:user) { create :super_admin_user, organisation: }
+
+      it "does create a default group" do
+        task.invoke
+        expect(organisation.reload.default_group).not_to be_nil
+      end
+    end
   end
 
   describe "default_groups:create_for_trial_users" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/82ZeBA9C/1598-investigate-forms-that-have-not-been-migrated-to-groups <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We have some organisations in production where the only users are super admins, so they got missed by the `create_organisation_default_groups` script. This commit fixes this.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?