### PR TITLE
Handle switching selection type

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list do |summary_list| %>
+<%= govuk_summary_list(classes: "app-summary-list") do |summary_list| %>
   <%= summary_list.with_row do |row| %>
     <%= row.with_key(text: t("page_settings_summary.answer_type")) %>
     <%= row.with_value(text: t("helpers.label.page.answer_type_options.names.#{@draft_question.answer_type}")) %>
@@ -8,10 +8,14 @@
   <% end %>
 
   <% if show_selection_settings_summary %>
-    <%= summary_list.with_row do |row| %>
+    <%= summary_list.with_row(classes: class_names("govuk-form-group--error": @errors&.has_key?(:selection_options))) do |row| %>
       <%= row.with_key(text: t("page_settings_summary.selection.options")) %>
       <%= row.with_value do %>
-        <%= row.with_value do %>
+          <% if @errors&.has_key?(:selection_options) %>
+            <p id="pages-question-input-selection-options-field-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden"><%= t("errors.prefix") %></span> <%= @errors.messages_for(:selection_options).first %>
+            </p>
+          <% end %>
           <p>
             <%= t("page_settings_summary.selection.options_count", number_of_options: selection_options.length) %>
           </p>
@@ -20,7 +24,6 @@
               <li><%= option[:name] %></li>
             <% end %>
           </ul>
-        <% end %>
       <% end %>
       <%= row.with_action(text: t("page_settings_summary.change"),
                     href: @change_selections_options_path,

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -5,10 +5,11 @@ module PageSettingsSummaryComponent
     include Rails.application.routes.url_helpers
     include PagesHelper
 
-    def initialize(draft_question:, long_lists_enabled: false)
+    def initialize(draft_question:, errors: nil, long_lists_enabled: false)
       super
       @draft_question = draft_question
       @long_lists_enabled = long_lists_enabled
+      @errors = errors
     end
 
     def before_render

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -9,6 +9,7 @@ $govuk-global-styles: true;
 @import "../styles/app_preview_area";
 @import "../styles/app_select_options";
 @import "../styles/app_summary_card";
+@import "../styles/app_summary_list";
 @import "../../components/task_list_component/";
 @import "../../components/page_list_component/";
 @import "../../components/header_component/";

--- a/app/frontend/styles/_app_summary_list.scss
+++ b/app/frontend/styles/_app_summary_list.scss
@@ -1,0 +1,9 @@
+.app-summary-list {
+  // Summary list component overrides
+  .govuk-form-group--error .govuk-summary-list__key {
+    @include govuk-media-query($from: tablet) {
+      padding-left: govuk-spacing(3);
+    }
+  }
+
+}

--- a/app/input_objects/pages/long_lists_selection/type_input.rb
+++ b/app/input_objects/pages/long_lists_selection/type_input.rb
@@ -19,4 +19,9 @@ class Pages::LongListsSelection::TypeInput < BaseInput
   def only_one_option_options
     [OpenStruct.new(id: "true"), OpenStruct.new(id: "false")]
   end
+
+  def need_to_reduce_options?
+    selection_options = draft_question&.answer_settings&.[](:selection_options)
+    selection_options.present? && selection_options.length > 30
+  end
 end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -45,7 +45,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(draft_question:, long_lists_enabled: form_object.group.long_lists_enabled) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question:, errors: question_input.errors, long_lists_enabled: form_object.group.long_lists_enabled) %>
 
   <ul class="govuk-list govuk-list--spaced">
     <li>

