### PR TITLE
Add report for when users last signed in

### DIFF
--- a/app/components/last_signed_in_at_report_component/view.rb
+++ b/app/components/last_signed_in_at_report_component/view.rb
@@ -1,0 +1,49 @@
+module LastSignedInAtReportComponent
+  class View < ViewComponent::Base
+    def initialize(caption, users, empty_message: nil)
+      @caption = caption
+      @users = users
+      @empty_message = empty_message
+
+      super
+    end
+
+    def render?
+      @users.present? || @empty_message.present?
+    end
+
+    def call
+      if @users.present?
+        govuk_table(
+          rows: rows(@users),
+          head:,
+          caption: @caption,
+          first_cell_is_header: true,
+        )
+      else
+        tag.h(@caption, class: "govuk-heading-m") +
+          tag.p(@empty_message, class: "govuk-body")
+      end
+    end
+
+  private
+
+    def head
+      [
+        { text: I18n.t("users.index.table_headings.name") },
+        { text: I18n.t("users.index.table_headings.email") },
+        { text: I18n.t("users.index.table_headings.access") },
+      ]
+    end
+
+    def rows(users)
+      users.order(:has_access, :name).map do |user|
+        [
+          { text: user.name || I18n.t("users.index.name_blank") },
+          { text: user.email },
+          { text: I18n.t("users.has_access.#{user.has_access}.name") },
+        ]
+      end
+    end
+  end
+end

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -25,9 +25,9 @@ module MetricsSummaryComponent
     end
 
     def formatted_date_range
-      start_date_format_string = start_date.year == end_date.year ? "%e %B" : "%e %B %Y"
-      formatted_start_date = format_date(start_date.strftime(start_date_format_string))
-      formatted_end_date = format_date(end_date.strftime("%e %B %Y"))
+      start_date_format = start_date.year == end_date.year ? :short : :default
+      formatted_start_date = format_date(start_date.to_date.to_fs(start_date_format))
+      formatted_end_date = format_date(end_date.to_date.to_fs)
       I18n.t("metrics_summary.date_range", start_date: formatted_start_date, end_date: formatted_end_date)
     end
 
@@ -55,7 +55,7 @@ module MetricsSummaryComponent
       if form_went_live_today?
         I18n.t("metrics_summary.heading_without_dates")
       elsif form_went_live_yesterday?
-        I18n.t("metrics_summary.heading_with_single_date", date: format_date(start_date.strftime("%e %B %Y")))
+        I18n.t("metrics_summary.heading_with_single_date", date: format_date(start_date.to_date.to_fs))
       else
         I18n.t("metrics_summary.heading_with_dates", number_of_days:, formatted_date_range:)
       end
@@ -64,7 +64,7 @@ module MetricsSummaryComponent
   private
 
     def format_date(date)
-      "<span class=\"app-metrics__date\">#{date.strip}</span>"
+      "<span class=\"app-metrics__date\">#{date}</span>"
     end
 
     def form_went_live_today?

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -2,7 +2,7 @@
 
 module MetricsSummaryComponent
   class View < ViewComponent::Base
-    attr_accessor :start_date, :end_date, :weekly_submissions, :weekly_starts, :weekly_started_but_not_completed, :weekly_completion_rate, :form_has_metrics, :error_message, :heading
+    attr_reader :start_date, :end_date, :weekly_submissions, :weekly_starts, :weekly_started_but_not_completed, :weekly_completion_rate, :form_has_metrics, :error_message, :heading
 
     def initialize(form_live_date, metrics_data)
       super
@@ -26,8 +26,8 @@ module MetricsSummaryComponent
 
     def formatted_date_range
       start_date_format = start_date.year == end_date.year ? :short : :default
-      formatted_start_date = format_date(start_date.to_date.to_fs(start_date_format))
-      formatted_end_date = format_date(end_date.to_date.to_fs)
+      formatted_start_date = format_date(start_date.to_fs(start_date_format))
+      formatted_end_date = format_date(end_date.to_fs)
       I18n.t("metrics_summary.date_range", start_date: formatted_start_date, end_date: formatted_end_date)
     end
 
@@ -55,7 +55,7 @@ module MetricsSummaryComponent
       if form_went_live_today?
         I18n.t("metrics_summary.heading_without_dates")
       elsif form_went_live_yesterday?
-        I18n.t("metrics_summary.heading_with_single_date", date: format_date(start_date.to_date.to_fs))
+        I18n.t("metrics_summary.heading_with_single_date", date: format_date(start_date.to_fs))
       else
         I18n.t("metrics_summary.heading_with_dates", number_of_days:, formatted_date_range:)
       end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -28,4 +28,8 @@ class ReportsController < ApplicationController
 
     render template: "reports/add_another_answer", locals: { data: }
   end
+
+  def last_signed_in_at
+    authorize Report, :can_view_reports?
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,4 +133,16 @@ module ApplicationHelper
 
     request.env["warden"].user
   end
