### PR TITLE
Add edit routes

### DIFF
--- a/app/controllers/pages/routes_controller.rb
+++ b/app/controllers/pages/routes_controller.rb
@@ -1,0 +1,6 @@
+class Pages::RoutesController < PagesController
+  def show
+    back_link_url = form_pages_path(current_form.id)
+    render locals: { current_form:, page:, pages: current_form.pages, back_link_url: }
+  end
+end

--- a/app/services/route_summary_card_data_service.rb
+++ b/app/services/route_summary_card_data_service.rb
@@ -1,0 +1,84 @@
+class RouteSummaryCardDataService
+  attr_reader :page, :pages
+
+  class << self
+    def call(**args)
+      new(**args)
+    end
+  end
+
+  def initialize(page:, pages:)
+    @page = page
+    @pages = pages
+  end
+
+  def summary_card_data
+    conditional_route_cards + [default_route_card]
+  end
+
+private
+
+  def all_routes
+    all_form_routing_conditions = pages.flat_map(&:routing_conditions).compact_blank
+    all_form_routing_conditions.reject { |rc| rc.routing_page_id != page.id || rc.check_page_id != page.id }
+  end
+
+  def conditional_routes
+    all_routes.select { |rc| rc.answer_value.present? }
+  end
+
+  def conditional_route_cards
+    conditional_routes.map.with_index(1) { |routing_condition, index| conditional_route_card(routing_condition, index) }
+  end
+
+  def conditional_route_card(routing_condition, index)
+    goto_page_name = routing_condition.skip_to_end ? end_page_name : page_name(routing_condition.goto_page_id)
+
+    {
+      card: {
+        title: I18n.t("page_route_card.conditional_route_title", index:),
+        classes: "app-summary-card",
+      },
+      rows: [
+        {
+          key: { text: I18n.t("page_route_card.if_answer_is") },
+          value: { text: I18n.t("page_route_card.conditional_answer_value", answer_value: routing_condition.answer_value) },
+        },
+        {
+          key: { text: I18n.t("page_route_card.take_the_person_to") },
+          value: { text: goto_page_name },
+        },
+      ],
+    }
+  end
+
+  def default_route_card
+    goto_page_name = page.has_next_page? ? page_name(page.next_page) : end_page_name
+
+    {
+      card: {
+        title: I18n.t("page_route_card.default_route_title"),
+        classes: "app-summary-card",
+      },
+      rows: [
+        {
+          key: { text: I18n.t("page_route_card.continue_to") },
+          value: { text: goto_page_name },
+        },
+      ],
+    }
+  end
+
+  def page_name(page_id)
+    target_page = pages.find { |page| page.id == page_id }
+
+    page_name = target_page.question_text
+    page_position = target_page.position
+
+    I18n.t("page_route_card.page_name", page_position:, page_name:)
+  end
+
+  def end_page_name
+    I18n.t("page_route_card.check_your_answers")
+  end
+end

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -12,7 +12,7 @@
       <%= govuk_summary_list(actions: false) do |summary_list|
           summary_list.with_row do |row|
               row.with_key { t("page_route_card.question_title", position: page.position) }
-              row.with_value { "\"#{page.question_text}\"" }
+              row.with_value { "#{page.question_text}" }
           end;
       end %>
 

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -1,0 +1,26 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.routes_show', position: page.position), false)) %>
+<% content_for :back_link, govuk_back_link_to(back_link_url, t('pages.go_to_your_questions')) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l"><%= current_form.name %></span>
+          <%= t("page_titles.routes_show", position: page.position) %>
+      </h1>
+
+      <%= govuk_summary_list(actions: false) do |summary_list|
+          summary_list.with_row do |row|
+              row.with_key { t("page_route_card.question_title", position: page.position) }
+              row.with_value { "\"#{page.question_text}\"" }
+          end;
+      end %>
+
+      <% RouteSummaryCardDataService.call(page:, pages:).summary_card_data.each do |card| %>
+          <%= govuk_summary_list(**card) %>
+      <% end %>
+
+      <%= govuk_link_to t("pages.go_to_your_questions"), form_pages_path(current_form.id) %>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -980,6 +980,15 @@ en:
       default: Selection from a list
       none_of_the_above: None of the above
       only_one_option: Selection from a list, one option only.
+  page_route_card:
+    check_your_answers: Check your answers before submitting
+    conditional_answer_value: '"%{answer_value}"'
+    conditional_route_title: Route %{index}
+    continue_to: Continue to
+    default_route_title: For any other answer
+    if_answer_is: If the answer is
+    page_name: "%{page_position}. %{page_name}"
+    take_the_person_to: take the person to
   page_settings_summary:
     address:
       address_type: Address type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -982,9 +982,9 @@ en:
       only_one_option: Selection from a list, one option only.
   page_route_card:
     check_your_answers: Check your answers before submitting
-    conditional_answer_value: '"%{answer_value}"'
+    conditional_answer_value: "%{answer_value}"
     conditional_route_title: Route %{index}
