### PR TITLE
Add rake task for changing groups organisation

### DIFF
--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -1,0 +1,61 @@
+namespace :groups do
+  desc "change the organisation of one or more groups"
+  task :change_organisation, [] => :environment do |_, args|
+    run_task("groups:change_organisation", args, rollback: false)
+  end
+
+  desc "move one or more forms into group"
+  task :change_organisation_dry_run, [] => :environment do |_, args|
+    run_task("groups:change_organisation_dry_run", args, rollback: true)
+  end
+end
+
+def run_task(task_name, args, rollback:)
+  *group_ids, org_id = args.to_a
+
+  usage_message = "usage: rake #{task_name}[<group_external_id>, ..., <organisation_id>]".freeze
+  abort usage_message if group_ids.blank? || org_id.blank?
+
+  ActiveRecord::Base.transaction do
+    change_organisation(group_ids, org_id, task_name:)
+    raise ActiveRecord::Rollback if rollback
+  end
+end
+
+def change_organisation(group_ids, org_id, task_name:)
+  missing_groups = []
+
+  begin
+    organisation = Organisation.find(org_id)
+  rescue ActiveRecord::RecordNotFound
+    abort "Organisation with ID #{org_id} not found!"
+  end
+
+  groups = group_ids.map do |group_id|
+    Group.find_by!(external_id: group_id)
+  rescue ActiveRecord::RecordNotFound
+    missing_groups << group_id
+    nil
+  end
+
+  groups = groups.compact
+
+  unless missing_groups.empty?
+    abort "Groups with external ids #{missing_groups.join(', ')} not found!"
+  end
+
+  groups.each do |group|
+    Rails.logger.info "#{task_name}: changing #{fmt_group(group)} from #{fmt_organisation(group.organisation)} to #{fmt_organisation(organisation)}"
+
+    group.organisation = organisation
+    group.save!
+  end
+end
+
+def fmt_organisation(org)
+  "organisation #{org.id} (#{org.name})"
+end
+
+def fmt_group(group)
+  "group #{group.external_id} (#{group.name})"
+end

--- a/spec/lib/tasks/groups.rake_spec.rb
+++ b/spec/lib/tasks/groups.rake_spec.rb
@@ -1,0 +1,122 @@
+require "rake"
+require "rails_helper"
+
+RSpec.describe "groups.rake" do
+  before do
+    Rake.application.rake_require "tasks/groups"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "groups:change_organisation" do
+    subject(:task) { Rake::Task["groups:change_organisation"].tap(&:reenable) }
+
+    let(:start_org) { create(:organisation, slug: "start-org") }
+    let(:target_org) { create(:organisation, slug: "target-org") }
+
+    let(:groups) do
+      create_list(:group, 3, organisation: start_org)
+    end
+
+    let(:single_group) { groups.first }
+
+    context "with valid arguments" do
+      context "with a single group" do
+        it "changes the group organisation to target organisation" do
+          expect {
+            task.invoke(single_group.external_id, target_org.id)
+          }.to change { single_group.reload.organisation }.from(start_org).to(target_org)
+        end
+      end
+
+      context "with multiple groups" do
+        it "changes the organisations of all specified groups to the target organisation" do
+          group_ids = groups.map(&:external_id)
+
+          expect {
+            task.invoke(*group_ids, target_org.id)
+          }.to change { groups.map { |g| g.reload.organisation } }.to([target_org] * groups.size)
+        end
+      end
+    end
+
+    context "with invalid arguments" do
+      it "aborts when group_ids are empty" do
+        expect {
+          task.invoke
+        }.to raise_error(SystemExit).and output(/usage: rake groups:change_organisation/).to_stderr
+      end
+
+      it "aborts when org_id is missing" do
+        expect {
+          task.invoke(single_group.external_id)
+        }.to raise_error(SystemExit).and output(/usage: rake groups:change_organisation/).to_stderr
+      end
+
+      it "aborts when the organisation is not found" do
+        non_existent_org_id = 999_999
+
+        expect {
+          task.invoke(single_group.external_id, non_existent_org_id)
+        }.to raise_error(SystemExit).and output(/Organisation with ID #{non_existent_org_id} not found!/).to_stderr
+      end
+
+      it "aborts when any groups are not found" do
+        non_existent_group_ids = [999_998, 999_999]
+
+        expect {
+          task.invoke(*non_existent_group_ids, target_org.id)
+        }.to raise_error(SystemExit).and output(/Groups with external ids #{non_existent_group_ids.join(', ')} not found!/).to_stderr
+      end
+
+      it "aborts when some groups are not found" do
+        existent_group_id = single_group.external_id
+        non_existent_group_id = 999_999
+
+        expect {
+          task.invoke(existent_group_id, non_existent_group_id, target_org.id)
+        }.to raise_error(SystemExit).and output(/Groups with external ids #{non_existent_group_id} not found!/).to_stderr
+      end
+    end
+  end
+
+  describe "groups:change_organisation_dry_run" do
+    subject(:task) { Rake::Task["groups:change_organisation_dry_run"].tap(&:reenable) }
+
+    let(:start_org) { create(:organisation, slug: "start-org") }
+    let(:target_org) { create(:organisation, slug: "target-org") }
+
+    let(:groups) do
+      create_list(:group, 3, organisation: start_org)
+    end
+
+    let(:single_group) { groups.first }
+
+    context "with valid arguments" do
+      context "with a single group" do
+        it "does not persist the organisation change" do
+          expect {
+            task.invoke(single_group.external_id, target_org.id)
+          }.not_to(change { single_group.reload.organisation })
+        end
+      end
+
+      context "with multiple groups" do
+        it "does not persist the organisation changes for any specified groups" do
+          group_ids = groups.map(&:external_id)
+
+          expect {
+            task.invoke(*group_ids, target_org.id)
+          }.not_to(change { groups.map { |g| g.reload.organisation } })
+        end
+      end
+    end
+
+    context "with invalid arguments" do
+      it "aborts when args are empty" do
+        expect {
+          task.invoke
+        }.to raise_error(SystemExit).and output(/usage: rake groups:change_organisation_dry_run/).to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WIP: changing groups organisations

Sometimes groups need to move from on organisation to another.

Currently, this would have to be done through the rails console, or in
production through the DB.

This commit adds a new rake tasks to change the organisation of one or
more groups.

A new namespace, groups, has been added. This contains the tasks
change_organisation and change_organisation_dry_run.

This layout is supposed to match the other tasks we have.

To invoke the task from the command line, use:

```
rake groups:change_organisation_dry_run[VcyzrC3R,2]
```

The task takes one or more groups external_ids and must end with
the id of the target organisation.

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
