### PR TITLE
Show an ordered list of forms from a form creator's groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,7 +22,8 @@ class GroupsController < ApplicationController
   # GET /groups/1
   def show
     authorize @group
-    @forms = @group.group_forms.map(&:form)
+    forms = @group.group_forms.map(&:form)
+    @form_list_presenter = FormListPresenter.call(forms:, group: @group) unless forms.empty?
   end
 
   # GET /groups/new

--- a/app/presenters/form_list_presenter.rb
+++ b/app/presenters/form_list_presenter.rb
@@ -43,7 +43,7 @@ private
   end
 
   def rows
-    forms.sort_by(&:name).map do |form|
+    forms.sort_by { |form| [form.name.downcase, form.created_at] }.map do |form|
       [{ text: form_name_link(form) },
        { text: find_creator_name(form) },
        { text: form_status_tags(form), numeric: true }].compact

--- a/app/presenters/form_list_presenter.rb
+++ b/app/presenters/form_list_presenter.rb
@@ -1,4 +1,4 @@
-class FormListService
+class FormListPresenter
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
   include GovukRailsCompatibleLinkHelper

--- a/app/presenters/form_list_presenter.rb
+++ b/app/presenters/form_list_presenter.rb
@@ -43,7 +43,7 @@ private
   end
 
   def rows
-    forms.map do |form|
+    forms.sort_by(&:name).map do |form|
       [{ text: form_name_link(form) },
        { text: find_creator_name(form) },
        { text: form_status_tags(form), numeric: true }].compact

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -57,6 +57,6 @@
 
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_group_form_path(@group)) %>
 
-<% if @forms.any? %>
-  <%= govuk_table(**FormListService.call(forms: @forms, group: @group).data) %>
+<% if @form_list_presenter %>
+  <%= govuk_table(**@form_list_presenter.data) %>
 <% end %>

--- a/spec/features/account/complete_user_account_spec.rb
+++ b/spec/features/account/complete_user_account_spec.rb
@@ -4,7 +4,7 @@ feature "Add account organisation to user without organisation", type: :feature 
   let(:user) { create :user, :with_no_org, name: nil, terms_agreed_at: nil }
   let!(:organisation) { create :organisation }
 
-  let(:form) { build :form, :with_active_resource, id: 1, name: "a form I created when I didn't have an organisation" }
+  let(:form) { build :form, :with_active_resource, id: 1, name: "a form I created when I didn't have an organisation", created_at: "2024-10-08T07:31:15.762Z" }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/features/form/create_or_edit_a_form_spec.rb
+++ b/spec/features/form/create_or_edit_a_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Create or edit a form", type: :feature do
-  let(:form) { build :form, :with_active_resource, id: 1, name: "Apply for a juggling license" }
+  let(:form) { build :form, :with_active_resource, id: 1, name: "Apply for a juggling license", created_at: "2024-10-08T07:31:15.762Z" }
   let(:group) { create :group, name: "Group 1" }
 
   before do

--- a/spec/presenters/form_list_presenter_spec.rb
+++ b/spec/presenters/form_list_presenter_spec.rb
@@ -4,7 +4,7 @@ describe FormListPresenter do
   let(:presenter) { described_class.call(forms:, group:) }
 
   let(:creator) { create :user }
-  let(:forms) { build_list :form, 5, :with_id, creator_id: creator.id }
+  let(:forms) { build_list :form, 5, :with_id, creator_id: creator.id, created_at: "2024-10-08T07:31:15.762Z" }
   let(:group) { build :group }
 
   describe "#data" do
@@ -44,9 +44,10 @@ describe FormListPresenter do
       context "when forms with names are random" do
         let(:forms) do
           [
-            build(:form, id: 1, name: "z"),
-            build(:form, id: 2, name: "b"),
-            build(:form, id: 3, name: "a"),
+            build(:form, id: 1, name: "z", created_at: "2024-10-08T07:31:15.762Z"),
+            build(:form, id: 2, name: "b", created_at: "2024-10-08T07:31:15.762Z"),
+            build(:form, id: 3, name: "a", created_at: "2024-10-08T07:31:15.762Z"),
+            build(:form, id: 4, name: "C", created_at: "2024-10-08T07:31:15.762Z"),
           ]
         end
         let(:presenter) { described_class.call(forms:, group:) }
