### PR TITLE
Refactor FormListService to remove non-groups code paths

### DIFF
--- a/app/service/form_list_service.rb
+++ b/app/service/form_list_service.rb
@@ -3,7 +3,7 @@ class FormListService
   include ActionView::Helpers::UrlHelper
   include GovukRailsCompatibleLinkHelper
 
-  attr_accessor :forms, :current_user, :organisation, :group
+  attr_accessor :forms, :group
 
   class << self
     def call(**args)
@@ -11,10 +11,8 @@ class FormListService
     end
   end
 
-  def initialize(forms:, current_user:, organisation: nil, group: nil)
+  def initialize(forms:, group:)
     @forms = forms
-    @current_user = current_user
-    @organisation = organisation || (current_user.trial? ? nil : current_user.organisation)
     @group = group
     @list_of_creator_id = forms.map(&:creator_id).uniq
     @list_of_creators = User.where(id: @list_of_creator_id)
@@ -33,11 +31,7 @@ class FormListService
 private
 
   def caption
-    return I18n.t("groups.form_table_caption", group_name: group.name) if group.present?
-
-    return I18n.t("home.your_forms") if organisation.blank?
-
-    I18n.t("home.form_table_caption", organisation_name: organisation.name)
+    I18n.t("groups.form_table_caption", group_name: group.name)
   end
 
   def head

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -58,5 +58,5 @@
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_group_form_path(@group)) %>
 
 <% if @forms.any? %>
-  <%= govuk_table(**FormListService.call(forms: @forms, current_user: @current_user, group: @group).data) %>
+  <%= govuk_table(**FormListService.call(forms: @forms, group: @group).data) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -632,9 +632,7 @@ en:
     created_by: Created by
     form_name_heading: Form name
     form_status_heading: Status
-    form_table_caption: "%{organisation_name} forms"
     preview: Preview this form
-    your_forms: Your forms
   internal_server_error:
     body: Please try again later.
     title: Sorry, there is a problem with the service

--- a/spec/service/form_list_service_spec.rb
+++ b/spec/service/form_list_service_spec.rb
@@ -1,144 +1,43 @@
 require "rails_helper"
 
 describe FormListService do
-  let(:service) { described_class.call(forms:, current_user:) }
+  let(:service) { described_class.call(forms:, group:) }
 
-  let(:forms) { build_list :form, 5, :with_id, creator_id: current_user.id }
-  let(:current_user) { create :user, :with_no_org }
+  let(:creator) { create :user }
+  let(:forms) { build_list :form, 5, :with_id, creator_id: creator.id }
+  let(:group) { build :group }
 
   describe "#data" do
     describe "caption" do
-      context "when user doesn't have an organisation" do
-        let(:current_user) { create :user, :with_no_org }
-
-        it "returns generic caption" do
-          expect(service.data).to include caption: I18n.t("home.your_forms")
-        end
-      end
-
-      context "when user has trial role" do
-        let(:current_user) { create :user, :with_trial_role }
-
-        it "returns generic caption" do
-          expect(service.data).to include caption: I18n.t("home.your_forms")
-        end
-      end
-
-      context "when user has organisation" do
-        let(:current_user) { create :editor_user }
-
-        it "returns specific organisation caption" do
-          organisation_name = current_user.organisation.name
-          expect(service.data).to include caption: I18n.t("home.form_table_caption", organisation_name:)
-        end
-      end
-
-      context "when organisation is given as a keyword argument" do
-        let(:service) { described_class.call(forms:, current_user:, organisation:) }
-
-        let(:organisation) { OpenStruct.new(name: "Organisation 1") }
-
-        it "returns specific organisation caption" do
-          organisation_name = organisation.name
-          expect(service.data).to include caption: I18n.t("home.form_table_caption", organisation_name:)
-        end
+      it "returns caption containing group name" do
+        expect(service.data).to include caption: I18n.t("groups.form_table_caption", group_name: group.name)
       end
     end
 
     describe "head" do
