### PR TITLE
Add Rake task for updating form submission email

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -24,6 +24,24 @@ namespace :forms do
       raise ActiveRecord::Rollback
     end
   end
+
+  namespace :submission_email do
+    desc "set the submission email for a form, without validation"
+    task :update, %i[form_id submission_email] => :environment do |_, args|
+      usage_message = "usage: rake forms:submission_email:update[<form_id>, <submission_email>]".freeze
+      abort usage_message if args[:form_id].blank? || args[:submission_email].blank?
+      raise "'#{args[:submission_email]}' is not an email address" unless args[:submission_email].match?(/.*@.*/)
+
+      form = Form.find(args[:form_id])
+      form.submission_email = args[:submission_email]
+
+      Rails.logger.info "forms:submission_email:update: setting #{fmt_form(form)} submission email to \'#{form.submission_email}\'"
+
+      form.save!
+
+      form.form_submission_email&.destroy!
+    end
+  end
 end
 
 def move_forms(form_ids, group_id)

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -142,4 +142,130 @@ RSpec.describe "forms.rake" do
       end
     end
   end
+
+  describe "forms:submission_email:update" do
+    subject(:task) do
+      Rake::Task["forms:submission_email:update"]
+        .tap(&:reenable)
+    end
+
+    let(:form) do
+      build :form, id: 1
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/#{form.id}", headers, form.to_json, 200
+        mock.put "/api/v1/forms/#{form.id}", put_headers
+      end
+    end
+
+    context "with valid arguments" do
+      let(:submission_email) { "test@example.gov.uk" }
+      let(:valid_args) { [form.id, submission_email] }
+
+      let(:request) do
+        ActiveResource::HttpMock.requests.find do |request|
+          request.method == :put && request.path == "/api/v1/forms/1"
+        end
+      end
+
+      shared_examples "submission email update" do
+        it "changes the form submission email" do
+          task.invoke(*valid_args)
+
+          form.from_json(request.body)
+
+          expect(form).to have_attributes(submission_email:)
+        end
+
+        it "updates the email confirmation status" do
+          task.invoke(*valid_args)
+
+          form.from_json(request.body)
+
+          expect(form).to have_attributes(email_confirmation_status: :email_set_without_confirmation)
+        end
+      end
+
+      include_examples "submission email update"
+
+      context "when the form has a submission email record" do
+        include_examples "submission email update"
+
+        it "is deleted" do
+          form_submission_email = FormSubmissionEmail.create!(form_id: form.id)
+
+          expect {
+            task.invoke(*valid_args)
+          }.to change(FormSubmissionEmail, :count).by(-1)
+
+          expect {
+            form_submission_email.reload
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "when the submission email is not a government email address" do
+        let(:submission_email) { "test@example.aws.com" }
+
+        include_examples "submission email update"
+
+        it "does not raise a validation error" do
+          expect {
+            task.invoke(*valid_args)
+          }.not_to raise_error
+        end
+      end
+    end
+
+    context "with invalid arguments" do
+      shared_examples_for "usage error" do
+        it "aborts with a usage message" do
+          expect {
+            task.invoke(*invalid_args)
+          }.to raise_error(SystemExit)
+           .and output(/usage: rake forms:submission_email:update/).to_stderr
+        end
+      end
+
+      context "with no arguments" do
+        it_behaves_like "usage error" do
+          let(:invalid_args) { [] }
+        end
+      end
+
+      context "with only one argument" do
+        it_behaves_like "usage error" do
+          let(:invalid_args) { [form.id] }
+        end
+      end
+
+      context "with invalid form_id" do
+        let(:invalid_args) { ["99", "test@example.com"] }
+
+        before do
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v1/forms/99", headers, nil, 404
+          end
+        end
+
+        it "raises an error" do
+          expect {
+            task.invoke(*invalid_args)
+          }.to raise_error(ActiveResource::ResourceNotFound)
+        end
+      end
+
+      context "with invalid email address" do
+        let(:invalid_args) { %w[99 not_an_email_address] }
+
+        it "raises an error" do
+          expect {
+            task.invoke(*invalid_args)
+          }.to raise_error(/not an email address/)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/a85eZ4lE/ <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

There are some scenarios in which we need to set the submission email for a form skipping the validation checking that the email is hosted on a recognised government domain.

This can be done via the API with a developer API key, but this PR adds a Rake task that does this as an alternative method.

The Rake task also takes care of removing any related `FormSubmissionEmail` records, because if there is one in the pending state this will stop the form being made live.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?