### PR TITLE
Silence tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
       activerecord (>= 6.1)
       request_store (~> 1.4)
     parallel (1.25.1)
-    parser (3.3.3.0)
+    parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.6)

--- a/spec/lib/mailchimp_list_synchronizer_spec.rb
+++ b/spec/lib/mailchimp_list_synchronizer_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe MailchimpListSynchronizer do
   subject(:mailchimp_list_synchronizer) { described_class }
 
+  before do
+    allow($stdout).to receive(:puts)
+  end
+
   describe "#synchronize" do
     let(:mailchimp_client) do
       instance_double(MailchimpMarketing::Client)

--- a/spec/lib/tasks/trial_users.rake_spec.rb
+++ b/spec/lib/tasks/trial_users.rake_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "trial_users.rake" do
 
     let(:summarizer_double) { instance_double(Summarizer) }
 
+    before do
+      allow($stdout).to receive(:puts)
+    end
+
     it "runs" do
       expect { task.invoke }.not_to raise_error
     end


### PR DESCRIPTION
### Reduce noise when running rspec

Currently when I run `rspec` it outputs:

```
warning: parser/current is loading parser/ruby33, which recognizes 3.3.3-compliant syntax, but you are running 3.3.4.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................Mailchimp server prefix: prefix
List id: list-1
Found Mailchimp list: List 1
Mailchimp list has 3 members
There are 1 to subscribe
There are 2 to unsubscribe
Subscribing any new users...
Unsubscribing any removed users...
.Mailchimp server prefix: prefix
List id: list-1
Found Mailchimp list: List 1
Mailchimp list has 3 members
There are 1 to subscribe
There are 2 to unsubscribe
Subscribing any new users...
Unsubscribing any removed users...
.Mailchimp server prefix: prefix
List id: list-1
Found Mailchimp list: List 1
Mailchimp list has 3 members
There are 1 to subscribe
There are 2 to unsubscribe
Subscribing any new users...
Unsubscribing any removed users...
.Mailchimp server prefix: prefix
List id: list-1
Found Mailchimp list: List 1
Mailchimp list has 3 members
There are 1 to subscribe
There are 2 to unsubscribe
Subscribing any new users...
Unsubscribing any removed users...
.Mailchimp server prefix: prefix
List id: list-1
Found Mailchimp list: List 1
Mailchimp list has 1001 members
There are 2 to subscribe
There are 1001 to unsubscribe
Subscribing any new users...
Unsubscribing any removed users...
....................................................{"total_forms_to_add_to_groups":0,"total_trial_user_forms_in_groups":0,"total_trial_user_forms_not_in_group":0,"total_trial_user_groups":0,"total_trial_user_groups_to_create":0,"total_trial_users":0,"total_trial_users_with_forms":0,"total_trial_users_with_groups":0,"total_trial_users_with_org_and_name":0,"total_trial_users_with_org_name_and_forms":0,"total_trial_users_without_org_or_name":0,"trial_user_forms_not_in_default_group":[]}
.null
...
```

This PR:
- updates the parser gem to stop the warning being printed
- stubs `puts` in tests which use it to stop them printing when the specs are run

I think there are other options for stopping puts printing in tests but given it's useful to use puts in tests sometimes, I've just stubbed it in the two places it's needed.

Sometimes I get a warning about a mismatch between chromedriver and chrome from the selenium tests. That's not solved here.
<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
