### PR TITLE
Add report page for all forms with add another answer

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,4 +20,12 @@ class ReportsController < ApplicationController
 
     render locals: { data: }
   end
+
+  def add_another_answer
+    authorize Report, :can_view_reports?
+
+    data = Report.find("features")
+
+    render template: "reports/add_another_answer", locals: { data: }
+  end
 end

--- a/app/views/reports/add_another_answer.html.erb
+++ b/app/views/reports/add_another_answer.html.erb
@@ -1,0 +1,28 @@
+<% set_page_title(t(".title")) %>
+<% content_for :back_link, govuk_back_link_to(reports_path, t("reports.back_link")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+    <h2 class="govuk-heading-m govuk-visually-hidden"><%= t(".heading") %></h2>
+    <%= govuk_table do |table| %>
+
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: t(".add_another_answer.table_headings.form_name")) %>
+          <%= row.with_cell(text: t(".add_another_answer.table_headings.question_text")) %>
+        <%end%>
+      <%end%>
+      <%= table.with_body do |body| %>
+        <% data.all_forms_with_add_another_answer.each do |form| %>
+          <% form.repeatable_pages.each do |question| %>
+            <%= body.with_row do |row| %>
+              <%= row.with_cell(text: govuk_link_to(form.name, form_url(form.form_id))) %>
+              <%= row.with_cell(text: question.question_text) %>
+            <%end%>
+          <%end%>
+        <%end%>
+      <%end%>
+    <%end%>
+  </div>
+</div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -5,6 +5,7 @@
     <ul class="govuk-list">
       <li><%= govuk_link_to t("reports.features.title"), report_features_path %></li>
       <li><%= govuk_link_to t("reports.users.title"), report_users_path %></li>
+      <li><%= govuk_link_to t("reports.add_another_answer.title"), report_add_another_answer_path %></li>
     </ul>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1154,6 +1154,13 @@ en:
       </ul>
     summary_text: Help people answer this question
   reports:
+    add_another_answer:
+      add_another_answer:
+        table_headings:
+          form_name: Form name
+          question_text: Add another answer question
+      heading: All forms with add another answer
+      title: All forms with add another answer
     back_link: Back to reports
     features:
       answer_types:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ Rails.application.routes.draw do
     get "/", to: "reports#index", as: :reports
     get "features", to: "reports#features", as: :report_features
     get "users", to: "reports#users", as: :report_users
+    get "add_another_answer", to: "reports#add_another_answer", as: :report_add_another_answer
   end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ReportsController, type: :request do
+  let(:question_text) { "Question text" }
   let(:report_data) do
     { total_live_forms: 3,
       live_forms_with_answer_type: { address: 1,
@@ -26,7 +27,8 @@ RSpec.describe ReportsController, type: :request do
       live_forms_with_payment: 1,
       live_forms_with_routing: 2,
       live_forms_with_add_another_answer: 3,
-      live_forms_with_csv_submission_enabled: 2 }
+      live_forms_with_csv_submission_enabled: 2,
+      all_forms_with_add_another_answer: [{ form_id: 3, name: "form name", repeatable_pages: [{ page_id: 5, question_text: }] }] }
   end
 
   before do
@@ -190,6 +192,61 @@ RSpec.describe ReportsController, type: :request do
 
       it "renders the users report view" do
         expect(response).to render_template("reports/users")
+      end
+    end
+  end
+
+  describe "#add_another_answer" do
+    context "when the user is an editor" do
+      before do
+        login_as_standard_user
+
+        get report_add_another_answer_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is an organisation admin" do
+      before do
+        login_as_organisation_admin_user
+
+        get report_add_another_answer_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get report_add_another_answer_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the features report view" do
+        expect(response).to render_template("reports/add_another_answer")
+      end
+
+      it "includes the report data" do
+        expect(response.body).to include "All forms with add another answer"
+        expect(response.body).to include question_text
       end
     end
   end

--- a/spec/views/reports/add_another_answer.html.erb_spec.rb
+++ b/spec/views/reports/add_another_answer.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe "reports/add_another_answer.html.erb" do
+  let(:form_id) { 3 }
+  let(:name) { "Form name" }
+  let(:question_text) { "Question text" }
+  let(:report) do
+    Report.new({ all_forms_with_add_another_answer: [{ form_id:, name:, repeatable_pages: [{ page_id: 5, question_text: }] }] })
+  end
+
+  before do
+    render template: "reports/add_another_answer", locals: { data: report }
+  end
+
+  describe "page title" do
+    it "matches the heading" do
+      expect(view.content_for(:title)).to eq "All forms with add another answer"
+    end
+  end
+
+  it "has a back link to the reports page" do
+    expect(view.content_for(:back_link)).to have_link("Back to reports", href: reports_path)
+  end
+
+  it "includes the form name" do
+    expect(rendered).to have_link(name, href: form_url(form_id))
+  end
+
+  it "includes the question text" do
+    expect(rendered).to have_content(question_text)
+  end
+end


### PR DESCRIPTION
This adds a new route to the reports controller, which leads to the full report for all forms that have a repeatable question. This report shows the form with a link to that form, and has a row for each question within the form that's currently set to be repeatable.

### What problem does this pull request solve?

Trello card: https://trello.com/c/a2bMFMxU/1827-5-report-when-forms-are-using-add-another-answer-single-qn

This adds a new report to the reports controller, which leads to the full list of all forms with add another answer. This is contingent on https://github.com/alphagov/forms-api/pull/615, which sets up the report from the API's side. 

The report lists all form names with a link to that forms' edit path - and the question text for each question in that form as a separate row. 

<img width="1019" alt="image" src="https://github.com/user-attachments/assets/d7f368a1-3ba4-46fe-aae0-0d7b303f612e">


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
