### PR TITLE
Add success notification banner for when user is added to group

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -19,7 +19,8 @@ class GroupMembersController < ApplicationController
 
     @group_member_input = GroupMemberInput.new(group_member_params)
     if @group_member_input.submit
-      redirect_to group_members_path(@group.external_id)
+      redirect_to group_members_path(@group.external_id),
+                  success: t(".success", user_name: @group_member_input.invited_user.name)
     else
       render :new, status: :unprocessable_entity, locals: { show_role_options: show_role_options? }
     end

--- a/app/input_objects/group_member_input.rb
+++ b/app/input_objects/group_member_input.rb
@@ -29,11 +29,11 @@ class GroupMemberInput < BaseInput
     Membership.roles.keys.map { |role| [I18n.t("membership.roles.#{role}"), role] }
   end
 
-private
-
   def invited_user
     @invited_user ||= User.find_by(email: member_email_address)
   end
+
+private
 
   def new_membership
     @new_membership ||= group.memberships.new(user: invited_user, role:, added_by: creator)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,8 @@ en:
     confirm_deletion_live_form: Deleting this draft will not remove the live form.
     confirm_deletion_page: Are you sure you want to delete this page?
   group_members:
+    create:
+      success: "%{user_name} has been added to this group and we’ve sent them an email to let them know"
     index:
       add_editor: Add an editor
       add_member: Add an editor or group admin

--- a/spec/requests/group_members_controller_spec.rb
+++ b/spec/requests/group_members_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "/groups/:group_id/members", type: :request, feature_groups: true
   end
 
   describe "POST /groups/:group_id/members" do
-    let(:user) { create :user, organisation: editor_user.organisation }
+    let(:user) { create :user, name: "A User", organisation: editor_user.organisation }
 
     context "with valid parameters" do
       it "creates a new membership" do
@@ -91,6 +91,11 @@ RSpec.describe "/groups/:group_id/members", type: :request, feature_groups: true
         }.to change(Membership, :count).by(1)
 
         expect(Membership.last.role).to eq "editor"
+      end
+
+      it "shows a success flash message" do
+        post group_members_url(group), params: { group_member_input: { member_email_address: user.email } }
+        expect(flash[:success]).to eq("A User has been added to this group and we’ve sent them an email to let them know")
       end
 
       context "and I'm an editor" do


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Updates the journey to add a member to a group to include a success notification banner, matching the designs [[1](https://www.figma.com/design/D2DtaS68qRvVZgtxaBQNjd/User-management---moving-to-a-'group'-model-for-public-beta?node-id=124-7025&t=PflVJCoqdCVoIkX8-0)].

#### Screen recording

https://github.com/alphagov/forms-admin/assets/503614/e2bf8118-d7a1-4a67-868b-ae64fdf77318

(Screen recording showing adding a user to a group. After the user is successfully added a green notification banner appears at the top of the group page.)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?