--- a/app/views/pages/long_lists_selection/type.html.erb
+++ b/app/views/pages/long_lists_selection/type.html.erb
@@ -5,9 +5,20 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @page.present? && @page.conditions.any? %>
+      <% if @selection_type_input.need_to_reduce_options? %>
+        <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+          <% banner.with_heading(text: t("selection_type.routing_and_reduce_your_options_combined_warning.heading"), tag: "h3") %>
+          <p><%= t("selection_type.routing_and_reduce_your_options_combined_warning.body", pages_link_url: form_pages_path(current_form)) %></p>
+        <% end %>
+      <% else %>
+        <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+          <% banner.with_heading(text: t("selection_type.routing_warning")) %>
+        <% end %>
+      <% end %>
+    <% elsif @selection_type_input.need_to_reduce_options? %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
-        <% banner.with_heading(text: t("selections_settings.routing_warning_about_change_only_one_option_heading"), tag: "h3") %>
-        <%= t("selections_settings.routing_warning_about_change_only_one_option_html", pages_link_url: form_pages_path(current_form)) %>
+        <% banner.with_heading(text: t("selection_type.reduce_your_options_warning.heading"), tag: "h3") %>
+        <p><%= t("selection_type.reduce_your_options_warning.body", pages_link_url: form_pages_path(current_form)) %></p>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,8 @@ en:
             question_text:
               blank: Enter a question
               too_long: Question text must be %{count} characters or less
+            selection_options:
+              too_many_selection_options: You cannot have more than 30 options in a list when people can select more than one option
   activerecord:
     errors:
       models:
@@ -269,6 +271,7 @@ en:
   errors:
     messages:
       non_government_email: Enter a government email address
+    prefix: 'Error:'
   footer:
     accessibility_statement: Accessibility statement
     cookies: Cookies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1276,6 +1276,14 @@ en:
     remove_html: Remove <span class="govuk-visually-hidden">option %{option_number}</span>
     select_more_than_one_option: People will be able to select more than one option from your list.
     select_one_option: People will be able to select one option from your list.
+  selection_type:
+    reduce_your_options_warning:
+      body: You can only have up to 30 options in a list where people can select one or more options. If you make this change, you’ll be able to edit your list on the next page.
+      heading: If you change this to ‘one or more options’, you’ll need to edit your list
+    routing_and_reduce_your_options_combined_warning:
+      body: You can only have up to 30 options in a list where people can select one or more options. If you make this change, you’ll be able to edit your list on the next page.
+      heading: If you change this to ‘one or more options’, the route from this question will be deleted and you’ll need to edit the list
+    routing_warning: If you change this to ‘one or more options’, the route from this question will be deleted
   selections_settings:
     add_another: Add another option
     add_options: Add options to your list

--- a/spec/input_objects/pages/long_lists_selection/type_input_spec.rb
+++ b/spec/input_objects/pages/long_lists_selection/type_input_spec.rb
@@ -73,4 +73,40 @@ RSpec.describe Pages::LongListsSelection::TypeInput do
       end
     end
   end
+
+  describe "need_to_reduce_options?" do
+    context "when there are no answer settings" do
+      let(:draft_question) { build :draft_question, answer_type: "selection" }
+
+      it "returns false" do
+        expect(input.need_to_reduce_options?).to be false
+      end
+    end
+
+    context "when there are no existing options" do
+      let(:draft_question) { build :draft_question, answer_type: "selection", answer_settings: {} }
+
+      it "returns false" do
+        expect(input.need_to_reduce_options?).to be false
+      end
+    end
+
+    context "when there are 30 options" do
+      let(:selection_options) { (1..30).to_a.map { |i| { name: i.to_s } } }
+      let(:draft_question) { build :draft_question, answer_type: "selection", answer_settings: { selection_options: } }
+
+      it "returns false" do
+        expect(input.need_to_reduce_options?).to be false
+      end
+    end
+
+    context "when there are more than 30 options" do
+      let(:selection_options) { (1..31).to_a.map { |i| { name: i.to_s } } }
+      let(:draft_question) { build :draft_question, answer_type: "selection", answer_settings: { selection_options: } }
+
+      it "returns true" do
+        expect(input.need_to_reduce_options?).to be true
+      end
+    end
+  end
 end

