### PR TITLE
Revert "Remove trial and editor roles"

### DIFF
--- a/app/components/act_as_user_banner_component/view.rb
+++ b/app/components/act_as_user_banner_component/view.rb
@@ -27,6 +27,10 @@ module ActAsUserBannerComponent
                     "an organisation admin"
                   elsif @acting_as_user.standard?
                     "a standard user"
+                  elsif @acting_as_user.editor?
+                    "an editor user"
+                  elsif @acting_as_user.trial?
+                    "a trial user"
                   else
                     "a user with role: #{@acting_as_user.role}"
                   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,8 @@ class User < ApplicationRecord
   enum :role, {
     super_admin: "super_admin",
     organisation_admin: "organisation_admin",
+    editor: "editor",
+    trial: "trial",
     standard: "standard",
   }
 
@@ -69,6 +71,10 @@ class User < ApplicationRecord
     else # Create a new user.
       create!(attributes)
     end
+  end
+
+  def standard_user?
+    trial? || editor? || standard?
   end
 
   def given_organisation?

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     </div>
   </div>
-<% elsif @current_user.standard? && !@current_user.current_org_has_mou? %>
+<% elsif @current_user.standard_user? && !@current_user.current_org_has_mou? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1147,6 +1147,9 @@ en:
       title: Users
       users_caption: All users
     roles:
+      editor:
+        description: Can create forms
+        name: Editor
       organisation_admin:
         description: Can manage groups and users in their organisation
         name: Organisation admin
@@ -1156,6 +1159,9 @@ en:
       super_admin:
         description: Can manage groups and users in all organisations - GOV.UK Forms team members only
         name: Super admin
+      trial:
+        description: Can create forms but cannot make them live
+        name: Trial
     save: Save
   what_happens_next:
     example:

--- a/lib/tasks/trial_users.rake
+++ b/lib/tasks/trial_users.rake
@@ -1,0 +1,65 @@
+namespace :trial_users do
+  desc "Output summary data about each trial user as newline-delimited JSON"
+  task summary: :environment do
+    puts(Summarizer.new.summarize.to_json)
+  end
+end
+
+class Summarizer
+  def summarize
+    total_trial_users = User.trial.count
+    trial_users_with_org_and_name = User.trial.where("organisation_id IS NOT NULL AND name IS NOT NULL")
+    total_trial_users_with_org_and_name = trial_users_with_org_and_name.count
+    total_trial_users_without_org_or_name = User.trial.where("organisation_id IS NULL OR name IS NULL").count
+
+    total_forms_to_add_to_groups = 0
+    total_trial_user_groups = 0
+    total_trial_users_with_groups = 0
+    total_trial_user_groups_to_create = 0
+    total_trial_users_with_forms = 0
+    total_trial_users_with_org_name_and_forms = 0
+    total_trial_users_with_default_group = 0
+    total_trial_user_forms_in_groups = 0
+    total_trial_user_forms_not_in_group = 0
+    trial_user_forms_not_in_default_group = Set.new
+
+    group_form_ids = Set.new(GroupForm.pluck(:form_id))
+
+    User.trial.find_each do |trial_user|
+      with_org_and_name = trial_user.organisation.present? && trial_user.name.present?
+      forms = Form.where(creator_id: trial_user.id)
+      trial_user_form_ids = Set.new(forms.map(&:id))
+      default_group = Group.find_by(creator: trial_user, name: "#{trial_user.name}’s trial group", status: :trial)
+      default_group_form_ids = GroupForm.where(group: default_group).pluck(:form_id).to_set
+
+      forms_without_group = trial_user_form_ids - group_form_ids
+
+      total_trial_users_with_forms += 1 if forms.present?
+      total_trial_user_groups_to_create += 1 if with_org_and_name && forms_without_group.present?
+      total_trial_users_with_org_name_and_forms += 1 if with_org_and_name && forms.present?
+      total_trial_users_with_default_group += 1 if default_group.present?
+      total_forms_to_add_to_groups += forms_without_group.count if with_org_and_name
+      total_trial_user_forms_in_groups += (trial_user_form_ids.count - forms_without_group.count)
+      total_trial_user_forms_not_in_group += forms_without_group.count
+      trial_user_forms_not_in_default_group += (trial_user_form_ids - forms_without_group - default_group_form_ids)
+
+      total_trial_user_groups += Group.where(creator_id: trial_user.id).count
+      total_trial_users_with_groups += 1 if Group.where(creator_id: trial_user.id).present?
+    end
+
+    {
+      total_forms_to_add_to_groups:,
+      total_trial_user_forms_in_groups:,
+      total_trial_user_forms_not_in_group:,
+      total_trial_user_groups:,
+      total_trial_user_groups_to_create:,
+      total_trial_users:,
+      total_trial_users_with_forms:,
+      total_trial_users_with_groups:,
+      total_trial_users_with_org_and_name:,
+      total_trial_users_with_org_name_and_forms:,
+      total_trial_users_without_org_or_name:,
+      trial_user_forms_not_in_default_group: trial_user_forms_not_in_default_group.to_a,
+    }
+  end
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,31 @@
+namespace :users do
+  desc "Update all trial and editor users to be standard users - dry run"
+  task update_user_roles_to_standard_dry_run: :environment do
+    ActiveRecord::Base.transaction do
+      update_user_roles
+      Rails.logger.info "users:update_user_roles_to_standard_dry_run rollback"
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  desc "Update all trial and editor users to be standard users"
+  task update_user_roles_to_standard: :environment do
+    update_user_roles
+  end
+end
+
+def update_user_roles
+  Rails.logger.info("Number of trial users: #{User.where(role: 'trial').count}")
+  Rails.logger.info("Number of editor users: #{User.where(role: 'editor').count}")
+  Rails.logger.info("Number of standard users: #{User.where(role: 'standard').count}")
+  Rails.logger.info("Number of organisation_admin users: #{User.where(role: 'organisation_admin').count}")
+  Rails.logger.info("Number of super_admin users: #{User.where(role: 'super_admin').count}")
+
+  User.where(role: %w[trial editor]).update_all(role: "standard")
+
+  Rails.logger.info("Number of trial users: #{User.where(role: 'trial').count}")
+  Rails.logger.info("Number of editor users: #{User.where(role: 'editor').count}")
+  Rails.logger.info("Number of standard users: #{User.where(role: 'standard').count}")
+  Rails.logger.info("Number of organisation_admin users: #{User.where(role: 'organisation_admin').count}")
+  Rails.logger.info("Number of super_admin users: #{User.where(role: 'super_admin').count}")
+end

