### PR TITLE
Content changes to edit question page

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -1,73 +1,81 @@
 <%= govuk_summary_list do |summary_list| %>
-  <%= summary_list.with_row do |row|
-      row.with_key(text: t("page_settings_summary.answer_type"))
-      row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}"))
-      row.with_action(text: t("page_settings_summary.change"),
-                 href: @change_answer_type_path,
-                 visually_hidden_text: t("page_settings_summary.answer_type")
-      ) end %>
+  <%= summary_list.with_row do |row| %>
+    <%= row.with_key(text: t("page_settings_summary.answer_type")) %>
+    <%= row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}")) %>
+    <%= row.with_action(text: t("page_settings_summary.change"),
+                    href: @change_answer_type_path,
+                    visually_hidden_text: t("page_settings_summary.answer_type")) %>
+  <% end %>
 
   <% if show_selection_settings_summary %>
-    <%= summary_list.with_row do |row|
-          row.with_key(text: t("page_settings_summary.selection.options"))
-          row.with_value(text: show_selection_options)
-          row.with_action(text: t("page_settings_summary.change"),
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: t("page_settings_summary.selection.options")) %>
+      <%= row.with_value(text: show_selection_options) %>
+      <%= row.with_action(text: t("page_settings_summary.change"),
                     href: @change_selections_options_path,
-                    visually_hidden_text: t("page_settings_summary.selection.options")) end %>
-    <%= summary_list.with_row do |row|
-          row.with_key(text: t("page_settings_summary.selection.only_one_option"))
-          row.with_value(text: answer_settings[:only_one_option] == "true" ? t("selections_settings.yes") : t("selections_settings.no"))
-          row.with_action(text: t("page_settings_summary.change"),
+                    visually_hidden_text: t("page_settings_summary.selection.options")) %>
+    <% end %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: t("page_settings_summary.selection.only_one_option")) %>
+      <%= row.with_value(text: answer_settings[:only_one_option] == "true" ? t("selections_settings.yes") : t("selections_settings.no")) %>
+      <%= row.with_action(text: t("page_settings_summary.change"),
                     href: @change_selections_only_one_option_path,
-                    visually_hidden_text: t("page_settings_summary.selection.only_one_option")) end %>
-    <%= summary_list.with_row do |row|
-          row.with_key(text: t("page_settings_summary.selection.include_none_of_the_above"))
-          row.with_value(text: @draft_question.is_optional ? t("selections_settings.yes") : t("selections_settings.no"))
-          row.with_action(text: t("page_settings_summary.change"),
+                    visually_hidden_text: t("page_settings_summary.selection.only_one_option")) %>
+    <% end %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: t("page_settings_summary.selection.include_none_of_the_above")) %>
+      <%= row.with_value(text: @draft_question.is_optional ? t("selections_settings.yes") : t("selections_settings.no")) %>
+      <%= row.with_action(text: t("page_settings_summary.change"),
                     href: @change_selections_options_path,
-                    visually_hidden_text: t("page_settings_summary.selection.include_none_of_the_above")) end %>
+                    visually_hidden_text: t("page_settings_summary.selection.include_none_of_the_above")) %>
+    <% end %>
   <% end %>
 
   <% if show_text_settings_summary %>
-    <%= summary_list.with_row do |row|
-          row.with_key(text: t("page_settings_summary.text.length"))
-          row.with_value(text: t("helpers.label.page.text_settings_options.names.#{answer_settings[:input_type]}"))
-          row.with_action(text: t("page_settings_summary.change"),
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: t("page_settings_summary.text.length")) %>
+      <%= row.with_value(text: t("helpers.label.page.text_settings_options.names.#{answer_settings[:input_type]}")) %>
+      <%= row.with_action(text: t("page_settings_summary.change"),
                     href: @change_text_settings_path,
-                    visually_hidden_text: t("page_settings_summary.text.length")) end %>
+                    visually_hidden_text: t("page_settings_summary.text.length"))  %>
+    <% end %>
   <% end %>
 
