### PR TITLE
Enable groups feature for GOV.UK Forms Adoption Team

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -4,6 +4,7 @@ features:
     organisations:
       driver_and_vehicle_standards_agency: true
       government_digital_service: true
+      govuk_forms_adoption_team: true
       insolvency_service: true
 
 # Use real authentication


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Enables the groups feature for the organisation "GOV.UK Forms Adoption Team" [[1]].

[1]: https://admin.forms.service.gov.uk/groups?search%5Borganisation_id%5D=GOV.UK+Forms+Adoption+Team&search%5Borganisation_id%5D=9


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?