### PR TITLE
Remove usages of form.organisation_id

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -32,8 +32,4 @@ private
   def mark_complete_input_params
     params.require(:forms_mark_complete_input).permit(:mark_complete).merge(form: current_form)
   end
-
-  def search_params
-    params[:search]&.permit(:organisation_id) || {}
-  end
 end

--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -16,7 +16,7 @@ class GroupFormsController < ApplicationController
     @group_form = GroupForm.new(group: @group)
     authorize @group_form
 
-    @form = Form.new(creator_id: @current_user.id, organisation_id: @current_user.organisation_id)
+    @form = Form.new(creator_id: @current_user.id)
 
     @name_input = Forms::NameInput.new(name_input_params(@form))
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -55,12 +55,6 @@ class Form < ActiveResource::Base
     post "archive"
   end
 
-  def self.update_organisation_for_creator(creator_id, organisation_id)
-    if creator_id.present? && organisation_id.present?
-      patch("update-organisation-for-creator", creator_id:, organisation_id:)
-    end
-  end
-
   def form_submission_email
     FormSubmissionEmail.find_by_form_id(id)
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -3,7 +3,6 @@ class Form < ActiveResource::Base
   self.include_format_in_path = false
   headers["X-API-Token"] = Settings.forms_api.auth_key
 
-  belongs_to :organisation
   has_many :pages
 
   def self.find_live(id)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,7 +1,6 @@
 class Organisation < ApplicationRecord
   has_paper_trail
 
-  has_many :forms
   has_many :groups
   has_many :users
 

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -43,13 +43,6 @@ def move_forms(form_ids, group_id)
     end
 
     group_form.update!(group:)
-
-    next unless form.organisation && form.organisation != group.organisation
-
-    Rails.logger.info "forms:move: updating #{fmt_form(form)} organisation from #{form.organisation.name} to #{group.organisation.name}"
-
-    form.organisation_id = group.organisation_id
-    form.save!
   end
 end
 

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -23,27 +23,4 @@ namespace :organisations do
 
     puts "Created #{organisation.inspect}"
   end
-
-  desc "Output summary data about each organisation as newline-delimited JSON"
-  task summary: :environment do
-    Organisation.with_users.unscope(:order).find_each do |organisation|
-      forms = Form.where(organisation_id: organisation.id)
-
-      puts({
-        id: organisation.id,
-        slug: organisation.slug,
-        name: organisation.name,
-        forms: forms.count,
-        live_forms: forms.select { |form| form.state == "live" }.count,
-        groups: organisation.groups.count,
-        mou_signatures: organisation.mou_signatures.count,
-        users: organisation.users.count,
-        organisation_admin_users: organisation.admin_users.count,
-        default_group: organisation.default_group.present?,
-        default_group_active: organisation.default_group&.active?,
-        default_group_forms: organisation.default_group&.group_forms&.count,
-        default_group_users: organisation.default_group&.memberships&.count,
-      }.to_json)
-    end
-  end
 end

--- a/spec/factories/input_objects/forms/search_input.rb
+++ b/spec/factories/input_objects/forms/search_input.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :search_input, class: "Forms::SearchInput" do
-    sequence(:organisation_id) { |n| n }
-  end
-end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     has_draft_version { true }
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
-    organisation_id { 1 }
     live_at { nil }
     support_email { nil }
     support_phone { nil }

--- a/spec/features/form/make_changes_live_spec.rb
+++ b/spec/features/form/make_changes_live_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Make changes live", type: :feature do
-  let(:form) { build :form, :live, :with_active_resource, id: 1, name: "Apply for a juggling license", organisation_id: 1 }
+  let(:form) { build :form, :live, :with_active_resource, id: 1, name: "Apply for a juggling license" }
   let(:org_forms) { [form] }
   let(:pages) { build_list :page, 5, form_id: form.id }
   let(:organisation) { build :organisation, id: 1 }

