### PR TITLE
Add share preview task

### DIFF
--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -197,7 +197,10 @@ private
   def statuses_by_user
     statuses = @task_statuses
 
-    statuses.delete(:make_live_status) unless Pundit.policy(@current_user, @form).can_make_form_live?
+    unless Pundit.policy(@current_user, @form).can_make_form_live?
+      statuses.delete(:share_preview_status)
+      statuses.delete(:make_live_status)
+    end
 
     statuses
   end
@@ -213,7 +216,6 @@ private
   def remove_optional_statuses(statuses)
     statuses.delete(:payment_link_status)
     statuses.delete(:receive_csv_status)
-    statuses.delete(:share_preview_status)
   end
 
   def can_enter_submission_email_code

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -156,18 +156,30 @@ private
   end
 
   def make_form_live_section_tasks
-    [{
-      task_name: live_task_name,
-      path: live_path,
-      status: @task_statuses[:make_live_status],
-      active: @form.all_ready_for_live?,
-    }]
+    [
+      {
+        task_name: share_preview_task_name,
+        path: share_preview_path(@form.id),
+        status: @task_statuses[:share_preview_status],
+        active: @form.pages.any?,
+      },
+      {
+        task_name: live_task_name,
+        path: live_path,
+        status: @task_statuses[:make_live_status],
+        active: @form.all_ready_for_live?,
+      },
+    ]
   end
 
   def live_title_name
     return I18n.t("forms.task_list_create.make_form_live_section.title") if @form.is_archived?
 
     I18n.t("forms.task_list_#{create_or_edit}.make_form_live_section.title")
+  end
+
+  def share_preview_task_name
+    I18n.t("forms.task_list_#{create_or_edit}.make_form_live_section.share_preview")
   end
 
   def live_task_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -325,6 +325,7 @@ en:
               A group admin can request to upgrade the group so forms can be made live. You can <a href="%{group_members_path}">view the members of the group</a> to find a group admin.
           no_org_admin: You cannot make this form live because it’s in a ‘trial’ group.
         make_live: Make your form live
+        share_preview: Share a preview of your draft form
         title: Make your form live
         user_cannot_administer:
           body_text: |
@@ -355,6 +356,7 @@ en:
         title: Change how you get completed forms
       make_form_live_section:
         make_live: Make your changes live
+        share_preview: Share a preview of your draft form
         title: Make your changes live
       payment_link_subsection:
         payment_link: Add a link to a payment page on GOV.UK Pay

--- a/spec/features/form/share_a_preview_spec.rb
+++ b/spec/features/form/share_a_preview_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+feature "Share a preview", type: :feature do
+  let(:form) { build :form, :with_active_resource, id: 1 }
+  let(:fake_page) { build :page, form_id: 1, id: 2 }
+  let(:pages) { [fake_page] }
+  let(:group) { create(:group, organisation: standard_user.organisation, status: "active") }
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/1", headers, form.to_json, 200
+      mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
+      mock.get "/api/v1/forms/1/pages/2", headers, fake_page.to_json, 200
+      mock.post "/api/v1/forms/1/pages", post_headers, fake_page.to_json, 200
+      mock.put "/api/v1/forms/1", post_headers, form.to_json, 200
+    end
+
+    GroupForm.create!(group:, form_id: form.id)
+    create(:membership, group:, user: standard_user, added_by: standard_user, role: :group_admin)
+
+    login_as standard_user
+  end
+
+  scenario "as a form editor" do
+    given_i_am_viewing_a_form
+    when_i_click_share_a_preview
+    then_i_am_shown_the_share_a_preview_page
+    when_i_click_the_copy_to_clipboard_button
+    then_the_preview_url_is_copied_to_my_clipboard
+    when_i_mark_the_task_complete
+    then_i_am_returned_to_the_form_page
+    then_i_see_a_success_message
+  end
+
+  def given_i_am_viewing_a_form
+    visit form_path(form.id)
+    expect(page.find("h1")).to have_text "Create a form"
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def when_i_click_share_a_preview
+    click_link_or_button "Share a preview of your draft form"
+  end
+
+  def then_i_am_shown_the_share_a_preview_page
+    expect(page.find("h1")).to have_text "Share a preview of your draft form"
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def when_i_click_the_copy_to_clipboard_button
+    click_link_or_button "Copy link to clipboard"
+  end
+
+  def then_the_preview_url_is_copied_to_my_clipboard
+    clipboard_text = get_clipboard_text
+    expect(clipboard_text).to eq("runner-host/preview-draft/#{form.id}/#{form.form_slug}")
+  end
+
+  def when_i_mark_the_task_complete
+    choose "Yes"
+    click_link_or_button "Save and continue"
+  end
+
+  def then_i_am_returned_to_the_form_page
+    expect(page.find("h1")).to have_text "Create a form"
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_css ".govuk-notification-banner--success", text: "The preview task has been completed"
+  end
+
+  def get_clipboard_text
+    cdp_params = {
+      origin: page.server_url,
+      permission: { name: "clipboard-read" },
+      setting: "granted",
+    }
+    page.driver.browser.execute_cdp("Browser.setPermission", **cdp_params)
+
+    page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
+  end
+end