--- a/spec/components/act_as_user_banner_component/view_spec.rb
+++ b/spec/components/act_as_user_banner_component/view_spec.rb
@@ -52,4 +52,20 @@ RSpec.describe ActAsUserBannerComponent::View, type: :component do
       expect(page).to have_text(/You are acting as .* a standard user/)
     end
   end
+
+  context "when the user is an editor user" do
+    let(:acting_as_user) { create :user, role: :editor }
+
+    it renders_the_user_role do
+      expect(page).to have_text(/You are acting as .* an editor user/)
+    end
+  end
+
+  context "when the user is a trial user" do
+    let(:acting_as_user) { create :user, role: :trial }
+
+    it renders_the_user_role do
+      expect(page).to have_text(/You are acting as .* a trial user/)
+    end
+  end
 end

--- a/spec/features/account/add_account_org_name_spec.rb
+++ b/spec/features/account/add_account_org_name_spec.rb
@@ -4,7 +4,7 @@ feature "Add account organisation to user without organisation", type: :feature 
   let(:user) { create :user, :with_no_org, name: nil }
   let!(:organisation) { create :organisation }
 
-  let(:form) { build :form, :with_active_resource, id: 1, name: "a form I created when I didn't have an organisation" }
+  let(:form) { build :form, :with_active_resource, id: 1, name: "a form I created when I was a trial user" }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
@@ -77,7 +77,7 @@ private
   end
 
   def and_i_can_open_my_form
-    click_link("a form I created when I didn't have an organisation")
-    expect(page.find("h1")).to have_text "a form I created when I didn't have an organisation"
+    click_link("a form I created when I was a trial user")
+    expect(page.find("h1")).to have_text "a form I created when I was a trial user"
   end
 end

