### PR TITLE
Remove policy check for submission email task

### DIFF
--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -74,22 +74,12 @@ private
   end
 
   def email_address_section
-    section = {
+    {
       title: I18n.t("forms.task_list_#{create_or_edit}.email_address_section.title"),
       section_number: 2,
       subsection: false,
+      rows: email_address_section_tasks,
     }
-
-    if Pundit.policy(@current_user, @form).can_view_form?
-      section[:rows] = email_address_section_tasks
-    else
-      section[:body_text] = I18n.t(
-        "forms.task_list_create.email_address_section.if_not_permitted.body_text",
-        submission_email: @form.submission_email,
-      )
-    end
-
-    section
   end
 
   def email_address_section_tasks

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,11 +234,6 @@ en:
         confirm_email: Enter the email address confirmation code
         email: Set the email address completed forms will be sent to
         hint_text_html: Completed forms will be sent to:<br> %{submission_email}
-        if_not_permitted:
-          body_text: |
-            When a draft form is completed it will be sent to your email address so you can see how form submissions will look.
-
-            Editor accounts can change the email address completed forms are sent to.
         title: Set email address for completed forms
       make_form_live_section:
         group_not_active:


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/nXOuz0qN/1609-migration-change-trial-and-editor-users-to-standard-users

There was a redundant check that the user could view the form when deciding whether to allow the user to complete the submission email task. This existed because previously we were checking that the user wasn't a trial user.

There was no need for this policy check now, as a user that doesn't have permission to view the form would not be able to visit the task list page.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
