### PR TITLE
Add repeatable page radio input

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -8,6 +8,7 @@ class Pages::QuestionsController < PagesController
                                                question_text: draft_question.question_text,
                                                answer_settings: draft_question.answer_settings,
                                                is_optional: draft_question.is_optional,
+                                               is_repeatable: draft_question.is_repeatable,
                                                draft_question:)
 
     # TODO: Remove this once we have a check your question view. The new view should also pull data directly from draft_question instead of through page model
@@ -34,6 +35,7 @@ class Pages::QuestionsController < PagesController
                                                question_text: draft_question.question_text,
                                                hint_text: draft_question.hint_text,
                                                is_optional: draft_question.is_optional,
+                                               is_repeatable: draft_question.is_repeatable,
                                                answer_settings: draft_question.answer_settings)
     render :edit, locals: { current_form:, draft_question: }
   end
@@ -55,7 +57,7 @@ class Pages::QuestionsController < PagesController
 private
 
   def page_params
-    params.require(:pages_question_input).permit(:question_text, :hint_text, :is_optional)
+    params.require(:pages_question_input).permit(:question_text, :hint_text, :is_optional, :is_repeatable)
   end
 
   def page_params_for_form_object

--- a/app/input_objects/pages/question_input.rb
+++ b/app/input_objects/pages/question_input.rb
@@ -1,7 +1,7 @@
 class Pages::QuestionInput < BaseInput
   include QuestionTextValidation
 
-  attr_accessor :question_text, :hint_text, :is_optional, :answer_type, :draft_question
+  attr_accessor :question_text, :hint_text, :is_optional, :answer_type, :draft_question, :is_repeatable
 
   # TODO: We could lose these attributes once we have an Check your answers page
   attr_accessor :answer_settings, :page_heading, :guidance_markdown
@@ -9,6 +9,7 @@ class Pages::QuestionInput < BaseInput
   validates :draft_question, presence: true
   validates :hint_text, length: { maximum: 500 }
   validates :is_optional, inclusion: { in: %w[false true] }
+  validates :is_repeatable, inclusion: { in: %w[false true] }, if: -> { Settings.features.repeatable_page_enabled }
 
   def submit
     return false if invalid?
@@ -17,6 +18,7 @@ class Pages::QuestionInput < BaseInput
       question_text:,
       hint_text:,
       is_optional:,
+      is_repeatable:,
     )
 
     draft_question.save!(validate: false)
@@ -24,5 +26,9 @@ class Pages::QuestionInput < BaseInput
 
   def default_options
     [OpenStruct.new(id: "false"), OpenStruct.new(id: "true")]
+  end
+
+  def repeatable_options
+    [OpenStruct.new(id: "true"), OpenStruct.new(id: "false")]
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -17,18 +17,23 @@ class Page < ActiveResource::Base
   validates :hint_text, length: { maximum: 500 }
 
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
-  before_validation :convert_is_optional_to_boolean
+  before_validation :convert_boolean_fields
 
   def has_next_page?
     attributes.include?("next_page") && !attributes["next_page"].nil?
   end
 
-  def convert_is_optional_to_boolean
+  def convert_boolean_fields
     self.is_optional = is_optional?
+    self.is_repeatable = is_repeatable?
   end
 
   def is_optional?
-    ActiveRecord::Type::Boolean.new.cast(is_optional) || false
+    ActiveRecord::Type::Boolean.new.cast(@attributes["is_optional"]) || false
+  end
+
+  def is_repeatable?
+    ActiveRecord::Type::Boolean.new.cast(@attributes["is_repeatable"]) || false
   end
 
   def move_page(direction)

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -34,6 +34,11 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
   <% end %>
 
+  <% if Settings.features.repeatable_page_enabled %>
+    <%= f.govuk_collection_radio_buttons :is_repeatable, question_input.repeatable_options, :id, :name, :description, legend: { size: 'm', tag: 'h2' }, bold_labels: false %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+  <% end %>
+
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
   <%= render PageSettingsSummaryComponent::View.new(draft_question) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,8 @@ en:
               too_long: Hint text must be %{count} characters or less
             is_optional:
               inclusion: Select ‘mandatory’ if people have to answer this question
+            is_repeatable:
+              inclusion: Select ‘Yes’ if someone can add more than one answer
             question_text:
               blank: Enter a question
               too_long: Question text must be %{count} characters or less
