### PR TITLE
Use 'match_array' to fix flaky Mailchimp test

### DIFF
--- a/spec/lib/tasks/mailchimp.rake_spec.rb
+++ b/spec/lib/tasks/mailchimp.rake_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "mailchimp.rake" do
     end
 
     it "runs the mailchimp synchronization on each list" do
-      expect(MailchimpListSynchronizer).to receive(:synchronize).with(list_id: Settings.mailchimp.active_users_list, users_to_synchronize: users_with_access).once
+      expect(MailchimpListSynchronizer).to receive(:synchronize).with(list_id: Settings.mailchimp.active_users_list, users_to_synchronize: match_array(users_with_access)).once
       expect(MailchimpListSynchronizer).to receive(:synchronize).with(list_id: Settings.mailchimp.mou_signers_list, users_to_synchronize: [mou_signer_with_access]).once
 
       expect { task.invoke }.to output.to_stdout


### PR DESCRIPTION

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Rspec provides a matcher 'match_array', which will match any array which has only the elements specified. This is useful in cases where we want to check that an array has the right items, but the order is unimportant.

This Mailchimp rake task test was occasionally returning `false` because the list of users to synchronise isn't always in the same order (I think this is because they're returned in the default database order, but would need to investigate further). This commit uses match_array to remove that flakiness.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
