### PR TITLE
Enable groups feature in development

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,4 +1,4 @@
-feature:
+features:
   groups:
     enabled: true
 


### PR DESCRIPTION
The groups feature flag should be on by default in development. Currently the flag is not enabled because of a typo in the development settings file.

This file fixes the typo to correctly enable the flag.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
