### PR TITLE
Tell Dependabot to manage vite_ruby

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    allow:
+      - depedency-type: "direct"
+      - dependecy-name: "vite_ruby"
 
   # Maintain dependencies for npm
   - package-ecosystem: npm


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

vite_ruby is a transitive dependency of `vite_rails` in the Bundler ecosystem, and also a implicit dependency of `vite-plugin-ruby` in the npm ecosystem.

We have an issue at the moment where `vite-plugin-ruby` can't be updated because `vite_ruby` is out of date (see PR #1418), but because the two packages are from two different ecosystems Dependabot can't manage this for us.

We don't want to get Dependabot PRs for all our indirect dependencies, but we do want to make sure `vite_ruby` is kept up-to-date, so this commit updates the configuration to explicitly tell Dependabot to manage that gem.

We also add a line telling Dependabot to manage all direct dependencies in Bundler, to make sure the default behaviour is still there.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?