### PR TITLE
Fix rendering act as user banner on error pages

### DIFF
--- a/app/components/act_as_user_banner_component/view.rb
+++ b/app/components/act_as_user_banner_component/view.rb
@@ -9,7 +9,7 @@ module ActAsUserBannerComponent
     end
 
     def render?
-      @original_user.present?
+      @original_user.present? && @acting_as_user.present?
     end
 
     def acting_as_banner_content

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -117,4 +117,20 @@ module ApplicationHelper
       end
     end
   end
+
+  def acting_as?
+    session[:acting_as_user_id].present?
+  end
+
+  def actual_user
+    return nil unless acting_as?
+
+    User.find(session[:original_user_id])
+  end
+
+  def acting_as_user
+    return nil unless acting_as?
+
+    request.env["warden"].user
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <%= t("phase_banner.after_link") %>
   <% end %>
   <%= yield :back_link %>
-  <%= render ActAsUserBannerComponent::View.new(@current_user, User.find_by(id: session[:original_user_id])) %>
+  <%= render ActAsUserBannerComponent::View.new(acting_as_user, actual_user) %>
 <% end %>
 
 <% content_for :footer do %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -282,4 +282,51 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#acting_as?" do
+    it "returns true when the signed in user is acting as another" do
+      session[:acting_as_user_id] = 1
+
+      expect(helper.acting_as?).to be true
+    end
+
+    it "returns false when the signed in user is not acting as another" do
+      session.delete :acting_as_user_id
+
+      expect(helper.acting_as?).to be false
+    end
+  end
+
+  describe "#actual_user?" do
+    it "returns the original user when the signed in user is acting as another" do
+      user = create :user
+      session[:acting_as_user_id] = 1
+      session[:original_user_id] = user.id
+
+      expect(helper.actual_user).to eq user
+    end
+
+    it "returns nil when the signed in user is not acting as another" do
+      session.delete :acting_as_user_id
+      session.delete :original_user_id
+
+      expect(helper.actual_user).to be_nil
+    end
+  end
+
+  describe "#acting_as_user?" do
+    it "returns the acting as user when the signed in user is acting as another" do
+      user = create :user
+      session[:acting_as_user_id] = user.id
+      request.env["warden"] = OpenStruct.new(user:)
+
+      expect(helper.acting_as_user).to be user
+    end
+
+    it "returns nil when the signed in user is not acting as another" do
+      session.delete :acting_as_user_id
+
+      expect(helper.acting_as_user).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/9abpfhCl/5-firebreak-pitch-view-as-user <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When an error page is rendered by the `ErrorsController`, the current_user instance variable is not set. This commit changes the application layout to use the new act as user view helpers, instead of relying on the current user.

### Screenshots

#### Before

<img width="825" alt="Screenshot of 500 error page when acting as another user before these changes. The error page is unstyled." src="https://github.com/alphagov/forms-admin/assets/503614/d2e081c5-35ce-4c62-9df6-e2d949528300">

#### After

<img width="825" alt="Screenshot of 500 error page when acting as another user after these changes. The error page is styled, and includes the act as user banner, and the link to stop acting as another user." src="https://github.com/alphagov/forms-admin/assets/503614/c8256ab9-f905-4018-b84e-d162b7fe51dd">

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?