-    continue_to: Continue to
+    continue_to: continue to
     default_route_title: For any other answer
     if_answer_is: If the answer is
     page_name: "%{page_position}. %{page_name}"
@@ -1043,7 +1043,7 @@ en:
     payment_link: Add a link to a payment page on GOV.UK Pay
     privacy_policy: Provide a link to privacy information for this form
     question_text: What’s your question?
-    routes_show: Edit question %{position}'s routes
+    routes_show: Question %{position}’s routes
     routing_page: Add a question route
     routing_page_delete: Delete question %{question_position}’s route
     routing_page_edit: Edit question %{question_position}’s route

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -988,6 +988,7 @@ en:
     default_route_title: For any other answer
     if_answer_is: If the answer is
     page_name: "%{page_position}. %{page_name}"
+    question_title: Question %{position}
     take_the_person_to: take the person to
   page_settings_summary:
     address:
@@ -1042,6 +1043,7 @@ en:
     payment_link: Add a link to a payment page on GOV.UK Pay
     privacy_policy: Provide a link to privacy information for this form
     question_text: What’s your question?
+    routes_show: Edit question %{position}'s routes
     routing_page: Add a question route
     routing_page_delete: Delete question %{question_position}’s route
     routing_page_edit: Edit question %{question_position}’s route

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,8 @@ Rails.application.routes.draw do
           delete "/:condition_id/delete" => "pages/conditions#destroy", as: :destroy_condition
         end
 
+        get "/routes" => "pages/routes#show", as: :show_routes
+
         scope "/edit" do
           get "/type-of-answer" => "pages/type_of_answer#edit", as: :type_of_answer_edit
           post "/type-of-answer" => "pages/type_of_answer#update", as: :type_of_answer_update

--- a/spec/requests/pages/routes_controller_spec.rb
+++ b/spec/requests/pages/routes_controller_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+describe Pages::RoutesController, type: :request do
+  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:pages) { form.pages }
+  let(:page) do
+    pages.first.tap do |first_page|
+      first_page.id = 101
+      first_page.is_optional = false
+      first_page.answer_type = "selection"
+      first_page.answer_settings = DataStruct.new(
+        only_one_option: true,
+        selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                            OpenStruct.new(attributes: { name: "Option 2" })],
+      )
+    end
+  end
+
+  let(:selected_page) { page }
+
+  let(:group) { create(:group, organisation: standard_user.organisation) }
+  let(:user) { standard_user }
+
+  before do
+    Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
+    GroupForm.create!(form_id: form.id, group_id: group.id)
+    login_as user
+  end
+
+  describe "#show" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1", headers, form.to_json, 200
+        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
+        mock.get "/api/v1/forms/1/pages/101", headers, selected_page.to_json, 200
+      end
+
+      get show_routes_path(form_id: form.id, page_id: selected_page.id)
+    end
+
+    it "Reads the form from the API" do
+      expect(form).to have_been_read
+    end
+
+    it "renders the routing page template" do
+      expect(response).to render_template("pages/routes/show")
+    end
+  end
+end

--- a/spec/services/route_summary_card_data_service_spec.rb
+++ b/spec/services/route_summary_card_data_service_spec.rb
@@ -32,7 +32,7 @@ describe RouteSummaryCardDataService do
 
         # conditional route
         expect(result[0][:card][:title]).to eq("Route 1")
-        expect(result[0][:rows][0][:value][:text]).to eq('"Yes"')
+        expect(result[0][:rows][0][:value][:text]).to eq("Yes")
         expect(result[0][:rows][1][:value][:text]).to eq("2. Next Question")
 
         # default route