-      context "when user is editor" do
-        let(:current_user) { create :editor_user }
-
-        it "contains a 'Name', `Created by` and 'Status' column heading" do
-          expect(service.data[:head]).to eq([I18n.t("home.form_name_heading"),
-                                             { text: I18n.t("home.created_by") },
-                                             { text: I18n.t("home.form_status_heading"), numeric: true }])
-        end
-      end
-
-      context "when user is super admin" do
-        let(:current_user) { create :super_admin_user }
-
-        it "contains a 'Name', `Created by` and 'Status' column heading" do
-          expect(service.data[:head]).to eq([I18n.t("home.form_name_heading"),
-                                             { text: I18n.t("home.created_by") },
-                                             { text: I18n.t("home.form_status_heading"), numeric: true }])
-        end
-      end
-
-      context "when user is trial" do
-        let(:current_user) { create :user, :with_trial_role }
-
-        it "contains a 'Name' and 'Status' column heading" do
-          expect(service.data[:head]).to eq([I18n.t("home.form_name_heading"), { text: I18n.t("home.created_by") }, { text: I18n.t("home.form_status_heading"), numeric: true }])
-        end
+      it "contains a 'Name', `Created by` and 'Status' column heading" do
+        expect(service.data[:head]).to eq([I18n.t("home.form_name_heading"),
+                                           { text: I18n.t("home.created_by") },
+                                           { text: I18n.t("home.form_status_heading"), numeric: true }])
       end
     end
 
     describe "rows" do
-      context "when user is trial user" do
-        let(:current_user) { create :user, :with_trial_role }
-
-        it "has a row for each form passed to the service" do
-          expect(service.data[:rows].size).to eq forms.size
-        end
-
-        it "returns the correct data for each form" do
-          service.data[:rows].each_with_index do |row, index|
-            form = forms[index]
-            expect(row).to eq([
-              { text: "<a class=\"govuk-link\" href=\"/forms/#{form.id}\">#{form.name}</a>" },
-              { text: current_user.name.to_s },
-              {
-                numeric: true,
-                text: "<div class='app-form-states'><strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n</div>",
-              },
-            ])
-          end
-        end
+      it "has a row for each form passed to the service" do
+        expect(service.data[:rows].size).to eq forms.size
       end
 
-      context "when user is editor" do
-        let(:current_user) { create :editor_user }
-
-        it "contains 3 columns" do
-          expect(service.data[:rows].first.size).to eq 3
-        end
-
-        it "returns the created by name" do
-          service.data[:rows].each_with_index do |row, index|
-            form = forms[index]
-            expect(row).to eq([
-              { text: "<a class=\"govuk-link\" href=\"/forms/#{form.id}\">#{form.name}</a>" },
-              { text: current_user.name },
-              {
-                numeric: true,
-                text: "<div class='app-form-states'><strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n</div>",
-              },
-            ])
-          end
-        end
-      end
-
-      context "when user is super admin" do
-        let(:current_user) { create :super_admin_user }
-
-        it "contains 3 columns" do
-          expect(service.data[:rows].first.size).to eq 3
-        end
-
-        it "returns the created by name" do
-          service.data[:rows].each_with_index do |row, index|
-            form = forms[index]
-            expect(row).to eq([
-              { text: "<a class=\"govuk-link\" href=\"/forms/#{form.id}\">#{form.name}</a>" },
-              { text: current_user.name },
-              {
-                numeric: true,
-                text: "<div class='app-form-states'><strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n</div>",
-              },
-            ])
-          end
+      it "returns the correct data for each form" do
+        service.data[:rows].each_with_index do |row, index|
+          form = forms[index]
+          expect(row).to eq([
+            { text: "<a class=\"govuk-link\" href=\"/forms/#{form.id}\">#{form.name}</a>" },
+            { text: creator.name.to_s },
+            {
+              numeric: true,
+              text: "<div class='app-form-states'><strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n</div>",
+            },
+          ])
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

We now only use the FormListService in the group view, so can remove any redundant code. Previously, we didn't display the created_by column in the forms table for trial users. This is no longer the case, so we've also removed the corresponding tests.

Trello card: https://trello.com/c/nXOuz0qN

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
