### PR TITLE
Prevent browser default behaviour when copy button is clicked

### DIFF
--- a/app/frontend/javascript/copy-to-clipboard/index.js
+++ b/app/frontend/javascript/copy-to-clipboard/index.js
@@ -20,7 +20,8 @@ const copyToClipboard = (element, copyTarget, buttonText) => {
   if (navigator?.clipboard?.writeText) {
     const button = createButton(buttonText)
     try {
-      button.addEventListener('click', () => {
+      button.addEventListener('click', event => {
+        event.preventDefault()
         navigator.clipboard.writeText(copyTarget.textContent.trim())
       })
       element.appendChild(button)

--- a/app/frontend/javascript/copy-to-clipboard/index.test.js
+++ b/app/frontend/javascript/copy-to-clipboard/index.test.js
@@ -39,4 +39,12 @@ describe('Copy to clipboard', () => {
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('It worked!')
   })
+
+  test('the click event calls event.preventDefault', () => {
+    const event = new window.Event('click')
+    event.preventDefault = vi.fn()
+    document.querySelector('button').dispatchEvent(event)
+
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
In the copy to clipboard javascript, we create a button and attach a click event handler to it which writes to the user's clipboard. However, this button also has default behaviour defined by the browser.

One of those default button behaviours is that when the button is inside a form, clicking it will submit the form. We don't want the clipboard button to do this, so this PR adds `event.preventDefault` to the click event handler to turn this behaviour off.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
