### PR TITLE
1924 add repository service to forms admin for form condition model

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -34,7 +34,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def edit
-    condition = Condition.find(params[:condition_id], params: { form_id: current_form.id, page_id: page.id })
+    condition = ConditionRepository.find(params[:condition_id], params: { form_id: current_form.id, page_id: page.id })
 
     condition_input = Pages::ConditionsInput.new(form: current_form, page:, record: condition, answer_value: condition.answer_value, goto_page_id: condition.goto_page_id, skip_to_end: condition.skip_to_end).assign_condition_values
 
@@ -44,7 +44,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def update
-    condition = Condition.find(params[:condition_id], params: { form_id: current_form.id, page_id: page.id })
+    condition = ConditionRepository.find(params[:condition_id], params: { form_id: current_form.id, page_id: page.id })
 
     form_params = condition_input_params.merge(record: condition)
 
@@ -58,7 +58,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def delete
-    condition = Condition.find(params[:condition_id], params: { form_id: current_form.id, page_id: page.id })
+    condition = ConditionRepository.find(params[:condition_id], params: { form_id: current_form.id, page_id: page.id })
 
     delete_condition_input = Pages::DeleteConditionInput.new(form: current_form, page:, record: condition, answer_value: condition.answer_value, goto_page_id: condition.goto_page_id)
 
@@ -66,7 +66,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def destroy
-    condition = Condition.find(params[:condition_id], params: { form_id: current_form.id, page_id: page.id })
+    condition = ConditionRepository.find(params[:condition_id], params: { form_id: current_form.id, page_id: page.id })
 
     form_params = delete_condition_input_params.merge(record: condition, answer_value: condition.answer_value, goto_page_id: condition.goto_page_id)
 

--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -8,13 +8,13 @@ class Pages::ConditionsInput < BaseInput
 
     assign_skip_to_end
 
-    Condition.create!(form_id: form.id,
-                      page_id: page.id,
-                      check_page_id: page.id,
-                      routing_page_id: page.id,
-                      answer_value:,
-                      goto_page_id:,
-                      skip_to_end:)
+    ConditionRepository.create!(form_id: form.id,
+                                page_id: page.id,
+                                check_page_id: page.id,
+                                routing_page_id: page.id,
+                                answer_value:,
+                                goto_page_id:,
+                                skip_to_end:)
   end
 
   def update_condition
@@ -26,7 +26,7 @@ class Pages::ConditionsInput < BaseInput
     record.goto_page_id = goto_page_id
     record.skip_to_end = skip_to_end
 
-    record.save!
+    ConditionRepository.save!(record)
   end
 
   def routing_answer_options

--- a/app/input_objects/pages/delete_condition_input.rb
+++ b/app/input_objects/pages/delete_condition_input.rb
@@ -7,7 +7,7 @@ class Pages::DeleteConditionInput < ConfirmActionInput
     result = true
 
     if confirmed?
-      result = record.destroy
+      result = ConditionRepository.destroy(record)
     end
 
     result

--- a/app/services/condition_repository.rb
+++ b/app/services/condition_repository.rb
@@ -1,0 +1,32 @@
+class ConditionRepository
+  class << self
+    def create!(form_id:,
+                page_id:,
+                check_page_id:,
+                routing_page_id:,
+                answer_value:,
+                goto_page_id:,
+                skip_to_end:)
+
+      Condition.create!(form_id:,
+                        page_id:,
+                        check_page_id:,
+                        routing_page_id:,
+                        answer_value:,
+                        goto_page_id:,
+                        skip_to_end:)
+    end
+
+    def find(condition_id, params:)
+      Condition.find(condition_id, params:)
+    end
+
+    def save!(record)
+      Condition.new(record.attributes, true).save!
+    end
+
+    def destroy(record)
+      Condition.new(record.attributes, true).destroy
+    end
+  end
+end

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
   describe "#submit" do
     context "when validation pass" do
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/1/pages/2/conditions", post_headers, { id: 2 }.to_json, 200
-        end
+        allow(ConditionRepository).to receive(:create!)
 
         page.id = 2
         conditions_input.answer_value = "Rabbit"
@@ -53,7 +51,9 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       end
 
       it "creates a condition" do
-        expect(conditions_input.submit).to be_truthy
+        conditions_input.submit
+
+        expect(ConditionRepository).to have_received(:create!)
       end
     end
 
