### PR TITLE
Add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ config/environments/*.local.yml
 *.swp
 
 /public/assets
+
+.DS_Store


### PR DESCRIPTION
.DS_Store files are macOS-specific metadata files that there is no need to share, so shouldn't be tracked by git