### PR TITLE
Change forms:move to also update form organisation

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -34,7 +34,7 @@ def move_forms(form_ids, group_id)
     group_form = GroupForm.find_or_initialize_by(form_id:)
 
     if group_form.group == group
-      Rails.logger.info "forms:move: keeping form #{fmt_form(form)} in #{fmt_group(group)}"
+      Rails.logger.info "forms:move: keeping #{fmt_form(form)} in #{fmt_group(group)}"
       next
     elsif group_form.persisted?
       Rails.logger.info "forms:move: moving #{fmt_form(form)} from #{fmt_group(group_form.group)} to #{fmt_group(group)}"
@@ -51,5 +51,5 @@ def fmt_form(form)
 end
 
 def fmt_group(group)
-  "group #{group.id} (\"#{group.name}\", #{group.organisation.name}, #{group.creator&.name || 'GOV.UK Forms Team'})"
+  "group #{group.external_id} (\"#{group.name}\", #{group.organisation.name}, #{group.creator&.name || 'GOV.UK Forms Team'})"
 end

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -43,6 +43,13 @@ def move_forms(form_ids, group_id)
     end
 
     group_form.update!(group:)
+
+    next unless form.organisation && form.organisation != group.organisation
+
+    Rails.logger.info "forms:move: updating #{fmt_form(form)} organisation from #{form.organisation.name} to #{group.organisation.name}"
+
+    form.organisation_id = group.organisation_id
+    form.save!
   end
 end
 

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -87,19 +87,30 @@ RSpec.describe "forms.rake" do
           task.invoke(form.id, group.external_id)
         end
 
-        context "not in an organisation" do
+        context "and not in an organisation" do
           let(:form_organisation) { nil }
 
-          it "does not change the group organisation" do
-            expect(ActiveResource::HttpMock.requests).not_to include ActiveResource::Request.new(:put, "/api/v1/forms/#{form.id}", hash_including(organisation_id: group.organisation_id), put_headers)
+          it "does not change the form's organisation" do
+            form.organisation_id = group.organisation_id
+            expect(form).not_to have_been_updated
           end
         end
 
-        context "in a different organisation to the group" do
+        context "and in the same organisation as the group" do
+          let(:form_organisation) { group.organisation }
+
+          it "does not change the form's organisation" do
+            form.organisation_id = group.organisation_id
+            expect(form).not_to have_been_updated
+          end
+        end
+
+        context "and in a different organisation to the group" do
           let(:form_organisation) { create :organisation, slug: "other-org" }
 
-          it "changes the group organisation" do
-            expect(ActiveResource::HttpMock.requests).to include ActiveResource::Request.new(:put, "/api/v1/forms/#{form.id}", hash_including(organisation_id: group.organisation_id), put_headers)
+          it "changes the form's organisation" do
+            form.organisation_id = group.organisation_id
+            expect(form).to have_been_updated
           end
         end
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/7EkOqWib/1605-add-rake-task-to-move-forms-from-one-group-to-another <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When moving a form to a group in a different organisation to the one it currently belongs to, we should update the form's organisation attribute.

Not doing so shouldn't have any effect when the groups feature is enabled, but until we remove the organisation attribute we should keep things consistent.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?