### PR TITLE
Add form state column to add another answer report

### DIFF
--- a/app/views/reports/add_another_answer.html.erb
+++ b/app/views/reports/add_another_answer.html.erb
@@ -11,14 +11,16 @@
         <%= head.with_row do |row| %>
           <%= row.with_cell(text: t(".add_another_answer.table_headings.form_name")) %>
           <%= row.with_cell(text: t(".add_another_answer.table_headings.question_text")) %>
+          <%= row.with_cell(text: t(".add_another_answer.table_headings.form_state")) %>
         <%end%>
       <%end%>
       <%= table.with_body do |body| %>
-        <% data.all_forms_with_add_another_answer.each do |form| %>
+        <% data.all_forms_with_add_another_answer.sort_by(&:state).each do |form| %>
           <% form.repeatable_pages.each do |question| %>
             <%= body.with_row do |row| %>
               <%= row.with_cell(text: govuk_link_to(form.name, form_url(form.form_id))) %>
               <%= row.with_cell(text: question.question_text) %>
+              <%= row.with_cell(text: form.state.capitalize.gsub("_", " ")) %>
             <%end%>
           <%end%>
         <%end%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1158,6 +1158,7 @@ en:
       add_another_answer:
         table_headings:
           form_name: Form name
+          form_state: Form state
           question_text: Add another answer question
       heading: All forms with add another answer
       title: All forms with add another answer

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ReportsController, type: :request do
       live_forms_with_routing: 2,
       live_forms_with_add_another_answer: 3,
       live_forms_with_csv_submission_enabled: 2,
-      all_forms_with_add_another_answer: [{ form_id: 3, name: "form name", repeatable_pages: [{ page_id: 5, question_text: }] }] }
+      all_forms_with_add_another_answer: [{ form_id: 3, name: "form name", state: "Draft", repeatable_pages: [{ page_id: 5, question_text: }] }] }
   end
 
   before do

--- a/spec/views/reports/add_another_answer.html.erb_spec.rb
+++ b/spec/views/reports/add_another_answer.html.erb_spec.rb
@@ -4,8 +4,9 @@ describe "reports/add_another_answer.html.erb" do
   let(:form_id) { 3 }
   let(:name) { "Form name" }
   let(:question_text) { "Question text" }
+  let(:state) { "live_with_draft" }
   let(:report) do
-    Report.new({ all_forms_with_add_another_answer: [{ form_id:, name:, repeatable_pages: [{ page_id: 5, question_text: }] }] })
+    Report.new({ all_forms_with_add_another_answer: [{ form_id:, name:, state:, repeatable_pages: [{ page_id: 5, question_text: }] }] })
   end
 
   before do
@@ -28,5 +29,9 @@ describe "reports/add_another_answer.html.erb" do
 
   it "includes the question text" do
     expect(rendered).to have_content(question_text)
+  end
+
+  it "includes the form state with transformations" do
+    expect(rendered).to have_content(state.capitalize.gsub("_", " "))
   end
 end


### PR DESCRIPTION
Adding the state column to the report containing all forms with add another answer questions. This is to make navigating the report a bit easier. The forms are ordered by state, so they're grouped up more sensibly.

### What problem does this pull request solve?

Trello card: https://trello.com/c/a2bMFMxU/1827-report-when-forms-are-using-add-another-answer-single-qn

Adds the state column to the add another answer report. It's ordered by state, so the rows are now grouped by states. 

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/5602c2ca-bbf0-4c2b-a22e-2dfa84958888">

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