--- a/spec/services/form_task_list_service_spec.rb
+++ b/spec/services/form_task_list_service_spec.rb
@@ -284,13 +284,12 @@ describe FormTaskListService do
     end
 
     describe "make form live section tasks" do
-      let(:form) { build(:form, :ready_for_live, id: 1, organisation:) }
-
       let(:section) do
         all_sections[5]
       end
 
       let(:section_rows) { section[:rows] }
+      let(:form) { build(:form, :ready_for_live, id: 1, organisation:) }
 
       context "when the form is in a trial group" do
         it "has no tasks" do
@@ -346,56 +345,6 @@ describe FormTaskListService do
       context "when the form is in an active group" do
         let(:group_status) { :active }
 
-        context "and the user can administer the group" do
-          let(:can_make_form_live) { true }
-          let(:can_administer_group) { true }
-
-          it "has link to make the form live" do
-            expect(section_rows.first[:task_name]).to eq "Make your form live"
-            expect(section_rows.first[:path]).to eq "/forms/1/make-live"
-          end
-
-          context "when form is ready to make live" do
-            let(:form) { build(:form, :ready_for_live, id: 1) }
-
-            it "has link to make the form live" do
-              expect(section_rows.first[:task_name]).to eq "Make your form live"
-              expect(section_rows.first[:path]).to eq "/forms/1/make-live"
-            end
-
-            it "has the correct default status" do
-              expect(section_rows.first[:status]).to eq :not_started
-            end
-          end
-
-          context "when form is live" do
-            before do
-              allow(form).to receive(:is_live?).and_return(true)
-            end
-
-            it "has tasks" do
-              expect(section_rows).not_to be_empty
-            end
-
-            it "describes the section title correctly" do
-              expect(section[:title]).to eq I18n.t("forms.task_list_edit.make_form_live_section.make_live")
-            end
-
-            it "describes the task correctly" do
-              expect(section_rows.first[:task_name]).to eq I18n.t("forms.task_list_edit.make_form_live_section.make_live")
-            end
-          end
-
-          context "when the form is archived" do
-            let(:form) { build(:form, :archived, id: 1) }
-
-            it "has link to make the form live" do
-              expect(section_rows.first[:task_name]).to eq "Make your form live"
-              expect(section_rows.first[:path]).to eq "/forms/1/make-live"
-            end
-          end
-        end
-
         context "and the user cannot administer the group" do
           it "has no tasks" do
             expect(section).not_to include(:rows)
@@ -407,6 +356,96 @@ describe FormTaskListService do
                 "forms.task_list_create.make_form_live_section.user_cannot_administer.body_text",
                 group_members_path: group_members_path(group),
               )
