### PR TITLE
Show form creator for trial users

### DIFF
--- a/app/service/form_list_service.rb
+++ b/app/service/form_list_service.rb
@@ -16,12 +16,10 @@ class FormListService
     @current_user = current_user
     @organisation = organisation || (current_user.trial? ? nil : current_user.organisation)
     @group = group
-    unless current_user.trial?
-      @list_of_creator_id = forms.map(&:creator_id).uniq
-      @list_of_creators = User.where(id: @list_of_creator_id)
-                               .select(:id, :name)
-                               .map { |user| { id: user.id, name: user.name } }
-    end
+    @list_of_creator_id = forms.map(&:creator_id).uniq
+    @list_of_creators = User.where(id: @list_of_creator_id)
+                             .select(:id, :name)
+                             .map { |user| { id: user.id, name: user.name } }
   end
 
   def data
@@ -45,7 +43,7 @@ private
   def head
     [
       I18n.t("home.form_name_heading"),
-      (current_user.trial? ? nil : { text: I18n.t("home.created_by") }),
+      { text: I18n.t("home.created_by") },
       { text: I18n.t("home.form_status_heading"), numeric: true },
     ].compact
   end
@@ -53,7 +51,7 @@ private
   def rows
     forms.map do |form|
       [{ text: form_name_link(form) },
-       (current_user.trial? ? nil : { text: find_creator_name(form) }),
+       { text: find_creator_name(form) },
        { text: form_status_tags(form), numeric: true }].compact
     end
   end

--- a/spec/service/form_list_service_spec.rb
+++ b/spec/service/form_list_service_spec.rb
@@ -70,7 +70,7 @@ describe FormListService do
         let(:current_user) { create :user, :with_trial_role }
 
         it "contains a 'Name' and 'Status' column heading" do
-          expect(service.data[:head]).to eq([I18n.t("home.form_name_heading"), { text: I18n.t("home.form_status_heading"), numeric: true }])
+          expect(service.data[:head]).to eq([I18n.t("home.form_name_heading"), { text: I18n.t("home.created_by") }, { text: I18n.t("home.form_status_heading"), numeric: true }])
         end
       end
     end
@@ -88,6 +88,7 @@ describe FormListService do
             form = forms[index]
             expect(row).to eq([
               { text: "<a class=\"govuk-link\" href=\"/forms/#{form.id}\">#{form.name}</a>" },
+              { text: current_user.name.to_s },
               {
                 numeric: true,
                 text: "<div class='app-form-states'><strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n</div>",


### PR DESCRIPTION
### What problem does this pull request solve?

There was a bug where trial users could not see the "Created by" column in the list of forms within a group they were a member of. This fixes this by showing the form creator for trial users. 

Note: this also makes the "Created by" column visible with the groups feature disabled, but on discussion we think this is fine.

Trello card: https://trello.com/c/nXOuz0qN

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
