### PR TITLE
Add Google analytics snippet

### DIFF
--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -3,6 +3,7 @@ import dfeAutocomplete from 'dfe-autocomplete'
 import copyToClipboard from '../javascript/copy-to-clipboard'
 import markdownEditorToolbar from '../javascript/markdown-editor-toolbar'
 import { pasteListener } from '../javascript/paste-html-to-markdown'
+import { installAnalyticsScript } from '../javascript/google-tag'
 import ajaxMarkdownPreview from '../javascript/ajax-markdown-preview'
 
 document
@@ -36,6 +37,10 @@ document
       JSON.parse(element.getAttribute('data-i18n'))
     )
   })
+
+if (document.body.dataset.googleAnalyticsEnabled === 'true') {
+  installAnalyticsScript(window)
+}
 
 initAll()
 

--- a/app/frontend/javascript/google-tag/index.js
+++ b/app/frontend/javascript/google-tag/index.js
@@ -1,0 +1,19 @@
+export function installAnalyticsScript (global) {
+  const GTAG_ID = 'GTM-T2SJXKKQ'
+  if (!window.ga) {
+    ;(function (w, d, s, l, i) {
+      w[l] = w[l] || []
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+      })
+
+      const j = d.createElement(s)
+      const dl = l !== 'dataLayer' ? '&l=' + l : ''
+
+      j.async = true
+      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+      document.head.appendChild(j)
+    })(global, document, 'script', 'dataLayer', GTAG_ID)
+  }
+}

--- a/app/frontend/javascript/google-tag/index.test.js
+++ b/app/frontend/javascript/google-tag/index.test.js
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { installAnalyticsScript } from '../google-tag'
+import { describe, afterEach, it, expect } from 'vitest'
+
+describe('google_tag.mjs', () => {
+  afterEach(() => {
+    document.getElementsByTagName('html')[0].innerHTML = ''
+  })
+
+  describe('installAnalyticsScript()', () => {
+    it('adds the google analytics script tag to the DOM', function () {
+      installAnalyticsScript(window)
+      expect(
+        document.querySelectorAll(
+          'script[src^="https://www.googletagmanager.com/gtm.js"]'
+        ).length
+      ).toBe(1)
+    })
+
+    describe('when google analytics is already present on the window', () => {
+      beforeEach(() => {
+        window.document.write = ''
+        Object.defineProperty(window, 'ga', {
+          writable: true,
+          value: true
+        })
+      })
+
+      it('does not add the google analytics script tag to the DOM', function () {
+        installAnalyticsScript(window)
+        expect(
+          document.querySelectorAll(
+            'script[src^="https://www.googletagmanager.com/gtm.js"]'
+          ).length
+        ).toBe(0)
+      })
+    })
+  })
+})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,6 +125,10 @@ class User < ApplicationRecord
     organisation&.mou_signatures.present?
   end
 
+  def collect_analytics?
+    Settings.analytics_enabled && !super_admin?
+  end
+
 private
 
   def requires_name?

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -20,7 +20,11 @@
     <%= vite_stylesheet_tag 'application.scss' %>
   </head>
 
-  <body class="govuk-template__body ">
+  <%= tag.body(
+    class: "govuk-template__body ",
+    data: { "google-analytics-enabled": Settings.analytics_enabled }
+    ) do %>
+
     <script>
       document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     </script>
@@ -55,5 +59,5 @@
     <%= vite_javascript_tag 'application' %>
 
     <%= yield :body_end %>
-  </body>
+  <% end %>
 </html>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -22,7 +22,7 @@
 
   <%= tag.body(
     class: "govuk-template__body ",
-    data: { "google-analytics-enabled": Settings.analytics_enabled }
+    data: { "google-analytics-enabled": @current_user&.collect_analytics? }
     ) do %>
 
     <script>

--- a/spec/features/analytics/analytics_spec.rb
+++ b/spec/features/analytics/analytics_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+feature "Google analytics", type: :feature do
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms?organisation_id=1", headers, [].to_json, 200
+    end
+
+    allow(Settings).to receive(:analytics_enabled).and_return(analytics_enabled)
+  end
+
+  context "when the analytics setting is not enabled" do
+    let(:analytics_enabled) { false }
+
+    before do
+      login_as_editor_user
+    end
+
+    it "does not load in Google Analytics" do
+      visit root_path
+      expect(page).not_to have_selector('script[src*="googletagmanager"]', visible: :hidden)
+    end
+  end
+
+  context "when the analytics setting is enabled" do
+    let(:analytics_enabled) { true }
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+      end
+
+      it "does not load in Google Analytics" do
+        visit root_path
+        expect(page).not_to have_selector('script[src*="googletagmanager"]', visible: :hidden)
+      end
+    end
+
+    context "when the user is not a super admin" do
+      before do
+        login_as_editor_user
+      end
+
+      it "loads in Google Analytics" do
+        visit root_path
+        expect(page).to have_selector('script[src*="googletagmanager"]', visible: :hidden)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -452,4 +452,50 @@ describe User, type: :model do
       end
     end
   end
+
+  describe "#collect_analytics?" do
+    before do
+      allow(Settings).to receive(:analytics_enabled).and_return(analytics_enabled)
+    end
+
+    context "when the analytics settings flag is off" do
+      let(:analytics_enabled) { false }
+
+      context "when the user is a super admin" do
+        let(:user) { create :super_admin_user }
+
+        it "returns false" do
+          expect(user.collect_analytics?).to eq(false)
+        end
+      end
+
+      context "when the user is not a super admin" do
+        let(:user) { create :editor_user }
+
+        it "returns false" do
+          expect(user.collect_analytics?).to eq(false)
+        end
+      end
+    end
+
+    context "when the analytics settings flag is on" do
+      let(:analytics_enabled) { true }
+
+      context "when the user is a super admin" do
+        let(:user) { create :super_admin_user }
+
+        it "returns false" do
+          expect(user.collect_analytics?).to eq(false)
+        end
+      end
+
+      context "when the user is not a super admin" do
+        let(:user) { create :editor_user }
+
+        it "returns true" do
+          expect(user.collect_analytics?).to eq(true)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/EmmWXBP5/1587-add-google-analytics-to-admin-to-track-what-form-builders-are-doing

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
This card adds Google analytics to any page, as long as:
- the user is not a super admin
- the flag (`Settings.analytics_enabled`) is `true`

You can test whether GA is running on an particular page by opening your browser console and seeing if typing `window.dataLayer` returns anything - if it returns `undefined` it isn't running, if it returns an array of event objects it is running.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
