### PR TITLE
Update content for repeatable question options

### DIFF
--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -39,6 +39,7 @@
       <%= f.hidden_field :is_repeatable, value: false %>
     <% else %>
       <%= f.govuk_collection_radio_buttons :is_repeatable, question_input.repeatable_options, :id, :name, :description, legend: { size: 'm', tag: 'h2' }, bold_labels: false %>
+      <%= govuk_details(summary_text: t('repeatable.summary_text'), text: t('repeatable.summary_content_html')) %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -571,7 +571,9 @@ en:
       pages_question_input:
         is_optional_options:
           'true': We’ll add ‘(optional)’ to the end of the question text.
-        is_repeatable: Select ‘Yes’ if you want to let someone add more than one answer (up to 50) — for example, listing all their company contacts.
+        is_repeatable: Select ‘Yes’ if you want to let someone add more than one answer - for example, listing all their current household members.
+        is_repeatable_options:
+          'true': After adding their first answer we’ll ask if they need to add another - up to a maximum of 50
     label:
       account_name_input:
         name: Enter your full name
@@ -680,7 +682,7 @@ en:
           'false': Mandatory
           'true': Optional
         is_repeatable_options:
-          'false': No — this question can only be answered once
+          'false': No - this question can only be answered once
           'true': 'Yes'
         question_text: Question text
     legend:
@@ -1105,6 +1107,16 @@ en:
       </p>
     heading: Provide a link to privacy information for this form
     submit_button: Save and continue
+  repeatable:
+    summary_content_html: |
+      <p>
+        You might want to use hint text to tell someone:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>that after adding one answer they'll be asked if they need to add another - up to a maximum of 50</li>
+        <li>who to contact if they need to add more than 50 answers</li>
+      </ul>
+    summary_text: Help people answer this question
   reports:
     back_link: Back to reports
     features:

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -46,6 +46,10 @@ describe "pages/_form.html.erb", type: :view do
       expect(rendered).to have_field("pages_question_input[is_repeatable]", type: :radio)
     end
 
+    it "has a details about repeatable questions" do
+      expect(rendered).to have_text(I18n.t("repeatable.summary_text"))
+    end
+
     context "when the question is an only one option selection" do
       let(:page) { build :page, :with_selections_settings, id: 2, form_id: form.id }
 


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/KeZEpgBq/1819-implement-iterated-designs-for-single-repeatable-question-mvp-following-ur

Updates the `repeatable` section of the question builder. I've added a before and after screenshot, this is [the mural design](https://app.mural.co/t/gaap0347/m/gaap0347/1687946839058/9e1b89cd76af287c05c82df1cdb307a830324315?wid=0-1726668954476) I was using

### Before
![image](https://github.com/user-attachments/assets/b03dc336-f5d8-4f03-ab62-6ee33aab62e3)
___

### After 
![image](https://github.com/user-attachments/assets/0d8a1e7b-1351-44dc-b23f-b5364d17cbbc)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
