### PR TITLE
Add terms of use link to footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
 <% end %>
 
 <% content_for :footer do %>
-    <% meta_links = {t("footer.accessibility_statement") => "https://www.forms.service.gov.uk/accessibility", t("footer.cookies") => "https://www.forms.service.gov.uk/cookies", t("footer.privacy") => "https://www.forms.service.gov.uk/privacy"} %>
+    <% meta_links = {t("footer.accessibility_statement") => "https://www.forms.service.gov.uk/accessibility", t("footer.cookies") => "https://www.forms.service.gov.uk/cookies", t("footer.privacy") => "https://www.forms.service.gov.uk/privacy", t("footer.terms_of_use") => "https://www.forms.service.gov.uk/terms-of-use"} %>
     <%= govuk_footer meta_items_title: t("footer.helpful_links"), meta_items: meta_links %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,6 +207,7 @@ en:
     cookies: Cookies
     helpful_links: Helpful links
     privacy: Privacy
+    terms_of_use: Terms of use
   forbidden:
     body_html: |
       You do not have permission to view this page.

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -179,6 +179,17 @@ RSpec.describe ApplicationController, type: :request do
     end
   end
 
+  describe "footer" do
+    it "contains links related to the service" do
+      get root_path
+
+      expect(response.body).to include('<a class="govuk-footer__link" href="https://www.forms.service.gov.uk/accessibility">Accessibility statement</a>')
+      expect(response.body).to include('<a class="govuk-footer__link" href="https://www.forms.service.gov.uk/cookies">Cookies</a>')
+      expect(response.body).to include('<a class="govuk-footer__link" href="https://www.forms.service.gov.uk/privacy">Privacy</a>')
+      expect(response.body).to include('<a class="govuk-footer__link" href="https://www.forms.service.gov.uk/terms-of-use">Terms of use</a>')
+    end
+  end
+
   def log_lines
     output.string.split("\n").map { |line| JSON.parse(line) }
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hORT21Wv

This PR adds a link to the terms of use page on the product pages to the footer of each page.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
