### PR TITLE
Update text max answers for repeatable question

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -522,7 +522,7 @@ en:
       pages_question_input:
         is_optional_options:
           'true': We’ll add ‘(optional)’ to the end of the question text.
-        is_repeatable: Select ‘Yes’ if you want to let someone add more than one answer (up to 10) — for example, listing all their company contacts.
+        is_repeatable: Select ‘Yes’ if you want to let someone add more than one answer (up to 50) — for example, listing all their company contacts.
     label:
       account_name_input:
         name: Enter your full name


### PR DESCRIPTION
This commit updates the text which shows when a form creator is making a
new question. Currently there is a warning that only 10 answers can be
given for a question which allows multiple answers.

That limit is being changed to 50. This commit updates the figure.

Further updates to the content are planned but this commit makes sure
the figure is correct for now.

### What problem does this pull request solve?

Trello card: https://trello.com/c/Lxdir7yz/1776-32dev-implement-changes-to-the-maximum-number-of-answers

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
