### PR TITLE
Include subfolder locales in checks

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -19,6 +19,7 @@ data:
     # - config/locales/%{locale}.yml
     ## More files:
     - config/locales/*.yml
+    - config/locales/**/*.yml
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules

--- a/config/locales/input_objects/address_settings.yml
+++ b/config/locales/input_objects/address_settings.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:
@@ -6,7 +7,7 @@ en:
           attributes:
             base:
               blank: Select the kind of addresses you expect to receive
-            uk_address:
-              inclusion: Select ‘UK addresses’ or ‘International addresses’
             international_address:
+              inclusion: Select ‘UK addresses’ or ‘International addresses’
+            uk_address:
               inclusion: Select ‘UK addresses’ or ‘International addresses’

--- a/config/locales/input_objects/confirm_action.yml
+++ b/config/locales/input_objects/confirm_action.yml
@@ -1,7 +1,8 @@
+---
 en:
   helpers:
     label:
       confirm_action_input:
         options:
-          yes: "Yes"
-          no: "No"
+          'no': 'No'
+          'yes': 'Yes'

--- a/config/locales/input_objects/confirm_archive.yml
+++ b/config/locales/input_objects/confirm_archive.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:

--- a/config/locales/input_objects/confirm_upgrade.yml
+++ b/config/locales/input_objects/confirm_upgrade.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:

--- a/config/locales/input_objects/contact_details.yml
+++ b/config/locales/input_objects/contact_details.yml
@@ -1,38 +1,38 @@
+---
 en:
-  helpers:
-    label:
-      forms_contact_details_input:
-        contact_details_supplied_options:
-          supply_email: Email
-          supply_phone: Phone
-          supply_link: Online contact link
-        email: Enter the email address
-        phone: Enter the phone number and its opening times
-        link_href: Enter the link
-        link_text: What text should be used to describe this link?
-        submit: wejwihaklsjfkljaslkfj
-    hint:
-      forms_contact_details_input:
-        link_href: For example, https://gov.uk/contact-form
-        link_text: For example, ‘Online contact form’
   activemodel:
     errors:
       models:
         forms/contact_details_input:
           attributes:
+            contact_details_supplied:
+              must_be_supply_contact_details: Select at least one option
             email:
               blank: Enter an email address
               invalid_email: Enter an email address in the correct format, like name@example.com
-            phone:
-              blank: Enter a phone number and opening hours
-              too_long: The phone number information cannot be longer than 500 characters
             link_href:
               blank: Enter an online contact link
-              url: Enter a link in the correct format, like https://www.gov.uk/contact
               too_long: The link cannot be longer than 120 characters
+              url: Enter a link in the correct format, like https://www.gov.uk/contact
             link_text:
               blank: Enter an online contact link description
               too_long: The link description cannot be longer than 120 characters
-            contact_details_supplied:
-              must_be_supply_contact_details: Select at least one option
-
+            phone:
+              blank: Enter a phone number and opening hours
+              too_long: The phone number information cannot be longer than 500 characters
+  helpers:
+    hint:
+      forms_contact_details_input:
+        link_href: For example, https://gov.uk/contact-form
+        link_text: For example, ‘Online contact form’
+    label:
+      forms_contact_details_input:
+        contact_details_supplied_options:
+          supply_email: Email
+          supply_link: Online contact link
+          supply_phone: Phone
+        email: Enter the email address
+        link_href: Enter the link
+        link_text: What text should be used to describe this link?
+        phone: Enter the phone number and its opening times
+        submit: wejwihaklsjfkljaslkfj

--- a/config/locales/input_objects/date_settings.yml
+++ b/config/locales/input_objects/date_settings.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:

--- a/config/locales/input_objects/declaration.yml
+++ b/config/locales/input_objects/declaration.yml
@@ -1,8 +1,5 @@
+---
 en:
-  helpers:
-    label:
-      forms_declaration_input:
-        declaration_text: Enter a declaration for people to agree to (optional)
   activemodel:
     errors:
       models:
