### PR TITLE
Add terms of use accepted page

### DIFF
--- a/app/controllers/account/terms_of_use_controller.rb
+++ b/app/controllers/account/terms_of_use_controller.rb
@@ -1,0 +1,36 @@
+module Account
+  class TermsOfUseController < ApplicationController
+    include AfterSignInPathHelper
+
+    before_action :redirect_if_terms_agreed
+    skip_before_action :redirect_if_account_not_completed
+
+    def edit
+      @terms_of_use_input = TermsOfUseInput.new(user: current_user)
+    end
+
+    def update
+      @terms_of_use_input = TermsOfUseInput.new(account_terms_of_use_input_params(current_user))
+
+      if @terms_of_use_input.submit
+        redirect_to next_path
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def account_terms_of_use_input_params(user)
+      params.require(:account_terms_of_use_input).permit(:agreed).merge(user:)
+    end
+
+  private
+
+    def redirect_if_terms_agreed
+      redirect_to root_path if current_user.terms_agreed_at.present?
+    end
+
+    def next_path
+      after_sign_in_next_path
+    end
+  end
+end

--- a/app/input_objects/account/terms_of_use_input.rb
+++ b/app/input_objects/account/terms_of_use_input.rb
@@ -1,0 +1,13 @@
+class Account::TermsOfUseInput < BaseInput
+  attr_accessor :user, :agreed
+
+  validates :agreed, acceptance: true
+
+  def submit
+    return false if invalid?
+
+    user.terms_agreed_at = Time.zone.now
+
+    user.save!
+  end
+end

--- a/app/views/account/terms_of_use/edit.html.erb
+++ b/app/views/account/terms_of_use/edit.html.erb
@@ -1,0 +1,23 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.account_terms_of_use"), @terms_of_use_input.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @terms_of_use_input, url: account_terms_of_use_path, method: :patch) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%=t("page_titles.account_terms_of_use")%>
+      </h1>
+
+      <%=t("account.terms_of_use_summary_html")%>
+
+      <%# terms of use content here %>
+
+      <%= f.govuk_check_boxes_fieldset :agreed, multiple: false, legend: { tag: 'h2', size: 'm' } do %>
+        <%= f.govuk_check_box :agreed, 1, 0, multiple: false, link_errors: true  %>
+      <% end %>
+
+      <%= f.govuk_submit t('save_and_continue') %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,9 @@ en:
     organisation_text_html: |
       <p>If you’re from a central government organisation that publishes content on the GOV.UK website but your organisation is not listed, please %{contact_link}.</p>
       <p>If you’re from a public sector organisation that does not publish content on GOV.UK you cannot use GOV.UK Forms yet. You can <a href="https://www.forms.service.gov.uk/forthcoming-features">read about our forthcoming features and sign up to our mailing list</a> for updates.</p>
+    terms_of_use_summary_html: |
+      <p>These terms apply to the way you use GOV.UK Forms.</p>
+      <p>You must accept these terms to continue to use GOV.UK Forms.</p>
   activemodel:
     errors:
       models:
@@ -16,6 +19,10 @@ en:
           attributes:
             organisation_id:
               blank: Select your organisation
+        account/terms_of_use_input:
+          attributes:
+            agreed:
+              accepted: You must agree to the terms of use to continue
         group_member_input:
           attributes:
             member_email_address:
@@ -520,6 +527,9 @@ en:
         name: Enter your full name
       account_organisation_input:
         organisation_id: Select your organisation
+      account_terms_of_use_input:
+        agreed_options:
+          '1': I agree to these terms
       forms_make_changes_live:
         confirm: Are you sure you want to make your draft live?
       forms_make_live_input:
@@ -624,6 +634,8 @@ en:
           'true': 'Yes'
         question_text: Question text
     legend:
+      account_terms_of_use_input:
+        agreed: Do you agree to these terms?
       mou_signature:
         agreed: Do you agree to the MOU?
       pages_question_input:
@@ -880,6 +892,7 @@ en:
     access_denied: You do not have permission to access GOV.UK Forms
     account_name: Enter your name
     account_organisation: Select your organisation
+    account_terms_of_use: Terms of use
     add_guidance: Add guidance
     address_settings: What kind of addresses do you expect to receive?
     archive_form_confirm: Archive this form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ Rails.application.routes.draw do
   namespace :account do
     resource :name, only: %i[edit update]
     resource :organisation, only: %i[edit update]
+    resource :terms_of_use, controller: :terms_of_use, only: %i[edit update]
   end
 
   resources :mou_signatures, only: %i[index], path: "mous"

--- a/db/migrate/20240822145640_add_terms_agreed_at_to_users.rb
+++ b/db/migrate/20240822145640_add_terms_agreed_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddTermsAgreedAtToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :terms_agreed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_20_140813) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_22_145640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -120,6 +120,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_20_140813) do
     t.bigint "organisation_id"
     t.boolean "has_access", default: true
     t.string "provider"
+    t.datetime "terms_agreed_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,7 +25,8 @@ if HostingEnvironment.local_development? && User.none?
                                 name: "A User",
                                 role: :super_admin,
                                 uid: "123456",
-                                provider: :mock_gds_sso })
+                                provider: :mock_gds_sso,
+                                terms_agreed_at: Time.zone.now })
 
   FactoryBot.create :mou_signature_for_organisation, organisation: gds
 

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     provider { "factory_bot" }
     role { :standard }
     has_access { true }
+    terms_agreed_at { Time.zone.now }
 
     factory :basic_auth_user do
       provider { "basic_auth" }

