### PR TITLE
Ensure single option selection questions can't be repeatable

### DIFF
--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -35,8 +35,12 @@
   <% end %>
 
   <% if Settings.features.repeatable_page_enabled %>
-    <%= f.govuk_collection_radio_buttons :is_repeatable, question_input.repeatable_options, :id, :name, :description, legend: { size: 'm', tag: 'h2' }, bold_labels: false %>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+    <% if question_input.answer_settings[:only_one_option] == "true" %>
+      <%= f.hidden_field :is_repeatable, value: false %>
+    <% else %>
+      <%= f.govuk_collection_radio_buttons :is_repeatable, question_input.repeatable_options, :id, :name, :description, legend: { size: 'm', tag: 'h2' }, bold_labels: false %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+    <% end %>
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     question_text { Faker::Lorem.question.truncate(250) }
     answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }
     is_optional { nil }
-    answer_settings { nil }
+    answer_settings { {} }
     hint_text { nil }
     routing_conditions { [] }
     sequence(:position) { |n| n }

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -7,7 +7,8 @@ describe "pages/_form.html.erb", type: :view do
     build :question_input,
           answer_type: page.answer_type,
           question_text: page.question_text,
-          hint_text: page.hint_text
+          hint_text: page.hint_text,
+          answer_settings: page.answer_settings
   end
   let(:form) { build :form, id: 1 }
   let(:is_new_page) { true }
@@ -43,6 +44,14 @@ describe "pages/_form.html.erb", type: :view do
   context "when feature repeatable page is enabled", :feature_repeatable_page_enabled do
     it "has a radio input for repeatable" do
       expect(rendered).to have_field("pages_question_input[is_repeatable]", type: :radio)
+    end
+
+    context "when the question is an only one option selection" do
+      let(:page) { build :page, :with_selections_settings, id: 2, form_id: form.id }
+
+      it "does not have the radio input for repeatable" do
+        expect(rendered).not_to have_field("pages_question_input[is_repeatable]", type: :radio)
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SXihoLCc/1745-5-stop-form-creators-from-trying-to-add-routing-to-a-repeatable-question

In order to ensure that an invalid route can't be set up with a repeatable selection question, this change means that if a question is changed to a selection/only-one-option combination, it will be forced to not be repeatable. The option for changing one of these questions to repeatable will not be available either.

### Things to consider when reviewing

Are you able to make a route based on a repeatable question? You shouldn't be able to if this change is working!

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
