### PR TITLE
Order list of groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,6 +5,8 @@ class Group < ApplicationRecord
 
   belongs_to :upgrade_requester, class_name: "User", optional: true
 
+  default_scope { order("LOWER(name)", :created_at) }
+
   has_many :memberships, dependent: :destroy do
     def ordered
       joins(:user).order("users.name")

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -294,4 +294,16 @@ RSpec.describe Group, type: :model do
       expect(group).to be_valid
     end
   end
+
+  describe "ordering" do
+    it "orders groups by name" do
+      user = create :user
+      organisation = create :organisation
+      group_c = create :group, organisation:, name: "C", creator: user
+      group_b = create :group, organisation:, name: "b", creator: user
+      group_a = create :group, organisation:, name: "a", creator: user
+
+      expect(described_class.for_organisation(group_c.organisation)).to eq [group_a, group_b, group_c]
+    end
+  end
 end


### PR DESCRIPTION
## What/Why

The listing of groups when you log in was unordered, appearing as they are in the database which makes no sense to the user. This adds an alphabetical and creation time ordering.

[Trello card](https://trello.com/c/0ObcUSir/1868-order-lists-of-groups-and-forms-in-admin)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
