### PR TITLE
Change memberships table to be sorted by user name

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,7 +5,11 @@ class Group < ApplicationRecord
 
   belongs_to :upgrade_requester, class_name: "User", optional: true
 
-  has_many :memberships, dependent: :destroy
+  has_many :memberships, dependent: :destroy do
+    def ordered
+      joins(:user).order("users.name")
+    end
+  end
   has_many :users, through: :memberships do
     def group_admins
       where(memberships: { role: "group_admin" })

--- a/app/views/group_members/index.html.erb
+++ b/app/views/group_members/index.html.erb
@@ -23,7 +23,7 @@
     end %>
 
     <%= table.with_body do |body| %>
-      <% @group.memberships.each do |membership| %>
+      <% @group.memberships.joins(:user).order("users.name").each do |membership| %>
         <%= body.with_row do |row| %>
           <%= row.with_cell { membership.user.name } %>
           <%= row.with_cell { membership.user.email } %>

--- a/app/views/group_members/index.html.erb
+++ b/app/views/group_members/index.html.erb
@@ -23,7 +23,7 @@
     end %>
 
     <%= table.with_body do |body| %>
-      <% @group.memberships.joins(:user).order("users.name").each do |membership| %>
+      <% @group.memberships.ordered.each do |membership| %>
         <%= body.with_row do |row| %>
           <%= row.with_cell { membership.user.name } %>
           <%= row.with_cell { membership.user.email } %>

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -112,6 +112,29 @@ RSpec.describe Group, type: :model do
       expect { group.destroy }.not_to change(User, :count)
     end
 
+    describe "#memberships" do
+      describe "#ordered" do
+        it "orders the membership records by name of the associated user" do
+          group = create :group
+          users = [
+            create(:user, name: "Barbara User"),
+            create(:user, name: "Alfred User"),
+            create(:user, name: "Charlie User"),
+          ]
+
+          users.each do |user|
+            Membership.create!(group:, user:, role: :editor, added_by: group.creator)
+          end
+
+          expect(group.memberships.ordered.map { _1.user.name }).to eq [
+            "Alfred User",
+            "Barbara User",
+            "Charlie User",
+          ]
+        end
+      end
+    end
+
     describe "#users" do
       describe "#group_admins" do
         it "returns all users who are group admins for the group" do

--- a/spec/views/group_members/index.html.erb_spec.rb
+++ b/spec/views/group_members/index.html.erb_spec.rb
@@ -51,6 +51,15 @@ describe "group_members/index", type: :view do
       end
     end
 
+    describe "sorting" do
+      let(:user1) { build :user, organisation:, name: "Bob Blob" }
+      let(:user2) { build :user, organisation:, name: "Alice Square" }
+
+      it "sorts the group memberships by user name" do
+        expect(rendered).to have_table(with_cols: [["Alice Square", "Bob Blob"]])
+      end
+    end
+
     it "has an add member link" do
       expect(rendered).to have_link(t("group_members.index.add_editor"), href: new_group_member_path(group))
     end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Currently the order of users in the table on the "Members of this group" page is whatever is returned by the database, which is not consistent; so when editing users the table can jump around between page loads, which is a bit disorientating.

This PR fixes things by ordering by name. This is a naive way, but at least is more likely to have consistent results.

### Screen recordings

#### Before

https://github.com/alphagov/forms-admin/assets/503614/4cb6522b-7ad6-4665-88df-d38a9a504bf1

(A screen recording showing editing users in a group before this change. The order of the users in the table changes each time a user is made a group admin.)

#### After


https://github.com/alphagov/forms-admin/assets/503614/3d60a9e4-f298-41f1-aaa6-101362713ffb

(A screen recording showing editing users in a group after this change. The order of the users in the table is the same each time a user is made a group admin.)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?