@@ -512,6 +514,7 @@ en:
       pages_question_input:
         is_optional_options:
           'true': We’ll add ‘(optional)’ to the end of the question text.
+        is_repeatable: Select ‘Yes’ if you want to let someone add more than one answer (up to 10) — for example, listing all their company contacts.
     label:
       account_name_input:
         name: Enter your full name
@@ -616,12 +619,16 @@ en:
         is_optional_options:
           'false': Mandatory
           'true': Optional
+        is_repeatable_options:
+          'false': No — this question can only be answered once
+          'true': 'Yes'
         question_text: Question text
     legend:
       mou_signature:
         agreed: Do you agree to the MOU?
       pages_question_input:
         is_optional: Should this question be mandatory or optional?
+        is_repeatable: Should people be able to answer this question more than once?
   home:
     change_filter: Change
     create_a_form: Create a form

--- a/db/migrate/20240820140813_add_is_repeatable_to_draft_question.rb
+++ b/db/migrate/20240820140813_add_is_repeatable_to_draft_question.rb
@@ -1,0 +1,5 @@
+class AddIsRepeatableToDraftQuestion < ActiveRecord::Migration[7.1]
+  def change
+    add_column :draft_questions, :is_repeatable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_24_124946) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_20_140813) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_124946) do
     t.jsonb "answer_settings", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_repeatable"
     t.index ["form_id"], name: "index_draft_questions_on_form_id"
     t.index ["user_id"], name: "index_draft_questions_on_user_id"
   end

--- a/spec/factories/input_objects/pages/question_input.rb
+++ b/spec/factories/input_objects/pages/question_input.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     question_text { Faker::Lorem.question }
     hint_text { nil }
     is_optional { "false" }
+    is_repeatable { "false" }
     answer_settings { nil }
     page_heading { nil }
     guidance_markdown { nil }

--- a/spec/factories/models/draft_questions.rb
+++ b/spec/factories/models/draft_questions.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     question_text { Faker::Lorem.question.truncate(250) }
     hint_text { nil }
     is_optional { false }
+    is_repeatable { false }
     answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }
     page_heading { nil }
     guidance_markdown { nil }

--- a/spec/input_objects/pages/question_input_spec.rb
+++ b/spec/input_objects/pages/question_input_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Pages::QuestionInput, type: :model do
-  let(:question_input) { build :question_input, question_text:, draft_question:, is_optional: }
+  let(:question_input) { build :question_input, question_text:, draft_question:, is_optional:, is_repeatable: }
   let(:draft_question) { build :draft_question, question_text: }
   let(:question_text) { "What is your full name?" }
   let(:is_optional) { "false" }
+  let(:is_repeatable) { "false" }
 
   it "has a valid factory" do
     expect(build(:question_input)).to be_valid
@@ -130,6 +131,66 @@ RSpec.describe Pages::QuestionInput, type: :model do
       end
     end
 
+    describe "#is_repeatable" do
+      let(:question_input) { build :question_input, is_repeatable: }
+
+      context "when feature repeatable page is not enabled", feature_repeatable_page_enabled: false do
+        context "and is_repeatable is nil" do
+          let(:is_repeatable) { nil }
+
+          it "is valid" do
+            expect(question_input).to be_valid
+          end
+
+          it "has no error message" do
+            question_input.valid?
+            expect(question_input.errors[:is_repeatable]).to be_empty
+          end
+        end
+      end
+
+      context "when feature repeatable page is enabled", :feature_repeatable_page_enabled do
+        context "and is_repeatable is nil" do
+          let(:is_repeatable) { nil }
+
+          it "is invalid" do
+            expect(question_input).not_to be_valid
+          end
+
+          it "has an error message" do
+            question_input.valid?
+            expect(question_input.errors[:is_repeatable]).to include(I18n.t("activemodel.errors.models.pages/question_input.attributes.is_repeatable.inclusion"))
+          end
+        end
+
+        context "and is_repeatable is true" do
+          let(:is_repeatable) { "true" }
+
+          it "is valid" do
+            expect(question_input).to be_valid
+          end
+
+          it "has no error message" do
+            question_input.valid?
+            expect(question_input.errors[:is_repeatable]).to be_empty
+          end
+        end
+
+        context "and is_repeatable is false" do
+          let(:is_repeatable) { "false" }
+
+          it "is valid" do
+            expect(question_input).to be_valid
+          end
+
+          it "has no error message" do
+            question_input.valid?
+            expect(question_input.errors[:is_repeatable]).to be_empty
+          end
+        end
+      end
+    end
+
     context "when not given a draft_question" do
       let(:draft_question) { nil }
 