+
+  def date_last_signed_in_at(user)
+    last_signed_in_at = user.last_signed_in_at
+
+    if last_signed_in_at.present?
+      last_signed_in_at.to_date.to_fs
+    elsif user.provider.to_sym == :gds
+      I18n.t("last_signed_in_at.not_since_auth0_enabled")
+    else
+      I18n.t("last_signed_in_at.not_since_last_signed_in_at_added")
+    end
+  end
 end

--- a/app/views/mou_signatures/show.html.erb
+++ b/app/views/mou_signatures/show.html.erb
@@ -2,7 +2,7 @@
 
 <% if @mou_signature.present? %>
   <%= govuk_notification_banner(title_text: "MOU has been agreed already") do |banner| %>
-    <% banner.with_heading(text: "The Memorandum of Understanding was agreed on #{@mou_signature.created_at.strftime("%-d %B %Y")}", tag: "p") %>
+    <% banner.with_heading(text: "The Memorandum of Understanding was agreed on #{@mou_signature.created_at.to_date.to_fs}", tag: "p") %>
   <% end %>
 <% end %>
 

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -6,6 +6,7 @@
       <li><%= govuk_link_to t("reports.features.title"), report_features_path %></li>
       <li><%= govuk_link_to t("reports.users.title"), report_users_path %></li>
       <li><%= govuk_link_to t("reports.add_another_answer.title"), report_add_another_answer_path %></li>
+      <li><%= govuk_link_to t("reports.last_signed_in_at.title"), report_last_signed_in_at_path %></li>
     </ul>
   </div>
 </div>

--- a/app/views/reports/last_signed_in_at.html.erb
+++ b/app/views/reports/last_signed_in_at.html.erb
@@ -1,0 +1,23 @@
+<% set_page_title(t(".title")) %>
+
+<% content_for :back_link, govuk_back_link_to(reports_path, t("reports.back_link")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+    <% _1_year_ago = 1.year.ago.to_date.to_fs %>
+    <%= render LastSignedInAtReportComponent::View.new(
+      t(".not_since", since: _1_year_ago), User.where("last_signed_in_at <= ?", 1.year.ago),
+      empty_message: t(".no_users", since: _1_year_ago)
+    ) %>
+
+    <%= render LastSignedInAtReportComponent::View.new(
+      t(".not_since_last_signed_in_at_added"), User.where(last_signed_in_at: nil),
+    ) %>
+
+    <%= render LastSignedInAtReportComponent::View.new(
+      t(".not_since_auth0_enabled"), User.where(provider: :gds),
+    ) %>
+  </div>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -130,6 +130,7 @@ ignore_unused:
 - 'activemodel.errors.*'
 - 'activerecord.errors.*'
 - 'errors.*'
+- 'date.formats.*'
 - 'helpers.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:

--- a/config/initializers/govuk_style.rb
+++ b/config/initializers/govuk_style.rb
@@ -1,0 +1,5 @@
+# https://www.gov.uk/guidance/style-guide
+
+# https://www.gov.uk/guidance/style-guide/a-to-z#dates
+Date::DATE_FORMATS[:default] = Date::DATE_FORMATS[:govuk] = "%-d %B %Y"
+Date::DATE_FORMATS[:short] = Date::DATE_FORMATS[:govuk_short] = "%-d %B"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -766,6 +766,9 @@ en:
   internal_server_error:
     body: Please try again later.
     title: Sorry, there is a problem with the service
+  last_signed_in_at:
+    not_since_auth0_enabled: Before 3 November 2023
+    not_since_last_signed_in_at_added: Sometime between 3 November 2023 and 4 November 2024
   made_live_form:
     archive_this_form: Archive this form
     contact_details: Your form’s contact details for support

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,6 +207,10 @@ en:
   contact_govuk_forms: contact the GOV.UK Forms team
   contact_url: mailto:govuk-forms-support@govuk.zendesk.com
   continue: Continue
+  date:
+    formats:
+      default: "%-d %B %Y"
+      short: "%-d %B"
   declaration_input:
     new:
       body_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1233,6 +1233,13 @@ en:
       title: Feature and answer type usage in live forms
     index:
       title: Reports
+    last_signed_in_at:
+      heading: When users last signed in
+      no_users: All users have signed in since %{since}.
+      not_since: People who last signed in before %{since}
+      not_since_auth0_enabled: People who last signed in before 3 November 2023
+      not_since_last_signed_in_at_added: People who last signed in sometime between 3 November 2023 and 4 November 2024
+      title: When users last signed in
     users:
       heading: Number of users per organisation
       table_headings:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,7 @@ Rails.application.routes.draw do
     get "features", to: "reports#features", as: :report_features
     get "users", to: "reports#users", as: :report_users
     get "add_another_answer", to: "reports#add_another_answer", as: :report_add_another_answer
+    get "last-signed-in-at", to: "reports#last_signed_in_at", as: :report_last_signed_in_at
   end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -24,24 +24,26 @@ RSpec.describe MetricsSummaryComponent::View, type: :component do
 
   describe "#formatted_date_range" do
     context "when the start and end dates are in different years" do
-      before do
-        metrics_summary.start_date = Time.zone.local(2023, 12, 25)
-        metrics_summary.end_date = Time.zone.local(2024, 0o1, 0o2)
+      around do |example|
+        travel_to(Time.zone.local(2024, 1, 3)) do
+          example.run
+        end
       end
 
       it "returns the full start and end dates" do
-        expect(metrics_summary.formatted_date_range).to eq("<span class=\"app-metrics__date\">25 December 2023</span> to <span class=\"app-metrics__date\">2 January 2024</span>")
+        expect(metrics_summary.formatted_date_range).to eq("<span class=\"app-metrics__date\">27 December 2023</span> to <span class=\"app-metrics__date\">2 January 2024</span>")
       end
     end
 
     context "when the start and end dates are in the same year" do
-      before do
-        metrics_summary.start_date = Time.zone.local(2023, 10, 31)
-        metrics_summary.end_date = Time.zone.local(2023, 11, 8)
+      around do |example|
+        travel_to(Time.zone.local(2023, 11, 7)) do
+          example.run
+        end
       end
 
       it "returns the start date without the year" do
-        expect(metrics_summary.formatted_date_range).to eq("<span class=\"app-metrics__date\">31 October</span> to <span class=\"app-metrics__date\">8 November 2023</span>")
+        expect(metrics_summary.formatted_date_range).to eq("<span class=\"app-metrics__date\">31 October</span> to <span class=\"app-metrics__date\">6 November 2023</span>")
       end
     end
   end
@@ -60,8 +62,6 @@ RSpec.describe MetricsSummaryComponent::View, type: :component do
 
   describe "#number_of_days" do
     it "returns the number of days between the start date and today's date, inclusive" do
-      metrics_summary.end_date = 1.day.ago.to_date
-
       expect(metrics_summary.number_of_days).to eq(7)
     end
   end

--- a/spec/config/initializers/govuk_style_spec.rb
+++ b/spec/config/initializers/govuk_style_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "config/initializers/govuk_style.rb" do
+  it "adds a date format matching GOV.UK style" do
+    expect(Date.new(2017, 6, 4).to_fs(:govuk)).to eq "4 June 2017"
+  end
+
+  it "changes the default date format to GOV.UK style" do
+    expect(Date.new(2017, 6, 4).to_fs).to eq "4 June 2017"
+  end
+
+  it "adds a short date format matching GOV.UK style without a year" do
+    expect(Date.new(2017, 6, 4).to_fs(:govuk_short)).to eq "4 June"
+  end
+
+  it "changes the short date format to GOV.UK style" do
+    expect(Date.new(2017, 6, 4).to_fs(:short)).to eq "4 June"
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -329,4 +329,37 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.acting_as_user).to be_nil
     end
   end