-  <% if show_date_settings_summary%>
-    <%= summary_list.with_row do |row|
-          row.with_key(text: t("page_settings_summary.date.date_of_birth"))
-          row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{answer_settings[:input_type]}"))
-          row.with_action(text: t("page_settings_summary.change"),
+  <% if show_date_settings_summary %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: t("page_settings_summary.date.date_of_birth")) %>
+      <%= row.with_value(text: t("helpers.label.page.date_settings_options.input_types.#{answer_settings[:input_type]}")) %>
+      <%= row.with_action(text: t("page_settings_summary.change"),
                     href: @change_date_settings_path,
-                    visually_hidden_text: t("page_settings_summary.date.date_of_birth")) end %>
+                    visually_hidden_text: t("page_settings_summary.date.date_of_birth"))  %>
+    <% end %>
   <% end %>
 
   <% if show_address_settings_summary %>
-    <%= summary_list.with_row do |row|
-          row.with_key(text: t("page_settings_summary.address.address_type"))
-          row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}"))
-          row.with_action(text: t("page_settings_summary.change"),
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: t("page_settings_summary.address.address_type")) %>
+      <%= row.with_value(text: t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}")) %>
+      <%= row.with_action(text: t("page_settings_summary.change"),
                      href: @change_address_settings_path,
-                     visually_hidden_text: t("page_settings_summary.address.address_type")) end %>
+                     visually_hidden_text: t("page_settings_summary.address.address_type")) %>
+    <% end %>
   <% end %>
 
   <% if show_name_settings_summary %>
-    <%= summary_list.with_row do |row|
-          row.with_key(text: t("page_settings_summary.name.name_fields"))
-          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:input_type]}"))
-          row.with_action(text: t("page_settings_summary.change"),
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: t("page_settings_summary.name.name_fields")) %>
+      <%= row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:input_type]}")) %>
+      <%= row.with_action(text: t("page_settings_summary.change"),
                      href: @change_name_settings_path,
-                     visually_hidden_text: t("page_settings_summary.name.name_fields")) end %>
+                     visually_hidden_text: t("page_settings_summary.name.name_fields")) %>
+    <% end %>
 
-    <%= summary_list.with_row do |row|
-          row.with_key(text: t("page_settings_summary.name.title_needed"))
-          row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:title_needed]}"))
-          row.with_action(text: t("page_settings_summary.change"),
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: t("page_settings_summary.name.title_needed")) %>
+      <%= row.with_value(text: t("helpers.label.page.name_settings_options.names.#{answer_settings[:title_needed]}")) %>
+      <%= row.with_action(text: t("page_settings_summary.change"),
                      href: @change_name_settings_path,
-                     visually_hidden_text: t("page_settings_summary.name.title_needed")) end %>
+                     visually_hidden_text: t("page_settings_summary.name.title_needed")) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -15,12 +15,22 @@
                     href: @change_selections_options_path,
                     visually_hidden_text: t("page_settings_summary.selection.options")) %>
     <% end %>
-    <%= summary_list.with_row do |row| %>
-      <%= row.with_key(text: t("page_settings_summary.selection.only_one_option")) %>
-      <%= row.with_value(text: answer_settings[:only_one_option] == "true" ? t("selections_settings.yes") : t("selections_settings.no")) %>
-      <%= row.with_action(text: t("page_settings_summary.change"),
-                    href: @change_selections_only_one_option_path,
-                    visually_hidden_text: t("page_settings_summary.selection.only_one_option")) %>
+    <% if @long_lists_enabled %>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t("page_settings_summary.selection.how_many_selections")) %>
+        <%= row.with_value(text: answer_settings[:only_one_option] == "true" ? t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.true") : t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")) %>
+        <%= row.with_action(text: t("page_settings_summary.change"),
+                            href: @change_selections_only_one_option_path,
+                            visually_hidden_text: t("page_settings_summary.selection.only_one_option")) %>
+      <% end %>
+    <% else %>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t("page_settings_summary.selection.only_one_option")) %>
+        <%= row.with_value(text: answer_settings[:only_one_option] == "true" ? t("selections_settings.yes") : t("selections_settings.no")) %>
+        <%= row.with_action(text: t("page_settings_summary.change"),
+                      href: @change_selections_only_one_option_path,
+                      visually_hidden_text: t("page_settings_summary.selection.only_one_option")) %>
+      <% end %>
     <% end %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: t("page_settings_summary.selection.include_none_of_the_above")) %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -10,7 +10,18 @@
   <% if show_selection_settings_summary %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: t("page_settings_summary.selection.options")) %>
