### PR TITLE
Make DraftQuestion forwards compatible with Page response

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -62,7 +62,10 @@ private
     edit_draft_question = DraftQuestion.find_or_initialize_by(form_id: current_form.id, user_id: current_user.id, page_id: page.id)
 
     if edit_draft_question.new_record?
-      edit_draft_question.attributes = page.attributes.except(:id, :position, :next_page, :has_routing_errors, :routing_conditions, :question_with_text)
+      attributes = page.attributes
+        .slice(*edit_draft_question.attribute_names)
+        .except(:id)
+      edit_draft_question.attributes = attributes
       edit_draft_question.save!(validate: false)
     end
     edit_draft_question

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -181,6 +181,28 @@ RSpec.describe Pages::QuestionsController, type: :request do
         page_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
         expect(ActiveResource::HttpMock.requests).to include page_request
       end
+
+      context "when page has unrecognised attributes" do
+        let(:page_response) do
+          {
+            id: 1,
+            form_id: 2,
+            question_text: draft_question.question_text,
+            hint_text: draft_question.hint_text,
+            answer_type: draft_question.answer_type,
+            answer_settings: nil,
+            is_optional: false,
+            page_heading: nil,
+            guidance_markdown: nil,
+            next_page:,
+            newly_added_to_api: "some value",
+          }
+        end
+
+        it "renders successfully" do
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UpuZ4LCB/1674-3-add-add-another-answer-attribute-to-questions-in-forms-api-3 <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Currently if an attribute is added to the Page model in forms-api trying to edit the question for that page will result in an error:

     Failure/Error: edit_draft_question.attributes = page.attributes.except(:id, :position, :next_page, :has_routing_errors, :routing_conditions, :question_with_text)

     ActiveModel::UnknownAttributeError:
       unknown attribute 'newly_added_to_api' for DraftQuestion.
     # ./app/controllers/pages_controller.rb:65:in `setup_draft_question_for_existing_page'
     # ./app/controllers/pages_controller.rb:47:in `draft_question'
     # ./app/controllers/pages/questions_controller.rb:3:in `block in <class:QuestionsController>'
     # ./spec/requests/pages/questions_controller_spec.rb:171:in `block (4 levels) in <top (required)>'
     # ./spec/support/features.rb:19:in `block (2 levels) in <top (required)>'

This is happening because the attributes passed to `edit_draft_question` includes the new attributes, but these attributes are not in the schema for the `draft_questions` table.

This PR fixes things by filtering the attributes set in `edit_draft_question` to only those known to the `DraftQuestion` model.

This makes it a lot easier to add attributes to pages in forms-api, otherwise we would have to worry about adding any new attribute to forms-admin first.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?