--- a/spec/lib/tasks/trial_users.rake_spec.rb
+++ b/spec/lib/tasks/trial_users.rake_spec.rb
@@ -1,0 +1,86 @@
+require "rake"
+
+require "rails_helper"
+
+RSpec.describe "trial_users.rake" do
+  before do
+    Rake.application.rake_require "tasks/trial_users"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "trial_users:summary" do
+    subject(:task) do
+      Rake::Task["trial_users:summary"]
+        .tap(&:reenable) # make sure task is invoked every time
+    end
+
+    let(:summarizer_double) { instance_double(Summarizer) }
+
+    before do
+      allow($stdout).to receive(:puts)
+    end
+
+    it "runs" do
+      expect { task.invoke }.not_to raise_error
+    end
+
+    it "calls summarize" do
+      allow(Summarizer).to receive(:new).and_return(summarizer_double)
+      allow(summarizer_double).to receive(:summarize)
+
+      task.invoke
+      expect(summarizer_double).to have_received(:summarize).once
+    end
+  end
+
+  describe "summarize" do
+    before do
+      user = create :user, :trial, name: "A User"
+      another_user_with_forms = create :user, :trial
+      user_without_forms = create :user, :trial
+      user_with_form_but_no_org_or_name = create :user, :trial, :with_no_name, :with_no_org
+      user_with_no_org_and_no_forms = create :user, :trial, :with_no_org
+      create :user, :editor
+
+      form = build :form, id: 1, creator_id: user.id
+      another_form = build :form, id: 2, creator_id: user.id
+      form_in_group = build :form, id: 3, creator_id: user.id
+      form_in_default_group = build :form, id: 4, creator_id: user.id
+      old_form = build :form, id: 5, creator_id: user_with_form_but_no_org_or_name
+      another_user_with_forms_forms = build_list(:form, 3) do |f, i|
+        f.id = 10 + i
+        f.creator_id = another_user_with_forms.id
+      end
+      group = create :group, creator: user
+      GroupForm.create!(form_id: form_in_group.id, group_id: group.id)
+      default_group = create :group, creator: user, name: "A User’s trial group", status: :trial
+      GroupForm.create!(form_id: form_in_default_group.id, group: default_group)
+
+      ActiveResource::HttpMock.respond_to do |mock|
+        headers = { "X-API-Token" => Settings.forms_api.auth_key, "Accept" => "application/json" }
+        mock.get "/api/v1/forms?creator_id=#{user.id}", headers, [form, another_form, form_in_group, form_in_default_group].to_json, 200
+        mock.get "/api/v1/forms?creator_id=#{user_without_forms.id}", headers, [].to_json, 200
+        mock.get "/api/v1/forms?creator_id=#{another_user_with_forms.id}", headers, another_user_with_forms_forms.to_json, 200
+        mock.get "/api/v1/forms?creator_id=#{user_with_form_but_no_org_or_name.id}", headers, [old_form].to_json, 200
+        mock.get "/api/v1/forms?creator_id=#{user_with_no_org_and_no_forms.id}", headers, [].to_json, 200
+      end
+    end
+
+    it "returns the right output" do
+      expect(Summarizer.new.summarize).to eq({
+        total_trial_users: 5,
+        total_trial_users_with_forms: 3,
+        total_trial_users_with_org_and_name: 3,
+        total_trial_users_without_org_or_name: 2,
+        total_trial_user_forms_in_groups: 2,
+        total_forms_to_add_to_groups: 5,
+        total_trial_user_groups_to_create: 2,
+        total_trial_user_groups: 2,
+        total_trial_users_with_org_name_and_forms: 2,
+        total_trial_users_with_groups: 1,
+        trial_user_forms_not_in_default_group: [3],
+        total_trial_user_forms_not_in_group: 6,
+      })
+    end
+  end
+end

--- a/spec/lib/tasks/users.rake_spec.rb
+++ b/spec/lib/tasks/users.rake_spec.rb
@@ -1,0 +1,42 @@
+require "rake"
+
+require "rails_helper"
+
+RSpec.describe "users.rake" do
+  before do
+    Rake.application.rake_require "tasks/users"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "users:update_user_roles_to_standard" do
+    subject(:task) do
+      Rake::Task["users:update_user_roles_to_standard"]
+        .tap(&:reenable) # make sure task is invoked every time
+    end
+
+    let!(:super_admin_user) { create(:user, :super_admin) }
+    let!(:org_admin_user) { create(:organisation_admin_user) }
+    let!(:editor_user) { create(:user, :editor) }
+    let!(:trial_user) { create(:user, :trial) }
+
+    before do
+      task.invoke
+    end
+
+    it "updates the role for a trial user" do
+      expect(trial_user.reload.role).to eq("standard")
+    end
+
+    it "updates the role for an editor user" do
+      expect(editor_user.reload.role).to eq("standard")
+    end
+
+    it "does not update the role for a super_admin user" do
+      expect(super_admin_user.reload.role).to eq("super_admin")
+    end
+
+    it "does not update the role for a organisation_admin user" do
+      expect(org_admin_user.reload.role).to eq("organisation_admin")
+    end
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -6,11 +6,11 @@ describe UserPolicy do
   let(:user) { build :super_admin_user }
   let!(:records) { create_list :user, 5 }
 
-  context "with super admin role" do
+  context "with super admin" do
     it { is_expected.to permit_actions(%i[can_manage_user]) }
   end
 
-  context "with standard role" do
+  context "with editor" do
     let(:user) { build :user }
 
     it { is_expected.to forbid_actions(%i[can_manage_user]) }
@@ -19,13 +19,13 @@ describe UserPolicy do
   describe UserPolicy::Scope do
     subject(:policy_scope) { described_class.new(user, User) }
 
-    context "with super admin role" do
+    context "with super admin" do
       it "returns a list of users" do
         expect(policy_scope.resolve).to eq(records)
       end
     end
 
-    context "with standard role" do
+    context "with editor" do
       let(:user) { build :user }
 
       it "returns nil" do

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ApplicationController, type: :request do
     end
 
     context "when a user is logged in from an access restricting organisation" do
