### PR TITLE
Add new report to show the organisation count of users

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,4 +12,12 @@ class ReportsController < ApplicationController
 
     render template: "reports/features", locals: { data: }
   end
+
+  def users
+    authorize Report, :can_view_reports?
+
+    data = UsersReportService.new.user_data
+
+    render locals: { data: }
+  end
 end

--- a/app/service/users_report_service.rb
+++ b/app/service/users_report_service.rb
@@ -1,0 +1,34 @@
+class UsersReportService
+  def user_data
+    {
+      caption: I18n.t("reports.users.heading"),
+      head: [
+        { text: I18n.t("reports.users.table_headings.organisation_name") },
+        { text: I18n.t("reports.users.table_headings.user_count"), numeric: true },
+      ],
+      rows:,
+    }
+  end
+
+private
+
+  def rows
+    as_data_rows(org_name_user_count)
+  end
+
+  def as_data_rows(raw_data)
+    raw_data.map do |org_name, count|
+      [{ text: org_name || I18n.t("users.index.organisation_blank") },
+       { text: count, numeric: true }]
+    end
+  end
+
+  def org_name_user_count
+    User.left_joins(:organisation)
+      .group("organisations.id")
+      .select("organisations.name, COUNT(users.id) AS user_count")
+      .order(Arel.sql("COUNT(users.id) DESC"))
+      .order("organisations.name")
+      .pluck("organisations.name", "COUNT(users.id)")
+  end
+end

--- a/app/service/users_report_service.rb
+++ b/app/service/users_report_service.rb
@@ -7,6 +7,7 @@ class UsersReportService
         { text: I18n.t("reports.users.table_headings.user_count"), numeric: true },
       ],
       rows:,
+      first_cell_is_header: true,
     }
   end
 

--- a/app/views/reports/features.html.erb
+++ b/app/views/reports/features.html.erb
@@ -1,5 +1,5 @@
 <% set_page_title(t(".title")) %>
-<% content_for :back_link, govuk_back_link_to(reports_path, t(".back_link")) %>
+<% content_for :back_link, govuk_back_link_to(reports_path, t("reports.back_link")) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t(".title") %></h1>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -4,6 +4,7 @@
     <h1 class="govuk-heading-l"><%= t(".title") %></h1>
     <ul class="govuk-list">
       <li><%= govuk_link_to t("reports.features.title"), report_features_path %></li>
+      <li><%= govuk_link_to t("reports.users.title"), report_users_path %></li>
     </ul>
   </div>
 </div>