--- a/spec/features/form/super_admin_view_forms_spec.rb
+++ b/spec/features/form/super_admin_view_forms_spec.rb
@@ -8,11 +8,6 @@ feature "View forms", type: :feature do
   let(:other_org_group) { create :group, organisation_id: other_org.id }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=#{super_admin_user.organisation_id}", headers, org_forms.to_json, 200
-      mock.get "/api/v1/forms?organisation_id=#{other_org.id}", headers, other_org_forms.to_json, 200
-    end
-
     # Orgs only show in the autocomplete if they have at least one user
     other_org_user
     other_org_group

--- a/spec/features/form/super_admin_view_forms_spec.rb
+++ b/spec/features/form/super_admin_view_forms_spec.rb
@@ -4,7 +4,7 @@ feature "View forms", type: :feature do
   let(:org_forms) { [build(:form, id: 1, name: "Org form")] }
   let(:other_org) { create :organisation, id: 2, slug: "Other org" }
   let(:other_org_user) { create :user, organisation: other_org }
-  let(:other_org_forms) { [build(:form, id: 2, organisation_id: other_org.id, name: "Other org form")] }
+  let(:other_org_forms) { [build(:form, id: 2, name: "Other org form")] }
   let(:other_org_group) { create :group, organisation_id: other_org.id }
 
   before do

--- a/spec/features/login/login_spec.rb
+++ b/spec/features/login/login_spec.rb
@@ -4,9 +4,6 @@ describe "Login to the service", type: :feature do
   let(:user) { standard_user }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=#{user.organisation_id}", headers, [].to_json, 200
-    end
     allow(Settings).to receive(:auth_provider).and_return("developer")
   end
 

--- a/spec/integration/organisation_autocomplete_spec.rb
+++ b/spec/integration/organisation_autocomplete_spec.rb
@@ -35,12 +35,6 @@ RSpec.describe "Selecting an organisation using accessible autocomplete", type: 
       create :user, organisation: Organisation.find_by(slug: "ministry-of-tests")
       create :user, organisation: Organisation.find_by(slug: "department-for-testing")
 
-      ActiveResource::HttpMock.respond_to do |mock|
-        Organisation.pluck(:id).each do |organisation_id|
-          mock.get "/api/v1/forms?organisation_id=#{organisation_id}", headers, [].to_json, 200
-        end
-      end
-
       visit root_path
     end
 

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -79,42 +79,6 @@ RSpec.describe "forms.rake" do
         end
       end
 
-      context "with a single form" do
-        let(:form) { build :form, id: 10, organisation_id: form_organisation&.id }
-        let(:forms) { [form] }
-
-        before do
-          task.invoke(form.id, group.external_id)
-        end
-
-        context "and not in an organisation" do
-          let(:form_organisation) { nil }
-
-          it "does not change the form's organisation" do
-            form.organisation_id = group.organisation_id
-            expect(form).not_to have_been_updated
-          end
-        end
-
-        context "and in the same organisation as the group" do
-          let(:form_organisation) { group.organisation }
-
-          it "does not change the form's organisation" do
-            form.organisation_id = group.organisation_id
-            expect(form).not_to have_been_updated
-          end
-        end
-
-        context "and in a different organisation to the group" do
-          let(:form_organisation) { create :organisation, slug: "other-org" }
-
-          it "changes the form's organisation" do
-            form.organisation_id = group.organisation_id
-            expect(form).to have_been_updated
-          end
-        end
-      end
-
       context "with a multiple forms" do
         let(:valid_args) { [*form_ids, group.external_id] }
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -200,37 +200,6 @@ describe Form, type: :model do
     end
   end
 
