### PR TITLE
Fix translations for only_one_option_options

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,8 +615,8 @@ en:
           'true': We’ll add ‘None of the above’ to the end of your list of options
       pages_long_lists_selection_type_input:
         only_one_option_options:
-          'false': Your list can have up to 1,000 options
-          'true': Your list can have up to 30 options
+          'false': Your list can have up to 30 options
+          'true': Your list can have up to 1,000 options
       pages_question_input:
         is_optional_options:
           'true': We’ll add ‘(optional)’ to the end of the question text.
@@ -738,8 +738,8 @@ en:
           'true': 'Yes'
       pages_long_lists_selection_type_input:
         only_one_option_options:
-          'false': One option only
-          'true': One or more options
+          'false': One or more options
+          'true': One option only
       pages_question_input:
         hint_text: Hint text (optional)
         is_optional_options:


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/qm6cUBD2/1936-review-all-the-long-list-content-and-update-as-necessary?filter=label:Feature%20team%20one,label:Tech%20Support,label:X%20feature%20teams (assigning this to the content sweep)

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
The 'true' and 'false' values were the wrong way round for these translations, so that it would show 'One or more options' for the 'One option only' radio button, and vice versa.

This PR switches them around so that they're correct.


### Screenshots
#### Before:
![image](https://github.com/user-attachments/assets/dc762ed7-0ba9-450f-b7fc-f97e514417a5)

#### After
![image](https://github.com/user-attachments/assets/388aa91d-57e3-4953-8147-f85bde30c2ab)

In both images, the top option sets `only_one_option` to `true` and the bottom one sets it to `false`

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