-      <%= row.with_value(text: show_selection_options) %>
+      <%= row.with_value do %>
+        <%= row.with_value do %>
+          <p>
+            <%= t("page_settings_summary.selection.options_count", number_of_options: selection_options.length) %>
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <% selection_options.each do |option| %>
+              <li><%= option[:name] %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
       <%= row.with_action(text: t("page_settings_summary.change"),
                     href: @change_selections_options_path,
                     visually_hidden_text: t("page_settings_summary.selection.options")) %>

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -41,8 +41,8 @@ module PageSettingsSummaryComponent
       @draft_question.answer_settings
     end
 
-    def show_selection_options
-      answer_settings[:selection_options].map { |option| option[:name] }.join(", ")
+    def selection_options
+      answer_settings[:selection_options]
     end
 
     def change_answer_type_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -727,8 +727,8 @@ en:
           'true': 'Yes'
       pages_long_lists_selection_type_input:
         only_one_option_options:
-          'false': People can choose more than one option
-          'true': People can choose only one option
+          'false': People can select one or more options
+          'true': People can select only one option
       pages_question_input:
         hint_text: Hint text (optional)
         is_optional_options:
@@ -1018,6 +1018,7 @@ en:
       name_fields: Name fields
       title_needed: Title needed
     selection:
+      how_many_selections: How many options can people select
       include_none_of_the_above: Include an option for ‘None of the above’
       only_one_option: People can only select one option
       options: Options
@@ -1067,7 +1068,7 @@ en:
     routing_page_edit: Edit question %{question_position}’s route
     routing_page_new: 'Add a question route: select answer and destination'
     selection_options: Create a list of options
-    selection_type: How do you need to collect the answer?
+    selection_type: How many options should people be able to select?
     separator: " – "
     set_email: Set the email address for completed forms
     share_preview: Share a preview of your draft form

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1022,6 +1022,7 @@ en:
       include_none_of_the_above: Include an option for ‘None of the above’
       only_one_option: People can only select one option
       options: Options
+      options_count: "%{number_of_options} options:"
     text:
       length: Length
   page_titles:

--- a/config/locales/input_objects/long_lists_selection/type.yml
+++ b/config/locales/input_objects/long_lists_selection/type.yml
@@ -6,4 +6,4 @@ en:
         pages/long_lists_selection/type_input:
           attributes:
             only_one_option:
-              inclusion: Select ‘People can choose only one option’ or ‘People can choose more than one option’
+              inclusion: Select ‘People can select only one option’ or ‘People can select one or more options’

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -69,7 +69,9 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
         expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
         expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
-        expect(rows[1].find(".govuk-summary-list__value")).to have_text "Option 1, Option 2"
+        expect(rows[1].find(".govuk-summary-list__value")).to have_text "2 options:"
+        expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 1")
+        expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 2")
         expect(rows[2].find(".govuk-summary-list__key")).to have_text "People can only select one option"
         expect(rows[2].find(".govuk-summary-list__value")).to have_text "Yes"
         expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
@@ -85,7 +87,9 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
           expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
           expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
           expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
-          expect(rows[1].find(".govuk-summary-list__value")).to have_text "Option 1, Option 2"
+          expect(rows[1].find(".govuk-summary-list__value")).to have_text "2 options:"
+          expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 1")
+          expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 2")
           expect(rows[2].find(".govuk-summary-list__key")).to have_text "People can only select one option"
           expect(rows[2].find(".govuk-summary-list__value")).to have_text "Yes"
           expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
@@ -111,7 +115,9 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
           expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
           expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
           expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
-          expect(rows[1].find(".govuk-summary-list__value")).to have_text "Option 1, Option 2"
+          expect(rows[1].find(".govuk-summary-list__value")).to have_text "2 options:"
+          expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 1")
+          expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 2")
           expect(rows[2].find(".govuk-summary-list__key")).to have_text I18n.t("page_settings_summary.selection.how_many_selections")
           expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")
           expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -95,6 +95,57 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
       context "when long_lists_enabled is true for the group" do
         let(:long_lists_enabled) { true }
