### PR TITLE
Temporarily exclude task to share preview from task count

### DIFF
--- a/app/service/form_task_list_service.rb
+++ b/app/service/form_task_list_service.rb
@@ -201,6 +201,7 @@ private
   def remove_optional_statuses(statuses)
     statuses.delete(:payment_link_status)
     statuses.delete(:receive_csv_status)
+    statuses.delete(:share_preview_status)
   end
 
   def can_enter_submission_email_code

--- a/spec/service/form_task_list_service_spec.rb
+++ b/spec/service/form_task_list_service_spec.rb
@@ -37,6 +37,7 @@ describe FormTaskListService do
         what_happens_next_status: "completed",
         payment_link_status: "optional",
         receive_csv_status: "optional",
+        share_preview_status: "completed",
       })
     end
     let(:form) { build(:form, id: 1, task_statuses: statuses) }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/QuqK5jmG/1867-add-new-task-to-share-a-preview-of-your-draft-form-for-drafts-of-new-live-and-archived-forms

We are adding a new mandatory task to share a preview of a draft form.

We need to add a task status to the form in forms-api before we add/ update the pages for this in forms-admin. Temporarily exclude this task from the counts for the `You've completed X out of X tasks` content on the task list page.

We can stop excluding this task from the counts at the same time we add the page for the new task and add it to the task list.

There is a draft PR to add the new task status to forms-api, which will only be merged after this PR has been merged https://github.com/alphagov/forms-api/pull/592

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
