### PR TITLE
Add a Rake task for revoking an MOU signature

### DIFF
--- a/lib/tasks/mou_signatures.rake
+++ b/lib/tasks/mou_signatures.rake
@@ -33,4 +33,23 @@ namespace :mou_signatures do
 
     puts "Updated MOU signature for User: #{user.email} and Organisation: #{current_organisation.name} to be for #{target_organisation.name}"
   end
+
+  desc "Revoke a user's signature on the MOU for an organisation"
+  task :revoke_user_signature, %i[user_email target_organisation_name] => :environment do |_, args|
+    usage = "usage: rake mou_signatures:revoke_organisation[<user_email>, <target_organisation_name>]".freeze
+    abort usage if args[:target_organisation_name].blank? || args[:user_email].blank?
+
+    user = User.find_by(email: args[:user_email])
+    abort "User with email address: #{args[:user_email]} not found" unless user
+
+    target_organisation = Organisation.find_by(name: args[:target_organisation_name])
+    abort "Organisation with name: #{args[:target_organisation_name]} not found" unless target_organisation
+
+    mou_signature = MouSignature.find_by(user:, organisation: target_organisation)
+    abort "User: #{user.email} has not signed the MOU for organisation: #{target_organisation.name}" unless mou_signature
+
+    mou_signature.delete
+
+    puts "Signature of user: #{user.email} on MOU for organisation: #{target_organisation.name} has been revoked"
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/vyL5cHJP/1933-undo-slc-mou-approval

We've had a case where an organisation has accidentally signed the MOU. When this happens, we need to be able to revoke the signature for that organisation.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