@@ -12,3 +9,7 @@ en:
               too_long: The declaration cannot be longer than 2,000 characters
             mark_complete:
               blank: You must choose an option
+  helpers:
+    label:
+      forms_declaration_input:
+        declaration_text: Enter a declaration for people to agree to (optional)

--- a/config/locales/input_objects/delete_confirmation.yml
+++ b/config/locales/input_objects/delete_confirmation.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:

--- a/config/locales/input_objects/form_name.yml
+++ b/config/locales/input_objects/form_name.yml
@@ -1,14 +1,5 @@
+---
 en:
-  helpers:
-    label:
-      forms_name_input:
-        name: What’s the name of your form?
-    hint:
-      forms_name_input:
-        name: |-
-          The form name will be shown at the top of each page of the form. Use a name
-          that describes what the form will help people to do. For example ‘Apply for a
-          juggling licence’.
   activemodel:
     errors:
       models:
@@ -16,4 +7,13 @@ en:
           attributes:
             name:
               blank: Enter a name for the form
-
+  helpers:
+    hint:
+      forms_name_input:
+        name: |-
+          The form name will be shown at the top of each page of the form. Use a name
+          that describes what the form will help people to do. For example ‘Apply for a
+          juggling licence’.
+    label:
+      forms_name_input:
+        name: What’s the name of your form?

--- a/config/locales/input_objects/long_lists_selection/options.yml
+++ b/config/locales/input_objects/long_lists_selection/options.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:
@@ -8,7 +9,7 @@ en:
               inclusion: Select whether to include an option for ‘None of the above’
             selection_options:
               blank: Add text for all of your options
-              uniqueness: All your options must be unique
-              minimum: Enter at least 2 options
-              maximum_choose_only_one_option: You cannot have more than 1000 options
               maximum_choose_more_than_one_option: You cannot have more than 30 options
+              maximum_choose_only_one_option: You cannot have more than 1000 options
+              minimum: Enter at least 2 options
+              uniqueness: All your options must be unique

--- a/config/locales/input_objects/long_lists_selection/type.yml
+++ b/config/locales/input_objects/long_lists_selection/type.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:

--- a/config/locales/input_objects/make_live.yml
+++ b/config/locales/input_objects/make_live.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:
@@ -6,9 +7,9 @@ en:
           attributes:
             confirm:
               blank: You must choose an option
+              missing_contact_details: You cannot make your form live because it does not have contact details. Answer ‘No’ and add contact details.
               missing_pages: You cannot make your form live because you have not finished adding questions. Answer ‘No’, add one or more questions, and mark the task as complete.
               missing_privacy_policy_url: You cannot make your form live because it does not have a link to privacy information. Answer ‘No’ and add a link.
               missing_submission_email: You cannot make your form live because it does not have an email address to send completed forms to. Answer ‘No’ and add an email address.
               missing_what_happens_next: You cannot make your form live because it does not have information about what happens next. Answer ‘No’ and add information about what happens next.
-              missing_contact_details: You cannot make your form live because it does not have contact details. Answer ‘No’ and add contact details.
               share_preview_not_completed: You cannot make your form live because you have not completed the ‘share a preview of your draft form’ task. Answer ‘No’ and complete the task.

--- a/config/locales/input_objects/mark_pages_section_complete.yml
+++ b/config/locales/input_objects/mark_pages_section_complete.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:

--- a/config/locales/input_objects/name_settings.yml
+++ b/config/locales/input_objects/name_settings.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:
@@ -10,4 +11,3 @@ en:
             title_needed:
               blank: Select yes if you need a title
               inclusion: Select ’Yes’ or ’No’
-

--- a/config/locales/input_objects/payment_link.yml
+++ b/config/locales/input_objects/payment_link.yml
@@ -1,12 +1,5 @@
+---
 en:
-  helpers:
-    label:
-      forms_payment_link_input:
-        payment_url: Enter the URL of your GOV.UK Pay payment link 
-    hint:
-      forms_payment_link_input:
-        payment_url: |-
-          For example, https://www.gov.uk/payments/your-payment-link
   activemodel:
     errors:
       models:
