### PR TITLE
Add tests to check authorisation for making forms live

### DIFF
--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe Forms::MakeLiveController, type: :request do
         expect(response).to render_template("make_archived_draft_live")
       end
     end
+
+    context "when current user is not a group admin" do
+      let(:group_role) { :editor }
+
+      it "is forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 
   describe "#create" do
@@ -175,7 +183,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
       end
     end
 
-    context "when current user has a trial account" do
+    context "when current user is not a group admin" do
       let(:group_role) { :editor }
 
       it "is forbidden" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/QoZWJP6I/1614-cleanup-forms-admin-policies-to-focus-on-the-groups-model

This PR supersedes https://github.com/alphagov/forms-admin/pull/1312, which mainly duplicated changes that were made in https://github.com/alphagov/forms-admin/pull/1282 which was worked on at the same time but merged first.

The only real difference between the 2 PRs was in `make_live_controller_spec.rb`, so this PR implements that change.

When tests were updated after enabling the groups feature, tests that check the user is authorised to GET/POST to `/make-live` were removed.

Re-add tests that check that a 403 response is returned when the user is not authorised to make forms live.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
