### PR TITLE
Bump Postgres from 11 to 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11-alpine
+        image: postgres:13-alpine
         ports:
           - "5432:5432"
         env:


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/cn9hyatr/1816-update-postgres-service-in-github-actions-workflows <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We are using Postgres 13 in production [[1]], we should use the same version
for our automated tests.

[1]: https://github.com/alphagov/forms-deploy/blob/2c7da572fd81ba45d1da6672d5423b929864e123/infra/modules/rds/rds.tf#L35


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?