@@ -14,3 +7,10 @@ en:
           attributes:
             payment_url:
               url: Enter a link in the correct format, like https://www.gov.uk/payments/your-payment-link
+  helpers:
+    hint:
+      forms_payment_link_input:
+        payment_url: For example, https://www.gov.uk/payments/your-payment-link
+    label:
+      forms_payment_link_input:
+        payment_url: Enter the URL of your GOV.UK Pay payment link 

--- a/config/locales/input_objects/privacy_policy.yml
+++ b/config/locales/input_objects/privacy_policy.yml
@@ -1,15 +1,5 @@
+---
 en:
-  errors:
-    messages:
-      url: Enter a link in the correct format, like https://www.gov.uk/help/privacy-notice
-  helpers:
-    label:
-      forms_privacy_policy_input:
-        privacy_policy_url: Enter a link to privacy information for this form
-    hint:
-      forms_privacy_policy_input:
-        privacy_policy_url: |-
-          For example, https://www.gov.uk/help/privacy-notice
   activemodel:
     errors:
       models:
@@ -17,3 +7,13 @@ en:
           attributes:
             privacy_policy_url:
               blank: Enter a link to privacy information
+  errors:
+    messages:
+      url: Enter a link in the correct format, like https://www.gov.uk/help/privacy-notice
+  helpers:
+    hint:
+      forms_privacy_policy_input:
+        privacy_policy_url: For example, https://www.gov.uk/help/privacy-notice
+    label:
+      forms_privacy_policy_input:
+        privacy_policy_url: Enter a link to privacy information for this form

--- a/config/locales/input_objects/question_text.yml
+++ b/config/locales/input_objects/question_text.yml
@@ -1,8 +1,5 @@
+---
 en:
-  helpers:
-    label:
-      pages_question_text_input:
-        question_text: What’s your question?
   activemodel:
     errors:
       models:
@@ -10,4 +7,8 @@ en:
           attributes:
             question_text:
               blank: Enter your question
-              too_long: "Your question must be %{count} characters or less"
+              too_long: Your question must be %{count} characters or less
+  helpers:
+    label:
+      pages_question_text_input:
+        question_text: What’s your question?

--- a/config/locales/input_objects/selections_settings_form.yml
+++ b/config/locales/input_objects/selections_settings_form.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:
@@ -6,6 +7,6 @@ en:
           attributes:
             selection_options:
               blank: Add text for all of your options
-              uniqueness: All your options must be unique
-              minimum: Enter at least 2 options
               maximum: You cannot have more than 30 options
+              minimum: Enter at least 2 options
+              uniqueness: All your options must be unique

--- a/config/locales/input_objects/share_preview.yml
+++ b/config/locales/input_objects/share_preview.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:

--- a/config/locales/input_objects/submission_email_form.yml
+++ b/config/locales/input_objects/submission_email_form.yml
@@ -1,17 +1,18 @@
+---
 en:
-  helpers:
-    label:
-      forms_submission_email_input:
-        temporary_submission_email: What email address should completed forms be sent to?
-        email_code: Enter the confirmation code
   activemodel:
     errors:
       models:
         forms/submission_email_input:
           attributes:
+            email_code:
+              email_code_mismatch: This code is not correct - double check the code or set the email address again to send a new one
+              invalid_email_code: The code should be 6 numbers - double check the code or set the email address again to send a new one
             temporary_submission_email:
               blank: Enter an email address
               invalid_email: Enter an email address in the correct format, like name@example.gov.uk
-            email_code:
-              invalid_email_code: The code should be 6 numbers - double check the code or set the email address again to send a new one
-              email_code_mismatch: This code is not correct - double check the code or set the email address again to send a new one
+  helpers:
+    label:
+      forms_submission_email_input:
+        email_code: Enter the confirmation code
+        temporary_submission_email: What email address should completed forms be sent to?

