### PR TITLE
Ensure requests specs are testing behaviour when groups feature is enabled

### DIFF
--- a/spec/requests/forms/archive_form_controller_spec.rb
+++ b/spec/requests/forms/archive_form_controller_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Forms::ArchiveFormController, type: :request do
   let(:form) { build(:form, :live, id:) }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/forms/archived_controller_spec.rb
+++ b/spec/requests/forms/archived_controller_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Forms::ArchivedController, type: :request do
   let(:id) { 2 }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
 
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Forms::ChangeNameController, type: :request do
   let(:user) { build :editor_user, id: 1, organisation: }
 
   before do
+    group = create :group
+    create(:membership, group:, user:)
+    GroupForm.create! group:, form_id: 2
+
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/2", headers, form_response_data, 200
       mock.post "/api/v1/forms", post_headers, { id: 2 }.to_json, 200

--- a/spec/requests/forms/contact_details_controller_spec.rb
+++ b/spec/requests/forms/contact_details_controller_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Forms::ContactDetailsController, type: :request do
   let(:current_user) { editor_user }
 
   before do
+    group = create :group
+    create :membership, group:, user: current_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as current_user
   end
 

--- a/spec/requests/forms/delete_confirmation_controller_spec.rb
+++ b/spec/requests/forms/delete_confirmation_controller_spec.rb
@@ -3,7 +3,14 @@ require "rails_helper"
 RSpec.describe Forms::DeleteConfirmationController, type: :request do
   let(:form) { build(:form, :with_active_resource, id: 2) }
 
+  let(:group) { create :group }
+
   before do
+    if group.present?
+      create :membership, group:, user: editor_user
+      GroupForm.create! group:, form_id: form.id
+    end
+
     login_as_editor_user
   end
 
@@ -25,19 +32,12 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
 
   describe "#destroy" do
     describe "Given a valid form" do
-      let(:group) { create :group, organisation_id: editor_user.organisation_id }
-
       before do
         ActiveResourceMock.mock_resource(form,
                                          {
                                            read: { response: form, status: 200 },
                                            delete: { response: {}, status: 200 },
                                          })
-        GroupForm.create!(group:, form_id: form.id) if group.present?
-
-        if group.present?
-          create(:membership, user: editor_user, group:)
-        end
 
         delete destroy_form_path(form_id: 2, forms_delete_confirmation_input: { confirm: "yes" })
       end

--- a/spec/requests/forms/delete_confirmation_controller_spec.rb
+++ b/spec/requests/forms/delete_confirmation_controller_spec.rb
@@ -49,20 +49,6 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
       it "deletes the form on the API" do
         expect(form).to have_been_deleted
       end
-
-      context "when the form is not in a group" do
-        let(:group) { nil }
-
-        it "redirects to the home page" do
-          expect(response).to redirect_to(root_path)
-        end
-      end
-
-      context "when the groups feature is not enabled", feature_groups: false do
-        it "redirects to the home page" do
-          expect(response).to redirect_to(root_path)
-        end
-      end
     end
   end
 end

--- a/spec/requests/forms/live_controller_spec.rb
+++ b/spec/requests/forms/live_controller_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Forms::LiveController, type: :request do
   end
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe Forms::MakeLiveController, type: :request do
         expect(response).to render_template("make_archived_draft_live")
       end
     end
+
+    context "when current user has an editor account" do
+      let(:user) { build :editor_user }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 
   describe "#create" do

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -82,14 +82,6 @@ RSpec.describe Forms::MakeLiveController, type: :request do
         expect(response).to render_template("make_archived_draft_live")
       end
     end
-
-    context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial_role }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
   end
 
   describe "#create" do
@@ -171,14 +163,6 @@ RSpec.describe Forms::MakeLiveController, type: :request do
       it "re-renders the page with an error" do
         expect(response).to render_template("make_your_form_live")
         expect(response.body).to include("You cannot make your form live because you have not finished adding questions.")
-      end
-    end
-
-    context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial_role }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::MakeLiveController, type: :request do
-  let(:user) { build :editor_user }
+  let(:user) { create :organisation_admin_user }
   let(:id) { 2 }
   let(:form) { build(:form, :ready_for_live, id:) }
 
@@ -18,6 +18,12 @@ RSpec.describe Forms::MakeLiveController, type: :request do
   end
 
   let(:form_params) { nil }
+
+  before do
+    group = create :group, status: :active
+    create(:membership, group:, user:)
+    GroupForm.create! group:, form_id: form.id
+  end
 
   describe "#new" do
     before do