--- a/spec/input_objects/pages/long_lists_selection/type_input_spec.rb
+++ b/spec/input_objects/pages/long_lists_selection/type_input_spec.rb
@@ -1,55 +1,75 @@
 require "rails_helper"
 
 RSpec.describe Pages::LongListsSelection::TypeInput do
+  subject(:input) { described_class.new(draft_question:, only_one_option:) }
+
   let(:draft_question) { build :draft_question, answer_type: "selection" }
+  let(:only_one_option) { nil }
 
   describe "validations" do
-    it "is invalid if only_one_option is blank" do
-      input = described_class.new(draft_question:, only_one_option: nil)
-      expect(input).not_to be_valid
-      expected_message = I18n.t("activemodel.errors.models.pages/long_lists_selection/type_input.attributes.only_one_option.inclusion")
-      expect(input.errors.full_messages_for(:only_one_option)).to include("Only one option #{expected_message}")
+    context "when only_one_option is blank" do
+      let(:only_one_option) { nil }
+
+      it "is invalid" do
+        expect(input).not_to be_valid
+        expected_message = I18n.t("activemodel.errors.models.pages/long_lists_selection/type_input.attributes.only_one_option.inclusion")
+        expect(input.errors.full_messages_for(:only_one_option)).to include("Only one option #{expected_message}")
+      end
     end
 
-    it "is invalid if only_one_option value is not in allowed values" do
-      input = described_class.new(draft_question:, only_one_option: "foo")
-      expect(input).not_to be_valid
-      expected_message = I18n.t("activemodel.errors.models.pages/long_lists_selection/type_input.attributes.only_one_option.inclusion")
-      expect(input.errors.full_messages_for(:only_one_option)).to include("Only one option #{expected_message}")
+    context "when only_one_option value is not in allowed values" do
+      let(:only_one_option) { "foo" }
+
+      it "is invalid" do
+        expect(input).not_to be_valid
+        expected_message = I18n.t("activemodel.errors.models.pages/long_lists_selection/type_input.attributes.only_one_option.inclusion")
+        expect(input.errors.full_messages_for(:only_one_option)).to include("Only one option #{expected_message}")
+      end
     end
 
-    it "is valid if only_one_option is true" do
-      input = described_class.new(draft_question:, only_one_option: "true")
-      expect(input).to be_valid
+    context "when only_one_option is true" do
+      let(:only_one_option) { "true" }
+
+      it "is valid" do
+        expect(input).to be_valid
+      end
     end
 
-    it "is valid if only_one_option is false" do
-      input = described_class.new(draft_question:, only_one_option: "false")
-      expect(input).to be_valid
+    context "when only_one_option is false" do
+      let(:only_one_option) { "false" }
+
+      it "is valid" do
+        expect(input).to be_valid
+      end
     end
   end
 
   describe "#submit" do
-    it "returns false if the form is invalid" do
-      input = described_class.new(draft_question:, only_one_option: nil)
-      expect(input.submit).to be false
+    context "when input is invalid" do
+      let(:only_one_option) { nil }
+
+      it "returns false" do
+        expect(input.submit).to be false
+      end
     end
 
-    it "sets only_one_option in draft_question answer_settings" do
-      input = described_class.new(draft_question:, only_one_option: "true")
-      input.submit
-      expect(draft_question.answer_settings).to include(only_one_option: "true")
-    end
+    context "when input is valid" do
+      let(:only_one_option) { "true" }
 
-    context "when there are existing answer settings" do
-      before do
-        draft_question.answer_settings = { foo: "bar" }
+      it "sets only_one_option in draft_question answer_settings" do
+        input.submit
+        expect(draft_question.answer_settings).to include(only_one_option: "true")
       end
 
