### PR TITLE
Add a PageRepository and reroute Page model usage through it

### DIFF
--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -53,11 +53,11 @@ module Forms
       @delete_confirmation_input = DeleteConfirmationInput.new
 
       if params[:page_id].present?
-        @page = Page.find(params[:page_id], params: { form_id: current_form.id })
-        @url = destroy_page_path(current_form, @page)
+        @page = PageRepository.find(page_id: params[:page_id], form_id: current_form.id)
+        @url = destroy_page_path(current_form, @page.id)
         @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion_page")
         @item_name = @page.question_text
-        @back_url = edit_question_path(current_form, @page)
+        @back_url = edit_question_path(current_form, @page.id)
       else
         @url = destroy_form_path(current_form)
         @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion")
@@ -80,7 +80,7 @@ module Forms
     def delete_page(form, page)
       success_url = form_pages_path(form)
 
-      if page.destroy
+      if PageRepository.destroy(page)
         redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{page.question_text}’"
       else
         raise StandardError, "Deletion unsuccessful"

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -19,9 +19,8 @@ class Pages::QuestionsController < PagesController
   def create
     @question_input = Pages::QuestionInput.new(page_params_for_form_object)
 
-    # TODO: Move Page creation to be part of the form submit method
-    if @question_input.submit
-      @page = PageRepository.create!(page_params_for_forms_api)
+    if @question_input.valid?
+      @page = @question_input.submit
       clear_draft_questions_data
       redirect_to edit_question_path(current_form, @page.id), success: "Your changes have been saved"
     else
@@ -44,8 +43,7 @@ class Pages::QuestionsController < PagesController
 
     @question_input = Pages::QuestionInput.new(page_params_for_form_object)
 
-    # TODO: Move Page creation to be part of the form submit method
-    if @question_input.submit && (@page = PageRepository.save!(@page))
+    if @question_input.update_page(@page)
       clear_draft_questions_data
       redirect_to edit_question_path(current_form, @page.id), success: "Your changes have been saved"
     else
@@ -61,6 +59,7 @@ private
 
   def page_params_for_form_object
     page_params.merge(draft_question:,
+                      form_id: current_form.id,
                       answer_type: draft_question.answer_type,
                       answer_settings: draft_question.answer_settings,
                       page_heading: draft_question.page_heading,

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -19,12 +19,11 @@ class Pages::QuestionsController < PagesController
   def create
     @question_input = Pages::QuestionInput.new(page_params_for_form_object)
 
-    @page = Page.new(page_params_for_forms_api)
-
     # TODO: Move Page creation to be part of the form submit method
-    if @question_input.submit && @page.save
+    if @question_input.submit
+      @page = PageRepository.create!(page_params_for_forms_api)
       clear_draft_questions_data
-      redirect_to edit_question_path(current_form, @page), success: "Your changes have been saved"
+      redirect_to edit_question_path(current_form, @page.id), success: "Your changes have been saved"
     else
       render :new, locals: { current_form:, draft_question: }, status: :unprocessable_entity
     end
@@ -46,9 +45,9 @@ class Pages::QuestionsController < PagesController
     @question_input = Pages::QuestionInput.new(page_params_for_form_object)
 
     # TODO: Move Page creation to be part of the form submit method
-    if @question_input.submit && page.save
+    if @question_input.submit && (@page = PageRepository.save!(@page))
       clear_draft_questions_data
-      redirect_to edit_question_path(current_form, @page), success: "Your changes have been saved"
+      redirect_to edit_question_path(current_form, @page.id), success: "Your changes have been saved"
     else
       render :edit, locals: { current_form:, draft_question: }, status: :unprocessable_entity
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,9 +15,9 @@ class PagesController < ApplicationController
   end
 
   def move_page
-    page_to_move = Page.find(move_params[:page_id], params: { form_id: move_params[:form_id] })
+    page_to_move = PageRepository.find(page_id: move_params[:page_id], form_id: move_params[:form_id])
 
-    page_to_move.move_page(move_params[:direction])
+    PageRepository.move_page(page_to_move, move_params[:direction])
 
     position = if move_params[:direction] == :up
                  page_to_move.position - 1
@@ -39,7 +39,7 @@ private
   end
 
   def page
-    @page ||= Page.find(params[:page_id], params: { form_id: current_form.id })
+    @page ||= PageRepository.find(page_id: params[:page_id], form_id: current_form.id)
   end
 
   def draft_question

--- a/app/input_objects/pages/question_input.rb
+++ b/app/input_objects/pages/question_input.rb
@@ -1,9 +1,9 @@
 class Pages::QuestionInput < BaseInput
   include QuestionTextValidation
 
-  attr_accessor :question_text, :hint_text, :is_optional, :answer_type, :draft_question, :is_repeatable
+  attr_accessor :question_text, :hint_text, :is_optional, :answer_type, :draft_question, :is_repeatable, :form_id
 
-  # TODO: We could lose these attributes once we have an Check your answers page
+  # TODO: We could lose these attributes once we have a Check your answers page
   attr_accessor :answer_settings, :page_heading, :guidance_markdown
 
   attr_reader :selection_options # only used for displaying error
@@ -25,6 +25,31 @@ class Pages::QuestionInput < BaseInput
     )
 
     draft_question.save!(validate: false)
