### PR TITLE
Display CSV submissions in features report

### DIFF
--- a/app/views/reports/features.html.erb
+++ b/app/views/reports/features.html.erb
@@ -22,6 +22,10 @@
         <%= row.with_key(text: t(".features.live_forms_with_add_another_answer")) %>
         <%= row.with_value(text: data.live_forms_with_add_another_answer) %>
       <%end%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".features.live_forms_with_csv_submission_enabled")) %>
+        <%= row.with_value(text: data.live_forms_with_csv_submission_enabled) %>
+      <%end%>
     <%end%>
 
     <h2 class="govuk-heading-m govuk-visually-hidden"><%= t(".answer_types.heading") %></h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1165,6 +1165,7 @@ en:
       features:
         heading: Feature usage
         live_forms_with_add_another_answer: Live forms with add another answer
+        live_forms_with_csv_submission_enabled: Live forms with CSV submission enabled
         live_forms_with_payments: Live forms with payments
         live_forms_with_routes: Live forms with routes
         total_live_forms: Total live forms

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe ReportsController, type: :request do
                                      text: 5 },
       live_forms_with_payment: 1,
       live_forms_with_routing: 2,
-      live_forms_with_add_another_answer: 3 }
+      live_forms_with_add_another_answer: 3,
+      live_forms_with_csv_submission_enabled: 2 }
   end
 
   before do

--- a/spec/views/reports/features.html.erb_spec.rb
+++ b/spec/views/reports/features.html.erb_spec.rb
@@ -25,7 +25,8 @@ describe "reports/features.html.erb" do
                                                 text: 5 },
                  live_forms_with_payment: 1,
                  live_forms_with_routing: 2,
-                 live_forms_with_add_another_answer: 3 })
+                 live_forms_with_add_another_answer: 3,
+                 live_forms_with_csv_submission_enabled: 2 })
   end
 
   before do
@@ -71,7 +72,8 @@ describe "reports/features.html.erb" do
                    live_pages_with_answer_type: { address: 1 },
                    live_forms_with_payment: 1,
                    live_forms_with_routing: 2,
-                   live_forms_with_add_another_answer: 3 })
+                   live_forms_with_add_another_answer: 3,
+                   live_forms_with_csv_submission_enabled: 2 })
     end
 
     it "displays 0 for live_forms_with_answer_type" do
@@ -93,5 +95,9 @@ describe "reports/features.html.erb" do
 
   it "includes the number of live forms with add another answer" do
     expect(rendered).to have_css(".govuk-summary-list__row", text: "Live forms with add another answer#{report.live_forms_with_add_another_answer}")
+  end
+
+  it "includes the number of live forms with CSV submission enabled" do
+    expect(rendered).to have_css(".govuk-summary-list__row", text: "Live forms with CSV submission enabled#{report.live_forms_with_csv_submission_enabled}")
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->None, followup from the additional submission types work

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds the number of forms which have CSV submissions enabled to the features report.

![Screenshot of features report showing new 'Live forms with CSV submission enabled' row with value 2](https://github.com/user-attachments/assets/e15d91aa-dadf-4823-bf39-4dc4023f8f4d)


Needs https://github.com/alphagov/forms-api/pull/607 to be merged first.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
