### PR TITLE
Small fixes for "when users last signed in" report

### DIFF
--- a/app/views/reports/last_signed_in_at.html.erb
+++ b/app/views/reports/last_signed_in_at.html.erb
@@ -9,7 +9,6 @@
     <% _1_year_ago = 1.year.ago.to_date.to_fs %>
     <%= render LastSignedInAtReportComponent::View.new(
       t(".not_since", since: _1_year_ago), User.where("last_signed_in_at <= ?", 1.year.ago),
-      empty_message: t(".no_users", since: _1_year_ago)
     ) %>
 
     <%= render LastSignedInAtReportComponent::View.new(

--- a/app/views/reports/last_signed_in_at.html.erb
+++ b/app/views/reports/last_signed_in_at.html.erb
@@ -12,7 +12,7 @@
     ) %>
 
     <%= render LastSignedInAtReportComponent::View.new(
-      t(".not_since_last_signed_in_at_added"), User.where(last_signed_in_at: nil),
+      t(".not_since_last_signed_in_at_added"), User.where.not(provider: :gds).where(last_signed_in_at: nil),
     ) %>
 
     <%= render LastSignedInAtReportComponent::View.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1243,7 +1243,6 @@ en:
       title: Reports
     last_signed_in_at:
       heading: When users last signed in
-      no_users: All users have signed in since %{since}.
       not_since: People who last signed in before %{since}
       not_since_auth0_enabled: People who last signed in before 3 November 2023
       not_since_last_signed_in_at_added: People who last signed in sometime between 3 November 2023 and 4 November 2024

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -250,4 +250,35 @@ RSpec.describe ReportsController, type: :request do
       end
     end
   end
+
+  describe "#last_signed_in_at" do
+    let!(:users) do
+      [
+        create(:user, provider: :auth0, last_signed_in_at: (1.year + 2.months).ago),
+        create(:user, provider: :auth0, last_signed_in_at: nil),
+        create(:user, provider: :gds, last_signed_in_at: nil),
+      ]
+    end
+
+    before do
+      login_as_super_admin_user
+
+      get report_last_signed_in_at_path
+    end
+
+    it "returns http code 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the last_signed_in_at report view" do
+      expect(response).to render_template("reports/last_signed_in_at")
+    end
+
+    it "includes the report data" do
+      expect(response.body).to include "When users last signed in"
+      expect(response.body).to include users.first.email
+      expect(response.body).to include users.second.email
+      expect(response.body).to include users.third.email
+    end
+  end
 end

--- a/spec/views/reports/last_signed_in_at.html.erb_spec.rb
+++ b/spec/views/reports/last_signed_in_at.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "reports/last_signed_in_at" do
+  let(:users) do
+    [
+      create(:user, provider: :auth0, last_signed_in_at: (1.year + 2.months).ago),
+      create(:user, provider: :auth0, last_signed_in_at: nil),
+      create(:user, provider: :gds, last_signed_in_at: nil),
+    ]
+  end
+
+  before do
+    users
+
+    render
+  end
+
+  describe "tables of when users last signed in" do
+    specify "users who are in one table are not duplicated in another" do
+      users.each do |user|
+        expect(rendered).to have_text(user.email, maximum: 1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/8WNltVGz/1917-find-out-which-accounts-have-been-inactive-for-over-a-year <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Tweak "When users last signed in" report to reduce confusion and fix duplication of users between tables.

See commit messages for more details.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?