--- a/spec/services/route_summary_card_data_service_spec.rb
+++ b/spec/services/route_summary_card_data_service_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe RouteSummaryCardDataService do
+  subject(:service) { described_class.new(page: current_page, pages:) }
+
+  let(:current_page) do
+    build(:page, id: 1, position: 1, question_text: "Current Question", next_page: next_page.id, routing_conditions: [routing_condition])
+  end
+
+  let(:next_page) do
+    build(:page, id: 2, position: 2, question_text: "Next Question")
+  end
+
+  let(:pages) { [current_page, next_page] }
+
+  let(:routing_condition) do
+    build(:condition, routing_page_id: 1, check_page_id: 1, answer_value: "Yes", goto_page_id: 2, skip_to_end: false)
+  end
+
+  describe ".call" do
+    it "instantiates and returns a new instance" do
+      service = described_class.call(page: current_page, pages:)
+      expect(service).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe "#summary_card_data" do
+    context "with conditional routes" do
+      it "returns an array of route cards including conditional and default routes" do
+        result = service.summary_card_data
+        expect(result.length).to eq(2) # 1 conditional + 1 default route
+
+        # conditional route
+        expect(result[0][:card][:title]).to eq("Route 1")
+        expect(result[0][:rows][0][:value][:text]).to eq('"Yes"')
+        expect(result[0][:rows][1][:value][:text]).to eq("2. Next Question")
+
+        # default route
+        expect(result[1][:card][:title]).to eq("For any other answer")
+        expect(result[1][:rows][0][:value][:text]).to eq("2. Next Question")
+      end
+    end
+
+    context "with skip to end condition" do
+      let(:routing_condition) do
+        build(:condition, routing_page_id: 1, check_page_id: 1, answer_value: "No", goto_page_id: nil, skip_to_end: true)
+      end
+
+      it 'shows "Check your answers" as destination' do
+        result = service.summary_card_data
+        expect(result[0][:rows][1][:value][:text]).to eq("Check your answers before submitting")
+      end
+    end
+
+    context "with no conditional routes" do
+      let(:routing_condition) { nil }
+
+      it "returns only the default route card" do
+        result = service.summary_card_data
+        expect(result.length).to eq(1)
+        expect(result[0][:card][:title]).to eq("For any other answer")
+      end
+    end
+
+    context "when page is the last page" do
+      let(:current_page) do
+        build(:page, id: 1, position: 1, question_text: "Current Question", next_page: nil)
+      end
+
+      it 'shows "Check your answers" as default destination' do
+        result = service.summary_card_data
+        expect(result[0][:rows][0][:value][:text]).to eq("Check your answers before submitting")
+      end
+    end
+  end
+end

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe "pages/routes/show.html.erb" do
+  let(:form) { build :form, id: 1, pages: [page] }
+  let(:page) { build :page, id: 1, position: 1 }
+
+  let(:route_cards) do
+    [
+      {
+        card: { title: "route 1" },
+        rows: [
+          { key: { text: "route 1 key" }, value: { text: "route 1 value" } },
+        ],
+      },
+    ]
+  end
+
+  let(:route_summary_card_data_service) { instance_double(RouteSummaryCardDataService, summary_card_data: route_cards) }
+
+  before do
+    allow(RouteSummaryCardDataService).to receive(:call).and_return(route_summary_card_data_service)
+    render template: "pages/routes/show", locals: { current_form: form, page:, pages: form.pages, back_link_url: "/back" }
+  end
+
+  it "has the correct title" do
+    expect(view.content_for(:title)).to have_content("Edit question 1's routes")
+  end
+
+  it "has the correct back link" do
+    expect(view.content_for(:back_link)).to have_link(I18n.t("pages.go_to_your_questions"), href: "/back")
+  end
+
+  it "has the correct heading and caption" do
+    expect(rendered).to have_selector("h1", text: form.name)
+    expect(rendered).to have_selector("h1", text: I18n.t("page_titles.routes_show", position: page.position))
+  end
+
+  it "shows the page title as a summary list" do
+    expect(rendered).to have_css(".govuk-summary-list__key", text: "Question #{page.position}")
+    expect(rendered).to have_css(".govuk-summary-list__value", text: "\"#{page.question_text}\"")
+  end
+
+  it "shows the correct route cards" do
+    expect(rendered).to have_css(".govuk-summary-list__key", text: "route 1 key")
+    expect(rendered).to have_css(".govuk-summary-list__value", text: "route 1 value")
+  end
+
+  it "has a back to questions link" do
+    expect(rendered).to have_link(I18n.t("pages.go_to_your_questions"), href: form_pages_path(form.id))
+  end
+end

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe "pages/routes/show.html.erb" do
   end
 
   it "has the correct title" do
-    expect(view.content_for(:title)).to have_content("Edit question 1's routes")
+    expect(view.content_for(:title)).to have_content("Question 1’s routes")
   end
 
   it "has the correct back link" do
@@ -37,7 +37,7 @@ describe "pages/routes/show.html.erb" do
 
   it "shows the page title as a summary list" do
     expect(rendered).to have_css(".govuk-summary-list__key", text: "Question #{page.position}")
-    expect(rendered).to have_css(".govuk-summary-list__value", text: "\"#{page.question_text}\"")
+    expect(rendered).to have_css(".govuk-summary-list__value", text: page.question_text)
   end
 
   it "shows the correct route cards" do


### PR DESCRIPTION
### Add a summary of the routes to a page

Trello card: https://trello.com/c/rwu6TDHu/1923-add-new-edit-routes-page

- Introduces a new "edit routes" page.
- This page will be displayed after the form creator clicks “Save and  continue” on the “Select answer and destination” page. Currently it's not  linked in until it's finished.
- Shows a summary card for each condition the question has.
- Includes a summary card explaining where the form filler goes for any other answer.

Still to do:
- Include an “Edit” link on each summary card that redirects to the “Select answer and destination” page.
- Provide a button to delete all routes for the question page. This button will link to the existing delete condition confirmation page for now.
- Change the “Edit” link for a route on the page list so it redirects the form creator to the new “edit routes” page.

<img width="1126" alt="Screenshot 2024-11-04 at 10 10 05" src="https://github.com/user-attachments/assets/7d0e26a4-eede-406a-a997-b09c739acc5a">

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