-      let(:user) { create :user, email: User::EMAIL_DOMAIN_DENYLIST.first }
+      let(:user) { create :user, :trial, email: User::EMAIL_DOMAIN_DENYLIST.first }
 
       before do
         login_as user

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when current user has a government email address not ending with .gov.uk" do
-      let(:user) { standard_user.tap { |user| user.email = "user@alb.example" } }
+      let(:user) { standard_user.tap { |editor| editor.email = "user@alb.example" } }
 
       it "redirects to the email code sent page" do
         expect(response).to redirect_to(submission_email_code_sent_path(form.id))

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe UsersController, type: :request do
       end
     end
 
+    context "when logged in with editor role" do
+      it "is forbidden" do
+        login_as_editor_user
+        get users_path
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when logged in with trial role" do
+      it "is forbidden" do
+        login_as_trial_user
+        get users_path
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
     context "when logged in with standard role" do
       it "is forbidden" do
         login_as_standard_user
@@ -59,7 +75,8 @@ RSpec.describe UsersController, type: :request do
               else
                 case user.role
                 when "super_admin" then expect(next_user.role).to eq "organisation_admin"
-                when "organisation_admin" then expect(next_user.role).to eq "standard"
+                when "organisation_admin" then expect(next_user.role).to eq "editor"
+                when "editor" then expect(next_user.role).to eq "trial"
                 end
               end
             else
@@ -88,6 +105,22 @@ RSpec.describe UsersController, type: :request do
 
       it "renders the correct page" do
         expect(response).to render_template("users/edit")
+      end
+    end
+
+    context "when logged in with editor role" do
+      it "is forbidden" do
+        login_as_editor_user
+        get edit_user_path(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when logged in with trial role" do
+      it "is forbidden" do
+        login_as_trial_user
+        get edit_user_path(user)
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
@@ -194,6 +227,22 @@ RSpec.describe UsersController, type: :request do
             expect(user.reload.organisation).to be_nil
           end
         end
+      end
+    end
+
+    context "when logged in with editor role" do
+      it "is forbidden" do
+        login_as_editor_user
+        put user_path(user), params: { user: { role: "super_admin" } }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when logged in with trial role" do
+      it "is forbidden" do
+        login_as_trial_user
+        put user_path(user), params: { user: { role: "super_admin" } }
+        expect(response).to have_http_status(:forbidden)
       end
     end
 

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -46,6 +46,14 @@ module AuthenticationFeatureHelpers
     @organisation_admin_user ||= FactoryBot.create(:organisation_admin_user, organisation: test_org)
   end
 
+  def editor_user
+    @editor_user ||= FactoryBot.create(:user, :editor, organisation: test_org)
+  end
+
+  def trial_user
+    @trial_user ||= FactoryBot.create(:user, :trial)
+  end
+
   def standard_user
     @standard_user ||= FactoryBot.create(:user, :standard, organisation: test_org)
   end
@@ -59,8 +67,16 @@ module AuthenticationFeatureHelpers
     end
   end
 
+  def login_as_editor_user
+    login_as editor_user
+  end
+
   def login_as_organisation_admin_user
     login_as organisation_admin_user
+  end
+
+  def login_as_trial_user
+    login_as trial_user
   end
 
   def login_as_standard_user

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "groups/index", type: :view do
     context "when the user has a standard role" do
       context "and org has not signed an MOU" do
         let(:current_user) do
-          instance_double User, standard?: true, organisation_admin?: false, super_admin?: false, current_org_has_mou?: false
+          instance_double User, standard_user?: true, organisation_admin?: false, super_admin?: false, current_org_has_mou?: false
         end
 
         it "shows the details text for users who are not org/super admins" do

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -81,6 +81,8 @@ describe "users/edit.html.erb" do
       expect(rendered).to have_checked_field("Standard user")
       expect(rendered).to have_unchecked_field("Super admin")
       expect(rendered).to have_unchecked_field("Organisation admin")
+      expect(rendered).to have_unchecked_field("Editor")
+      expect(rendered).to have_unchecked_field("Trial")
     end
 
     it "has a name field" do

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -5,6 +5,7 @@ describe "users/index.html.erb" do
   let(:users) do
     build_list(:user, 3) do |user, i|
       user.id = i
+      user.role = :editor
     end
   end
 
@@ -31,7 +32,7 @@ describe "users/index.html.erb" do
   end
 
   it "contains role" do
-    expect(rendered).to have_text("Standard")
+    expect(rendered).to have_text("Editor")
   end
 
   it "contains access" do


### PR DESCRIPTION
Reverts alphagov/forms-admin#1353.

It seems there must be users with roles other than "standard", "super_admin", or "organisation_admin", as the Users view is not working, and we get Sentry alerts that correspond to this.

We'll revert this PR, and figure out what roles are causing the problem.