+          end
+        end
+      end
+
+      describe "share preview task" do
+        context "when the user can make the form live" do
+          let(:can_make_form_live) { true }
+
+          context "when the form does not have any pages" do
+            before do
+              form.pages = []
+            end
+
+            it "has the correct task name" do
+              expect(section_rows.first[:task_name]).to eq(I18n.t("forms.task_list_create.make_form_live_section.share_preview"))
+            end
+
+            it "is not active" do
+              expect(section_rows.first[:active]).to be false
+            end
+          end
+
+          context "when the form has at least one page" do
+            it "has the correct task name" do
+              expect(section_rows.first[:task_name]).to eq(I18n.t("forms.task_list_create.make_form_live_section.share_preview"))
+            end
+
+            it "is active" do
+              expect(section_rows.first[:active]).to be true
+            end
+
+            it "has a link to the share preview task" do
+              expect(section_rows.first[:path]).to eq(share_preview_path(form.id))
+            end
+          end
+        end
+      end
+
+      describe "make live task" do
+        context "when the form is in an active group" do
+          let(:group_status) { :active }
+
+          context "and the user can administer the group" do
+            let(:can_make_form_live) { true }
+            let(:can_administer_group) { true }
+
+            it "has link to make the form live" do
+              expect(section_rows.second[:task_name]).to eq "Make your form live"
+              expect(section_rows.second[:path]).to eq "/forms/1/make-live"
+            end
+
+            context "when form is ready to make live" do
+              let(:form) { build(:form, :ready_for_live, id: 1) }
+
+              it "has link to make the form live" do
+                expect(section_rows.second[:task_name]).to eq "Make your form live"
+                expect(section_rows.second[:path]).to eq "/forms/1/make-live"
+              end
+
+              it "has the correct default status" do
+                expect(section_rows.second[:status]).to eq :not_started
+              end
+            end
+
+            context "when form is live" do
+              before do
+                allow(form).to receive(:is_live?).and_return(true)
+              end
+
+              it "has tasks" do
+                expect(section_rows).not_to be_empty
+              end
+
+              it "describes the section title correctly" do
+                expect(section[:title]).to eq I18n.t("forms.task_list_edit.make_form_live_section.make_live")
+              end
+
+              it "describes the task correctly" do
+                expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_edit.make_form_live_section.make_live")
+              end
+            end
+
+            context "when the form is archived" do
+              let(:form) { build(:form, :archived, id: 1) }
+
+              it "has link to make the form live" do
+                expect(section_rows.second[:task_name]).to eq "Make your form live"
+                expect(section_rows.second[:path]).to eq "/forms/1/make-live"
+              end
+            end
           end
         end
       end

--- a/spec/services/form_task_list_service_spec.rb
+++ b/spec/services/form_task_list_service_spec.rb
@@ -57,7 +57,7 @@ describe FormTaskListService do
       it "returns counts of tasks" do
         result = described_class.new(form:, current_user:)
 
-        expected_hash = { completed: 5, total: 9 }
+        expected_hash = { completed: 6, total: 10 }
         expect(EmailTaskStatusService).to have_received(:new)
         expect(result.task_counts).to eq expected_hash
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/QuqK5jmG/1867-add-new-task-to-share-a-preview-of-your-draft-form-for-drafts-of-new-live-and-archived-forms

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Adds the new share preview task to the task list. We previously added the page (https://github.com/alphagov/forms-admin/pull/1504) and the make live validation (https://github.com/alphagov/forms-admin/pull/1513) for this feature so this PR just covers:
- Adding the new item to the task list
- Including the task in the task count
- adding a feature test

The task will be made mandatory in the corresponding forms-api PR: https://github.com/alphagov/forms-api/pull/599

### Screenshots
![Screenshot of the make form live section on the task list page, showing the new task 'Share a preview of your draft form' with status 'not started'.](https://github.com/user-attachments/assets/dd7bf399-0889-4fb1-ba57-e83d3b628199)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
