### PR TITLE
Revert change to use rails default logger when running locally

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,12 +71,6 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 
-  # For development - to prevent logs from being noisy, we use the default rails logger. In application.rb we configure
-  # a custom logger that adds additional context to logs to make them easier to search and manipulate in Splunk.
-  # To test the custom logger that we use in production locally, comment this out.
-  config.logger = ActiveSupport::Logger.new($stdout)
-    .tap { |logger| logger.formatter = config.log_formatter }
-
   # Make request logs less noisy when running locally. To test the additional logging context we add for production,
   # comment this line out.
   config.lograge.custom_options = nil


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/tjnJrmjR/7-improve-default-information-we-add-to-logs

Our custom ApplicationLogger has a slightly different interface than the rails default logger which allows for passing in a hash of additional arguments to add to the structured log as a second parameter.

This means we can't just swap this out for the ActiveSupport::Logger class when running in development mode.

Undo the change to make logs less noisy for development by swapping the logger. If we want to do this, we will have to make changes to the ApplicationLogger to allow for this.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
