### PR TITLE
Revert change to make local request logs less noisy

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,8 +70,4 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
-
-  # Make request logs less noisy when running locally. To test the additional logging context we add for production,
-  # comment this line out.
-  config.lograge.custom_options = nil
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/tjnJrmjR/7-improve-default-information-we-add-to-logs

This change was made with the intention of making logs less noisy for local development by removing our custom log context (request_id, user_id etc) from the logs.

Initially we did this for the application (non-request) logs too, but this change broke the logging locally so it was reverted.

Also revert the change for the request logs so that application and request logs are consistent. We can revisit this if we find that logs are too noisy for local development.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