@@ -70,10 +70,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       let(:condition) { Condition.new id: 3, form_id: 1, page_id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
 
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/1/pages/2/conditions", post_headers, condition.to_json, 200
-          mock.put "/api/v1/forms/1/pages/2/conditions/3", post_headers, condition.to_json, 200
-        end
+        allow(ConditionRepository).to receive(:save!)
 
         conditions_input.answer_value = "England"
         conditions_input.goto_page_id = 4
@@ -88,7 +85,9 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       end
 
       it "updates a condition" do
-        expect(conditions_input.update_condition).to be_truthy
+        conditions_input.update_condition
+
+        expect(ConditionRepository).to have_received(:save!)
       end
     end
 

--- a/spec/input_objects/pages/delete_condition_input_spec.rb
+++ b/spec/input_objects/pages/delete_condition_input_spec.rb
@@ -21,14 +21,12 @@ RSpec.describe Pages::DeleteConditionInput, type: :model do
 
   describe "#delete" do
     context "when validation pass" do
-      it "destroys a condition" do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.delete "/api/v1/forms/#{form.id}/pages/#{page.id}/conditions/", delete_headers, nil, 204
-        end
-
+      it "destroys the condition" do
+        allow(ConditionRepository).to receive(:destroy).and_return(true)
         delete_condition_input.confirm = "yes"
 
-        expect(delete_condition_input.submit).to be_truthy
+        delete_condition_input.submit
+        expect(ConditionRepository).to have_received(:destroy)
       end
     end
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -195,8 +195,9 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, condition.to_json, 200
       end
+
+      allow(ConditionRepository).to receive(:find).and_return(condition)
 
       allow(Pages::ConditionsInput).to receive(:new).and_return(conditions_input)
       allow(conditions_input).to receive(:check_errors_from_api)
@@ -244,10 +245,11 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, condition.to_json, 200
       end
 
       conditions_input = Pages::ConditionsInput.new(form:, page: selected_page, record: condition, answer_value: "Yes", goto_page_id: 3)
+
+      allow(ConditionRepository).to receive(:find).and_return(condition)
 
       allow(conditions_input).to receive(:update_condition).and_return(submit_result)
 
@@ -307,8 +309,9 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, condition.to_json, 200
       end
+
+      allow(ConditionRepository).to receive(:find).and_return(condition)
 
       delete_condition_input = Pages::DeleteConditionInput.new(form:, page: selected_page, record: condition, answer_value: "Yes", goto_page_id: 3)
 
@@ -352,9 +355,10 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, condition.to_json, 200
-        mock.delete "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, nil, 204
       end
+
+      allow(ConditionRepository).to receive(:find).and_return(condition)
+      allow(ConditionRepository).to receive(:destroy)
 
       delete_condition_input = Pages::DeleteConditionInput.new(form:, page: selected_page, record: condition, answer_value: "Wales", goto_page_id: 3, confirm:)
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -136,11 +136,11 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages/1", headers, selected_page.to_json, 200
       end
 
-      conditional_form = Pages::ConditionsInput.new(form:, page: selected_page, answer_value: "Yes", goto_page_id: 3)
+      conditions_input = Pages::ConditionsInput.new(form:, page: selected_page, answer_value: "Yes", goto_page_id: 3)
 
-      allow(conditional_form).to receive(:submit).and_return(submit_result)
+      allow(conditions_input).to receive(:submit).and_return(submit_result)
 
-      allow(Pages::ConditionsInput).to receive(:new).and_return(conditional_form)
+      allow(Pages::ConditionsInput).to receive(:new).and_return(conditions_input)
 
       post create_condition_path(form_id: form.id, page_id: selected_page.id, params: { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: 3, answer_value: "Wales" } })
     end
@@ -247,11 +247,11 @@ RSpec.describe Pages::ConditionsController, type: :request do
         mock.get "/api/v1/forms/1/pages/#{selected_page.id}/conditions/1", headers, condition.to_json, 200
       end
 
-      conditional_form = Pages::ConditionsInput.new(form:, page: selected_page, record: condition, answer_value: "Yes", goto_page_id: 3)
+      conditions_input = Pages::ConditionsInput.new(form:, page: selected_page, record: condition, answer_value: "Yes", goto_page_id: 3)
 
-      allow(conditional_form).to receive(:update_condition).and_return(submit_result)
+      allow(conditions_input).to receive(:update_condition).and_return(submit_result)
 
-      allow(Pages::ConditionsInput).to receive(:new).and_return(conditional_form)
+      allow(Pages::ConditionsInput).to receive(:new).and_return(conditions_input)
 
       put update_condition_path(form_id: form.id,
                                 page_id: selected_page.id,

--- a/spec/services/condition_repository_spec.rb
+++ b/spec/services/condition_repository_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+describe ConditionRepository do
+  describe "#create!" do
+    let(:condition_params) do
+      { form_id: 1,
+        page_id: 2,
+        check_page_id: 2,
+        routing_page_id: 2,
+        answer_value: "Yes",
+        goto_page_id: 3,
+        skip_to_end: false }
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms/1/pages/2/conditions", post_headers, { id: 4 }.to_json, 200
+      end
+    end
+
+    it "creates a condition through ActiveResource" do
+      described_class.create!(**condition_params)
+      expect(Condition.new(**condition_params)).to have_been_created
+    end
+  end
+
+  describe "#find" do
+    let(:condition) { build(:condition, id: 4, form_id: 1, page_id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1/pages/2/conditions/#{condition.id}", headers, condition.to_json, 200
+      end
+    end
+
+    it "finds the condition through ActiveResource" do
+      described_class.find(condition.id, params: { form_id: 1, page_id: 2 })
+      expect(Condition.new(id: 4, form_id: 1, page_id: 2)).to have_been_read
+    end
+  end
+
+  describe "#save" do
+    let(:condition) { build(:condition, id: 4, skip_to_end: false, form_id: 1, page_id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.put "/api/v1/forms/1/pages/2/conditions/4", post_headers
+      end
+    end
+
+    it "updates the condition through ActiveResource" do
+      condition.skip_to_end = true
+      described_class.save!(condition)
+      expect(Condition.new(id: 4, skip_to_end: true, form_id: 1, page_id: 2)).to have_been_updated
+    end
+  end
+
+  describe "#destroy" do
+    let(:condition) { build(:condition, id: 4, form_id: 1, page_id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.delete "/api/v1/forms/1/pages/2/conditions/4", delete_headers, nil, 204
+      end
+    end
+
+    it "destroys the condition through ActiveResource" do
+      described_class.destroy(condition)
+      expect(Condition.new(id: 4, form_id: 1, page_id: 2)).to have_been_deleted
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/b/9cKfKKdR/govuk-forms-sprint-board

Adds a `ConditionRepository`, which is a new service which acts as a buffer between the app and calls to the Condition model. This is intended to add an abstraction layer between our ActiveResource usage and the rest of the app. 

There's also a refactor for the name of a test var referencing the ConditionsInput object.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