+
+    PageRepository.create!(form_id:,
+                           question_text:,
+                           hint_text:,
+                           is_optional:,
+                           is_repeatable:,
+                           answer_settings:,
+                           page_heading:,
+                           guidance_markdown:,
+                           answer_type:)
+  end
+
+  def update_page(page)
+    return false if invalid?
+
+    draft_question.assign_attributes(
+      question_text:,
+      hint_text:,
+      is_optional:,
+      is_repeatable:,
+    )
+
+    draft_question.save!(validate: false)
+
+    PageRepository.save!(page)
   end
 
   def default_options

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -46,10 +46,6 @@ class Page < ActiveResource::Base
     answer_settings.selection_options.map { |option| option.attributes[:name] }.join(", ")
   end
 
-  def submit
-    save!
-  end
-
   def conditions
     routing_conditions.map { |routing_condition| Condition.new(routing_condition.attributes) }
   end

--- a/app/services/page_repository.rb
+++ b/app/services/page_repository.rb
@@ -4,8 +4,25 @@ class PageRepository
       Page.find(page_id, params: { form_id: })
     end
 
-    def create!(params)
-      Page.create!(params)
+    def create!(form_id:,
+                question_text:,
+                hint_text:,
+                is_optional:,
+                is_repeatable:,
+                answer_settings:,
+                page_heading:,
+                guidance_markdown:,
+                answer_type:)
+
+      Page.create!(form_id:,
+                   question_text:,
+                   hint_text:,
+                   is_optional:,
+                   is_repeatable:,
+                   answer_settings:,
+                   page_heading:,
+                   guidance_markdown:,
+                   answer_type:)
     end
 
     def save!(record)

--- a/app/services/page_repository.rb
+++ b/app/services/page_repository.rb
@@ -1,0 +1,30 @@
+class PageRepository
+  class << self
+    def find(page_id:, form_id:)
+      Page.find(page_id, params: { form_id: })
+    end
+
+    def create!(params)
+      Page.create!(params)
+    end
+
+    def save!(record)
+      page = Page.new(record.attributes, true)
+      page.prefix_options = record.prefix_options
+      page.save!
+      page
+    end
+
+    def destroy(record)
+      page = Page.new(record.attributes, true)
+      page.prefix_options = record.prefix_options
+      page.destroy # rubocop:disable Rails/SaveBang
+    end
+
+    def move_page(record, direction)
+      page = Page.new(record.attributes, true)
+      page.prefix_options = record.prefix_options
+      page.move_page(direction)
+    end
+  end
+end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     has_routing_errors { false }
     page_heading { nil }
     guidance_markdown { nil }
+    is_repeatable { false }
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda.truncate(500) }

--- a/spec/input_objects/pages/question_input_spec.rb
+++ b/spec/input_objects/pages/question_input_spec.rb
@@ -233,11 +233,50 @@ RSpec.describe Pages::QuestionInput, type: :model do
 
     context "when form is valid valid" do
       before do
+        allow(PageRepository).to receive(:create!)
+
         question_input.question_text = "How old are you?"
         question_input.hint_text = "As a number"
         question_input.is_optional = "false"
         question_input.is_repeatable = "true"
         question_input.submit