-  describe "#update_organisation_for_creator" do
-    before do
-      ActiveResource::HttpMock.reset!
-    end
-
-    it "makes patch request to the API" do
-      creator_id = 123
-      organisation_id = 1
-      expected_path = "/api/v1/forms/update-organisation-for-creator?creator_id=123&organisation_id=1"
-
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.patch expected_path, patch_headers, {}.to_json, 200
-      end
-
-      described_class.update_organisation_for_creator(creator_id, organisation_id)
-
-      request = ActiveResource::Request.new(:patch, expected_path, {}, patch_headers)
-      expect(ActiveResource::HttpMock.requests).to include request
-    end
-
-    %w[creator_id organisation].each do |missing_param|
-      it "does not make request to the API with #{missing_param} missing" do
-        params = [missing_param == "creator_id" ? nil : 123, missing_param == "organisation" ? nil : "organisation"]
-
-        described_class.update_organisation_for_creator(*params)
-
-        expect(ActiveResource::HttpMock.requests).to be_empty
-      end
-    end
-  end
-
   describe "#made_live_date" do
     it "returns nil" do
       expect(form.made_live_date).to be_nil

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -5,18 +5,6 @@ describe Form, type: :model do
   let(:organisation) { build :organisation, id: 1 }
   let(:form) { described_class.new(id:, name: "Form 1", organisation:, submission_email: "") }
 
-  describe "validations" do
-    it "does not require an org" do
-      form.org = nil
-      expect(form).to be_valid
-    end
-
-    it "does not require an organisation_id" do
-      form.organisation_id = nil
-      expect(form).to be_valid
-    end
-  end
-
   describe "#destroy" do
     context "when form is in a group" do
       it "destroys the group" do

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -4,7 +4,7 @@ describe FormPolicy do
   subject(:policy) { described_class.new(user, form) }
 
   let(:organisation) { build :organisation, :with_signed_mou, id: 1 }
-  let(:form) { build :form, id: 1, organisation_id: 1, creator_id: 123 }
+  let(:form) { build :form, id: 1, creator_id: 123 }
   let(:group) { create(:group, name: "Group 1", organisation:, status: group_status) }
   let(:group_status) { :trial }
   let(:user) { build :user, organisation: }
@@ -106,7 +106,7 @@ describe FormPolicy do
   end
 
   describe "#can_add_page_routing_conditions?" do
-    let(:form) { build :form, id: 1, pages:, organisation_id: 1 }
+    let(:form) { build :form, id: 1, pages: }
     let(:pages) { [] }
 
     context "and the form has one page" do

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -76,10 +76,6 @@ RSpec.describe AuthenticationController, type: :request do
         # shorten the auth_valid_for time for testing
         GDS::SSO::Config.auth_valid_for = 1
 
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms?organisation_id=#{standard_user.organisation_id}", headers, [].to_json, 200
-        end
-
         logout
       end
 

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Forms::ChangeNameController, type: :request do
     {
       id: 2,
       name: "Form name",
-      organisation_id: 1,
       creator_id: 123,
     }.to_json
   end
@@ -39,8 +38,8 @@ RSpec.describe Forms::ChangeNameController, type: :request do
 
   describe "#update" do
     it "renames form" do
-      post change_form_name_path(form_id: 2), params: { forms_name_input: { name: "new_form_name", organisation_id: 1, creator_id: 123 } }
-      expected_request = ActiveResource::Request.new(:put, "/api/v1/forms/2", { "id": 2, "name": "new_form_name", organisation_id: 1, creator_id: 123 }.to_json, post_headers)
+      post change_form_name_path(form_id: 2), params: { forms_name_input: { name: "new_form_name", creator_id: 123 } }
+      expected_request = ActiveResource::Request.new(:put, "/api/v1/forms/2", { "id": 2, "name": "new_form_name", creator_id: 123 }.to_json, post_headers)
       expect(ActiveResource::HttpMock.requests).to include expected_request
       expect(ActiveResource::HttpMock.requests[1].body).to eq expected_request.body
       expect(response).to redirect_to(form_path(form_id: 2))

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
   let(:user) { standard_user }
   let(:user_outside_group) { build :user, id: 2, organisation: }
 