--- a/config/locales/input_objects/text_settings.yml
+++ b/config/locales/input_objects/text_settings.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:

--- a/config/locales/input_objects/type_of_answer.yml
+++ b/config/locales/input_objects/type_of_answer.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:

--- a/config/locales/input_objects/what_happens_next.yml
+++ b/config/locales/input_objects/what_happens_next.yml
@@ -1,3 +1,4 @@
+---
 en:
   activemodel:
     errors:
@@ -5,5 +6,5 @@ en:
         forms/what_happens_next_input:
           attributes:
             what_happens_next_markdown:
-              unsupported_markdown_syntax: The information about what happens next can only contain formatting for links, bulleted lists (*), or numbered lists (1.)
               too_long: The information about what happens next cannot be longer than 5,000 characters
+              unsupported_markdown_syntax: The information about what happens next can only contain formatting for links, bulleted lists (*), or numbered lists (1.)

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -1,17 +1,13 @@
+---
 en:
-  helpers:
-    label:
-      pages_conditions_input:
-        answer_value: is answered as
-        goto_page_id: take the person to
   activemodel:
     errors:
       models:
         pages/conditions_input:
           attributes:
             answer_value:
-              blank: Select the answer you want to base your route on
               answer_value_doesnt_exist: Select the answer you want to base your route on, or delete this route
+              blank: Select the answer you want to base your route on
             goto_page_id:
               blank: Select the question or page you want to take the person to
               cannot_have_goto_page_before_routing_page: Select the question or page you want to take the person to, or delete this route
@@ -25,3 +21,8 @@ en:
           attributes:
             routing_page_id:
               blank: Select the question you want your route to start from
+  helpers:
+    label:
+      pages_conditions_input:
+        answer_value: is answered as
+        goto_page_id: take the person to

--- a/config/locales/pages/guidance.yml
+++ b/config/locales/pages/guidance.yml
@@ -1,27 +1,35 @@
+---
 en:
-  helpers:
-    hint:
-      pages_guidance_input:
-        page_heading: When you add guidance your question text will no longer be the main page heading, so you need to use a different one. Use a heading that’s a statement rather than a question - for example, ‘Interview needs’.
-        guidance_markdown: Use Markdown if you need to format your guidance content. Formatting help can be found below.
-    label:
-      pages_guidance_input:
-        page_heading: Give your page a heading
-        guidance_markdown: Add guidance text
   activemodel:
     errors:
       models:
         pages/guidance_input:
-          attributes: &guidance_validation
-            page_heading:
-              blank: Enter a page heading
-              too_long: "Page heading must be %{count} characters or less"
+          attributes:
             guidance_markdown:
               blank: Enter guidance text
-              unsupported_markdown_syntax: Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
               too_long: Guidance text must be 5,000 characters or less
+              unsupported_markdown_syntax: Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
+            page_heading:
+              blank: Enter a page heading
+              too_long: Page heading must be %{count} characters or less
   activerecord:
     errors:
       models:
         draft_question:
-          attributes: *guidance_validation
+          attributes:
+            guidance_markdown:
+              blank: Enter guidance text
+              too_long: Guidance text must be 5,000 characters or less
+              unsupported_markdown_syntax: Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
+            page_heading:
+              blank: Enter a page heading
+              too_long: Page heading must be %{count} characters or less
+  helpers:
+    hint:
+      pages_guidance_input:
+        guidance_markdown: Use Markdown if you need to format your guidance content. Formatting help can be found below.
+        page_heading: When you add guidance your question text will no longer be the main page heading, so you need to use a different one. Use a heading that’s a statement rather than a question - for example, ‘Interview needs’.
+    label:
+      pages_guidance_input:
+        guidance_markdown: Add guidance text
+        page_heading: Give your page a heading


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We had the `i18n-tasks` gem configured so that it only looked at files in the top level of `config/locales`. We have quite a lot of locale files in subfolders of `config/locales`, which weren't covered by these checks.

This PR:
- updates the config to include the subfolders in the checks
- normalizes the files with `i18n-tasks normalize`

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