+      end
+
+      it "sets a draft_question question_text" do
+        expect(question_input.draft_question.question_text).to eq question_input.question_text
+      end
+
+      it "sets a draft_question hint_text" do
+        expect(question_input.draft_question.hint_text).to eq question_input.hint_text
+      end
+
+      it "sets a draft_question is_optional" do
+        expect(question_input.draft_question.is_optional.to_s).to eq question_input.is_optional
+      end
+
+      it "sets a draft_question is_repeatable" do
+        expect(question_input.draft_question.is_repeatable.to_s).to eq question_input.is_repeatable
+      end
+    end
+  end
+
+  describe "#update_page" do
+    let(:page) { build(:page, form_id: 1) }
+
+    it "returns false if the form is invalid" do
+      allow(question_input).to receive(:invalid?).and_return(true)
+      expect(question_input.update_page(page)).to be false
+    end
+
+    context "when form is valid valid" do
+      before do
+        allow(PageRepository).to receive(:save!).and_return(page)
+
+        question_input.question_text = "How old are you?"
+        question_input.hint_text = "As a number"
+        question_input.is_optional = "false"
+        question_input.is_repeatable = "true"
+        question_input.update_page(page)
       end
 
       it "sets a draft_question question_text" do

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -139,25 +139,6 @@ RSpec.describe Pages::QuestionsController, type: :request do
         expect(banner_contents).to have_link(text: "Add a question", href: start_new_question_path(form_id: 2))
         expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: 2))
       end
-
-      context "when passing is_repeatable as a param" do
-        let(:params) do
-          { pages_question_input: {
-            question_text: "What is your home address?",
-            hint_text: "This should be the location stated in your contract.",
-            is_optional: false,
-            is_repeatable: true,
-          } }
-        end
-
-        it "creates the page on the API with the correct is_repeatable value" do
-          matched_request = ActiveResource::HttpMock.requests.find do |request|
-            request.method == :post && request.path == "/api/v1/forms/2/pages"
-          end
-
-          expect(JSON.parse(matched_request.body)).to include("is_repeatable" => true)
-        end
-      end
     end
 
     context "when question_input has invalid data" do
@@ -350,29 +331,6 @@ RSpec.describe Pages::QuestionsController, type: :request do
 
           expect(banner_contents).to have_link(text: "Edit next question", href: edit_question_path(form_id: 2, page_id: 4))
           expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: 2))
-        end
-      end
-
-      context "when passing is_repeatable as a param" do
-        let(:params) do
-          { pages_question_input: {
-            form_id: 2,
-            question_text: "What is your home address?",
-            hint_text: "This should be the location stated in your contract.",
-            answer_type: "address",
-            is_optional: "false",
-            is_repeatable: "true",
-            page_heading: "New page heading",
-            guidance_markdown: "## Heading level 2",
-          } }
-        end
-
-        it "updates the page on the API with the correct is_repeatable value" do
-          matched_request = ActiveResource::HttpMock.requests.find do |request|
-            request.method == :put && request.path == "/api/v1/forms/2/pages/1"
-          end
-
-          expect(JSON.parse(matched_request.body)).to include("is_repeatable" => true)
         end
       end
     end

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -243,6 +243,8 @@ RSpec.describe Pages::QuestionsController, type: :request do
       }
     end
 