-  let(:form) { build :form, id: 1, creator_id: 1, organisation_id: 1 }
+  let(:form) { build :form, id: 1, creator_id: 1 }
 
   let(:submission_email_mailer_spy) do
     submission_email_mailer = instance_spy(SubmissionEmailMailer)
@@ -213,7 +213,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when draft version submission email is different from live version" do
-      let(:form) { build :form, :live, id: 1, creator_id: 1, organisation_id: 1 }
+      let(:form) { build :form, :live, id: 1, creator_id: 1 }
       let(:previous_live_version) { form.clone }
 
       before do

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -1,14 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Forms::WhatHappensNextController, type: :request do
-  let(:form_organisation_id) { standard_user.organisation_id }
   let(:form_response_data) do
     {
       id: 2,
       name: "Form name",
       submission_email: "submission@email.com",
       start_page: 1,
-      organisation_id: form_organisation_id,
       what_happens_next_markdown: "Good things come to those who wait",
       live_at: nil,
     }.to_json
@@ -19,7 +17,6 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
       name: "Form name",
       submission_email: "submission@email.com",
       id: 2,
-      organisation_id: form_organisation_id,
       what_happens_next_markdown: "",
       live_at: nil,
     )
@@ -30,7 +27,6 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
       name: "Form name",
       submission_email: "submission@email.com",
       id: 2,
-      organisation_id: form_organisation_id,
       what_happens_next_markdown: "Wait until you get a reply",
       live_at: nil,
     })

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
         expect(JSON(ActiveResource::HttpMock.requests.first.body, symbolize_names: true)).to eq({
           name: "Test form",
           creator_id: standard_user.id,
-          organisation_id: standard_user.organisation.id,
         })
       end
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Pages::ConditionsController, type: :request do
-  let(:organisation_id) { standard_user.organisation_id }
-  let(:other_organisation_id) { standard_user.organisation_id + 1 }
-  let(:form) { build :form, :ready_for_routing, id: 1, organisation_id: }
+  let(:form) { build :form, :ready_for_routing, id: 1 }
   let(:pages) { form.pages }
   let(:page) do
     pages.first.tap do |first_page|

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -36,16 +36,12 @@ RSpec.describe PagesController, type: :request do
       expect(ActiveResource::HttpMock.requests).to include pages_request
     end
 
-    context "with a form from another organisation" do
-      let(:form) do
-        build :form, organisation_id: 2, id: 2
-      end
+    context "with a form in a group that the user is not a member of" do
+      let(:form) { build :form, id: 2 }
+      let(:other_group) { create(:group) }
 
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", headers, form.to_json, 200
-        end
-
+        other_group.group_forms.build(form_id: form.id)
         get form_pages_path(2)
       end
 

--- a/spec/service/user_update_service_spec.rb
+++ b/spec/service/user_update_service_spec.rb
@@ -26,13 +26,7 @@ describe UserUpdateService do
         allow(user).to receive(:update).and_return(false)
       end
 
-      it "does not run add_organisation_to_user_forms if user is not updated" do
-        allow(Form).to receive(:update_organisation_for_creator)
-        user_update_service.update_user
-        expect(Form).not_to have_received(:update_organisation_for_creator)
-      end
-
-      it "does not run add_organisation_to_user_mou if user is not updated" do
+      it "does not run add_mou_signature_organisation if user is not updated" do
         allow(MouSignature).to receive(:add_mou_signature_organisation)
         user_update_service.update_user
         expect(MouSignature).not_to have_received(:add_mou_signature_organisation)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ZHGNp5Lk/1774-remove-organisationid-from-forms-api

We no longer rely on the organisation_id of the form in any production code in admin. We have also stopped setting this column for forms in some cases since moving to the groups model, meaning the data in the column cannot be relied upon. This PR cleans up any remaining usages in the code to allow for the column to be dropped from the forms table in forms-api.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
