### PR TITLE
Increase the number of options allowed in selections to 30

### DIFF
--- a/app/input_objects/pages/selections_settings_input.rb
+++ b/app/input_objects/pages/selections_settings_input.rb
@@ -35,7 +35,7 @@ class Pages::SelectionsSettingsInput < BaseInput
     filter_out_blank_options
 
     return errors.add(:selection_options, :minimum) if selection_options.length < 2
-    return errors.add(:selection_options, :maximum) if selection_options.length > 20
+    return errors.add(:selection_options, :maximum) if selection_options.length > 30
 
     errors.add(:selection_options, :uniqueness) if selection_options.uniq.length != selection_options.length
   end

--- a/app/views/pages/selections_settings.html.erb
+++ b/app/views/pages/selections_settings.html.erb
@@ -43,7 +43,7 @@
       <% end %>
 
       <div>
-        <%if @selections_settings_input.selection_options.length < 20 %>
+        <%if @selections_settings_input.selection_options.length < 30 %>
           <%= f.govuk_submit t("selections_settings.add_another"), name: :add_another, secondary: true  %>
         <% else %>
           <p class="govuk-inset-text"><%= t("selections_settings.cannot_add_more_options") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1071,8 +1071,8 @@ en:
   selections_settings:
     add_another: Add another option
     add_options: Add options to your list
-    add_options_hint: You can add up to 20 options
-    cannot_add_more_options: You cannot add any more options as you have reached the maximum of 20 options.
+    add_options_hint: You can add up to 30 options
+    cannot_add_more_options: You cannot add any more options as you have reached the maximum of 30 options.
     heading: Create a list of options
     include_none_of_the_above: Include an option for ‘None of the above’
     list_settings: List settings

--- a/config/locales/input_objects/selections_settings_form.yml
+++ b/config/locales/input_objects/selections_settings_form.yml
@@ -8,4 +8,4 @@ en:
               blank: Add text for all of your options
               uniqueness: All your options must be unique
               minimum: Enter at least 2 options
-              maximum: You cannot have more than 20 options
+              maximum: You cannot have more than 30 options

--- a/spec/input_objects/pages/selections_settings_input_spec.rb
+++ b/spec/input_objects/pages/selections_settings_input_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Pages::SelectionsSettingsInput, type: :model do
     end
 
     it "is invalid if more than 20 selection options are provided" do
-      selections_settings_input.selection_options = (1..21).to_a.map { |i| OpenStruct.new(name: i.to_s) }
+      selections_settings_input.selection_options = (1..31).to_a.map { |i| OpenStruct.new(name: i.to_s) }
       error_message = I18n.t("activemodel.errors.models.pages/selections_settings_input.attributes.selection_options.maximum")
       expect(selections_settings_input).not_to be_valid
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ZMi9kq7P

Increases the maximum number of items in a selection type question to 30, from 20.

### Things to consider when reviewing

Did I catch all the places?

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
