### PR TITLE
update seeds to add new form to end to end group

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,4 +64,7 @@ if HostingEnvironment.local_development? && User.none?
 
   # add a form to a test group (assumes database seed being used for forms-api)
   GroupForm.create! group: test_group, form_id: 1
+
+  # add form with submission_type of s3 to end to end group (assumes database seed being used for forms-api)
+  GroupForm.create! group: end_to_end_group, form_id: 2
 end


### PR DESCRIPTION
### What problem does this pull request solve?

we're adding a new end to end test that will test forms with a submission type of s3. There's no front end way to set a form  to a type of s3, so we can't create the form in the e2e tests. Instead, when testing locally, we will use a new seeded form that has been created in forms-api.

This commit connects the new form and adds it to the end to end group.

[Trello card](https://trello.com/c/64CM50hZ/1921-add-an-e2e-test-for-s3-submissions)

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