+        let(:only_one_option) { "false" }
+        let(:draft_question) do
+          build :selection_draft_question,
+                is_optional: false,
+                answer_settings: {
+                  only_one_option:,
+                  selection_options: [{ name: "Option 1" }, { name: "Option 2" }],
+                }
+        end
+
+        it "renders the selection settings" do
+          rows = page.find_all(".govuk-summary-list__row")
+
+          expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
+          expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
+          expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
+          expect(rows[1].find(".govuk-summary-list__value")).to have_text "Option 1, Option 2"
+          expect(rows[2].find(".govuk-summary-list__key")).to have_text I18n.t("page_settings_summary.selection.how_many_selections")
+          expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")
+          expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
+          expect(rows[3].find(".govuk-summary-list__value")).to have_text "No"
+        end
+
+        context "when only_one_option is true" do
+          let(:only_one_option) { "true" }
+
+          it "says people can select one or more options in the summary table" do
+            rows = page.find_all(".govuk-summary-list__row")
+            expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.true")
+          end
+        end
+
+        # This ensures there is backwards compatibility for existing questions as we previously set "only_one_option" to
+        # "0" rather than "false"
+        context "when only_one_option has value '0'" do
+          let(:only_one_option) { "0" }
+
+          it "says people can select only one option in the summary table" do
+            rows = page.find_all(".govuk-summary-list__row")
+            expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")
+          end
+        end
+
+        context "when is_optional is true" do
+          let(:only_one_option) { "false" }
+
+          it "says people can select one or more options in the summary table" do
+            rows = page.find_all(".govuk-summary-list__row")
+            expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")
+          end
+        end
 
         it "the change button for only one option links to the long lists type page" do
           expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: edit_long_lists_selection_type_path)

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -227,16 +227,16 @@ private
   end
 
   def and_i_select_people_can_only_choose_one_option
-    expect(page.find("h1")).to have_text "How do you need to collect the answer?"
+    expect(page.find("h1")).to have_text "How many options should people be able to select?"
     expect_page_to_have_no_axe_errors(page)
-    choose "People can choose only one option"
+    choose "People can select only one option"
     click_button "Continue"
   end
 
   def and_i_select_people_can_choose_one_or_more_options
-    expect(page.find("h1")).to have_text "How do you need to collect the answer?"
+    expect(page.find("h1")).to have_text "How many options should people be able to select?"
     expect_page_to_have_no_axe_errors(page)
-    choose "People can choose more than one option"
+    choose "People can select one or more options"
     click_button "Continue"
   end
 

--- a/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
+++ b/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
@@ -137,7 +137,9 @@ private
     expect(find_field("Option 1").value).to eq "Option 1"
     expect(find_field("Option 2").value).to eq "Option 2"
     click_button "Continue"
-    expect(page.find_all(".govuk-summary-list__value")[1]).to have_text "Option 1, Option 2"
+    expect(page.find_all(".govuk-summary-list__value")[1]).to have_text "2 options:"
+    expect(page.find_all(".govuk-summary-list__value")[1]).to have_css("li", text: "Option 1")
+    expect(page.find_all(".govuk-summary-list__value")[1]).to have_css("li", text: "Option 2")
     expect(page.find_all(".govuk-summary-list__value")[2]).to have_text "Yes"
     expect(page.find_all(".govuk-summary-list__value")[3]).to have_text "Yes"
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/aVhQN4uC/1935-update-the-edit-your-question-page-for-long-list-autocomplete

Update the content displayed in the summary table on the "Edit your question" for selection questions.

When the `long_lists_enabled` flag is turned on for the group, use the new content for displaying the answer to the question asking how many options people should be able to select on the edit question page. Keep the old content for the old journey when the `long_lists_enabled` flag is turned off for the group.

Also update the content on the page to answer this question with the latest iteration of content from the designs.

List the selection options as a bulleted list in the summary table on the "Edit your question" page with the number of options that were entered displayed. This change will apply regardless of whether the `long_lists_enabled` flag  is enabled.

<img width="801" alt="Screenshot 2024-11-07 at 08 54 29" src="https://github.com/user-attachments/assets/a1ff524c-a160-4789-aaeb-b58996bf8f68">

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
