### PR TITLE
Make sure groups feature is enabled everywhere

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,7 +1,3 @@
-features:
-  groups:
-    enabled: true
-
 forms_api:
   # URL to form-api endpoints
   base_url: http://localhost:9292

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,12 +1,3 @@
-features:
-  groups:
-    enabled: false
-    organisations:
-      driver_and_vehicle_standards_agency: true
-      government_digital_service: true
-      govuk_forms_adoption_team: true
-      insolvency_service: true
-
 # Use real authentication
 auth_provider: gds_sso
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,7 +1,3 @@
-features:
-  groups:
-    enabled: true
-
 forms_api:
   # URL to form-api endpoints
   base_url: http://localhost:9292


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Trello card: https://trello.com/c/k3WbZBZw/36-remove-groups-feature-flag

We're confident now that we want to use the groups feature going forward, and have started removing the legacy code, so we want it enabled everywhere.

This commit removes the groups feature flag override from settings/*.yml files so that the global value is used and we have the groups feature enabled for everyone everywhere.

Note that the feature flag code is still around, we're just making sure that it's always set to true.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?