### PR TITLE
Add rake tasks to enable/disable long lists enabled

### DIFF
--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -44,6 +44,24 @@ namespace :groups do
       raise ActiveRecord::Rollback
     end
   end
+
+  desc "Enable long lists feature"
+  task :enable_long_lists, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:enable_long_lists[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+
+    Group.find_by(external_id: args[:group_id]).update!(long_lists_enabled: true)
+    Rails.logger.info("Updated long_lists_enabled to true for group #{args[:group_id]}")
+  end
+
+  desc "Disable long lists feature"
+  task :disable_long_lists, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:disable_long_lists[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+
+    Group.find_by(external_id: args[:group_id]).update!(long_lists_enabled: false)
+    Rails.logger.info("Updated long_lists_enabled to false for group #{args[:group_id]}")
+  end
 end
 
 def run_task(task_name, args, rollback:)


### PR DESCRIPTION


### What problem does this pull request solve?

Trello card: https://trello.com/c/ufPgMvic/1930-build-the-workflow-for-adding-long-lists-on-forms

Adds rake tasks to enable/disable the `long_lists_enabled` flag for a group.

Tests haven't been added for these tasks as the logic is simple, and this will only need to be used a few times.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
