### PR TITLE
Add make live validation for share preview status

### DIFF
--- a/config/locales/input_objects/make_live.yml
+++ b/config/locales/input_objects/make_live.yml
@@ -11,3 +11,4 @@ en:
               missing_submission_email: You cannot make your form live because it does not have an email address to send completed forms to. Answer ‘No’ and add an email address.
               missing_what_happens_next: You cannot make your form live because it does not have information about what happens next. Answer ‘No’ and add information about what happens next.
               missing_contact_details: You cannot make your form live because it does not have contact details. Answer ‘No’ and add contact details.
+              share_preview_not_completed: You cannot make your form live because you have not completed the ‘share a preview of your draft form‘ task. Answer ‘No’ and complete the task.

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     has_routing_errors { false }
     creator_id { nil }
     ready_for_live { false }
-    incomplete_tasks { %i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next] }
+    incomplete_tasks { %i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed] }
     state { :draft }
 
     transient do

--- a/spec/input_objects/forms/make_live_input_spec.rb
+++ b/spec/input_objects/forms/make_live_input_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe Forms::MakeLiveInput, type: :model do
         expect(make_live_input).not_to be_valid
         expect(make_live_input.errors.full_messages_for(:confirm)).to include("Confirm #{I18n.t('activemodel.errors.models.forms/make_live_input.attributes.confirm.missing_submission_email')}")
       end
+
+      context "when the API returns incomplete tasks" do
+        let(:incomplete_tasks) { %i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed] }
+
+        before do
+          make_live_input.form.incomplete_tasks = incomplete_tasks
+        end
+
+        it "shows a validation message for the incomplete task" do
+          expect(make_live_input).not_to be_valid
+
+          incomplete_tasks.each do |incomplete_task_name|
+            expect(make_live_input.errors.full_messages_for(:confirm)).to include("Confirm #{I18n.t("activemodel.errors.models.forms/make_live_input.attributes.confirm.#{incomplete_task_name}")}")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -60,7 +60,7 @@ describe Form, type: :model do
       let(:new_form) { build :form, :new_form }
 
       it "returns a set of keys related to missing fields" do
-        expect(new_form.all_incomplete_tasks).to match_array(%i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details missing_what_happens_next])
+        expect(new_form.all_incomplete_tasks).to match_array(%i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed])
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/QuqK5jmG/1867-add-new-task-to-share-a-preview-of-your-draft-form-for-drafts-of-new-live-and-archived-forms#comment-670921da24e1e3431e7b696c

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds a validation message when the user tries to make the form live without completing the share preview task first.

This should be merged before https://github.com/alphagov/forms-api/pull/599 or users will potentially see an unfriendly error message.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
