### PR TITLE
Use details to show selection options

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -11,11 +11,20 @@
     <%= summary_list.with_row(classes: class_names("govuk-form-group--error": @errors&.has_key?(:selection_options))) do |row| %>
       <%= row.with_key(text: t("page_settings_summary.selection.options")) %>
       <%= row.with_value do %>
-          <% if @errors&.has_key?(:selection_options) %>
-            <p id="pages-question-input-selection-options-field-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden"><%= t("errors.prefix") %></span> <%= @errors.messages_for(:selection_options).first %>
-            </p>
+        <% if @errors&.has_key?(:selection_options) %>
+          <p id="pages-question-input-selection-options-field-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden"><%= t("errors.prefix") %></span> <%= @errors.messages_for(:selection_options).first %>
+          </p>
+        <% end %>
+        <% if selection_options.count > 9 %>
+          <%= govuk_details(summary_text: t("page_settings_summary.selection.options_summary", number_of_options: selection_options.length)) do %>
+            <ul class="govuk-list govuk-list--bullet">
+              <% selection_options.each do |option| %>
+                <li><%= option[:name] %></li>
+              <% end %>
+            </ul>
           <% end %>
+        <% else %>
           <p>
             <%= t("page_settings_summary.selection.options_count", number_of_options: selection_options.length) %>
           </p>
@@ -24,6 +33,7 @@
               <li><%= option[:name] %></li>
             <% end %>
           </ul>
+        <% end %>
       <% end %>
       <%= row.with_action(text: t("page_settings_summary.change"),
                     href: @change_selections_options_path,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1042,6 +1042,7 @@ en:
       only_one_option: People can only select one option
       options: Options
       options_count: "%{number_of_options} options:"
+      options_summary: Show %{number_of_options} options
     text:
       length: Length
   page_titles:

--- a/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
+++ b/spec/components/page_settings_summary_component/page_settings_summary_component_preview.rb
@@ -14,6 +14,24 @@ class PageSettingsSummaryComponent::PageSettingsSummaryComponentPreview < ViewCo
     render(PageSettingsSummaryComponent::View.new(draft_question:))
   end
 
+  def with_selection_answer_type_and_10_or_more_options
+    draft_question = DraftQuestion.new(form_id: 1,
+                                       is_optional: "false",
+                                       answer_type: "selection",
+                                       answer_settings: { only_one_option: "true",
+                                                          selection_options: [{ name: "Option 1" },
+                                                                              { name: "Option 2" },
+                                                                              { name: "Option 3" },
+                                                                              { name: "Option 4" },
+                                                                              { name: "Option 5" },
+                                                                              { name: "Option 6" },
+                                                                              { name: "Option 7" },
+                                                                              { name: "Option 8" },
+                                                                              { name: "Option 9" },
+                                                                              { name: "Option 10" }] })
+    render(PageSettingsSummaryComponent::View.new(draft_question:))
+  end
+
   def with_text_answer_type
     draft_question = DraftQuestion.new(form_id: 1,
                                        answer_type: "text",

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -83,6 +83,42 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         expect(rows[3].find(".govuk-summary-list__value")).to have_text "No"
       end
 
+      context "when there are 10 or more selection options" do
+        let(:only_one_option) { "false" }
+        let(:draft_question) do
+          build :selection_draft_question,
+                answer_settings: {
+                  only_one_option:,
+                  selection_options: [{ name: "Option 1" },
+                                      { name: "Option 2" },
+                                      { name: "Option 3" },
+                                      { name: "Option 4" },
+                                      { name: "Option 5" },
+                                      { name: "Option 6" },
+                                      { name: "Option 7" },
+                                      { name: "Option 8" },
+                                      { name: "Option 9" },
+                                      { name: "Option 10" }],
+                }
+        end
+
+        it "has a details element containing the selection options" do
+          details = page.find(".govuk-summary-list__row details")
+
+          expect(details).to have_css("summary", text: I18n.t("page_settings_summary.selection.options_summary", number_of_options: "10"))
+          expect(details).to have_css("li", text: "Option 1", visible: :all)
+          expect(details).to have_css("li", text: "Option 2", visible: :all)
+          expect(details).to have_css("li", text: "Option 3", visible: :all)
+          expect(details).to have_css("li", text: "Option 4", visible: :all)
+          expect(details).to have_css("li", text: "Option 5", visible: :all)
+          expect(details).to have_css("li", text: "Option 6", visible: :all)
+          expect(details).to have_css("li", text: "Option 7", visible: :all)
+          expect(details).to have_css("li", text: "Option 8", visible: :all)
+          expect(details).to have_css("li", text: "Option 9", visible: :all)
+          expect(details).to have_css("li", text: "Option 10", visible: :all)
+        end
+      end
+
       context "when there is an error for the selection options" do
         let(:selection_options_error_messages) { ["A selection options error"] }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/djqTBCoO/1983-add-show-x-options-details-component-for-lists-on-edit-question-page?filter=label:Feature%20team%20one,label:Tech%20Support,label:X%20feature%20teams

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Renders the list of selection options in a details component if there are 10 of more entries in the list.

### Screenshots
#### Closed (the default):
![A GOV.UK summary list item with key 'Options', and a change link. In the value area it has a closed GOV.UK details component with summary value '10 options'.](https://github.com/user-attachments/assets/eb073aa5-8b8d-4ad0-8ed0-9e5ee5be41a1)


#### Open:
![The same summary list item shown in the image above, but the details component is now open, revealing 10 bullet points named 'Option 1', 'Option 2', Option 3' and so on until 'Option 10'.](https://github.com/user-attachments/assets/5c93c884-08f8-44e8-85fa-5ee4ca1057d9)



### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
