### PR TITLE
Add rake task to remove an empty group

### DIFF
--- a/spec/lib/tasks/groups.rake_spec.rb
+++ b/spec/lib/tasks/groups.rake_spec.rb
@@ -247,4 +247,50 @@ RSpec.describe "groups.rake" do
       end
     end
   end
+
+  describe "groups:remove_group" do
+    subject(:task) { Rake::Task["groups:remove_group"].tap(&:reenable) }
+
+    it "with correct arguments removes the group" do
+      group = create(:group)
+
+      expect {
+        task.invoke(group.external_id)
+      }.to change(Group, :count).by(-1)
+    end
+
+    it "with no arguments raises an error" do
+      expect {
+        task.invoke
+      }.to raise_error(SystemExit)
+    end
+
+    it "with invalid group id raises an error" do
+      invalid_args = %w[some_id_that_does_not_exist]
+      expect {
+        task.invoke(*invalid_args)
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "with group that has forms raises an error" do
+      group = create(:group)
+      group.group_forms.create!(form_id: 1)
+      group.save!
+      expect {
+        task.invoke(group.external_id)
+      }.to raise_error(SystemExit)
+    end
+  end
+
+  describe "groups:remove_group_dry_run" do
+    subject(:task) { Rake::Task["groups:remove_group_dry_run"].tap(&:reenable) }
+
+    it "with correct arguments does not remove the group" do
+      group = create(:group)
+
+      expect {
+        task.invoke(group.external_id)
+      }.not_to change(Group, :count)
+    end
+  end
 end


### PR DESCRIPTION
# Delete two trial groups made in error

### What problem does this pull request solve?

Trello card: https://trello.com/c/uwpvcpyz/1889-delete-2-trial-groups-from-dvsa-made-in-error

When users create groups they don't want, we need a way to remove them
from the organisation and remove them. This can happen if a user selects
the wrong organisation at login.

This commit adds a simple rake task to remove a group when given a group
external id.

The group must not contain any forms. This avoids any complications
about what should happen to those forms.

To remove a group which has forms, remove the forms first.


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
