### PR TITLE
Fix warning about scoped order

### DIFF
--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -26,7 +26,7 @@ namespace :organisations do
 
   desc "Output summary data about each organisation as newline-delimited JSON"
   task summary: :environment do
-    Organisation.with_users.find_each do |organisation|
+    Organisation.with_users.unscope(:order).find_each do |organisation|
       forms = Form.where(organisation_id: organisation.id)
 
       puts({


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Currently when running the `organisations:summary` task we get a warning from Rails about `Scoped order is ignored, it's forced to be batch order.`, because we're using `find_each` but the `with_users` scope adds an `ORDER BY` clause.

This PR fixes things by removing the order relation with [unscope](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-order).

When testing locally the warning appears in `log/development.log`, but in production it is emitted to stdout.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?