### PR TITLE
Fix vitest silent failures

### DIFF
--- a/app/frontend/javascript/google-tag/index.test.js
+++ b/app/frontend/javascript/google-tag/index.test.js
@@ -150,9 +150,20 @@ describe('google_tag.mjs', () => {
       data: 'Some existing data in the dataLayer'
     }
 
+    const preventDefault = event => {
+      event.preventDefault()
+    }
+
     beforeEach(() => {
       window.document.body.innerHTML = `<a href="${targetLinkUrl}">${targetLinkText}</a>`
       window.dataLayer = [existingDataLayerObject]
+
+      // stop link clicks from navigating, since jsdom can't do navigation
+      document.querySelector('a').addEventListener('click', preventDefault)
+    })
+
+    afterEach(() => {
+      document.querySelector('a').removeEventListener('click', preventDefault)
     })
 
     it('the existing dataLayer content is preserved', function () {

--- a/app/frontend/test/setup.js
+++ b/app/frontend/test/setup.js
@@ -1,0 +1,14 @@
+import { beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+  // in some cases the console.error is called immediately after the test is
+  // run, so we have to do this here instead of an afterEach block
+  vi.restoreAllMocks()
+
+  // mock console.error and make it throw a real error in the test suite context
+  vi.spyOn(console, 'error').mockImplementation(message => {
+    throw new Error(
+      `Failing due to test calling console.error with message: ${message}`
+    )
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,6 +27,7 @@ export default defineConfig({
     }
   },
   test: {
-    globals: true
+    globals: true,
+    setupFiles: ['test/setup.js']
   }
 })


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->None

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Error messages in our vitest specs weren't causing the tests to fail - for example: https://github.com/alphagov/forms-admin/actions/runs/10419073126/job/28856405937?pr=1383#step:11:24

In this case the error turned out to be specific to the test, but these silent failures are risky as they mean we might accidentally break our javascript and not be alerted to it.

This PR:
- updates our vitest config to throw an error when a test calls `console.error`
- fixes the jsdom error that caused the error we saw by stubbing out the navigation behaviour.

See commit messages for complete context.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
