### PR TITLE
Add edit, delete buttons, links, redirect to route show

### DIFF
--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -61,7 +61,7 @@
               </dd>
 
               <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
-                <%= govuk_link_to edit_condition_path(form_id: @form_id, page_id: page.id, condition_id: condition.id) do %>
+                <%= govuk_link_to show_routes_path(form_id: @form_id, page_id: page.id) do %>
                   <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", page_index: page.position)) %>
                 <% end %>
               </dd>

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -27,7 +27,7 @@ class Pages::ConditionsController < PagesController
     condition_input = Pages::ConditionsInput.new(condition_input_params)
 
     if condition_input.submit
-      redirect_to form_pages_path(current_form), success: t("banner.success.route_created", question_position: condition_input.page.position)
+      redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_created", question_position: condition_input.page.position)
     else
       render template: "pages/conditions/new", locals: { condition_input: }, status: :unprocessable_entity
     end

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -51,7 +51,7 @@ class Pages::ConditionsController < PagesController
     condition_input = Pages::ConditionsInput.new(form_params)
 
     if condition_input.update_condition
-      redirect_to form_pages_path(current_form), success: t("banner.success.route_updated", question_position: condition_input.page.position)
+      redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_updated", question_position: condition_input.page.position)
     else
       render template: "pages/conditions/edit", locals: { condition_input: }, status: :unprocessable_entity
     end

--- a/app/services/route_summary_card_data_service.rb
+++ b/app/services/route_summary_card_data_service.rb
@@ -1,5 +1,9 @@
 class RouteSummaryCardDataService
-  attr_reader :page, :pages
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::UrlHelper
+  include GovukRailsCompatibleLinkHelper
+
+  attr_reader :form, :page, :pages
 
   class << self
     def call(**args)
@@ -7,9 +11,10 @@ class RouteSummaryCardDataService
     end
   end
 
-  def initialize(page:, pages:)
+  def initialize(form:, page:, pages:)
     @page = page
     @pages = pages
+    @form = form
   end
 
   def summary_card_data
@@ -38,6 +43,9 @@ private
       card: {
         title: I18n.t("page_route_card.conditional_route_title", index:),
         classes: "app-summary-card",
+        actions: [
+          govuk_link_to("Edit", edit_condition_path(form_id: form.id, page_id: page.id, condition_id: routing_condition.id)),
+        ],
       },
       rows: [
         {

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -16,11 +16,21 @@
           end;
       end %>
 
-      <% RouteSummaryCardDataService.call(page:, pages:).summary_card_data.each do |card| %>
+      <% RouteSummaryCardDataService.call(form: current_form, page:, pages:).summary_card_data.each do |card| %>
           <%= govuk_summary_list(**card) %>
       <% end %>
 
-      <%= govuk_link_to t("pages.go_to_your_questions"), form_pages_path(current_form.id) %>
+      <% if page.conditions.present? %>
+          <ul class="govuk-list govuk-list--spaced">
+              <li>
+                  <%= govuk_button_link_to t("page_route_card.delete_route"), destroy_condition_path(form_id: current_form.id, page_id: page.id, condition_id: page.conditions.first.id), warning: true %>
+              </li>
+              <li>
+                  <%= govuk_link_to t("pages.go_to_your_questions"), form_pages_path(current_form.id) %>
+              </li>
+          </ul>
+      <% else %>
+          <%= govuk_link_to t("pages.go_to_your_questions"), form_pages_path(current_form.id) %>
+      <% end %>
 
-  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1002,6 +1002,7 @@ en:
     conditional_route_title: Route %{index}
     continue_to: continue to
     default_route_title: For any other answer
+    delete_route: Delete routes
     if_answer_is: If the answer is
     page_name: "%{page_position}. %{page_name}"
     question_title: Question %{position}

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     it "redirects to the page list" do
-      expect(response).to redirect_to form_pages_path(form.id)
+      expect(response).to redirect_to show_routes_path(form:, page:)
     end
 
     it "displays success message" do

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     it "redirects to the page list" do
-      expect(response).to redirect_to form_pages_path(form.id)
+      expect(response).to redirect_to show_routes_path(form:, page:)
     end
 
     it "displays success message" do

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -48,4 +48,12 @@ describe "pages/routes/show.html.erb" do
   it "has a back to questions link" do
     expect(rendered).to have_link(I18n.t("pages.go_to_your_questions"), href: form_pages_path(form.id))
   end
+
+  context "when the page has routing conditions" do
+    let(:page) { build :page, id: 1, position: 1, routing_conditions: [build(:condition, id: 101)] }
+
+    it "has a delete link" do
+      expect(rendered).to have_link(I18n.t("page_route_card.delete_route", href: destroy_condition_path(form_id: form.id, page_id: page.id, condition_id: page.routing_conditions.first.id)))
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/rwu6TDHu/1923-add-new-edit-routes-page

Add the missing links and buttons to the routes page.

This PR also redirects the user to the routes page after a condition is created
or updated.

- **Change PageListComponent edit link to show routes**
- **Add edit link to route card**
- **Add delete button to routes#show**
- **Add show routes to condition#create**
- **Add redirect to show_routes on condition update**

<img width="758" alt="image" src="https://github.com/user-attachments/assets/0ac27649-da74-4eef-a0a5-ac8d17d99d15">


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
