### PR TITLE
Prevent forms without groups being made live if groups are enabled

### DIFF
--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -97,29 +97,43 @@ describe FormPolicy do
         it { is_expected.to forbid_action(:can_make_form_live) }
       end
 
-      context "and the group status is active" do
-        let(:group_status) { :active }
+      context "and the form is in the user's group" do
+        let(:group_role) { :editor }
 
-        context "and the user's role is super admin" do
-          let(:user) { build :super_admin_user, organisation: }
-
-          it { is_expected.to permit_action(:can_make_form_live) }
+        before do
+          Membership.create!(user:, group:, added_by: user, role: group_role)
         end
 
-        context "and the user is organisation admin for the group" do
-          let(:user) { build :organisation_admin_user, organisation: }
+        context "and the group status is not active" do
+          let(:group_status) { :trial }
 
-          it { is_expected.to permit_action(:can_make_form_live) }
-        end
-
-        context "and the user's role within the group is group admin" do
-          let(:group_role) { :group_admin }
-
-          it { is_expected.to permit_action(:can_make_form_live) }
-        end
-
-        context "and the user's role within the group is editor" do
           it { is_expected.to forbid_action(:can_make_form_live) }
+        end
+
+        context "and the group status is active" do
+          let(:group_status) { :active }
+
+          context "and the user's role is super admin" do
+            let(:user) { build :super_admin_user, organisation: }
+
+            it { is_expected.to permit_action(:can_make_form_live) }
+          end
+
+          context "and the user is organisation admin for the group" do
+            let(:user) { build :organisation_admin_user, organisation: }
+
+            it { is_expected.to permit_action(:can_make_form_live) }
+          end
+
+          context "and the user's role within the group is group admin" do
+            let(:group_role) { :group_admin }
+
+            it { is_expected.to permit_action(:can_make_form_live) }
+          end
+
+          context "and the user's role within the group is editor" do
+            it { is_expected.to forbid_action(:can_make_form_live) }
+          end
         end
       end
     end


### PR DESCRIPTION
Previously, we were allowing forms without a group to be made live. Although these wouldn't be listed in groups and the forms index would've been unreachable, if a user had the url for an existing form they could have made the form live.

### What problem does this pull request solve?

Trello card: https://trello.com/c/EsoNSIL4

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
