### PR TITLE
Add task for adding/moving forms in groups

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -1,0 +1,47 @@
+namespace :forms do
+  desc "move one or more forms into group"
+  task :move, [] => :environment do |_, args|
+    *form_ids, group_id = args.to_a
+
+    usage_message = "usage: rake forms:move[<form_id>, ..., <group_id>]".freeze
+    abort usage_message if form_ids.blank? || group_id.blank?
+
+    ActiveRecord::Base.transaction do
+      move_forms(form_ids, group_id)
+    end
+  end
+
+  desc "move one or more forms into group"
+  task :move_dry_run, [] => :environment do |_, args|
+    *form_ids, group_id = args.to_a
+
+    usage_message = "usage: rake forms:move_dry_run[<form_id>, ..., <group_id>]".freeze
+    abort usage_message if form_ids.blank? || group_id.blank?
+
+    ActiveRecord::Base.transaction do
+      move_forms(form_ids, group_id)
+      Rails.logger.info "forms:move_dry_run rollback"
+      raise ActiveRecord::Rollback
+    end
+  end
+end
+
+def move_forms(form_ids, group_id)
+  group = Group.find_by! external_id: group_id
+
+  form_ids.each do |form_id|
+    form = Form.find(form_id)
+    group_form = GroupForm.find_or_initialize_by(form_id:)
+
+    if group_form.group == group
+      Rails.logger.info "forms:move: keeping form #{form_id} (#{form.name}) in group #{group_id} (#{group.name})"
+      next
+    elsif group_form.persisted?
+      Rails.logger.info "forms:move: moving form #{form_id} (#{form.name}) to group #{group_id} (#{group.name})"
+    else
+      Rails.logger.info "forms:move: adding form #{form_id} (#{form.name}) to group #{group_id} (#{group.name})"
+    end
+
+    group_form.update!(group:)
+  end
+end

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -34,14 +34,22 @@ def move_forms(form_ids, group_id)
     group_form = GroupForm.find_or_initialize_by(form_id:)
 
     if group_form.group == group
-      Rails.logger.info "forms:move: keeping form #{form_id} (#{form.name}) in group #{group_id} (#{group.name})"
+      Rails.logger.info "forms:move: keeping form #{fmt_form(form)} in #{fmt_group(group)}"
       next
     elsif group_form.persisted?
-      Rails.logger.info "forms:move: moving form #{form_id} (#{form.name}) to group #{group_id} (#{group.name})"
+      Rails.logger.info "forms:move: moving #{fmt_form(form)} from #{fmt_group(group_form.group)} to #{fmt_group(group)}"
     else
-      Rails.logger.info "forms:move: adding form #{form_id} (#{form.name}) to group #{group_id} (#{group.name})"
+      Rails.logger.info "forms:move: adding #{fmt_form(form)} to #{fmt_group(group)}"
     end
 
     group_form.update!(group:)
   end
+end
+
+def fmt_form(form)
+  "form #{form.id} (\"#{form.name}\")"
+end
+
+def fmt_group(group)
+  "group #{group.id} (\"#{group.name}\", #{group.organisation.name}, #{group.creator.name})"
 end

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -1,0 +1,144 @@
+require "rake"
+require "rails_helper"
+
+RSpec.describe "forms.rake" do
+  before do
+    Rake.application.rake_require "tasks/forms"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "forms:move" do
+    subject(:task) do
+      Rake::Task["forms:move"]
+        .tap(&:reenable)
+    end
+
+    let(:group) { create :group }
+    let(:forms) do
+      build_list(:form, 3) { |form, i| form.id = i }
+    end
+    let(:form_ids) { forms.map(&:id) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        forms.each do |form|
+          mock.get "/api/v1/forms/#{form.id}", headers, form.to_json, 200
+        end
+      end
+    end
+
+    context "with valid arguments" do
+      context "with a single form not in a group" do
+        let(:form_id) { form_ids.first }
+        let(:valid_args) { [form_id, group.external_id] }
+
+        it "adds the form to the group" do
+          expect {
+            task.invoke(*valid_args)
+          }.to change(GroupForm, :count).by(1)
+
+          expect(GroupForm.last).to eq(GroupForm.new(form_id:, group:))
+        end
+      end
+
+      context "with a single form already in a group" do
+        let(:form_id) { form_ids.first }
+        let(:old_group) { create :group }
+        let(:valid_args) { [form_id, group.external_id] }
+
+        before do
+          GroupForm.create! form_id:, group: old_group
+        end
+
+        it "adds the form to the group" do
+          expect {
+            task.invoke(*valid_args)
+          }.not_to change(GroupForm, :count)
+
+          expect(GroupForm.find_by(form_id:))
+            .to eq(GroupForm.new(form_id:, group:))
+        end
+      end
+
+      context "with a single form already in the target group" do
+        let(:form_id) { form_ids.first }
+        let(:valid_args) { [form_id, group.external_id] }
+
+        before do
+          GroupForm.create! form_id:, group:
+        end
+
+        it "keeps the form in the group" do
+          expect {
+            task.invoke(*valid_args)
+          }.not_to change(GroupForm, :count)
+
+          expect(GroupForm.find_by(form_id:))
+            .to eq(GroupForm.new(form_id:, group:))
+        end
+      end
+
+      context "with a multiple forms" do
+        let(:valid_args) { [*form_ids, group.external_id] }
+
+        it "adds each form to the group" do
+          task.invoke(*valid_args)
+
+          form_ids.each do |form_id|
+            expect(GroupForm.find_by(form_id:))
+              .to eq(GroupForm.new(form_id:, group:))
+          end
+        end
+      end
+    end
+
+    context "with invalid arguments" do
+      shared_examples_for "usage error" do
+        it "aborts with a usage message" do
+          expect {
+            task.invoke(*invalid_args)
+          }.to raise_error(SystemExit)
+           .and output(/usage: rake forms:move/).to_stderr
+        end
+      end
+
+      context "with no arguments" do
+        it_behaves_like "usage error" do
+          let(:invalid_args) { [] }
+        end
+      end
+
+      context "with only one argument" do
+        it_behaves_like "usage error" do
+          let(:invalid_args) { [form_ids.first] }
+        end
+      end
+
+      context "with invalid group_id" do
+        let(:invalid_args) { [*form_ids, "not_a_group_id"] }
+
+        it "raises an error" do
+          expect {
+            task.invoke(*invalid_args)
+          }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Group/)
+        end
+      end
+
+      context "with invalid form_id" do
+        let(:invalid_args) { ["99", group.external_id] }
+
+        before do
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v1/forms/99", headers, nil, 404
+          end
+        end
+
+        it "raises an error" do
+          expect {
+            task.invoke(*invalid_args)
+          }.to raise_error(ActiveResource::ResourceNotFound)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/7EkOqWib/1605-add-rake-task-to-move-forms-from-one-group-to-another <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We expect that users will want to move forms from one group to another. As we don't yet have a design for users to do this themselves, this commit adds a Rake task that a developer can run as a support task.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?