+    let(:page) { build(:page, **page_response) }
+
     describe "Given a page" do
       let(:params) do
         { pages_question_input: {
@@ -258,6 +260,8 @@ RSpec.describe Pages::QuestionsController, type: :request do
       end
 
       before do
+        allow(PageRepository).to receive_messages(find: page, save!: page)
+
         post update_question_path(form_id: 2, page_id: 1), params:
       end
 

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe Pages::QuestionsController, type: :request do
     }
   end
 
+  let(:page) do
+    build(:page,
+          id: 1,
+          form_id: 2,
+          question_text: draft_question.question_text,
+          hint_text: draft_question.hint_text,
+          answer_type: draft_question.answer_type,
+          answer_settings: nil,
+          is_optional: false,
+          is_repeatable: false,
+          page_heading: nil,
+          guidance_markdown: nil,
+          next_page:)
+  end
+
   let(:updated_page_data) do
     {
       id: 1,
@@ -38,6 +53,20 @@ RSpec.describe Pages::QuestionsController, type: :request do
     }
   end
 
+  let(:updated_page) do
+    build(:page,
+          id: 1,
+          question_text: "What is your home address?",
+          hint_text: "This should be the location stated in your contract.",
+          answer_type: "address",
+          answer_settings: {},
+          is_optional: false,
+          is_repeatable: false,
+          page_heading: "New page heading",
+          guidance_markdown: "## Heading level 2",
+          next_page:)
+  end
+
   let(:form_pages_response) do
     [page_response].to_json
   end
@@ -48,10 +77,9 @@ RSpec.describe Pages::QuestionsController, type: :request do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/2", headers, form_response.to_json, 200
       mock.get "/api/v1/forms/2/pages", headers, form_pages_response, 200
-      mock.get "/api/v1/forms/2/pages/1", headers, page_response.to_json, 200
-      mock.post "/api/v1/forms/2/pages", post_headers, page_response.to_json, 200
-      mock.put "/api/v1/forms/2/pages/1", post_headers, updated_page_data.to_json, 200
     end
+
+    allow(PageRepository).to receive_messages(create!: page, find: page, save!: updated_page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form_response.id, group_id: group.id)
@@ -120,17 +148,6 @@ RSpec.describe Pages::QuestionsController, type: :request do
         expect(response).to redirect_to(edit_question_path(form_id: 2, page_id: 1))
       end
 
-      it "Creates the page on the API" do
-        expected_request = ActiveResource::Request.new(:post, "/api/v1/forms/2/pages", new_page_data.to_json, post_headers)
-        matched_request = ActiveResource::HttpMock.requests.find do |request|
-          request.method == expected_request.method &&
-            request.path == expected_request.path &&
-            request.body == expected_request.body
-        end
-
-        expect(matched_request).to eq expected_request
-      end
-
       it "displays a notification banner with call to action links" do
         follow_redirect!
         results = Capybara.string(response.body)
@@ -175,32 +192,24 @@ RSpec.describe Pages::QuestionsController, type: :request do
         get edit_question_path(form_id: 2, page_id: 1)
       end
 
-      it "Reads the page from the API" do
-        form_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
-        expect(ActiveResource::HttpMock.requests).to include form_request
-
-        form_pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
-        expect(ActiveResource::HttpMock.requests).to include form_pages_request
-
-        page_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
-        expect(ActiveResource::HttpMock.requests).to include page_request
+      it "Reads the page from the page repository" do
+        expect(PageRepository).to have_received(:find)
       end
 
       context "when page has unrecognised attributes" do
-        let(:page_response) do
-          {
-            id: 1,
-            form_id: 2,
-            question_text: draft_question.question_text,
-            hint_text: draft_question.hint_text,
-            answer_type: draft_question.answer_type,
-            answer_settings: nil,
-            is_optional: false,
-            page_heading: nil,
-            guidance_markdown: nil,
-            next_page:,
-            newly_added_to_api: "some value",
-          }
+        let(:page) do
+          build(:page,
+                id: 1,
+                form_id: 2,
+                question_text: draft_question.question_text,
+                hint_text: draft_question.hint_text,
+                answer_type: draft_question.answer_type,
+                answer_settings: nil,
+                is_optional: false,
+                page_heading: nil,
+                guidance_markdown: nil,
+                next_page:,
+                newly_added_to_api: "some value")
         end
 
         it "renders successfully" do
@@ -252,23 +261,12 @@ RSpec.describe Pages::QuestionsController, type: :request do
         post update_question_path(form_id: 2, page_id: 1), params:
       end
 
-      it "Reads the page from the API" do
-        form_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
-        expect(ActiveResource::HttpMock.requests).to include form_request
-
-        page_request = ActiveResource::Request.new(:put, "/api/v1/forms/2/pages/1", {}, post_headers)
-        expect(ActiveResource::HttpMock.requests).to include page_request
+      it "Reads the page from the PageRepository" do
+        expect(PageRepository).to have_received(:find)
       end
 
-      it "Updates the page on the API" do
-        expected_request = ActiveResource::Request.new(:put, "/api/v1/forms/2/pages/1", updated_page_data.to_json, post_headers)
-        matched_request = ActiveResource::HttpMock.requests.find do |request|
-          request.method == expected_request.method &&
-            request.path == expected_request.path &&
-            request.body == expected_request.body
-        end
-
-        expect(matched_request).to eq expected_request
+      it "Updates the page through the page repository" do
+        expect(PageRepository).to have_received(:save!)
       end
 
       it "Redirects you to edit page for question that was updated" do
@@ -299,25 +297,6 @@ RSpec.describe Pages::QuestionsController, type: :request do
             page_heading: "New page heading",
             guidance_markdown: "## Heading level 2",
           } }
