### PR TITLE
Add another answer feature report

### DIFF
--- a/app/views/reports/features.html.erb
+++ b/app/views/reports/features.html.erb
@@ -18,6 +18,10 @@
         <%= row.with_key(text: t(".features.live_forms_with_payments")) %>
         <%= row.with_value(text: data.live_forms_with_payment) %>
       <%end%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".features.live_forms_with_add_another_answer")) %>
+        <%= row.with_value(text: data.live_forms_with_add_another_answer) %>
+      <%end%>
     <%end%>
 
     <h2 class="govuk-heading-m govuk-visually-hidden"><%= t(".answer_types.heading") %></h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1160,6 +1160,7 @@ en:
           number_of_pages: Number of pages of this answer type on live forms
       features:
         heading: Features
+        live_forms_with_add_another_answer: Live forms with add another answer
         live_forms_with_payments: Live forms with payments
         live_forms_with_routes: Live forms with routes
         total_live_forms: Total live forms

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe ReportsController, type: :request do
                                      selection: 4,
                                      text: 5 },
       live_forms_with_payment: 1,
-      live_forms_with_routing: 2 }
+      live_forms_with_routing: 2,
+      live_forms_with_add_another_answer: 3 }
   end
 
   before do

--- a/spec/views/reports/features.html.erb_spec.rb
+++ b/spec/views/reports/features.html.erb_spec.rb
@@ -24,7 +24,8 @@ describe "reports/features.html.erb" do
                                                 selection: 4,
                                                 text: 5 },
                  live_forms_with_payment: 1,
-                 live_forms_with_routing: 2 })
+                 live_forms_with_routing: 2,
+                 live_forms_with_add_another_answer: 3 })
   end
 
   before do
@@ -69,7 +70,8 @@ describe "reports/features.html.erb" do
                    live_forms_with_answer_type: { address: 1 },
                    live_pages_with_answer_type: { address: 1 },
                    live_forms_with_payment: 1,
-                   live_forms_with_routing: 2 })
+                   live_forms_with_routing: 2,
+                   live_forms_with_add_another_answer: 3 })
     end
 
     it "displays 0 for live_forms_with_answer_type" do
@@ -87,5 +89,9 @@ describe "reports/features.html.erb" do
 
   it "includes the number of live forms with payments" do
     expect(rendered).to have_css(".govuk-summary-list__row", text: "Live forms with payments#{report.live_forms_with_payment}")
+  end
+
+  it "includes the number of live forms with add another answer" do
+    expect(rendered).to have_css(".govuk-summary-list__row", text: "Live forms with add another answer#{report.live_forms_with_add_another_answer}")
   end
 end


### PR DESCRIPTION
Adds the live_forms_with_add_another_answer report to the list of feature reports. This counts the number of live forms that have at least one question that is repeatable (which at the moment means a single repeatable question)

### What problem does this pull request solve?

Trello card: https://trello.com/c/a2bMFMxU/1827-5-report-when-forms-are-using-add-another-answer-single-qn

Adds the 'Live forms with add another answer' row to the features report page. 

<img width="768" alt="image" src="https://github.com/user-attachments/assets/403c1b97-1f84-4d5d-a4c0-b2d5919211a1">


This is the first of two parts to this, and only counts the feature usage within live forms.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
