### PR TITLE
Handle mailchimp unsubscribers

### DIFF
--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -21,6 +21,7 @@ class MailchimpListSynchronizer
     puts "Mailchimp list has #{target_list['stats']['total_contacts']} total members"
 
     currently_subscribed_members = []
+    unsubscribed_members = []
 
     # Set up API pagination
     total_list_size = target_list["stats"]["total_contacts"]
@@ -32,6 +33,7 @@ class MailchimpListSynchronizer
 
       api_response["members"].each do |member|
         currently_subscribed_members.push(member["email_address"]) if member["status"] == "subscribed"
+        unsubscribed_members.push(member["email_address"]) if member["status"] == "unsubscribed"
       end
 
       offset += page_size
@@ -43,8 +45,10 @@ class MailchimpListSynchronizer
     currently_subscribed_members_set = currently_subscribed_members
                              .to_set
 
+    unsubscribed_members_set = unsubscribed_members.to_set
+
     users_to_archive = currently_subscribed_members_set - users_to_synchronize_set
-    users_to_subscribe = users_to_synchronize_set - currently_subscribed_members_set
+    users_to_subscribe = (users_to_synchronize_set - currently_subscribed_members_set) - unsubscribed_members_set
 
     puts "There are #{users_to_subscribe.size} to subscribe"
     puts "There are #{users_to_archive.size} to archive"

--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -13,16 +13,17 @@ class MailchimpListSynchronizer
     })
     puts "List id: #{list_id}"
 
-    target_list = mailchimp.lists.get_list(list_id)
+    target_list = mailchimp.lists.get_list(list_id, include_total_contacts: true)
     target_list or raise
 
     puts "Found Mailchimp list: #{target_list['name']}"
-    puts "Mailchimp list has #{target_list['stats']['member_count']} members"
+    puts "Mailchimp list has #{target_list['stats']['member_count']} active members"
+    puts "Mailchimp list has #{target_list['stats']['total_contacts']} total members"
 
     existing_members = []
 
     # Set up API pagination
-    total_list_size = target_list["stats"]["member_count"]
+    total_list_size = target_list["stats"]["total_contacts"]
     offset = 0
     page_size = 1000 # maximum page size is 1000 results, default is 10
 

--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -21,6 +21,7 @@ class MailchimpListSynchronizer
     puts "Mailchimp list has #{target_list['stats']['total_contacts']} total members"
 
     currently_subscribed_members = []
+    members_who_can_be_archived = []
     unsubscribed_members = []
 
     # Set up API pagination
@@ -33,6 +34,7 @@ class MailchimpListSynchronizer
 
       api_response["members"].each do |member|
         currently_subscribed_members.push(member["email_address"]) if member["status"] == "subscribed"
+        members_who_can_be_archived.push(member["email_address"]) if %w[subscribed cleaned pending transactional].include?(member["status"])
         unsubscribed_members.push(member["email_address"]) if member["status"] == "unsubscribed"
       end
 
@@ -47,8 +49,10 @@ class MailchimpListSynchronizer
 
     unsubscribed_members_set = unsubscribed_members.to_set
 
-    users_to_archive = currently_subscribed_members_set - users_to_synchronize_set
+    members_who_can_be_archived_set = members_who_can_be_archived.to_set
+
     users_to_subscribe = (users_to_synchronize_set - currently_subscribed_members_set) - unsubscribed_members_set
+    users_to_archive = members_who_can_be_archived_set - users_to_synchronize_set
 
     puts "There are #{users_to_subscribe.size} to subscribe"
     puts "There are #{users_to_archive.size} to archive"

--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -40,14 +40,14 @@ class MailchimpListSynchronizer
     existing_members_set = existing_members
                              .to_set
 
-    deleted_users = existing_members_set - users_to_synchronize_set
-    added_users = users_to_synchronize_set - existing_members_set
+    users_to_archive = existing_members_set - users_to_synchronize_set
+    users_to_subscribe = users_to_synchronize_set - existing_members_set
 
-    puts "There are #{added_users.size} to subscribe"
-    puts "There are #{deleted_users.size} to unsubscribe"
+    puts "There are #{users_to_subscribe.size} to subscribe"
+    puts "There are #{users_to_archive.size} to archive"
 
     puts "Subscribing any new users..."
-    added_users.each do |email|
+    users_to_subscribe.each do |email|
       subscriber_hash = Digest::MD5.hexdigest email.downcase
       mailchimp.lists.set_list_member(
         list_id,
@@ -63,12 +63,12 @@ class MailchimpListSynchronizer
       warn "Continuing"
     end
 
-    puts "Unsubscribing any removed users..."
-    deleted_users.each do |email|
+    puts "Archiving any removed users..."
+    users_to_archive.each do |email|
       subscriber_hash = Digest::MD5.hexdigest email.downcase
       mailchimp.lists.delete_list_member(list_id, subscriber_hash)
     rescue MailchimpMarketing::ApiError => e
-      warn "Could not unsubscribe user with subscriber hash #{subscriber_hash} from list #{list_id}"
+      warn "Could not archive user with subscriber hash #{subscriber_hash} from list #{list_id}"
       warn "#{e.title}: #{e.detail}"
       warn "Continuing"
     end

--- a/spec/lib/mailchimp_list_synchronizer_spec.rb
+++ b/spec/lib/mailchimp_list_synchronizer_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe MailchimpListSynchronizer do
         "name" => "List 1",
         "stats" => {
           "member_count" => 3,
+          "total_contacts" => 3,
         },
       }
     end
@@ -117,7 +118,8 @@ RSpec.describe MailchimpListSynchronizer do
         {
           "name" => "List 1",
           "stats" => {
-            "member_count" => 1001,
+            "member_count" => 995,
+            "total_contacts" => 1001,
           },
         }
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/tr2zhSTd/1668-we-need-to-handle-mailchimp-unsubscribes-better

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
If users manually unsubscribe form a MailChimp list (e.g. by clicking the unsubscribe link in an email) MailChimp assigns them the 'unsubscribed' status. Users with this status cannot be resubscribed or archived via the API, and attempting to do so results in an error.

This PR updates the task to avoid trying to resubscribe these users. In the process there were also a few other changes:
- fixed a bug where users who get archived (e.g. by having their Forms accounts disabled) aren't resubscribed if they become active again
- fixed a bug with the pagination logic (we were looping through the wrong number of items)
- various renames to make it more obvious what the script is doing in MailChimp
- rewrote the tests to make them more obvious and more explicit about how the different MailChimp statuses should be handled

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
