### PR TITLE
Make find invited user by email case insensitive

### DIFF
--- a/app/input_objects/group_member_input.rb
+++ b/app/input_objects/group_member_input.rb
@@ -30,7 +30,7 @@ class GroupMemberInput < BaseInput
   end
 
   def invited_user
-    @invited_user ||= User.find_by(email: member_email_address)
+    @invited_user ||= User.find_by("LOWER(email)= ?", member_email_address.downcase)
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
   validates :organisation_id, presence: true, if: :requires_organisation?
   validates :has_access, inclusion: [true, false]
   validates :role, exclusion: %w[organisation_admin], unless: :current_org_has_mou?
+  validates :email, uniqueness: { case_sensitive: false }
 
   before_create do
     self.has_access = false if organisation_restricted_access?

--- a/db/migrate/20240705141343_add_unique_index_on_email_to_users.rb
+++ b/db/migrate/20240705141343_add_unique_index_on_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnEmailToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_03_134957) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_05_141343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -119,6 +119,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_03_134957) do
     t.bigint "organisation_id"
     t.boolean "has_access", default: true
     t.string "provider"
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end

--- a/spec/input_objects/group_member_input_spec.rb
+++ b/spec/input_objects/group_member_input_spec.rb
@@ -46,6 +46,13 @@ describe GroupMemberInput do
       expect(group_member_input).to be_valid
     end
 
+    it "is valid with a email address that is a GOV.UK forms user but case does not match" do
+      create(:user, email: "foo.bar@email.gov.uk")
+      group_member_input.member_email_address = "Foo.Bar@email.gov.uk"
+      group_member_input.role = :editor
+      expect(group_member_input).to be_valid
+    end
+
     describe "#submit" do
       context "when the new Membership has errors" do
         let(:group_member_input) { described_class.new }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 describe User, type: :model do
   subject(:user) { described_class.new }
 
+  let(:organisation) { create :organisation }
+
   describe "validations" do
     it "validates" do
       expect(user).to be_valid
@@ -22,6 +24,16 @@ describe User, type: :model do
         user.organisation_id = nil
 
         expect(user).to be_valid
+      end
+    end
+
+    describe "email" do
+      it "does not allow users to be created with the same email with different case" do
+        create(:user, email: "foo.bar@email.gov.uk")
+
+        expect {
+          described_class.create!(name: Faker.name, email: "Foo.Bar@email.gov.uk", role: :editor, organisation_id: organisation.id)
+        }.to raise_error ActiveRecord::RecordInvalid, /Email has already been taken/
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/JBBA5kyk/1623-make-email-matching-case-insensitive-when-adding-someone-to-a-group

When users are created in Signon and Auth0, the email is downcased when it is stored.

When inviting users to join groups, we should therefore ignore the case when locating the user to invite. Previously, we were showing an error saying that the user does not have a Forms account when the case did not match the stored email for the user.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
