### PR TITLE
Change Mailchimp synchronizer to archive users instead of permanent delete

### DIFF
--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -64,7 +64,7 @@ class MailchimpListSynchronizer
     puts "Unsubscribing any removed users..."
     deleted_users.each do |email|
       subscriber_hash = Digest::MD5.hexdigest email.downcase
-      mailchimp.lists.delete_list_member_permanent(list_id, subscriber_hash)
+      mailchimp.lists.delete_list_member(list_id, subscriber_hash)
     rescue MailchimpMarketing::ApiError
       warn "Could not unsubscribe user with subscriber hash #{subscriber_hash} from list #{list_id}. Continuing"
     end

--- a/spec/lib/mailchimp_list_synchronizer_spec.rb
+++ b/spec/lib/mailchimp_list_synchronizer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe MailchimpListSynchronizer do
       allow(mailchimp_client).to receive(:lists).and_return(mailchimp_client_lists)
 
       allow(mailchimp_client_lists).to receive(:set_list_member)
-      allow(mailchimp_client_lists).to receive(:delete_list_member_permanent)
+      allow(mailchimp_client_lists).to receive(:delete_list_member)
 
       allow(mailchimp_client_lists).to receive(:get_list) do |list_id|
         case list_id
@@ -95,7 +95,7 @@ RSpec.describe MailchimpListSynchronizer do
     it "removes users from MailChimp who do not appear in the database, but do appear in the mailing list" do
       removed_email_hash = Digest::MD5.hexdigest "remove@domain.org"
 
-      expect(mailchimp_client_lists).to receive(:delete_list_member_permanent).with("list-1", removed_email_hash)
+      expect(mailchimp_client_lists).to receive(:delete_list_member).with("list-1", removed_email_hash)
 
       described_class.synchronize(list_id: "list-1", users_to_synchronize:)
     end
@@ -103,7 +103,7 @@ RSpec.describe MailchimpListSynchronizer do
     it "removes users from MailChimp who exist in the database, but do not have access" do
       removed_email_hash = Digest::MD5.hexdigest "retireduser@domain.org"
 
-      expect(mailchimp_client_lists).to receive(:delete_list_member_permanent).with("list-1", removed_email_hash)
+      expect(mailchimp_client_lists).to receive(:delete_list_member).with("list-1", removed_email_hash)
 
       described_class.synchronize(list_id: "list-1", users_to_synchronize:)
     end
@@ -126,7 +126,7 @@ RSpec.describe MailchimpListSynchronizer do
       end
 
       it "handles all of the results" do
-        expect(mailchimp_client_lists).to receive(:delete_list_member_permanent).with("list-1", anything).exactly(1001).times
+        expect(mailchimp_client_lists).to receive(:delete_list_member).with("list-1", anything).exactly(1001).times
 
         described_class.synchronize(list_id: "list-1", users_to_synchronize:)
       end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Permanently deleting a user from a Mailchimp audience prevents them from being added back [[1]], and seems to be mainly aimed at actioning GDPR deletion requests [[2]].

In most cases where a user is being removed from a email subscription list by our Rake task, it will be because we've denied them access to the platform, but this could be a temporary state of affairs; for instance if they haven't signed in for a while.

This commit changes `MailchimpListSynchronizer` so that it archives the subscriber instead of permanently deleting them; they won't count towards our billing but will be easy to add back if needed.

[1]: https://mailchimp.com/developer/marketing/api/list-members/delete-list-member/
[2]: https://mailchimp.com/help/delete-contacts/

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?