### PR TITLE
Ensure trial and editor users have the same permissions when groups feature is enabled

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,6 +73,10 @@ class User < ApplicationRecord
     end
   end
 
+  def standard_user?
+    trial? || editor?
+  end
+
   def organisation_valid?
     trial? || organisation.present?
   end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -35,7 +35,7 @@ class FormPolicy
   def can_view_form?
     return true if user.super_admin?
 
-    if FeatureService.new(user).enabled?(:groups) && form.group.present?
+    if groups_enabled?
       return user.groups.include?(form.group) || user.is_organisations_admin?(form.group.organisation)
     end
 
@@ -60,7 +60,7 @@ class FormPolicy
 
   def can_make_form_live?
     # TODO: we should remove the check the form is within a group when we remove the feature flag
-    return can_change_form_submission_email? unless FeatureService.new(user).enabled?(:groups) && form.group.present?
+    return can_change_form_submission_email? unless groups_enabled?
     return can_change_form_submission_email? if form.group.active? && can_administer_group?
 
     false
@@ -71,6 +71,10 @@ class FormPolicy
   end
 
 private
+
+  def groups_enabled?
+    FeatureService.new(user).enabled?(:groups) && form.group.present?
+  end
 
   def user_is_form_creator
     form.creator_id.present? ? user.id == form.creator_id : false

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -48,7 +48,9 @@ class FormPolicy
   end
 
   def can_change_form_submission_email?
-    can_view_form? && !user.trial?
+    return false if user.trial? && !groups_enabled?
+
+    can_view_form?
   end
 
   def can_add_page_routing_conditions?

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     </div>
   </div>
-<% elsif @current_user.editor? && !@current_user.current_org_has_mou? %>
+<% elsif @current_user.standard_user? && !@current_user.current_org_has_mou? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -131,6 +131,18 @@ describe User, type: :model do
       expect(described_class.roles.keys).to eq(%w[super_admin organisation_admin editor trial])
       expect(described_class.roles.values).to eq(%w[super_admin organisation_admin editor trial])
     end
+
+    describe "#standard_user?" do
+      it "returns true if the user has the editor role" do
+        user.role = :editor
+        expect(user).to be_standard_user
+      end
+
+      it "returns true if the user has the trial role" do
+        user.role = :trial
+        expect(user).to be_standard_user
+      end
+    end
   end
 
   it_behaves_like "a gds-sso user class"

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -136,6 +136,32 @@ describe FormPolicy, feature_groups: true do
   end
 
   describe "can_change_form_submission_email?" do
+    shared_examples "standard user" do
+      context "when user is in the group" do
+        before do
+          Membership.create!(user:, group:, added_by: user)
+        end
+
+        it { is_expected.to permit_action(:can_change_form_submission_email) }
+      end
+
+      context "when user is not in the group" do
+        it { is_expected.to forbid_action(:can_change_form_submission_email) }
+      end
+    end
+
+    context "with a form editor" do
+      let(:user) { build :editor_user, organisation: }
+
+      include_examples "standard user"
+    end
+
+    context "with a trial role" do
+      let(:user) { build :user, role: :trial, organisation: }
+
+      include_examples "standard user"
+    end
+
     shared_examples "without group" do
       context "with a form editor" do
         it { is_expected.to permit_action(:can_change_form_submission_email) }

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -41,13 +41,19 @@ RSpec.describe "groups/index", type: :view do
       expect(rendered).not_to have_select "search[organisation_id]"
     end
 
-    context "when the user is an editor" do
-      it "shows the details text for users who are not org/super admins" do
-        expect(rendered).to have_content("If you need access to an existing form or group, ask someone who has access to that group to add you.")
-      end
+    context "when the user has a standard role" do
+      context "and org has not signed an MOU" do
+        let(:current_user) do
+          instance_double User, standard_user?: true, organisation_admin?: false, super_admin?: false, current_org_has_mou?: false
+        end
 
-      it "shows a notification banner explaining forms cannot be made live" do
-        expect(rendered).to have_css ".govuk-notification-banner", text: "You cannot make any forms live yet"
+        it "shows the details text for users who are not org/super admins" do
+          expect(rendered).to have_content("If you need access to an existing form or group, ask someone who has access to that group to add you.")
+        end
+
+        it "shows a notification banner explaining forms cannot be made live" do
+          expect(rendered).to have_css ".govuk-notification-banner", text: "You cannot make any forms live yet"
+        end
       end
 
       context "and org has signed an MOU" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SoKlQmep/1597-migration-ensure-trial-editor-and-standard-roles-are-equivalent-when-groups-feature-is-enabled <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We need to be sure that when the groups feature is enabled that users with the trial or editor role will have the same permissions, as shortly afterwards we want to get rid of the trial role and rename the editor role to 'standard'.

This means that any restrictions that apply to users with the trial role should be lifted when the groups feature is enabled.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?