### PR TITLE
Fix creation of standard users in db/seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,7 +36,7 @@ if HostingEnvironment.local_development? && User.none?
   FactoryBot.create :organisation, slug: "closed-org", closed: true
 
   # create extra standard users
-  FactoryBot.create_list :standard, 3, organisation: test_org
+  FactoryBot.create_list :user, 3, :standard, organisation: test_org
 
   # create extra super admins
   FactoryBot.create_list :super_admin_user, 3, organisation: gds


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/nXOuz0qN

During the replacement of trial and editors roles with standard, we replaced the `editor_user` factory with the default user factory with `:standard` shorthand syntax. We made a mistake doing this in the database seed, which this PR fixes.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