-      it "does not overwrite other answer_settings" do
-        input = described_class.new(draft_question:, only_one_option: "true")
-        input.submit
-        expect(draft_question.answer_settings).to include({ only_one_option: "true", foo: "bar" })
+      context "when there are existing answer settings" do
+        before do
+          draft_question.answer_settings = { foo: "bar" }
+        end
+
+        it "does not overwrite other answer_settings" do
+          input.submit
+          expect(draft_question.answer_settings).to include({ only_one_option: "true", foo: "bar" })
+        end
       end
     end
   end

--- a/spec/input_objects/pages/question_input_spec.rb
+++ b/spec/input_objects/pages/question_input_spec.rb
@@ -198,6 +198,48 @@ RSpec.describe Pages::QuestionInput, type: :model do
         expect(question_input).to be_invalid
       end
     end
+
+    describe "selection options" do
+      let(:selection_options) { (1..31).to_a.map { |i| { name: i.to_s } } }
+      let(:only_one_option) { "false" }
+      let(:draft_question) { build :selection_draft_question, answer_settings: { selection_options:, only_one_option: } }
+
+      context "when only_one_option is true" do
+        let(:only_one_option) { "true" }
+
+        context "when there are more than 30 options" do
+          it "is valid" do
+            expect(question_input).to be_valid
+          end
+        end
+      end
+
+      context "when only_one_option is false" do
+        context "when there are 30 options" do
+          let(:selection_options) { (1..30).to_a.map { |i| { name: i.to_s } } }
+
+          it "is valid" do
+            expect(question_input).to be_valid
+          end
+        end
+
+        context "when there are more than 30 options" do
+          it "is invalid" do
+            expect(question_input).to be_invalid
+            expect(question_input.errors[:selection_options])
+              .to include(I18n.t("activemodel.errors.models.pages/question_input.attributes.selection_options.too_many_selection_options"))
+          end
+        end
+      end
+
+      context "when answer type is not selection" do
+        let(:draft_question) { build :name_draft_question, answer_settings: { selection_options:, only_one_option: } }
+
+        it "is valid" do
+          expect(question_input).to be_valid
+        end
+      end
+    end
   end
 
   describe "#submit" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/vdNsBNFy

#### Warning on the "How many options should people be able to select?" page

Display a warning on the "How many options should people be able to select?" page if there are more than 30 existing selection options.

There is a limit of 30 options when the user selects "People can select one or more options", so if the user is changing their answer to this question we want to warn them that they will need to reduce the number of options.

We already display a warning if the question has routes, as changing to "People can select one or more options" will cause the routes to be deleted. Reword this error to make sense with the new way we are asking this question.

If we would display both warnings, insead display a single notification banner with content about both these things.

#### Error message on the "Edit your question" page

Add validation on the "Edit your question" page to ensure that the form creator hasn't managed to switch the selection type to "People can select one or more options" when there are more than 30 options. This is possible if the form creator changes this setting and then clicks the back button after they are taken to the page to edit their selection options.

Display the error as an error in the summary list table, similar to how we display routing errors on the list questions page.

Warning when there are more than 30 options:

<img width="889" alt="Screenshot 2024-11-12 at 10 17 30" src="https://github.com/user-attachments/assets/292e8086-2e29-42e8-b1cb-b6d6eaa6aef7">

Warning when there is a route from the question:

<img width="889" alt="Screenshot 2024-11-12 at 10 16 42" src="https://github.com/user-attachments/assets/6b0a34e2-f895-45c7-a16a-541326ea1e7e">

Warning when there is both more than 30 options and a route from the question:

<img width="889" alt="Screenshot 2024-11-12 at 10 17 18" src="https://github.com/user-attachments/assets/0c2d40b5-7224-42c1-a944-b7fa6ccd9d28">

Error on the edit your question page, if the user clicks back before reducing the number of options to 30 or less.

<img width="551" alt="Screenshot 2024-11-12 at 14 29 54" src="https://github.com/user-attachments/assets/8ddef480-41e1-4473-8f96-50a5dd761acf">

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
