### PR TITLE
Add repeatable_page_enabled feature flag

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
   groups: true # Do not switch off!
+  repeatable_page_enabled: false
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -23,6 +23,7 @@ describe "Settings" do
     features = settings[:features]
 
     include_examples expected_value_test, :groups, features, true
+    include_examples expected_value_test, :repeatable_page_enabled, features, false
   end
 
   describe "forms_api" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/J74xCxkW/1700-5-5-implement-add-another-answer-in-forms-admin-for-single-question-only

Add a new feature flag, repeatable_page_enabled, which will be used to
decide whether to allow pages to be set as is_repeatable or not.

This PR only adds the setting. It doesn't do anything with it.

To turn the feature on, either set it in your environment's settings
file or as a shell environment variable:

```
SETTINGS__FEATURES__REPEATABLE_PAGE_ENABLED=true bundle exec rails s
```

See the PR in the deploy repository:

https://github.com/alphagov/forms-deploy/pull/976


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
