### PR TITLE
Remove unnecessary full stop

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -995,7 +995,7 @@ en:
     selection_type:
       default: Selection from a list
       none_of_the_above: None of the above
-      only_one_option: Selection from a list, one option only.
+      only_one_option: Selection from a list, one option only
   page_route_card:
     check_your_answers: Check your answers before submitting
     conditional_answer_value: "%{answer_value}"

--- a/spec/services/page_options_service_spec.rb
+++ b/spec/services/page_options_service_spec.rb
@@ -110,7 +110,7 @@ describe PageOptionsService do
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
-          { key:  { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list, one option only." } },
+          { key:  { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list, one option only" } },
           { key:  { text: I18n.t("selections_settings.options_title") }, value: { text: "<ul class=\"govuk-list\"><li>Option 1</li><li>Option 2</li></ul>" } },
         ])
       end


### PR DESCRIPTION
### What problem does this pull request solve?

This full stop is not needed, is not to style and is inconsistent with the other answer type descriptors.

Trello card:n/a

### Things to consider when reviewing
- did Hannah break anything? 
- did Hannah miss any tests?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
