### PR TITLE
Update payment_link.yml

### DIFF
--- a/config/locales/input_objects/payment_link.yml
+++ b/config/locales/input_objects/payment_link.yml
@@ -6,11 +6,11 @@ en:
     hint:
       forms_payment_link_input:
         payment_url: |-
-          For example, https://gov.uk/payments/your-payment-link
+          For example, https://www.gov.uk/payments/your-payment-link
   activemodel:
     errors:
       models:
         forms/payment_link_input:
           attributes:
             payment_url:
-              url: Enter a link in the correct format, like https://www.gov.uk/payments/organisation/service
+              url: Enter a link in the correct format, like https://www.gov.uk/payments/your-payment-link

--- a/spec/input_objects/forms/payment_link_input_spec.rb
+++ b/spec/input_objects/forms/payment_link_input_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Forms::PaymentLinkInput, type: :model do
         payment_link_input.validate(:payment_url)
 
         expect(payment_link_input.errors.full_messages_for(:payment_url)).to include(
-          "Payment url Enter a link in the correct format, like https://www.gov.uk/payments/organisation/service",
+          "Payment url Enter a link in the correct format, like https://www.gov.uk/payments/your-payment-link",
         )
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe Forms::PaymentLinkInput, type: :model do
         payment_link_input.validate(:payment_url)
 
         expect(payment_link_input.errors.full_messages_for(:payment_url)).to include(
-          "Payment url Enter a link in the correct format, like https://www.gov.uk/payments/organisation/service",
+          "Payment url Enter a link in the correct format, like https://www.gov.uk/payments/your-payment-link",
         )
       end
     end


### PR DESCRIPTION
Small microcopy change: updates typo in example for payment links (currently example link wouldn't validate, because it's missing the "www.").

Replaces example in error message, so it's the same as that used in the on-page example - for consistency.