### PR TITLE
Remove organisation hint from edit user page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -59,8 +59,7 @@
         form_field: f.govuk_collection_select(:organisation_id, Organisation.order(:name), :id, :name_with_abbreviation,
                                               class: ['govuk-!-width-three-quarters'],
                                               options: { prompt: t('users.edit.organisation_prompt') },
-                                              label: { text: t('users.edit.organisation'), size: 'm', tag: 'h2' },
-                                              hint: { text: t('users.edit.organisation_hint') })
+                                              label: { text: t('users.edit.organisation'), size: 'm', tag: 'h2' })
       ) %>
 
       <%= f.govuk_collection_radio_buttons :role, user_role_options, :value, :label, :description,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1140,7 +1140,6 @@ en:
       has_access: Access to GOV.UK Forms
       mou_banner: You cannot upgrade this user’s role until someone from their organisation agrees to the MOU
       organisation: Organisation
-      organisation_hint: The user will only be able to see their organisation’s forms
       organisation_prompt: Select an organisation
       role: Role
       title: Edit user


### PR DESCRIPTION
### What problem does this pull request solve?

An edit of content on the 'edit user' page that was missed. Removing the 'organisation' hint as it is not really needed and is potentially misleading now that most users will only see forms in groups they are in (rather than all their organisation's forms). 

Trello card:https://trello.com/c/nXOuz0qN/1609-migration-change-trial-and-editor-users-to-standard-users

### Things to consider when reviewing

I have not run this locally. I have just guessed that this will work. Please check my changes carefully! 

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