--- a/spec/input_objects/account/terms_of_use_input_spec.rb
+++ b/spec/input_objects/account/terms_of_use_input_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+describe Account::TermsOfUseInput do
+  include ActiveSupport::Testing::TimeHelpers
+
+  subject(:terms_of_use_input) { described_class.new(user:) }
+
+  let(:user) { create(:user) }
+
+  describe "validations" do
+    it "is valid when the user has agreed" do
+      terms_of_use_input.agreed = true
+      expect(terms_of_use_input).to be_valid
+    end
+
+    it "is invalid when the user has not agreed" do
+      terms_of_use_input.agreed = false
+
+      expect(terms_of_use_input).not_to be_valid
+      expect(terms_of_use_input.errors[:agreed]).to include(I18n.t("activemodel.errors.models.account/terms_of_use_input.attributes.agreed.accepted"))
+    end
+  end
+
+  describe "#submit" do
+    context "with valid attributes" do
+      before do
+        terms_of_use_input.agreed = true
+      end
+
+      it "updates the terms agreed at timestamp" do
+        current_time = Time.zone.now.midnight
+        travel_to current_time
+
+        expect { terms_of_use_input.submit }.to change { user.reload.terms_agreed_at }.to(current_time)
+      end
+
+      it "returns true" do
+        expect(terms_of_use_input.submit).to be true
+      end
+    end
+
+    context "with invalid params" do
+      before do
+        terms_of_use_input.agreed = false
+      end
+
+      it "does not update the terms agreed at timestamp" do
+        expect { terms_of_use_input.submit }.not_to(change { user.reload.terms_agreed_at })
+      end
+
+      it "returns false" do
+        expect(terms_of_use_input.submit).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/account/terms_of_use_controller_spec.rb
+++ b/spec/requests/account/terms_of_use_controller_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+describe Account::TermsOfUseController do
+  let(:user) { create(:user, terms_agreed_at: nil) }
+
+  before do
+    login_as user
+  end
+
+  describe "GET #edit" do
+    context "when user does has not agreed to the terms of use" do
+      it "renders the edit template" do
+        get edit_account_terms_of_use_path
+        expect(response).to render_template(:edit)
+      end
+
+      it "assigns a new TermsOfUseInput to @terms_of_use_input" do
+        get edit_account_terms_of_use_path
+        expect(assigns(:terms_of_use_input)).to be_a(Account::TermsOfUseInput)
+      end
+    end
+
+    context "when the user has already agreed to the terms of use" do
+      let(:user) { create(:user) }
+
+      it "redirects to the root path" do
+        get edit_account_terms_of_use_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    context "with valid params" do
+      let(:valid_params) { { account_terms_of_use_input: { agreed: "1" } } }
+      let(:current_time) { Time.zone.now.midnight }
+
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(AfterSignInPathHelper).to receive(:after_sign_in_next_path).and_return("/next-path")
+        # rubocop:enable RSpec/AnyInstance
+
+        travel_to current_time
+      end
+
+      it "updates the user's terms agreed at timestamp" do
+        put account_terms_of_use_path, params: valid_params
+        expect(user.reload.terms_agreed_at).to eq(current_time)
+      end
+
+      it "redirects to the root path" do
+        put account_terms_of_use_path, params: valid_params
+        expect(response).to redirect_to("/next-path")
+      end
+    end
+
+    context "with invalid params" do
+      let(:invalid_params) { { account_terms_of_use_input: { agreed: "0" } } }
+
+      it "does not update the user's name" do
+        put account_terms_of_use_path, params: invalid_params
+        expect(user.reload.terms_agreed_at).to be_nil
+      end
+
+      it "renders the edit template" do
+        put account_terms_of_use_path, params: invalid_params
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/views/account/terms_of_use/edit.html.erb_spec.rb
+++ b/spec/views/account/terms_of_use/edit.html.erb_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "account/terms_of_use/edit.html.erb" do
+  let(:terms_of_use_input) { Account::TermsOfUseInput.new }
+
+  before do
+    assign(:terms_of_use_input, terms_of_use_input)
+  end
+
+  context "when there are no errors" do
+    before do
+      render
+    end
+
+    it "sets the page title" do
+      expect(view.content_for(:title)).to eq(t("page_titles.account_terms_of_use"))
+    end
+
+    it "displays the form" do
+      expect(rendered).to have_selector('form[action="/account/terms_of_use"][method="post"]')
+      expect(rendered).to have_field("_method", with: "patch", type: :hidden)
+
+      within "form" do
+        expect(rendered).to have_selector("govuk_check_boxes_fieldset")
+        expect(rendered).to have_selector("govuk_check_box")
+      end
+
+      expect(rendered).to have_button(I18n.t("save_and_continue"))
+    end
+  end
+
+  context "when there are errors" do
+    before do
+      terms_of_use_input.errors.add(:base, "Some error")
+      render
+    end
+
+    it "displays the error summary" do
+      expect(rendered).to have_selector(".govuk-error-summary")
+    end
+
+    it "sets the page title with error prefix" do
+      expect(view.content_for(:title)).to eq(title_with_error_prefix(t("page_titles.account_terms_of_use"), true))
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/xdOq34ui

This PR adds a terms of use input object, view, and controller. It doesn't add the full terms of use content itself, as this is yet to be finalised. 

It also doesn't extend the account check before_action to prompt a user to agree to the terms of use before continuing use of forms-admin. This will be added in a subsequent PR.

The reason to merge this before content is finalised and before enforcing agreement, is to allow the E2E test users to agree to the terms of use so that the E2E aren't broken when the enforcement is introduced.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
