### PR TITLE
Remove user missing organisation error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,10 +18,6 @@ class ApplicationController < ActionController::Base
     render template: "errors/not_found", status: :not_found
   end
 
-  rescue_from FormPolicy::UserMissingOrganisationError do
-    render template: "errors/user_missing_organisation_error", status: :forbidden
-  end
-
   rescue_from Pundit::NotAuthorizedError do |_exception|
     # Useful when we start adding more policies that require custom errors
     # policy_name = exception.policy.class.to_s.underscore

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,10 +77,6 @@ class User < ApplicationRecord
     trial? || editor? || standard?
   end
 
-  def organisation_valid?
-    trial? || organisation.present?
-  end
-
   def given_organisation?
     organisation_id.present? && organisation_id_previously_changed?(from: nil)
   end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -4,8 +4,6 @@ class FormPolicy
   class UserMissingOrganisationError < StandardError; end
 
   def initialize(user, form)
-    raise UserMissingOrganisationError, "Missing required attribute organisation_id" unless user.organisation_valid?
-
     @user = user
     @form = form
   end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -1,8 +1,6 @@
 class FormPolicy
   attr_reader :user, :form
 
-  class UserMissingOrganisationError < StandardError; end
-
   def initialize(user, form)
     @user = user
     @form = form

--- a/app/views/errors/user_missing_organisation_error.html.erb
+++ b/app/views/errors/user_missing_organisation_error.html.erb
@@ -1,9 +1,0 @@
-<% set_page_title(t("page_titles.user_missing_organisation")) %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('user_missing_organisation.title') %></h1>
-    <%= simple_format(t('user_missing_organisation.body', contact_link: contact_link)) %>
-  </div>
-</div>
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -922,7 +922,6 @@ en:
     text_settings: How much text will people need to provide?
     type_of_answer: What kind of answer do you need to this question?
     unarchive_form: Make your form live again
-    user_missing_organisation: You do not have an organisation set for your account
     what_happens_next: Add information about what happens next
     your_changes_are_live: Your changes are live
     your_form_is_live: Your form is live
@@ -1121,9 +1120,6 @@ en:
         <p>
           After you have made your form live, completed forms will be sent to %{submission_email}.
         </p>
-  user_missing_organisation:
-    body: "%{contact_link} to assign an organisation to your account."
-    title: You do not have an organisation set for your account
   users:
     act_as_user_html: Act as this user <span class="govuk-visually-hidden">%{user_email}</span>
     cancel: Cancel

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -15,26 +15,6 @@ describe FormPolicy do
     end
   end
 
-  describe "#initialize?" do
-    context "when user does not belong to an organisation" do
-      context "with editor role" do
-        let(:user) { build :editor_user, :with_no_org }
-
-        it "raises an error" do
-          expect { policy }.to raise_error FormPolicy::UserMissingOrganisationError
-        end
-      end
-
-      context "with trial role" do
-        let(:user) { build :user, :with_trial_role }
-
-        it "does not raise an error" do
-          expect { policy }.not_to raise_error
-        end
-      end
-    end
-  end
-
   describe "#can_view_form?" do
     context "when user is in the group" do
       before do


### PR DESCRIPTION
### What problem does this pull request solve?

We longer need to raise UserMissingOrganisationError in the form policy, as the policies appropriately handle a user's organisation being missing. This PR removes the error itself, raising of it, handling it, and the template shown when raised. 

Trello card: https://trello.com/c/nXOuz0qN

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