--- a/spec/requests/forms/payment_link_controller_spec.rb
+++ b/spec/requests/forms/payment_link_controller_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Forms::PaymentLinkController, type: :request do
   end
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/2", headers, form.to_json, 200
       mock.put "/api/v1/forms/2", headers

--- a/spec/requests/forms/privacy_policy_controller_spec.rb
+++ b/spec/requests/forms/privacy_policy_controller_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Forms::PrivacyPolicyController, type: :request do
   end
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/2", headers, form.to_json, 200
       mock.put "/api/v1/forms/2", headers

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -36,22 +36,6 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     it "renders the correct page" do
       expect(response).to render_template(:new)
     end
-
-    context "when current user does not own form" do
-      let(:form) { build :form, id: 1, creator_id: 2, organisation_id: 2 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial_role, id: 1 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
   end
 
   describe "#create" do
@@ -85,22 +69,6 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
       end
     end
 
-    context "when current user does not own form" do
-      let(:form) { build :form, id: 1, creator_id: 2, organisation_id: 2 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial_role, id: 1 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
     context "when current user has a government email address not ending with .gov.uk" do
       let(:user) { build :editor_user, email: "user@alb.example", id: 1 }
 
@@ -122,22 +90,6 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     it "renders the correct page" do
       expect(response).to render_template(:submission_email_code_sent)
     end
-
-    context "when current user does not own form" do
-      let(:form) { build :form, id: 1, creator_id: 2, organisation_id: 2 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial_role, id: 1 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
   end
 
   describe "#submission_email_code" do
@@ -151,22 +103,6 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
 
     it "renders the correct page" do
       expect(response).to render_template(:submission_email_code)
-    end
-
-    context "when current user does not own form" do
-      let(:form) { build :form, id: 1, creator_id: 2, organisation_id: 2 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial_role, id: 1 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
     end
   end
 
@@ -204,22 +140,6 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
         expect(response).to have_http_status :unprocessable_entity
       end
     end
-
-    context "when current user does not own form" do
-      let(:form) { build :form, id: 1, creator_id: 2, organisation_id: 2 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial_role, id: 1 }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
   end
 
   describe "#submission_email_confirmed" do
@@ -234,22 +154,6 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
 
       it "renders the correct page" do
         expect(response).to render_template(:submission_email_confirmed)
-      end
-
-      context "when current user does not own form" do
-        let(:form) { build :form, id: 1, creator_id: 2, organisation_id: 2 }
-
-        it "is forbidden" do
-          expect(response).to have_http_status(:forbidden)
-        end
-      end
-
-      context "when current user has a trial account" do
-        let(:user) { build :user, :with_trial_role, id: 1 }
-
-        it "is forbidden" do
-          expect(response).to have_http_status(:forbidden)
-        end
       end
     end
 

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
   end
 
   before do
+    group = create :group
+    create(:membership, group:, user:)
+    GroupForm.create! group:, form_id: form.id
+
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms", headers, [form].to_json, 200
       mock.get "/api/v1/forms/1", headers, form.to_json, 200

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -3,9 +3,11 @@ require "rails_helper"
 RSpec.describe Forms::SubmissionEmailController, type: :request do
   include ActionView::Helpers::TextHelper
 
+  let(:form) { build :form, id: 1, creator_id: 1, organisation_id: 1 }
+  let(:group) { create :group }
+  let(:membership) { create :membership, group:, user: }
   let(:organisation) { build :organisation, id: 1, slug: "test-org" }
   let(:user) { build :editor_user, id: 1, organisation: }
-  let(:form) { build :form, id: 1, creator_id: 1, organisation_id: 1 }
 
   let(:submission_email_mailer_spy) do
     submission_email_mailer = instance_spy(SubmissionEmailMailer)
@@ -14,8 +16,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
   end
 
   before do
-    group = create :group
-    create(:membership, group:, user:)
+    membership
     GroupForm.create! group:, form_id: form.id
 
     ActiveResource::HttpMock.respond_to do |mock|
@@ -39,6 +40,14 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
 
     it "renders the correct page" do
       expect(response).to render_template(:new)
+    end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 
@@ -73,6 +82,14 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
       end
     end
 
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
     context "when current user has a government email address not ending with .gov.uk" do
       let(:user) { build :editor_user, email: "user@alb.example", id: 1 }
 
@@ -94,6 +111,14 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     it "renders the correct page" do
       expect(response).to render_template(:submission_email_code_sent)
     end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 
   describe "#submission_email_code" do
@@ -107,6 +132,14 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
 
     it "renders the correct page" do
       expect(response).to render_template(:submission_email_code)
+    end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 
@@ -144,6 +177,14 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
         expect(response).to have_http_status :unprocessable_entity
       end
     end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 
   describe "#submission_email_confirmed" do
@@ -158,6 +199,14 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
 
       it "renders the correct page" do
         expect(response).to render_template(:submission_email_confirmed)
+      end
+
+      context "when current user is not in group for form" do
+        let(:membership) { nil }
+
+        it "is forbidden" do
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
 

--- a/spec/requests/forms/unarchive_controller_spec.rb
+++ b/spec/requests/forms/unarchive_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::UnarchiveController, type: :request do
-  let(:user) { build :editor_user }
+  let(:user) { build :organisation_admin_user }
 
   let(:form) do
     build(:form,
@@ -22,6 +22,12 @@ RSpec.describe Forms::UnarchiveController, type: :request do
   end
 
   let(:form_params) { nil }
+
+  before do
+    group = create :group, status: :active
+    create(:membership, group:, user:)
+    GroupForm.create! group:, form_id: form.id
+  end
 
   describe "#new" do
     before do

--- a/spec/requests/forms/unarchive_controller_spec.rb
+++ b/spec/requests/forms/unarchive_controller_spec.rb
@@ -52,14 +52,6 @@ RSpec.describe Forms::UnarchiveController, type: :request do
     it "renders the confirmation page" do
       expect(response).to render_template("unarchive_form")
     end
-
-    context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial_role }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
   end
 
   describe "#create" do
@@ -126,14 +118,6 @@ RSpec.describe Forms::UnarchiveController, type: :request do
       it "re-renders the page with an error" do
         expect(response).to render_template("unarchive_form")
         expect(response.body).to include("You must choose an option")
-      end
-    end
-
-    context "when current user has a trial account" do
-      let(:user) { build :user, :with_trial_role }
-
-      it "is forbidden" do
-        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
   end
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/2", headers, form.to_json, 200
       mock.put "/api/v1/forms/2", headers

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -64,14 +64,6 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
     it "Reads the form from the API" do
       expect(form).to have_been_read
     end
-
-    context "when the user is not authorised to view the form" do
-      let(:form_organisation_id) { 999 }
-
-      it "returns 403" do
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
   end
 
   describe "#create" do
@@ -131,14 +123,6 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
 
         it "returns 422" do
           expect(response).to have_http_status(:unprocessable_entity)
-        end
-      end
-
-      context "when the user is not authorised to view the form" do
-        let(:form_organisation_id) { 999 }
-
-        it "returns 403" do
-          expect(response).to have_http_status(:forbidden)
         end
       end
     end
@@ -204,14 +188,6 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
 
       it "returns 200" do
         expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context "when the user is not authorised to view the form" do
-      let(:form_organisation_id) { 999 }
-
-      it "returns 403" do
-        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -36,9 +36,11 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
     })
   end
 
+  let(:group) { create :group }
+  let(:membership) { create :membership, group:, user: editor_user }
+
   before do
-    group = create :group
-    create :membership, group:, user: editor_user
+    membership
     GroupForm.create! group:, form_id: form.id
 
     ActiveResource::HttpMock.respond_to do |mock|
@@ -67,6 +69,14 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
 
     it "Reads the form from the API" do
       expect(form).to have_been_read
+    end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 
@@ -127,6 +137,14 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
 
         it "returns 422" do
           expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context "when current user is not in group for form" do
+        let(:membership) { nil }
+
+        it "returns 403" do
+          expect(response).to have_http_status(:forbidden)
         end
       end
     end
@@ -192,6 +210,14 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
 
       it "returns 200" do
         expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe FormsController, type: :request do
   let(:form) { build(:form, :with_active_resource, id: 2) }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -51,54 +51,6 @@ RSpec.describe FormsController, type: :request do
         expect(response).to render_template("forms/show")
       end
     end
-
-    context "with a form from another organisation" do
-      let(:form) do
-        create :organisation, id: 111, slug: "another-org"
-        build :form, organisation_id: 111, id: 2
-      end
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", headers, form.to_json, 200
-        end
-
-        get form_path(2)
-      end
-
-      it "Renders the forbidden page" do
-        expect(response).to render_template("errors/forbidden")
-      end
-
-      it "Returns a 403 status" do
-        expect(response.status).to eq(403)
-      end
-    end
-
-    context "with a user with a trial account" do
-      let(:user) { build(:user, :with_trial_role, id: 123) }
-      let(:form) { build(:form, :ready_for_live, :with_active_resource, id: 2, creator_id: user.id) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", headers, form.to_json, 200
-          mock.get "/api/v1/forms/2/pages", headers, form.pages.to_json, 200
-        end
-
-        login_as user
-
-        get form_path(2)
-      end
-
-      it "does not include setting the submission email address" do
-        expect(response.body).not_to include(submission_email_input_path(2))
-        expect(response.body).not_to include(submission_email_code_path(2))
-      end
-
-      it "does not include making a form live" do
-        expect(response.body).not_to include(make_live_path(2))
-      end
-    end
   end
 
   describe "no form found" do

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -55,6 +55,27 @@ RSpec.describe FormsController, type: :request do
         expect(response).to render_template("forms/show")
       end
     end
+
+    context "when current user is not in group for form" do
+      before do
+        other_group = create :group
+        GroupForm.find_by_form_id(form.id).update!(group: other_group)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms/2", headers, form.to_json, 200
+        end
+
+        get form_path(2)
+      end
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
+    end
   end
 
   describe "no form found" do

--- a/spec/requests/pages/address_settings_controller_spec.rb
+++ b/spec/requests/pages/address_settings_controller_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
   let(:address_settings_input) { build :address_settings_input, draft_question: }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Pages::ConditionsController, type: :request do
   let(:submit_result) { true }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
   let(:organisation_id) { editor_user.organisation_id }
   let(:other_organisation_id) { editor_user.organisation_id + 1 }
   let(:form) { build :form, :ready_for_routing, id: 1, organisation_id: }
+  let(:group) { create :group }
+  let(:membership) { create :membership, group:, user: editor_user }
   let(:pages) { form.pages }
   let(:page) do
     pages.first.tap do |first_page|
@@ -21,8 +23,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
   let(:submit_result) { true }
 
   before do
-    group = create :group
-    create :membership, group:, user: editor_user
+    membership
     GroupForm.create! group:, form_id: form.id
 
     login_as_editor_user
@@ -67,6 +68,18 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     it "redirects the user to the new conditions page" do
       expect(response).to redirect_to new_condition_path(form.id, selected_page.id)
+    end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
     end
 
     context "when the routing page is not set" do
@@ -209,6 +222,18 @@ RSpec.describe Pages::ConditionsController, type: :request do
     it "renders the new condition page template" do
       expect(response).to render_template("pages/conditions/edit")
     end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
+    end
   end
 
   describe "#update" do
@@ -260,6 +285,18 @@ RSpec.describe Pages::ConditionsController, type: :request do
         expect(response).to render_template("pages/conditions/edit")
       end
     end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
+    end
   end
 
   describe "#delete" do
@@ -290,6 +327,18 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     it "renders the delete condition page template" do
       expect(response).to render_template("pages/conditions/delete")
+    end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
     end
   end
 
@@ -360,6 +409,18 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
       it "renders the delete page" do
         expect(response).to render_template("pages/conditions/delete")
+      end
+    end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
       end
     end
   end

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -65,18 +65,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
       expect(response).to redirect_to new_condition_path(form.id, selected_page.id)
     end
 
-    context "when user should not be allowed to add routes to pages" do
-      let(:organisation_id) { other_organisation_id }
-
-      it "Renders the forbidden page" do
-        expect(response).to render_template("errors/forbidden")
-      end
-
-      it "Returns a 403 status" do
-        expect(response.status).to eq(403)
-      end
-    end
-
     context "when the routing page is not set" do
       let(:params) { { pages_routing_page_input: { routing_page_id: nil } } }
 
@@ -217,18 +205,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
     it "renders the new condition page template" do
       expect(response).to render_template("pages/conditions/edit")
     end
-
-    context "when user should not be allowed to add routes to pages" do
-      let(:organisation_id) { other_organisation_id }
-
-      it "Renders the forbidden page" do
-        expect(response).to render_template("errors/forbidden")
-      end
-
-      it "Returns a 403 status" do
-        expect(response.status).to eq(403)
-      end
-    end
   end
 
   describe "#update" do
@@ -280,18 +256,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
         expect(response).to render_template("pages/conditions/edit")
       end
     end
-
-    context "when user should not be allowed to add routes to pages" do
-      let(:organisation_id) { other_organisation_id }
-
-      it "Renders the forbidden page" do
-        expect(response).to render_template("errors/forbidden")
-      end
-
-      it "Returns a 403 status" do
-        expect(response.status).to eq(403)
-      end
-    end
   end
 
   describe "#delete" do
@@ -322,18 +286,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     it "renders the delete condition page template" do
       expect(response).to render_template("pages/conditions/delete")
-    end
-
-    context "when user should not be allowed to add routes to pages" do
-      let(:organisation_id) { other_organisation_id }
-
-      it "Renders the forbidden page" do
-        expect(response).to render_template("errors/forbidden")
-      end
-
-      it "Returns a 403 status" do
-        expect(response.status).to eq(403)
-      end
     end
   end
 
@@ -404,18 +356,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
       it "renders the delete page" do
         expect(response).to render_template("pages/conditions/delete")
-      end
-    end
-
-    context "when user should not be allowed to add routes to pages" do
-      let(:organisation_id) { other_organisation_id }
-
-      it "Renders the forbidden page" do
-        expect(response).to render_template("errors/forbidden")
-      end
-
-      it "Returns a 403 status" do
-        expect(response.status).to eq(403)
       end
     end
   end

--- a/spec/requests/pages/date_settings_controller_spec.rb
+++ b/spec/requests/pages/date_settings_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Pages::DateSettingsController, type: :request do
   let(:date_settings_input) { build :date_settings_input }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Pages::GuidanceController, type: :request do
   end
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/pages/name_settings_controller_spec.rb
+++ b/spec/requests/pages/name_settings_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Pages::NameSettingsController, type: :request do
   let(:name_settings_input) { build :name_settings_input }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/pages/question_text_controller_spec.rb
+++ b/spec/requests/pages/question_text_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Pages::QuestionTextController, type: :request do
   let(:question_text_input) { build :question_text_input, form: }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe Pages::QuestionsController, type: :request do
   end
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: 2
+
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/2", headers, form_response.to_json, 200
       mock.get "/api/v1/forms/2/pages", headers, form_pages_response, 200

--- a/spec/requests/pages/selections_settings_controller_spec.rb
+++ b/spec/requests/pages/selections_settings_controller_spec.rb
@@ -19,6 +19,10 @@ describe Pages::SelectionsSettingsController, type: :request do
   let(:page_id) { nil }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/pages/text_settings_controller_spec.rb
+++ b/spec/requests/pages/text_settings_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Pages::TextSettingsController, type: :request do
   let(:text_settings_input) { build :text_settings_input }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
   let(:type_of_answer_input) { build :type_of_answer_input }
 
   before do
+    group = create :group
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: form.id
+
     login_as_editor_user
   end
 

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -3,7 +3,12 @@ require "rails_helper"
 RSpec.describe PagesController, type: :request do
   let(:form_response) { build :form, id: 2 }
 
+  let(:group) { create :group }
+
   before do
+    create :membership, group:, user: editor_user
+    GroupForm.create! group:, form_id: 2
+
     login_as_editor_user
   end
 
@@ -39,6 +44,8 @@ RSpec.describe PagesController, type: :request do
     let(:original_draft_question) { create :draft_question, form_id: 1, user: editor_user }
 
     before do
+      GroupForm.create! group:, form_id: current_form.id
+
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, current_form.to_json, 200
       end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -32,28 +32,6 @@ RSpec.describe PagesController, type: :request do
       pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
       expect(ActiveResource::HttpMock.requests).to include pages_request
     end
-
-    context "with a form from another organisation" do
-      let(:form) do
-        build :form, organisation_id: 2, id: 2
-      end
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", headers, form.to_json, 200
-        end
-
-        get form_pages_path(2)
-      end
-
-      it "Renders the forbidden page" do
-        expect(response).to render_template("errors/forbidden")
-      end
-
-      it "Returns a 403 status" do
-        expect(response.status).to eq(403)
-      end
-    end
   end
 
   describe "#start_new_question" do

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe PagesController, type: :request do
   let(:form_response) { build :form, id: 2 }
 
   let(:group) { create :group }
+  let(:membership) { create :membership, group:, user: editor_user }
 
   before do
-    create :membership, group:, user: editor_user
+    membership
     GroupForm.create! group:, form_id: 2
 
     login_as_editor_user
@@ -36,6 +37,18 @@ RSpec.describe PagesController, type: :request do
 
       pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
       expect(ActiveResource::HttpMock.requests).to include pages_request
+    end
+
+    context "when current user is not in group for form" do
+      let(:membership) { nil }
+
+      it "Renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "Returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We are now using the groups feature everywhere, and we want to make sure our specs are testing things with the groups feature enabled. For our request specs this means making sure that forms belong to a group (especially when testing code related to access control).

This does make our request specs a bit larger and slower though; it might be worth asking whether we should be mocking more things in these specs. Currently I think we treat them like integration tests though, and I wasn't sure that now was the time to open that question, and instead focused on making it so that we can remove our legacy non-groups code.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
