### PR TITLE
Add fallback for form creator name in move task

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -51,5 +51,5 @@ def fmt_form(form)
 end
 
 def fmt_group(group)
-  "group #{group.id} (\"#{group.name}\", #{group.organisation.name}, #{group.creator.name})"
+  "group #{group.id} (\"#{group.name}\", #{group.organisation.name}, #{group.creator&.name || 'GOV.UK Forms Team'})"
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->N/A

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds a fallback so that the `forms:move` task doesn't error when run on one of the groups created by the `default_groups:create` task.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
