### PR TITLE
Display standard user role option on users screen correctly

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1153,6 +1153,9 @@ en:
       organisation_admin:
         description: Can manage groups and users in their organisation
         name: Organisation admin
+      standard:
+        description: Can be an editor or a group admin in groups in their organisation
+        name: Standard user
       super_admin:
         description: Can manage groups and users in all organisations - GOV.UK Forms team members only
         name: Super admin

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -80,7 +80,9 @@ describe "users/edit.html.erb" do
     it "has role fields" do
       expect(rendered).to have_checked_field("Editor")
       expect(rendered).to have_unchecked_field("Super admin")
+      expect(rendered).to have_unchecked_field("Organisation admin")
       expect(rendered).to have_unchecked_field("Trial")
+      expect(rendered).to have_unchecked_field("Standard user")
     end
 
     it "has a name field" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/nXOuz0qN/1609-migration-change-trial-and-editor-users-to-standard-users

Add translations to display the radio button for selecting the standard user rule on the edit user page correctly.

For now, it will still be possible to select "Trial" and "Editor" roles, but we will remove these options after we have migrated trial and editor users to be standard users.

<img width="792" alt="Screenshot 2024-07-25 at 14 04 36" src="https://github.com/user-attachments/assets/8f19bde4-bd68-4a4b-ae15-15abeae5611b">

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