@@ -150,6 +211,7 @@ RSpec.describe Pages::QuestionInput, type: :model do
         question_input.question_text = "How old are you?"
         question_input.hint_text = "As a number"
         question_input.is_optional = "false"
+        question_input.is_repeatable = "true"
         question_input.submit
       end
 
@@ -163,6 +225,10 @@ RSpec.describe Pages::QuestionInput, type: :model do
 
       it "sets a draft_question is_optional" do
         expect(question_input.draft_question.is_optional.to_s).to eq question_input.is_optional
+      end
+
+      it "sets a draft_question is_repeatable" do
+        expect(question_input.draft_question.is_repeatable.to_s).to eq question_input.is_repeatable
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -77,17 +77,17 @@ describe Page, type: :model do
     end
   end
 
-  describe "#convert_is_optional_to_boolean" do
+  describe "#convert_boolean_fields" do
     context "when a question is optional" do
       it "set the model attribute to true" do
         page = described_class.new(is_optional: "true")
-        page.convert_is_optional_to_boolean
+        page.convert_boolean_fields
         expect(page.is_optional).to be true
       end
 
       it "returns true if it is not set to a falsey value" do
         page = described_class.new(is_optional: "something")
-        page.convert_is_optional_to_boolean
+        page.convert_boolean_fields
         expect(page.is_optional).to be true
       end
     end
@@ -95,14 +95,42 @@ describe Page, type: :model do
     context "when a question is required" do
       it "returns false if value is false" do
         page = described_class.new(is_optional: "false")
-        page.convert_is_optional_to_boolean
+        page.convert_boolean_fields
         expect(page.is_optional).to be false
       end
 
       it "returns false if value is 0" do
         page = described_class.new(is_optional: "0")
-        page.convert_is_optional_to_boolean
+        page.convert_boolean_fields
         expect(page.is_optional).to be false
+      end
+    end
+
+    context "when a question is repeatable" do
+      it "set the model attribute to true" do
+        page = described_class.new(is_repeatable: "true")
+        page.convert_boolean_fields
+        expect(page.is_repeatable).to be true
+      end
+
+      it "returns true if it is not set to a falsey value" do
+        page = described_class.new(is_repeatable: "something")
+        page.convert_boolean_fields
+        expect(page.is_repeatable).to be true
+      end
+    end
+
+    context "when a question is not repeatable" do
+      it "returns false if value is false" do
+        page = described_class.new(is_repeatable: "false")
+        page.convert_boolean_fields
+        expect(page.is_repeatable).to be false
+      end
+
+      it "returns false if value is 0" do
+        page = described_class.new(is_repeatable: "0")
+        page.convert_boolean_fields
+        expect(page.is_repeatable).to be false
       end
     end
   end

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
       answer_type: draft_question.answer_type,
       answer_settings: nil,
       is_optional: false,
+      is_repeatable: false,
       page_heading: nil,
       guidance_markdown: nil,
       next_page:,
@@ -30,6 +31,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
       answer_type: "address",
       answer_settings: {},
       is_optional: false,
+      is_repeatable: false,
       page_heading: "New page heading",
       guidance_markdown: "## Heading level 2",
       next_page:,
@@ -95,6 +97,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
           page_heading: nil,
           guidance_markdown: nil,
           answer_type: draft_question.answer_type,
+          is_repeatable: false,
         }
       end
       let(:params) do
@@ -134,6 +137,25 @@ RSpec.describe Pages::QuestionsController, type: :request do
 
         expect(banner_contents).to have_link(text: "Add a question", href: start_new_question_path(form_id: 2))
         expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: 2))
+      end
+
+      context "when passing is_repeatable as a param" do
+        let(:params) do
+          { pages_question_input: {
+            question_text: "What is your home address?",
+            hint_text: "This should be the location stated in your contract.",
+            is_optional: false,
+            is_repeatable: true,
+          } }
+        end
+
+        it "creates the page on the API with the correct is_repeatable value" do
+          matched_request = ActiveResource::HttpMock.requests.find do |request|
+            request.method == :post && request.path == "/api/v1/forms/2/pages"
+          end
+
+          expect(JSON.parse(matched_request.body)).to include("is_repeatable" => true)
+        end
       end
     end
 
