### PR TITLE
Move authorization for delete_confirmtion_controller#destroy to start

### DIFF
--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -9,6 +9,8 @@ module Forms
     end
 
     def destroy
+      authorize current_form
+
       load_page_variables
       @delete_confirmation_input = DeleteConfirmationInput.new(delete_confirmation_input_params)
 
@@ -68,7 +70,6 @@ module Forms
     def delete_form(form)
       success_url = groups_enabled && form.group.present? ? group_path(form.group) : root_path
 
-      authorize form
       if form.destroy
         redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{form.name}’"
       else
@@ -79,7 +80,6 @@ module Forms
     def delete_page(form, page)
       success_url = form_pages_path(form)
 
-      authorize form
       if page.destroy
         redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{page.question_text}’"
       else

--- a/spec/requests/forms/delete_confirmation_controller_spec.rb
+++ b/spec/requests/forms/delete_confirmation_controller_spec.rb
@@ -46,5 +46,25 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
         expect(form).to have_been_deleted
       end
     end
+
+    context "when the user has decided not to delete the form" do
+      before do
+        ActiveResourceMock.mock_resource(form,
+                                         {
+                                           read: { response: form, status: 200 },
+                                           delete: { response: {}, status: 200 },
+                                         })
+
+        delete destroy_form_path(form_id: 2, forms_delete_confirmation_input: { confirm: "no" })
+      end
+
+      it "redirects you to the form page" do
+        expect(response).to redirect_to(form_path(2))
+      end
+
+      it "does not delete the form on the API" do
+        expect(form).not_to have_been_deleted
+      end
+    end
   end
 end

--- a/spec/requests/forms/delete_confirmation_controller_spec.rb
+++ b/spec/requests/forms/delete_confirmation_controller_spec.rb
@@ -2,10 +2,12 @@ require "rails_helper"
 
 RSpec.describe Forms::DeleteConfirmationController, type: :request do
   let(:form) { build(:form, :with_active_resource, id: 2) }
+
   let(:group) { create(:group, organisation: editor_user.organisation) }
+  let(:membership) { create :membership, group:, user: editor_user }
 
   before do
-    Membership.create!(group_id: group.id, user: editor_user, added_by: editor_user)
+    membership
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_editor_user
   end
@@ -22,6 +24,14 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
 
       it "reads the form from the API" do
         expect(form).to have_been_read
+      end
+
+      context "when current user is not in group for form" do
+        let(:membership) { nil }
+
+        it "returns an error" do
+          expect(response).to have_http_status :forbidden
+        end
       end
     end
   end
@@ -44,6 +54,18 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
 
       it "deletes the form on the API" do
         expect(form).to have_been_deleted
+      end
+
+      context "when current user is not in group for form" do
+        let(:membership) { nil }
+
+        it "returns an error" do
+          expect(response).to have_http_status :forbidden
+        end
+
+        it "does not delete the form on the API" do
+          expect(form).not_to have_been_deleted
+        end
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Because we were authorizing the delete in the `delete_page` and `delete_form` helpers, we weren't checking the user was authorized when they decided not to delete or did not send a valid request.

This PR fixes things by making sure that checking the user's authorization is the first things we do in the action.

We also add a spec for when user chooses not to delete form. This bug was introduced because we weren't testing the path when a user presses the delete button for a form but then chooses not to delete it at the confirmation page.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?