### PR TITLE
Redirect to correct version of selection options page

### DIFF
--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -3,6 +3,8 @@
 module PageSettingsSummaryComponent
   class View < ViewComponent::Base
     include Rails.application.routes.url_helpers
+    include PagesHelper
+
     def initialize(draft_question:, long_lists_enabled: false)
       super
       @draft_question = draft_question
@@ -105,9 +107,9 @@ module PageSettingsSummaryComponent
 
     def change_selections_options_long_lists_enabled_path
       if is_new_question?
-        long_lists_selection_options_new_path(form_id: @draft_question.form_id)
+        selection_options_new_path_for_draft_question(@draft_question)
       else
-        long_lists_selection_options_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
+        selection_options_edit_path_for_draft_question(@draft_question)
       end
     end
 

--- a/app/controllers/pages/long_lists_selection/type_controller.rb
+++ b/app/controllers/pages/long_lists_selection/type_controller.rb
@@ -1,4 +1,5 @@
 class Pages::LongListsSelection::TypeController < PagesController
+  include PagesHelper
   def new
     @selection_type_input = Pages::LongListsSelection::TypeInput.new(only_one_option:, draft_question:)
     @selection_type_path = long_lists_selection_type_create_path(current_form)
@@ -12,7 +13,7 @@ class Pages::LongListsSelection::TypeController < PagesController
     @back_link_url = question_text_new_path(current_form)
 
     if @selection_type_input.submit
-      redirect_to long_lists_selection_options_new_path
+      redirect_to selection_options_new_path_for_draft_question(draft_question)
     else
       render "pages/long_lists_selection/type", locals: { current_form: }
     end
@@ -31,7 +32,7 @@ class Pages::LongListsSelection::TypeController < PagesController
     @back_link_url = edit_question_path(current_form)
 
     if @selection_type_input.submit
-      redirect_to long_lists_selection_options_edit_path
+      redirect_to selection_options_edit_path_for_draft_question(draft_question)
     else
       render "pages/long_lists_selection/type", locals: { current_form: }
     end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,0 +1,23 @@
+module PagesHelper
+  def selection_options_new_path_for_draft_question(draft_question)
+    options = draft_question_selection_options(draft_question)
+    if options.present? && options.length > 30
+      long_lists_selection_bulk_options_new_path(form_id: draft_question.form_id)
+    else
+      long_lists_selection_options_new_path(form_id: draft_question.form_id)
+    end
+  end
+
+  def selection_options_edit_path_for_draft_question(draft_question)
+    options = draft_question_selection_options(draft_question)
+    if options.present? && options.length > 30
+      long_lists_selection_bulk_options_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id)
+    else
+      long_lists_selection_options_edit_path(form_id: draft_question.form_id, page_id: draft_question.page_id)
+    end
+  end
+
+  def draft_question_selection_options(draft_question)
+    draft_question.answer_settings[:selection_options]
+  end
+end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe PagesHelper, type: :helper do
+  let(:page_id) { 2 }
+  let(:draft_question) { build :draft_question, page_id: }
+
+  describe "#selection_options_new_path_for_draft_question" do
+    context "when draft_question has no answer_settings" do
+      it "returns options path" do
+        expect(helper.selection_options_new_path_for_draft_question(draft_question))
+          .to eq(long_lists_selection_options_new_path(form_id: draft_question.form_id))
+      end
+    end
+
+    context "when draft_question has 30 selection options" do
+      let(:selection_options) { (1..30).to_a.map { |i| { name: i.to_s } } }
+      let(:draft_question) { build :draft_question, answer_settings: { selection_options: } }
+
+      it "returns options path" do
+        expect(helper.selection_options_new_path_for_draft_question(draft_question))
+          .to eq(long_lists_selection_options_new_path(form_id: draft_question.form_id))
+      end
+    end
+
+    context "when draft_question has more than 30 selection options" do
+      let(:selection_options) { (1..31).to_a.map { |i| { name: i.to_s } } }
+      let(:draft_question) { build :draft_question, answer_settings: { selection_options: } }
+
+      it "returns bulk options path" do
+        expect(helper.selection_options_new_path_for_draft_question(draft_question))
+          .to eq(long_lists_selection_bulk_options_new_path(form_id: draft_question.form_id))
+      end
+    end
+  end
+
+  describe "#selection_options_edit_path_for_draft_question" do
+    context "when draft_question has no answer_settings" do
+      it "returns options path" do
+        expect(helper.selection_options_edit_path_for_draft_question(draft_question))
+          .to eq(long_lists_selection_options_edit_path(form_id: draft_question.form_id, page_id:))
+      end
+    end
+
+    context "when draft_question has 30 selection options" do
+      let(:selection_options) { (1..30).to_a.map { |i| { name: i.to_s } } }
+      let(:draft_question) { build :draft_question, page_id:, answer_settings: { selection_options: } }
+
+      it "returns options path" do
+        expect(helper.selection_options_edit_path_for_draft_question(draft_question))
+          .to eq(long_lists_selection_options_edit_path(form_id: draft_question.form_id, page_id:))
+      end
+    end
+
+    context "when draft_question has more than 30 selection options" do
+      let(:selection_options) { (1..31).to_a.map { |i| { name: i.to_s } } }
+      let(:draft_question) { build :draft_question, page_id:, answer_settings: { selection_options: } }
+
+      it "returns bulk options path" do
+        expect(helper.selection_options_edit_path_for_draft_question(draft_question))
+          .to eq(long_lists_selection_bulk_options_edit_path(form_id: draft_question.form_id, page_id:))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ufPgMvic/

We want to decide whether to show the version of the selection options page with fields per option, or a textbox to bulk enter all options depending on how many existing options the draft question has.

If there are no existing options, or less than or equal to 30 options we want to show the page with indivudual fields. If greater than 30, we want to show the page with the textbox.

We need to redirect to the correct version of the page when either redirecting from the "How do you need to collect the answer?" page or from the edit question page. Add helper methods to share the code between these 2 places.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
