### PR TITLE
Update make live confirmation content

### DIFF
--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -19,7 +19,7 @@ module Forms
       @make_form_live_service = MakeFormLiveService.call(current_form:, current_user:)
       @make_form_live_service.make_live
 
-      render "confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title }
+      render "confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title, confirmation_page_body: @make_form_live_service.confirmation_page_body }
     end
 
   private

--- a/app/controllers/forms/unarchive_controller.rb
+++ b/app/controllers/forms/unarchive_controller.rb
@@ -19,7 +19,7 @@ module Forms
       @make_form_live_service = MakeFormLiveService.call(current_form:, current_user:)
       @make_form_live_service.make_live
 
-      render "forms/make_live/confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title }
+      render "forms/make_live/confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title, confirmation_page_body: @make_form_live_service.confirmation_page_body }
     end
 
   private

--- a/app/service/make_form_live_service.rb
+++ b/app/service/make_form_live_service.rb
@@ -31,6 +31,12 @@ class MakeFormLiveService
     I18n.t("page_titles.your_form_is_live")
   end
 
+  def confirmation_page_body
+    return I18n.t("make_changes_live.confirmation.body_html").html_safe if @current_form.is_live?
+
+    I18n.t("make_live.confirmation.body_html").html_safe
+  end
+
 private
 
   def live_form_submission_email_has_changed

--- a/app/views/forms/make_live/confirmation.html.erb
+++ b/app/views/forms/make_live/confirmation.html.erb
@@ -10,7 +10,7 @@
 
     <%= render FormUrlComponent::View.new(link_to_runner(Settings.forms_runner.url, current_form.id, current_form.form_slug, mode: :live )) %>
 
-    <%= t("make_live.confirmation.body_html") %>
+    <%= confirmation_page_body %>
 
     <p>
       <%= govuk_link_to t("make_live.confirmation.continue_link"), live_form_path(current_form.id) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -690,6 +690,14 @@ en:
           After you have made your form live, completed forms will be sent to %{submission_email}.
         </p>
   make_changes_live:
+    confirmation:
+      body_html: |
+        <p>
+          A link to your form needs to be published on GOV⁠.⁠UK so people can find it.
+        </p>
+        <p>
+          If a link to this form has not been published yet, contact your organisation’s GOV⁠.⁠UK publishing team to do this.
+        </p>
     url_will_remain_same: Links to the form will still work, even if you’ve changed the form’s name.
     warning: |
       When you make your changes live, there may be an impact on people who are

--- a/spec/service/make_form_live_service_spec.rb
+++ b/spec/service/make_form_live_service_spec.rb
@@ -82,4 +82,27 @@ describe MakeFormLiveService do
       end
     end
   end
+
+  describe "#confirmation_page_body" do
+    it "returns a confirmation page body" do
+      expect(make_form_live_service.confirmation_page_body).to eq I18n.t("make_live.confirmation.body_html")
+    end
+
+    context "when changes to live form are being made live" do
+      let(:live_form) { build :form, :live }
+      let(:current_form) do
+        live_form.clone
+      end
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms/#{live_form.id}/live", headers, live_form.to_json, 200
+        end
+      end
+
+      it "returns different confirmation page body" do
+        expect(make_form_live_service.confirmation_page_body).to eq I18n.t("make_changes_live.confirmation.body_html")
+      end
+    end
+  end
 end

--- a/spec/views/forms/make_live/confirmation.html.erb_spec.rb
+++ b/spec/views/forms/make_live/confirmation.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe "forms/make_live/confirmation.html.erb" do
   let(:current_form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1") }
 
   before do
-    render template: "forms/make_live/confirmation", locals: { current_form:, confirmation_page_title: "Your form is live" }
+    render template: "forms/make_live/confirmation", locals: { current_form:, confirmation_page_title: "Your form is live", confirmation_page_body: I18n.t("make_changes_live.confirmation.body_html").html_safe }
   end
 
   it "contains a confirmation panel with a title" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/uxol6PeR

This PR updates the content for the make changes live confirmation page. To do this without creating a view per confirmation case, it passes in the confirmation body from the make live service.

<details><summary>Screenshots</summary>

### Screenshots

#### Make your changes live confirmation
![Screenshot 2024-09-12 at 16 17 10](https://github.com/user-attachments/assets/ca12fa40-0f39-488e-9d68-e95cd0e364e0)

#### Make your form live confirmation
![Screenshot 2024-09-12 at 16 16 39](https://github.com/user-attachments/assets/79fc0580-ce5e-4778-b646-a0516a72ff1a)

#### Unarchive a form
![Screenshot 2024-09-12 at 16 38 20](https://github.com/user-attachments/assets/f5f0021d-5b8c-4604-93a6-275f927725f5)


</details> 


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
