### PR TITLE
Adjust spacing on share preview page

### DIFF
--- a/app/views/forms/share_preview/new.html.erb
+++ b/app/views/forms/share_preview/new.html.erb
@@ -22,7 +22,7 @@
         <%= t("share_preview.body_html") %>
       </div>
 
-      <div class="govuk-!-margin-bottom-4">
+      <div class="govuk-!-margin-bottom-8">
         <%= render FormUrlComponent::View.new(runner_link: link_to_runner(Settings.forms_runner.url, @share_preview_input.form.id, @share_preview_input.form.form_slug, mode: :preview_draft),
                                               heading_text: t("share_preview.preview_link_heading"),
                                               button_text: t("share_preview.preview_link_button")) %>


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/QuqK5jmG/1867-add-new-task-to-share-a-preview-of-your-draft-form-for-drafts-of-new-live-and-archived-forms

Increase the spacing so it looks better when JavaScript is disabled, and so the copy to clipboard button doesn't show.

With JavaScript enabled:

<img width="1100" alt="Screenshot 2024-10-16 at 11 21 04" src="https://github.com/user-attachments/assets/80ea742c-92a6-43ff-90e7-38599834af2f">

With JavaScript disabled:

<img width="1100" alt="Screenshot 2024-10-16 at 11 21 33" src="https://github.com/user-attachments/assets/09750ee0-8bc1-4691-be54-7c70ce0c25cf">


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
