### PR TITLE
Allows valid payment urls without the 'www' prefix

### DIFF
--- a/app/input_objects/forms/payment_link_input.rb
+++ b/app/input_objects/forms/payment_link_input.rb
@@ -19,6 +19,6 @@ class Forms::PaymentLinkInput < BaseInput
   end
 
   def is_pay_url?
-    errors.add :payment_url, :url unless payment_url.starts_with?("https://www.gov.uk/payments/")
+    errors.add :payment_url, :url unless payment_url.starts_with?("https://www.gov.uk/payments/", "https://gov.uk/payments/")
   end
 end

--- a/spec/input_objects/forms/payment_link_input_spec.rb
+++ b/spec/input_objects/forms/payment_link_input_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe Forms::PaymentLinkInput, type: :model do
       end
     end
 
+    context "when given a Pay URL without 'www' prefix" do
+      it "validates succesfully" do
+        payment_link_input = described_class.new(form:, payment_url: "https://gov.uk/payments/test-org/test-service")
+
+        expect(payment_link_input).to be_valid
+      end
+    end
+
     context "when given a blank payment_url" do
       it "validates successfully" do
         payment_link_input = described_class.new(form:, payment_url: "")


### PR DESCRIPTION
### What problem does this pull request solve?

Allows `payment_url` to be valid whether or not there's a `www` prefixing it.
### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