-        end
-
-        it "Reads the page from the API" do
-          form_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
-          expect(ActiveResource::HttpMock.requests).to include form_request
-
-          page_request = ActiveResource::Request.new(:put, "/api/v1/forms/2/pages/1", {}, post_headers)
-          expect(ActiveResource::HttpMock.requests).to include page_request
-        end
-
-        it "Updates the page on the API" do
-          expected_request = ActiveResource::Request.new(:put, "/api/v1/forms/2/pages/1", updated_page_data.to_json, post_headers)
-          matched_request = ActiveResource::HttpMock.requests.find do |request|
-            request.method == expected_request.method &&
-              request.path == expected_request.path &&
-              request.body == expected_request.body
-          end
-
-          expect(matched_request).to eq expected_request
         end
 
         it "Redirects you to edit page for new question" do

--- a/spec/services/page_repository_spec.rb
+++ b/spec/services/page_repository_spec.rb
@@ -36,7 +36,7 @@ describe PageRepository do
     end
 
     it "creates a page through ActiveResource" do
-      described_class.create!(page_params)
+      described_class.create!(**page_params)
       expect(Page.new(page_params)).to have_been_created
     end
   end

--- a/spec/services/page_repository_spec.rb
+++ b/spec/services/page_repository_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+describe PageRepository do
+  describe "#find" do
+    let(:page) { build(:page, id: 2, form_id: 1) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
+      end
+    end
+
+    it "finds the page through ActiveResource" do
+      described_class.find(page_id: page.id, form_id: 1)
+      expect(Page.new(id: 2, form_id: 1)).to have_been_read
+    end
+  end
+
+  describe "#create!" do
+    let(:page_params) do
+      { question_text: "asdf",
+        hint_text: "",
+        is_optional: false,
+        is_repeatable: false,
+        form_id: 1,
+        answer_settings: {},
+        page_heading: nil,
+        guidance_markdown: nil,
+        answer_type: "organisation_name" }
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms/1/pages", post_headers, Page.new(page_params).to_json, 200
+      end
+    end
+
+    it "creates a page through ActiveResource" do
+      described_class.create!(page_params)
+      expect(Page.new(page_params)).to have_been_created
+    end
+  end
+
+  describe "#save!" do
+    let(:page) { build(:page, id: 2, form_id: 1, is_optional: false) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
+        mock.put "/api/v1/forms/1/pages/2", post_headers
+      end
+    end
+
+    it "updates the page through ActiveResource" do
+      page = described_class.find(page_id: 2, form_id: 1)
+      page.is_optional = true
+      described_class.save!(page)
+      expect(Page.new(id: 2, form_id: 1, is_optional: true)).to have_been_updated
+    end
+  end
+
+  describe "#destroy" do
+    let(:page) { build(:page, id: 2, form_id: 1) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
+        mock.delete "/api/v1/forms/1/pages/2", delete_headers, nil, 204
+      end
+    end
+
+    it "destroys the page through ActiveResource" do
+      page = described_class.find(page_id: 2, form_id: 1)
+      described_class.destroy(page)
+      expect(Page.new(id: 2, form_id: 1)).to have_been_deleted
+    end
+  end
+
+  describe "#move_page" do
+    let(:page) { build(:page, id: 2, form_id: 1) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
+        mock.put "/api/v1/forms/1/pages/2/up", post_headers
+      end
+    end
+
+    it "calls the move endpoint through ActiveResource" do
+      move_request = ActiveResource::Request.new(:put, "/api/v1/forms/1/pages/2/up", {}, post_headers)
+      page = described_class.find(page_id: 2, form_id: 1)
+      described_class.move_page(page, :up)
+      expect(ActiveResource::HttpMock.requests).to include move_request
+    end
+  end
+end


### PR DESCRIPTION
The PageRepository being introduced is used as an interface between the application and any Page method calls that result in an API call through ActiveResource. The intention is to create a layer of separation, so that database requests can be rerouted more easily as part of the Admin/API responsibilities shifting.

### What problem does this pull request solve?

Trello card: https://trello.com/c/QuEeu8uI/1939-add-repository-service-to-forms-admin-for-form-page-model

This PR adds the PageRepository, which is intended to act as a buffer between the app and any ActiveResource API usage when using the Page model. I've tried to go through and find all the spots where we use Page model requests, it's a little fiddly! 

As well as CRUD ops, it also implements the `move_page`, as this also hooks into the API.

If you know of anywhere else that we use the API's Page model, please leave a comment and I'll reroute it through the PageRepository.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
