### PR TITLE
Fix Sass 'mixed declarations' warning

### DIFF
--- a/app/components/metrics_summary_component/_index.scss
+++ b/app/components/metrics_summary_component/_index.scss
@@ -9,11 +9,11 @@
 }
 
 .app-metrics__big-number {
-  @include govuk-font-size(19);
-  @include govuk-typography-common;
-
   padding: govuk-spacing(1) govuk-spacing(0);
   margin-bottom: govuk-spacing(2);
+
+  @include govuk-font-size(19);
+  @include govuk-typography-common;
 
   @include govuk-media-query(tablet) {
     @supports (display: grid) {
@@ -28,11 +28,11 @@
 }
 
 .app-metrics__big-number-number {
-  @include govuk-font-size(48);
-  @include govuk-typography-weight-bold;
-
   display: block;
   margin-top: govuk-spacing(1);
+
+  @include govuk-font-size(48);
+  @include govuk-typography-weight-bold;
 }
 
 .app-metrics__date {

--- a/app/frontend/styles/_app_summary_card.scss
+++ b/app/frontend/styles/_app_summary_card.scss
@@ -1,13 +1,15 @@
 .app-summary-card {
   // Summary list component overrides
   .govuk-summary-list {
-    @include govuk-font($size: 16);
     margin-bottom: govuk-spacing(-2);
+
+    @include govuk-font($size: 16);
   }
 
   .govuk-summary-list .govuk-list {
-    @include govuk-font($size: 16);
     margin-bottom: govuk-spacing(-2);
+
+    @include govuk-font($size: 16);
   }
 
   // Remove last item’s bottom border on mobile


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/m5hB6sVM/2088-resolve-sass-mixed-declarations-deprecation-warning

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Fixes a [deprecation warning](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) related to the way that the sass declarations are ordered. In v2, the way these  declarations are turned into CSS will change and if they're left as they are they'll generate more CSS than is necessary.

There shouldn't be any visual differences as a result of these changes. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
