### PR TITLE
Update content for selecting list type

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -613,6 +613,10 @@ en:
       pages_long_lists_selection_options_input:
         include_none_of_the_above_options:
           'true': We’ll add ‘None of the above’ to the end of your list of options
+      pages_long_lists_selection_type_input:
+        only_one_option_options:
+          'false': Your list can have up to 1,000 options
+          'true': Your list can have up to 30 options
       pages_question_input:
         is_optional_options:
           'true': We’ll add ‘(optional)’ to the end of the question text.
@@ -734,8 +738,8 @@ en:
           'true': 'Yes'
       pages_long_lists_selection_type_input:
         only_one_option_options:
-          'false': People can select one or more options
-          'true': People can select only one option
+          'false': One option only
+          'true': One or more options
       pages_question_input:
         hint_text: Hint text (optional)
         is_optional_options:

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -123,9 +123,10 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       context "when long_lists_enabled is true for the group" do
         let(:long_lists_enabled) { true }
         let(:only_one_option) { "false" }
+        let(:is_optional) { false }
         let(:draft_question) do
           build :selection_draft_question,
-                is_optional: false,
+                is_optional:,
                 answer_settings: {
                   only_one_option:,
                   selection_options: [{ name: "Option 1" }, { name: "Option 2" }],
@@ -168,11 +169,11 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         end
 
         context "when is_optional is true" do
-          let(:only_one_option) { "false" }
+          let(:is_optional) { "true" }
 
-          it "says people can select one or more options in the summary table" do
+          it "says an option for None of the above will be included" do
             rows = page.find_all(".govuk-summary-list__row")
-            expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")
+            expect(rows[3].find(".govuk-summary-list__value")).to have_text "Yes"
           end
         end
 

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -229,14 +229,14 @@ private
   def and_i_select_people_can_only_choose_one_option
     expect(page.find("h1")).to have_text "How many options should people be able to select?"
     expect_page_to_have_no_axe_errors(page)
-    choose "People can select only one option"
+    choose "One option only"
     click_button "Continue"
   end
 
   def and_i_select_people_can_choose_one_or_more_options
     expect(page.find("h1")).to have_text "How many options should people be able to select?"
     expect_page_to_have_no_axe_errors(page)
-    choose "People can select one or more options"
+    choose "One or more options"
     click_button "Continue"
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/r9QERYzv/1982-add-hint-text-for-radio-or-checkbox-options-when-creating-a-list-and-update-the-option-labels

Update content on the "How many options should people be able to select?" page with new legends and hint text. 
The error message on this page will be updated by https://github.com/alphagov/forms-admin/pull/1597

This also updates the values in the summary table on the "Edit your question" page.

<img width="1048" alt="Screenshot 2024-11-12 at 17 13 12" src="https://github.com/user-attachments/assets/a1f73e2e-4d5a-4eb8-b0aa-43dbfb56826b">

<img width="755" alt="Screenshot 2024-11-12 at 17 12 50" src="https://github.com/user-attachments/assets/969df16a-95d4-43f1-b2d4-ac28a8a366bb">

<img width="771" alt="Screenshot 2024-11-12 at 17 13 24" src="https://github.com/user-attachments/assets/c84521d3-9374-42a9-893f-3ceda81be2b9">

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
