### PR TITLE
Reduce authorisation session timeout to 8 hours

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -47,7 +47,11 @@ sentry:
 # How we authenticate users
 auth_provider: # use default auth_provider from environment
 
-auth_valid_for: 86400 # the time after which re-authentication is required, in seconds
+# The time the user's authorisation session is valid for. After this time, the session with have to be re-authorised
+# with Auth0. If the user's session on Auth0 is still valid, the user will not be required to login again.
+# If we change this value, we should also change the session timeout for the Auth0 tenant (configured in terraform) to
+# match it.
+auth_valid_for: 28800 # 8 hours
 
 auth0:
   client_id: changeme


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/nIuSV6Fa/1563-rtp-ref-7-reduce-forms-admin-user-session-timeout-to-8-hours

Change the length of time the authorisation sesssion is valid for to 8 hours. This means that we will require the user to login again after this time has elapsed.

For Auth0, this will force a check with Auth0 that the session with Auth0 is still valid, if it is the user won't be required to login again. We will separately adjust the Auth0 application configuration to reduce the length of time the session is valid for.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