@@ -55,7 +56,28 @@ describe FormListPresenter do
           rows = presenter.data[:rows]
           expect(rows[0][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/3\">a</a>")
           expect(rows[1][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/2\">b</a>")
-          expect(rows[2][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/1\">z</a>")
+          expect(rows[2][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/4\">C</a>")
+          expect(rows[3][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/1\">z</a>")
+        end
+      end
+
+      context "when multiple forms have the same name" do
+        let(:forms) do
+          [
+            build(:form, id: 1, name: "a", created_at: "2024-10-08T07:31:15.762Z"),
+            build(:form, id: 2, name: "b", created_at: "2024-10-08T07:31:15.762Z"),
+            build(:form, id: 3, name: "a", created_at: "2024-10-08T08:31:15.762Z"),
+            build(:form, id: 4, name: "a", created_at: "2024-10-08T09:31:15.762Z"),
+          ]
+        end
+        let(:presenter) { described_class.call(forms:, group:) }
+
+        it "sorts alphabetically first, then by created_at time" do
+          rows = presenter.data[:rows]
+          expect(rows[0][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/1\">a</a>")
+          expect(rows[1][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/3\">a</a>")
+          expect(rows[2][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/4\">a</a>")
+          expect(rows[3][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/2\">b</a>")
         end
       end
     end

--- a/spec/presenters/form_list_presenter_spec.rb
+++ b/spec/presenters/form_list_presenter_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-describe FormListService do
-  let(:service) { described_class.call(forms:, group:) }
+describe FormListPresenter do
+  let(:presenter) { described_class.call(forms:, group:) }
 
   let(:creator) { create :user }
   let(:forms) { build_list :form, 5, :with_id, creator_id: creator.id }
@@ -10,25 +10,25 @@ describe FormListService do
   describe "#data" do
     describe "caption" do
       it "returns caption containing group name" do
-        expect(service.data).to include caption: I18n.t("groups.form_table_caption", group_name: group.name)
+        expect(presenter.data).to include caption: I18n.t("groups.form_table_caption", group_name: group.name)
       end
     end
 
     describe "head" do
       it "contains a 'Name', `Created by` and 'Status' column heading" do
-        expect(service.data[:head]).to eq([I18n.t("home.form_name_heading"),
-                                           { text: I18n.t("home.created_by") },
-                                           { text: I18n.t("home.form_status_heading"), numeric: true }])
+        expect(presenter.data[:head]).to eq([I18n.t("home.form_name_heading"),
+                                             { text: I18n.t("home.created_by") },
+                                             { text: I18n.t("home.form_status_heading"), numeric: true }])
       end
     end
 
     describe "rows" do
-      it "has a row for each form passed to the service" do
-        expect(service.data[:rows].size).to eq forms.size
+      it "has a row for each form passed to the presenter" do
+        expect(presenter.data[:rows].size).to eq forms.size
       end
 
       it "returns the correct data for each form" do
-        service.data[:rows].each_with_index do |row, index|
+        presenter.data[:rows].each_with_index do |row, index|
           form = forms[index]
           expect(row).to eq([
             { text: "<a class=\"govuk-link\" href=\"/forms/#{form.id}\">#{form.name}</a>" },

--- a/spec/presenters/form_list_presenter_spec.rb
+++ b/spec/presenters/form_list_presenter_spec.rb
@@ -40,6 +40,24 @@ describe FormListPresenter do
           ])
         end
       end
+
+      context "when forms with names are random" do
+        let(:forms) do
+          [
+            build(:form, id: 1, name: "z"),
+            build(:form, id: 2, name: "b"),
+            build(:form, id: 3, name: "a"),
+          ]
+        end
+        let(:presenter) { described_class.call(forms:, group:) }
+
+        it "sorts alphabetically" do
+          rows = presenter.data[:rows]
+          expect(rows[0][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/3\">a</a>")
+          expect(rows[1][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/2\">b</a>")
+          expect(rows[2][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/1\">z</a>")
+        end
+      end
     end
   end
 end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -160,9 +160,8 @@ RSpec.describe "/groups", type: :request do
         expect(response).to be_successful
       end
 
-      it "shows the forms in the group" do
+      it "assigns a list of forms in the group to present" do
         forms = build_list(:form, 3) { |form, i| form.id = i }
-
         ActiveResource::HttpMock.respond_to do |mock|
           headers = { "X-API-Token" => Settings.forms_api.auth_key, "Accept" => "application/json" }
           forms.each do |form|
@@ -173,8 +172,10 @@ RSpec.describe "/groups", type: :request do
         member_group.group_forms << forms.map { |form| GroupForm.create! form_id: form.id, group_id: member_group.id }
         member_group.save!
 
+        form_list_presenter = FormListPresenter.call(forms:, group: member_group)
+
         get group_url(member_group)
-        expect(assigns[:forms]).to match_array(forms)
+        expect(assigns[:form_list_presenter].data[:rows]).to match_array(form_list_presenter.data[:rows])
       end
     end
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe "/groups", type: :request do
       end
 
       it "assigns a list of forms in the group to present" do
-        forms = build_list(:form, 3) { |form, i| form.id = i }
+        forms = build_list(:form, 3, created_at: "2024-10-08T07:31:15.762Z") { |form, i| form.id = i }
         ActiveResource::HttpMock.respond_to do |mock|
           headers = { "X-API-Token" => Settings.forms_api.auth_key, "Accept" => "application/json" }
           forms.each do |form|

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe "groups/show", type: :view do
   context "when the group has one of more forms" do
     let(:forms) do
       [
-        build(:form, id: 1, name: "Form 1"),
-        build(:form, :live, id: 2, name: "Form 2"),
-        build(:form, :live_with_draft, id: 3, name: "Form 3"),
+        build(:form, id: 1, name: "Form 1", created_at: "2024-10-08T07:31:15.762Z"),
+        build(:form, :live, id: 2, name: "Form 2", created_at: "2024-10-08T07:31:15.762Z"),
+        build(:form, :live_with_draft, id: 3, name: "Form 3", created_at: "2024-10-08T07:31:15.762Z"),
       ]
     end
 

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "groups/show", type: :view do
   let(:forms) { [] }
   let(:group) { create :group, name: "My Group" }
 
+  let(:form_list_presenter) { FormListPresenter.call(forms:, group:) }
+
   let(:membership_role) { :editor }
   let(:upgrade?) { false }
   let(:edit?) { true }
@@ -17,14 +19,16 @@ RSpec.describe "groups/show", type: :view do
     assign(:current_user, current_user)
     assign(:group, group)
     assign(:forms, forms)
+    assign(:form_list_presenter, form_list_presenter)
 
     without_partial_double_verification do
-      double = instance_double(GroupPolicy,
-                               upgrade?: upgrade?,
-                               edit?: edit?,
-                               request_upgrade?: request_upgrade?,
-                               review_upgrade?: review_upgrade?)
-      allow(view).to receive(:policy).and_return(double)
+      policy_double = instance_double(GroupPolicy,
+                                      upgrade?: upgrade?,
+                                      edit?: edit?,
+                                      request_upgrade?: request_upgrade?,
+                                      review_upgrade?: review_upgrade?)
+
+      allow(view).to receive(:policy).and_return(policy_double)
     end
 
     render
@@ -59,7 +63,9 @@ RSpec.describe "groups/show", type: :view do
   end
 
   context "when the group has no forms" do
-    let(:forms) { [] }
+    let(:form_list_presenter) { nil }
+
+    before { assign(:form_list_presenter, form_list_presenter) }
 
     it "does not have a table of forms" do
       expect(rendered).not_to have_table


### PR DESCRIPTION
## What problem does this pull request solve?

Trello card: https://trello.com/c/0ObcUSir

The list of forms was appearing as they are returned by the API which doesn't make sense to the user. This PR applies alphabetical sorting.

## Before
![localhost_3000_groups_NBgwE3D4](https://github.com/user-attachments/assets/dd90736d-d2ce-42d1-9e75-dd837cddeadb)


## After
![localhost_3000_groups_NBgwE3D4 (1)](https://github.com/user-attachments/assets/e3abe6e2-bbf5-44b7-b00f-99cab7a55c0f)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
