### PR TITLE
Record time when users last signed in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,6 +105,10 @@ class User < ApplicationRecord
     Settings.analytics_enabled && !super_admin?
   end
 
+  def signed_in!
+    update!(last_signed_in_at: Time.zone.now)
+  end
+
 private
 
   def requires_name?

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -51,4 +51,6 @@ Warden::Manager.after_authentication do |user, auth, _opts|
   if user.provider == "auth0"
     auth.session["auth0_connection_strategy"] = auth.env["omniauth.auth"][:extra][:raw_info][:auth0_connection_strategy]
   end
+
+  user.signed_in!
 end

--- a/db/migrate/20241031082440_add_last_signed_in_at_to_users.rb
+++ b/db/migrate/20241031082440_add_last_signed_in_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastSignedInAtToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :last_signed_in_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_25_102427) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_31_082440) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -122,6 +122,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_25_102427) do
     t.boolean "has_access", default: true
     t.string "provider"
     t.datetime "terms_agreed_at"
+    t.datetime "last_signed_in_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/spec/features/users/last_signed_in_at_spec.rb
+++ b/spec/features/users/last_signed_in_at_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+feature "Record time when user last signed in" do
+  let(:user) { create :user, last_signed_in_at: nil }
+
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:auth0] = Faker::Omniauth.auth0(
+      uid: user.uid,
+      email: user.email,
+    )
+
+    allow(Settings).to receive(:auth_provider).and_return("auth0")
+
+    freeze_time
+  end
+
+  after do
+    unfreeze_time
+
+    OmniAuth.config.mock_auth[:auth0] = nil
+    OmniAuth.config.test_mode = false
+  end
+
+  scenario "user authenticates" do
+    when_i_sign_in
+    then_my_last_signed_in_at_time_is_updated
+  end
+
+private
+
+  def when_i_sign_in
+    visit root_path
+  end
+
+  def then_my_last_signed_in_at_time_is_updated
+    user.reload
+    expect(user.last_signed_in_at).to eq Time.zone.now
+  end
+end

--- a/spec/integration/warden_spec.rb
+++ b/spec/integration/warden_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "usage of Warden framework" do
+  describe "after_authentication callbacks" do
+    let(:user) { create :user }
+
+    before do
+      set_run_callbacks(true)
+    end
+
+    after do
+      set_run_callbacks(false)
+    end
+
+    it "notifies the user model that the user has signed in" do
+      allow(user).to receive(:signed_in!)
+
+      login_as user
+      get "/"
+
+      expect(user).to have_received(:signed_in!)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -412,4 +412,18 @@ describe User, type: :model do
       end
     end
   end
+
+  describe "#signed_in!" do
+    around do |example|
+      freeze_time do
+        example.run
+      end
+    end
+
+    it "updates last_signed_in_at" do
+      expect {
+        user.signed_in!
+      }.to change(user, :last_signed_in_at).to(Time.zone.now)
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/8WNltVGz/1917-find-out-which-accounts-have-been-inactive-for-over-a-year <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be able to find out when users haven't signed in to our service for a while. This PR will make it easier in future, by starting to save the time when users sign in to the database.

I think that we don’t need the information to be that granular, so I propose we update the time `last_signed_in_at` on the user record whenever they authenticate. As our session policy requires form creators to sign in every 20 hours and we're most likely interested in users who have been inactive for 12 months or more this seems like a reasonable level of resolution to me, and requires much fewer writes to the database.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?