### PR TITLE
Log form_organisation_id field

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -89,6 +89,8 @@ class ApplicationController < ActionController::Base
 
   def current_form
     @current_form ||= Form.find(params[:form_id])
+    CurrentLoggingAttributes.form_organisation_id = @current_form&.group&.organisation&.id if params[:form_id].present?
+    @current_form
   end
 
   def groups_enabled

--- a/app/models/current_logging_attributes.rb
+++ b/app/models/current_logging_attributes.rb
@@ -1,4 +1,4 @@
 class CurrentLoggingAttributes < ActiveSupport::CurrentAttributes
   attribute :host, :request_id, :session_id_hash, :trace_id, :user_ip, :user_id, :user_email, :user_organisation_slug,
-            :form_id, :page_id
+            :form_id, :form_organisation_id, :page_id
 end


### PR DESCRIPTION
### What problem does this pull request solve?

As forms no longer have an `organisation_id` property, we are unable to use this property in Splunk searches to filter logs by the organisation the form is in. Add `form_organisation_id` field to log the organisation ID.

Only log after we have looked up the `current_form` for the request to ensure that we aren't making a request to forms API to look up the  form where we were not previously. We would expect all requests  containing a `form_id` in the path params to lookup the form when authorizing the request.

Logging this field will cause a database lookup to find the `group_form` and associated organisation_id. 

> [!NOTE] 
> This PR will be a bit easier to review if you hide whitespace changes in the diff, as some indentation changed in the tests.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
