### PR TITLE
Bump webrick to v1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,7 +497,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)


### PR DESCRIPTION
### What problem does this pull request solve?

Bumps webrick to v1.8.2 in order to fix a merge-blocking security audit failure.

Release notes: https://github.com/ruby/webrick/releases/tag/v1.8.2

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