@@ -223,6 +245,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
         answer_type: "address",
         answer_settings: nil,
         is_optional: false,
+        is_repeatable: false,
         page_heading: "New page heading",
         guidance_markdown: "## Heading level 2",
         next_page:,
@@ -289,6 +312,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
             hint_text: "This should be the location stated in your contract.",
             answer_type: "address",
             is_optional: "false",
+            is_repeatable: "false",
             page_heading: "New page heading",
             guidance_markdown: "## Heading level 2",
           } }
@@ -324,6 +348,63 @@ RSpec.describe Pages::QuestionsController, type: :request do
 
           expect(banner_contents).to have_link(text: "Edit next question", href: edit_question_path(form_id: 2, page_id: 4))
           expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: 2))
+        end
+      end
+
+      context "when passing is_repeatable as a param" do
+        let(:params) do
+          { pages_question_input: {
+            form_id: 2,
+            question_text: "What is your home address?",
+            hint_text: "This should be the location stated in your contract.",
+            answer_type: "address",
+            is_optional: "false",
+            is_repeatable: "true",
+            page_heading: "New page heading",
+            guidance_markdown: "## Heading level 2",
+          } }
+        end
+
+        it "updates the page on the API with the correct is_repeatable value" do
+          matched_request = ActiveResource::HttpMock.requests.find do |request|
+            request.method == :put && request.path == "/api/v1/forms/2/pages/1"
+          end
+
+          expect(JSON.parse(matched_request.body)).to include("is_repeatable" => true)
+        end
+      end
+
+      context "when given a page with is_repeatable set to true and not passing is_repeatable as a param" do
+        let(:page_response) do
+          {
+            id: 1,
+            form_id: 2,
+            question_text: "What is your work address?",
+            hint_text: "This should be the location stated in your contract.",
+            answer_type: "address",
+            answer_settings: nil,
+            is_optional: false,
+            is_repeatable: true,
+            page_heading: "New page heading",
+            guidance_markdown: "## Heading level 2",
+            next_page:,
+          }
+        end
+
+        let(:params) do
+          { pages_question_input: {
+            form_id: 2,
+            question_text: "What is your home address?",
+            is_optional: "false",
+          } }
+        end
+
+        it "does not set is_repeatable" do
+          matched_request = ActiveResource::HttpMock.requests.find do |request|
+            request.method == :put && request.path == "/api/v1/forms/2/pages/1"
+          end
+
+          expect(JSON.parse(matched_request.body)).to include("is_repeatable" => true)
         end
       end
     end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -40,6 +40,18 @@ describe "pages/_form.html.erb", type: :view do
     expect(rendered).to have_unchecked_field("pages_question_input[is_optional]")
   end
 
+  context "when feature repeatable page is enabled", :feature_repeatable_page_enabled do
+    it "has a radio input for repeatable" do
+      expect(rendered).to have_field("pages_question_input[is_repeatable]", type: :radio)
+    end
+  end
+
+  context "when feature repeatable page is not enabled", feature_repeatable_page_enabled: false do
+    it "does not have a radio input for repeatable" do
+      expect(rendered).not_to have_field("pages_question_input[is_repeatable]", type: :radio)
+    end
+  end
+
   it "has a submit button with the correct text" do
     expect(rendered).to have_button(I18n.t("pages.submit_save"))
   end


### PR DESCRIPTION
### Add a new input for creating/editing pages to allow multiple answers

Trello card: https://trello.com/c/J74xCxkW/1700-5-5-implement-add-another-answer-in-forms-admin-for-single-question-only

This work is behind the repeating_page_enabled feature flag.

This PR adds a new radio option when creating or editing the page of a form. This option sets the `is_repeating` boolean field on pages in the API.

The feature flag is only used to guard the control in the view. This means that it's possible using developer tools to set `is_repeating` on pages regardless of the value of the feature flag.

Given that:
- the feature flag is only there to make release easier
- the API and runner both support the `is_repeating` field

It shouldn't be a problem. It should also make removing the feature flag easier.

![image](https://github.com/user-attachments/assets/6655542e-ecfa-4871-b368-57dc36c06080)


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