+
+  describe "#date_last_signed_in_at" do
+    subject(:date_last_signed_in_at) { helper.date_last_signed_in_at(user) }
+
+    let(:user) { build :user, last_signed_in_at:, provider: }
+    let(:provider) { nil }
+
+    context "when user has signed in since last_signed_in_at code was added" do
+      let(:last_signed_in_at) { Time.zone.iso8601 "2024-11-04T15:45:00" }
+
+      it "renders the date" do
+        expect(date_last_signed_in_at).to eq("4 November 2024")
+      end
+    end
+
+    context "when user has signed in since Auth0 was enabled but not since last_signed_in_at code was added" do
+      let(:provider) { :auth0 }
+      let(:last_signed_in_at) { nil }
+
+      it "renders text explaining that we don't know when exact time, but that it was more recent than since Auth0 being enabled" do
+        expect(date_last_signed_in_at).to eq "Sometime between 3 November 2023 and 4 November 2024"
+      end
+    end
+
+    context "when user has not signed in since Auth0 was enabled" do
+      let(:provider) { :gds }
+      let(:last_signed_in_at) { nil }
+
+      it "renders text explaining that we don't know exact time, but that it was less recent than Auth0 being enabled" do
+        expect(date_last_signed_in_at).to eq "Before 3 November 2023"
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/8WNltVGz/1917-find-out-which-accounts-have-been-inactive-for-over-a-year <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to know if there are any users who have not signed in for more than a year.

This PR adds a simple report to show users who have not signed in since Auth0 was enabled ([on 3 November 2023](https://github.com/alphagov/forms-deploy/pull/401)), or since the `last_signed_in_at` code was added ([on 4 November 2024](https://github.com/alphagov/forms-admin/commit/87a9d73907555273337fa59d282677b5694577d4)).

### Screenshots

![Screenshot of the when users last signed in report page](https://github.com/user-attachments/assets/f8bd7f57-493a-4ff6-a41c-5f8b4096ba47)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?