### PR TITLE
Improve have_been_updated RSpec matcher

### DIFF
--- a/spec/requests/forms/contact_details_controller_spec.rb
+++ b/spec/requests/forms/contact_details_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Forms::ContactDetailsController, type: :request do
       end
 
       it "updates the form on the API" do
-        expect(updated_form).to have_been_updated
+        expect(form).to have_been_updated_to(updated_form)
       end
 
       it "redirects to the confirmation page" do
@@ -83,7 +83,7 @@ RSpec.describe Forms::ContactDetailsController, type: :request do
       end
 
       it "does not update the form on the API" do
-        expect(updated_form).not_to have_been_updated
+        expect(form).not_to have_been_updated
       end
 
       it "shows the error state" do
@@ -100,7 +100,7 @@ RSpec.describe Forms::ContactDetailsController, type: :request do
       end
 
       it "does not update the form on the API" do
-        expect(updated_form).not_to have_been_updated
+        expect(form).not_to have_been_updated
       end
 
       it "shows the error state" do
@@ -129,7 +129,7 @@ RSpec.describe Forms::ContactDetailsController, type: :request do
       end
 
       it "updates the form on the API" do
-        expect(updated_form).to have_been_updated
+        expect(form).to have_been_updated_to(updated_form)
       end
 
       it "redirects to the confirmation page" do

--- a/spec/requests/forms/payment_link_controller_spec.rb
+++ b/spec/requests/forms/payment_link_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Forms::PaymentLinkController, type: :request do
     end
 
     it "Updates the form on the API" do
-      expect(updated_form).to have_been_updated
+      expect(form).to have_been_updated_to(updated_form)
     end
 
     it "Redirects you to the form overview page" do

--- a/spec/requests/forms/privacy_policy_controller_spec.rb
+++ b/spec/requests/forms/privacy_policy_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Forms::PrivacyPolicyController, type: :request do
     end
 
     it "Updates the form on the API" do
-      expect(updated_form).to have_been_updated
+      expect(form).to have_been_updated_to(updated_form)
     end
 
     it "Redirects you to the form overview page" do

--- a/spec/requests/forms/receive_csv_controller_spec.rb
+++ b/spec/requests/forms/receive_csv_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Forms::ReceiveCsvController, type: :request do
       end
 
       it "Updates the form on the API" do
-        expect(updated_form).to have_been_updated
+        expect(form).to have_been_updated_to(updated_form)
       end
 
       it "Redirects you to the form overview page" do

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
     end
 
     it "Updates the form on the API" do
-      expect(updated_form).to have_been_updated
+      expect(form).to have_been_updated_to(updated_form)
     end
 
     it "Redirects you to the form overview page" do

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe FormsController, type: :request do
     end
 
     it "Updates the form on the API" do
-      expect(updated_form).to have_been_updated
+      expect(form).to have_been_updated_to(updated_form)
     end
 
     it "Redirects you to the form overview page" do

--- a/spec/support/matchers/active_resource/have_been_updated.rb
+++ b/spec/support/matchers/active_resource/have_been_updated.rb
@@ -1,11 +1,9 @@
 RSpec::Matchers.define :have_been_updated do
   match do |resource|
     expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
-    expected_request = ActiveResource::Request.new(:put, expected_request_path, resource.to_json)
     matched_request = ActiveResource::HttpMock.requests.find do |request|
-      request.method == expected_request.method &&
-        request.path == expected_request.path &&
-        JSON.parse(request.body) == JSON.parse(expected_request.body)
+      request.method == :put &&
+        request.path == expected_request_path
     end
 
     !matched_request.nil?
@@ -13,8 +11,16 @@ RSpec::Matchers.define :have_been_updated do
 
   failure_message do |resource|
     expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
-    expected_request = ActiveResource::Request.new(:put, expected_request_path, resource.to_json)
+    expected_request = ActiveResource::Request.new(:put, expected_request_path)
 
     HelperMethods.format_failure_message(resource, expected_request, ActiveResource::HttpMock.requests)
+  end
+
+  failure_message_when_negated do |resource|
+    msg = []
+    msg << "Expected #{resource.class} with ID #{resource.id} not to have been updated, but found a request to update it."
+    msg << "The following requests have been made:"
+    msg << ActiveResource::HttpMock.requests.to_s
+    msg.join("\r\n")
   end
 end

--- a/spec/support/matchers/active_resource/have_been_updated_to.rb
+++ b/spec/support/matchers/active_resource/have_been_updated_to.rb
@@ -1,0 +1,20 @@
+RSpec::Matchers.define :have_been_updated_to do |updated_resource|
+  match do |resource|
+    expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
+    expected_request = ActiveResource::Request.new(:put, expected_request_path, updated_resource.to_json)
+    matched_request = ActiveResource::HttpMock.requests.find do |request|
+      request.method == expected_request.method &&
+        request.path == expected_request.path &&
+        JSON.parse(request.body) == JSON.parse(expected_request.body)
+    end
+
+    !matched_request.nil?
+  end
+
+  failure_message do |resource|
+    expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
+    expected_request = ActiveResource::Request.new(:put, expected_request_path, resource.to_json)
+
+    HelperMethods.format_failure_message(resource, expected_request, ActiveResource::HttpMock.requests)
+  end
+end

--- a/spec/support/matchers/negated_matchers/not_have_been_updated.rb
+++ b/spec/support/matchers/negated_matchers/not_have_been_updated.rb
@@ -1,1 +1,0 @@
-RSpec::Matchers.define_negated_matcher :not_have_been_updated, :have_been_updated


### PR DESCRIPTION
### What problem does this pull request solve?

This matcher was confusing, because it accepted the updated version of the resource as the subject of the matcher. It makes more sense to accept the version of the resource we expect to be updated as the subject of the matcher, and the version of the resource we expect it to be updated to as an argument.

Add a `have_been_updated_to` matcher that accepts the resource we expect in the PUT request body as an argument. This is called like:

```
expect(form).to have_been_updated_to(updated_form)
```

Keep a matcher named `have_been_updated` that will check whether a PUT request with any body has been made for the resource. The main use for this is to use the negated matcher.

When we call `.not_to have_been_updated`, this expectaction should fail if any PUT request was made for the resource. Previously, however, this expecation passed if there was a PUT request made but it had a different request body to that constructed from the subject of the expectation.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
