### PR TITLE
Update user name and org validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,6 +122,6 @@ private
   end
 
   def requires_organisation?
-    organisation_id_was.present? || role_changed?(to: :editor) || role_changed?(to: :organisation_admin)
+    organisation_id_was.present? || role_changed?(to: :organisation_admin)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,7 +118,7 @@ class User < ApplicationRecord
 private
 
   def requires_name?
-    name_was.present? || role_changed?(from: :trial)
+    name_was.present?
   end
 
   def requires_organisation?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,11 +40,9 @@ describe User, type: :model do
     context "when updating organisation" do
       let(:user) { create :user, :with_no_org, role: :trial }
 
-      context "when user has been created with a trial account" do
-        it "is valid to leave organisation unset" do
-          user.organisation_id = nil
-          expect(user).to be_valid
-        end
+      it "is valid to leave organisation unset" do
+        user.organisation_id = nil
+        expect(user).to be_valid
       end
 
       it "is not valid to unset organisation if it is already set" do
@@ -52,11 +50,6 @@ describe User, type: :model do
         user.save!
 
         user.organisation_id = nil
-        expect(user).to be_invalid
-      end
-
-      it "is not valid to leave organisation unset if changing role to editor" do
-        user.role = :editor
         expect(user).to be_invalid
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -94,16 +94,6 @@ describe User, type: :model do
         user.name = nil
         expect(user).to be_invalid
       end
-
-      it "is not valid to leave name unset if changing role to editor" do
-        user.role = :editor
-        expect(user).to be_invalid
-      end
-
-      it "is not valid to leave name unset if changing role to super admin" do
-        user.role = :super_admin
-        expect(user).to be_invalid
-      end
     end
 
     context "when the user belongs to an organisation that doesn't have a signed mou" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -191,8 +191,8 @@ RSpec.describe UsersController, type: :request do
           expect(user.reload.organisation).to be_nil
         end
 
-        it "returns an error if organisation is not chosen and role is changed to editor" do
-          put user_path(user), params: { user: { role: "editor", organisation_id: nil } }
+        it "returns an error if organisation is not chosen and role is changed to organisation_admin" do
+          put user_path(user), params: { user: { role: "organisation_admin", organisation_id: nil } }
           expect(response).to have_http_status(:unprocessable_entity)
           expect(user.reload.role).to eq("trial")
         end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -175,16 +175,10 @@ RSpec.describe UsersController, type: :request do
       context "with a trial user with no name set" do
         let(:user) { create(:user, :with_trial_role, name: nil) }
 
-        it "does not return error if name is not chosen and role is not changed" do
+        it "successfully updates the user when a name is not set" do
           put user_path(user), params: { user: { role: "trial", name: nil } }
           expect(response).to redirect_to(users_path)
           expect(user.reload.name).to be_nil
-        end
-
-        it "returns an error if name is not chosen and role is changed to editor" do
-          put user_path(user), params: { user: { role: "editor", name: nil } }
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(user.reload.role).to eq("trial")
         end
       end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Previously, when checking whether we needed to validate a user's name or organisation, we checked whether that user's role had changed from trial. This is no longer needed, as we require all users to set their name and organisation regardless of role. It is enough to just prevent name and organisation from being unset.

Trello card: https://trello.com/c/nXOuz0qN

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
