### PR TITLE
Exclude CSV task from status count

### DIFF
--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -200,6 +200,7 @@ private
 
   def remove_optional_statuses(statuses)
     statuses.delete(:payment_link_status)
+    statuses.delete(:receive_csv_status)
   end
 
   def can_enter_submission_email_code

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -36,6 +36,7 @@ describe FormTaskListService do
         support_contact_details_status: "not_started",
         what_happens_next_status: "completed",
         payment_link_status: "optional",
+        receive_csv_status: "optional",
       })
     end
     let(:form) { build(:form, id: 1, task_statuses: statuses) }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Excludes the 'Get completed forms as CSV files' task from the count of completed/uncompleted tasks, since we do that for the other optional task.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
