### PR TITLE
Add default Google Analytics consent

### DIFF
--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -8,6 +8,7 @@ import {
   sendPageViewEvent,
   attachExternalLinkTracker
 } from '../javascript/google-tag'
+import { saveConsentStatus } from '../javascript/utils/cookie-consent'
 import ajaxMarkdownPreview from '../javascript/ajax-markdown-preview'
 
 document
@@ -43,6 +44,7 @@ document
   })
 
 if (document.body.dataset.googleAnalyticsEnabled === 'true') {
+  saveConsentStatus(true)
   installAnalyticsScript(window)
   sendPageViewEvent()
   attachExternalLinkTracker()

--- a/app/frontend/javascript/google-tag/index.js
+++ b/app/frontend/javascript/google-tag/index.js
@@ -18,6 +18,18 @@ export function installAnalyticsScript (global) {
   }
 }
 
+export function setDefaultConsent () {
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push([
+    'consent',
+    'default',
+    {
+      ad_storage: 'denied',
+      analytics_storage: 'granted'
+    }
+  ])
+}
+
 export function sendPageViewEvent () {
   // Ideally this should be placed above the GTM container snippet and early within the <head> tags
   window.dataLayer = window.dataLayer || []

--- a/app/frontend/javascript/google-tag/index.test.js
+++ b/app/frontend/javascript/google-tag/index.test.js
@@ -5,7 +5,8 @@
 import {
   installAnalyticsScript,
   sendPageViewEvent,
-  attachExternalLinkTracker
+  attachExternalLinkTracker,
+  setDefaultConsent
 } from '../google-tag'
 import { describe, afterEach, it, expect, beforeEach } from 'vitest'
 
@@ -40,6 +41,53 @@ describe('google_tag.mjs', () => {
             'script[src^="https://www.googletagmanager.com/gtm.js"]'
           ).length
         ).toBe(0)
+      })
+    })
+  })
+
+  describe('setDefaultConsent()', () => {
+    describe('when the dataLayer array is not already present on the window object', () => {
+      beforeEach(() => {
+        window.dataLayer = undefined
+      })
+
+      it('creates the dataLayer array and sets the default consent to "granted"', function () {
+        setDefaultConsent()
+        expect(window.dataLayer).toContainEqual([
+          'consent',
+          'default',
+          {
+            ad_storage: 'denied',
+            analytics_storage: 'granted'
+          }
+        ])
+      })
+    })
+
+    describe('when the dataLayer array is already present on the window object', () => {
+      const existingDataLayerObject = {
+        data: 'Some existing data in the dataLayer'
+      }
+
+      beforeEach(() => {
+        window.dataLayer = [existingDataLayerObject]
+      })
+
+      it('the existing dataLayer content is preserved', function () {
+        setDefaultConsent()
+        expect(window.dataLayer).toContainEqual(existingDataLayerObject)
+      })
+
+      it('sets the default consent to "granted"', function () {
+        setDefaultConsent()
+        expect(window.dataLayer).toContainEqual([
+          'consent',
+          'default',
+          {
+            ad_storage: 'denied',
+            analytics_storage: 'granted'
+          }
+        ])
       })
     })
   })

--- a/app/frontend/javascript/utils/cookie-consent/index.js
+++ b/app/frontend/javascript/utils/cookie-consent/index.js
@@ -1,0 +1,11 @@
+import { setDefaultConsent } from '../../google-tag'
+
+export const COOKIE_NAME = 'analytics_consent'
+
+export function saveConsentStatus (consent, date) {
+  date = date || new Date()
+  date.setTime(date.getTime() + 365 * 24 * 60 * 60 * 1000)
+  document.cookie =
+    COOKIE_NAME + '=' + consent + '; expires=' + date.toGMTString() + '; path=/'
+  setDefaultConsent()
+}

--- a/app/frontend/javascript/utils/cookie-consent/index.test.js
+++ b/app/frontend/javascript/utils/cookie-consent/index.test.js
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { saveConsentStatus } from './index.js'
+import { describe, beforeEach, afterEach, it, expect } from 'vitest'
+
+describe('Cookie', () => {
+  afterEach(() => {
+    // delete all cookies between tests
+    const cookies = document.cookie.split(';')
+
+    cookies.forEach(function (cookie) {
+      const name = cookie.split('=')[0]
+      document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT'
+    })
+  })
+
+  describe('saveConsentStatus', () => {
+    beforeEach(() => {
+      Object.defineProperty(window.document, 'cookie', {
+        writable: true,
+        value: ''
+      })
+    })
+
+    it('writes the correct value to the cookie', () => {
+      const fixedTestDate = new Date(2023, 1, 1, 0, 0, 0, 0)
+      saveConsentStatus(true, fixedTestDate)
+      expect(window.document.cookie).toBe(
+        'analytics_consent=true; expires=Thu, 01 Feb 2024 00:00:00 GMT; path=/'
+      )
+    })
+  })
+})


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/qAojecL7/1602-enable-google-analytics-in-admin-and-runner

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
In forms-admin, we don't ask the user for analytics consent because it's an internal tool and we're not required to. However, our Google tag code and google analytics still expect to be told whether the user has consented.

This PR does this by:
- setting the `analytics_consent` cookie to `true` on page load
- passing the default consent item to the dataLayer: 
```js
[
  'consent',
  'default',
  {
    ad_storage: 'denied',
    analytics_storage: 'granted'
  }
]
```

### Testing instructions
Firstly:

- Set analytics_enabled: true in your development.yml file
- login as a non-super admin user
- open the broswer console

Then test cookies:
- go to 'Storage' in Firefox devtools or  'Application' in the chrome
- check that there is an `analytics_enabled` cookie with value `true`  

And test the dataLayer consent item:
- go to the console and type 'dataLayer'
- check that one of the items in the array looks like the default consent item above

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
