### PR TITLE
Log actual user when super admin is acting as another user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,9 +43,19 @@ class ApplicationController < ActionController::Base
     CurrentLoggingAttributes.trace_id = request.env["HTTP_X_AMZN_TRACE_ID"].presence
     CurrentLoggingAttributes.user_ip = user_ip(request.env.fetch("HTTP_X_FORWARDED_FOR", ""))
     if current_user.present?
-      CurrentLoggingAttributes.user_id = current_user.id
-      CurrentLoggingAttributes.user_email = current_user.email
-      CurrentLoggingAttributes.user_organisation_slug = current_user.organisation&.slug
+      if acting_as?
+        CurrentLoggingAttributes.user_id = actual_user.id
+        CurrentLoggingAttributes.user_email = actual_user.email
+        CurrentLoggingAttributes.user_organisation_slug = actual_user.organisation&.slug
+
+        CurrentLoggingAttributes.acting_as_user_id = acting_as_user.id
+        CurrentLoggingAttributes.acting_as_user_email = acting_as_user.email
+        CurrentLoggingAttributes.acting_as_user_organisation_slug = acting_as_user.organisation&.slug
+      else
+        CurrentLoggingAttributes.user_id = current_user.id
+        CurrentLoggingAttributes.user_email = current_user.email
+        CurrentLoggingAttributes.user_organisation_slug = current_user.organisation&.slug
+      end
     end
     CurrentLoggingAttributes.form_id = params[:form_id] if params[:form_id].present?
     CurrentLoggingAttributes.page_id = params[:page_id] if params[:page_id].present?
@@ -78,6 +88,18 @@ class ApplicationController < ActionController::Base
 
   def current_user
     warden.user if user_signed_in
+  end
+
+  def acting_as?
+    session[:acting_as_user_id].present?
+  end
+
+  def actual_user
+    @actual_user ||= User.find(session[:original_user_id]) if acting_as?
+  end
+
+  def acting_as_user
+    current_user if acting_as?
   end
 
   def authenticate_user!

--- a/app/models/current_logging_attributes.rb
+++ b/app/models/current_logging_attributes.rb
@@ -1,4 +1,6 @@
 class CurrentLoggingAttributes < ActiveSupport::CurrentAttributes
-  attribute :host, :request_id, :session_id_hash, :trace_id, :user_ip, :user_id, :user_email, :user_organisation_slug,
-            :form_id, :page_id
+  attribute :host, :request_id, :session_id_hash, :trace_id, :user_ip,
+            :user_id, :user_email, :user_organisation_slug, :acting_as_user_id,
+            :acting_as_user_email, :acting_as_user_organisation_slug, :form_id,
+            :page_id
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -193,6 +193,38 @@ RSpec.describe ApplicationController, type: :request do
       it "adds the acting as user ID to the session" do
         expect(session["acting_as_user_id"]).to eq acting_as_user.id
       end
+
+      describe "logging" do
+        before do
+          allow(Lograge).to receive(:logger).and_return(logger)
+
+          get root_path
+        end
+
+        it "includes the acting as user id on log lines" do
+          expect(log_lines[0]["acting_as_user_id"]).to eq(acting_as_user.id)
+        end
+
+        it "includes the acting as user email on log lines" do
+          expect(log_lines[0]["acting_as_user_email"]).to eq(acting_as_user.email)
+        end
+
+        it "includes the acting as user organisation_slug on log lines" do
+          expect(log_lines[0]["acting_as_user_organisation_slug"]).to eq(acting_as_user.organisation.slug)
+        end
+
+        it "includes the actual user id on log lines" do
+          expect(log_lines[0]["user_id"]).to eq(super_admin_user.id)
+        end
+
+        it "includes the actual user email on log lines" do
+          expect(log_lines[0]["user_email"]).to eq(super_admin_user.email)
+        end
+
+        it "includes the actual user organisation_slug on log lines" do
+          expect(log_lines[0]["user_organisation_slug"]).to eq(super_admin_user.organisation.slug)
+        end
+      end
     end
   end
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -172,6 +172,30 @@ RSpec.describe ApplicationController, type: :request do
     end
   end
 
+  describe "act as user" do
+    context "when a super admin is acting as another user" do
+      let(:actual_user) { super_admin_user }
+      let(:acting_as_user) { create :user }
+
+      before do
+        allow(Settings).to receive(:act_as_user_enabled).and_return(true)
+
+        login_as_super_admin_user actual_user
+
+        post act_as_user_start_path(acting_as_user.id)
+        follow_redirect!
+      end
+
+      it "adds the super admin user ID to the session" do
+        expect(session["original_user_id"]).to eq actual_user.id
+      end
+
+      it "adds the acting as user ID to the session" do
+        expect(session["acting_as_user_id"]).to eq acting_as_user.id
+      end
+    end
+  end
+
   describe "#up" do
     it "returns http code 200" do
       get rails_health_check_path

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -50,8 +50,8 @@ module AuthenticationFeatureHelpers
     @standard_user ||= FactoryBot.create(:user, :standard, organisation: test_org)
   end
 
-  def login_as_super_admin_user
-    login_as super_admin_user
+  def login_as_super_admin_user(user = nil)
+    login_as(user || super_admin_user)
 
     # All super-admins should have logged in via Auth0 with the Google workspace login
     Warden.on_next_request do |proxy|


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to make sure that when the "Act as user" feature is used that our logs don't confuse the actions taken by the actual user with something done by the user they are acting as.

This is especially important for some operations such as signing an MoU, as it could have legal ramifications if our logs make it look like a person has done something that was actually done by a super admin.

This commit changes our logging so that if a super admin is acting as another user we log the super admin's details.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?