--- a/app/views/reports/users.html.erb
+++ b/app/views/reports/users.html.erb
@@ -1,0 +1,10 @@
+<% set_page_title(t(".title")) %>
+<% content_for :back_link, govuk_back_link_to(reports_path, t("reports.back_link")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <%= govuk_table(**data) %>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1049,6 +1049,7 @@ en:
       table_headings:
         organisation_name: Organisation
         user_count: User count
+      title: Number of users per organisation
   routing_page:
     body_text: "You can send people directly to the question or page you want, based on their previous answer. \nThis means they’ll only see questions that are relevant to them.\n"
     dropdown_default_text: Select a question to start your route from

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1044,6 +1044,11 @@ en:
       title: Feature usage on live forms
     index:
       title: Reports
+    users:
+      heading: Number of users per organisation
+      table_headings:
+        organisation_name: Organisation
+        user_count: User count
   routing_page:
     body_text: "You can send people directly to the question or page you want, based on their previous answer. \nThis means they’ll only see questions that are relevant to them.\n"
     dropdown_default_text: Select a question to start your route from

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1028,6 +1028,7 @@ en:
     heading: Provide a link to privacy information for this form
     submit_button: Save and continue
   reports:
+    back_link: Back to reports
     features:
       answer_types:
         heading: Answer types
@@ -1035,7 +1036,6 @@ en:
           answer_type: Answer type
           number_of_forms: Number of live forms which ask for this answer type
           number_of_pages: Number of pages of this answer type on live forms
-      back_link: Back to reports
       features:
         heading: Features
         live_forms_with_payments: Live forms with payments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,7 @@ Rails.application.routes.draw do
   scope :reports do
     get "/", to: "reports#index", as: :reports
     get "features", to: "reports#features", as: :report_features
+    get "users", to: "reports#users", as: :report_users
   end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -141,4 +141,54 @@ RSpec.describe ReportsController, type: :request do
       end
     end
   end
+
+  describe "#users" do
+    context "when the user is an editor" do
+      before do
+        login_as_standard_user
+
+        get report_users_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is an organisation admin" do
+      before do
+        login_as_organisation_admin_user
+
+        get report_users_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get report_users_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the users report view" do
+        expect(response).to render_template("reports/users")
+      end
+    end
+  end
 end

--- a/spec/service/users_report_service_spec.rb
+++ b/spec/service/users_report_service_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe UsersReportService do
+  subject(:users_report_service) do
+    described_class.new
+  end
+
+  describe "#user_data" do
+    it "returns the correct format" do
+      expect(users_report_service.user_data).to match({
+        caption: I18n.t("reports.users.heading"),
+        head: [
+          { text: I18n.t("reports.users.table_headings.organisation_name") },
+          { text: I18n.t("reports.users.table_headings.user_count"), numeric: true },
+        ],
+        rows: [],
+      })
+    end
+
+    context "with orgs and users" do
+      it "returns the correct rows" do
+        org1 = create :organisation, slug: "with-most-users"
+        org2 = create :organisation, slug: "with-one-user"
+        create :organisation, slug: "with-no-users"
+        create :user, organisation: org1
+        create :user, organisation: org1
+        create :user, organisation: org2
+        create :user, :with_no_org
+        expect(users_report_service.user_data[:rows]).to eq([
+          [{ text: org1.name }, { text: 2, numeric: true }],
+          [{ text: org2.name }, { text: 1, numeric: true }],
+          [{ text: I18n.t("users.index.organisation_blank") }, { text: 1, numeric: true }],
+        ])
+      end
+    end
+  end
+end

--- a/spec/service/users_report_service_spec.rb
+++ b/spec/service/users_report_service_spec.rb
@@ -9,6 +9,7 @@ describe UsersReportService do
     it "returns the correct format" do
       expect(users_report_service.user_data).to match({
         caption: I18n.t("reports.users.heading"),
+        first_cell_is_header: true,
         head: [
           { text: I18n.t("reports.users.table_headings.organisation_name") },
           { text: I18n.t("reports.users.table_headings.user_count"), numeric: true },

--- a/spec/views/reports/users.html.erb_spec.rb
+++ b/spec/views/reports/users.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe "reports/useres.html.erb" do
+  let(:data) do
+    {
+      caption: "table caption",
+      head: [
+        { text: "org name" },
+        { text: "user count", numeric: true },
+      ],
+      rows: [
+        [{ text: "org 1" }, { text: 2, numeric: true }],
+        [{ text: "org 2" }, { text: 1, numeric: true }],
+      ],
+    }
+  end
+
+  before do
+    render template: "reports/users", locals: { data: }
+  end
+
+  describe "page title" do
+    it "matches the heading" do
+      expect(view.content_for(:title)).to eq "Number of users per organisation"
+    end
+  end
+
+  it "has a back link to the live form page" do
+    expect(view.content_for(:back_link)).to have_link("Back to reports", href: reports_path)
+  end
+
+  it "contains page heading" do
+    expect(rendered).to have_css("h1.govuk-heading-l", text: "Number of users per organisation")
+  end
+
+  it "contains the table" do
+    expect(rendered).to have_table(with_rows: [["org 1", "2"], ["org 2", "1"]])
+  end
+end

--- a/spec/views/reports/users.html.erb_spec.rb
+++ b/spec/views/reports/users.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "reports/useres.html.erb" do
+describe "reports/users.html.erb" do
   let(:data) do
     {
       caption: "table caption",


### PR DESCRIPTION
### Create a report showing simple stats about users in organisations

Trello card: https://trello.com/c/lbm0G3EX/1659-create-report-to-show-number-of-users-per-organisation

This PR adds a simple report to show organisations and the number of users which belong to those organisations.

It's really likely that we will want to iterate this:
- improving he content
- changing the stats reported, e.g. to add user types
- add export as CSV or other formats

This PR is only the MVP.

The reports index page:
![image](https://github.com/user-attachments/assets/87ac5af6-01fa-445a-bfa0-9bdb933aef61)

The user report:
![image](https://github.com/user-attachments/assets/d16dee28-9c52-40ab-9a13-060372177382)

There is no need to display the table caption and heading as they are the same. I'll change it when the content is checked to see if there are any changes needed.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
