### PR TITLE
Add pages for selection question reports

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,8 +22,25 @@ class ReportsController < ApplicationController
     render template: "reports/add_another_answer", locals: { data: }
   end
 
-  def last_signed_in_at
   def last_signed_in_at; end
+
+  def selection_questions_with_autocomplete
+    data = Report.find("selection-questions-with-autocomplete")
+
+    render template: "reports/selection_questions/autocomplete", locals: { data: }
+  end
+
+  def selection_questions_with_radios
+    data = Report.find("selection-questions-with-radios")
+
+    render template: "reports/selection_questions/radios", locals: { data: }
+  end
+
+  def selection_questions_with_checkboxes
+    data = Report.find("selection-questions-with-checkboxes")
+
+    render template: "reports/selection_questions/checkboxes", locals: { data: }
+  end
 
 private
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -24,6 +24,12 @@ class ReportsController < ApplicationController
 
   def last_signed_in_at; end
 
+  def selection_questions_summary
+    data = Report.find("selection-questions-summary")
+
+    render template: "reports/selection_questions/summary", locals: { data: }
+  end
+
   def selection_questions_with_autocomplete
     data = Report.find("selection-questions-with-autocomplete")
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,35 +1,33 @@
 class ReportsController < ApplicationController
+  before_action :check_user_has_permission
   after_action :verify_authorized
 
-  def index
-    authorize Report, :can_view_reports?
-  end
+  def index; end
 
   def features
-    authorize Report, :can_view_reports?
-
     data = Report.find("features")
 
     render template: "reports/features", locals: { data: }
   end
 
   def users
-    authorize Report, :can_view_reports?
-
     data = UsersReportService.new.user_data
 
     render locals: { data: }
   end
 
   def add_another_answer
-    authorize Report, :can_view_reports?
-
     data = Report.find("features")
 
     render template: "reports/add_another_answer", locals: { data: }
   end
 
   def last_signed_in_at
+  def last_signed_in_at; end
+
+private
+
+  def check_user_has_permission
     authorize Report, :can_view_reports?
   end
 end

--- a/app/views/reports/features.html.erb
+++ b/app/views/reports/features.html.erb
@@ -5,28 +5,28 @@
     <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
     <h2 class="govuk-heading-m"><%= t(".features.heading") %></h2>
-    <%= govuk_summary_list do |summary_list|%>
+    <%= govuk_summary_list do |summary_list| %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.total_live_forms")) %>
         <%= row.with_value(text: data.total_live_forms) %>
-      <%end%>
+      <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_routes")) %>
         <%= row.with_value(text: data.live_forms_with_routing) %>
-      <%end%>
+      <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_payments")) %>
         <%= row.with_value(text: data.live_forms_with_payment) %>
-      <%end%>
+      <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_add_another_answer")) %>
         <%= row.with_value(text: data.live_forms_with_add_another_answer) %>
-      <%end%>
+      <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_csv_submission_enabled")) %>
         <%= row.with_value(text: data.live_forms_with_csv_submission_enabled) %>
-      <%end%>
-    <%end%>
+      <% end %>
+    <% end %>
 
     <h2 class="govuk-heading-m govuk-visually-hidden"><%= t(".answer_types.heading") %></h2>
     <%= govuk_table do |table| %>
@@ -37,17 +37,23 @@
           <%= row.with_cell(text: t(".answer_types.table_headings.answer_type")) %>
           <%= row.with_cell(text: t(".answer_types.table_headings.number_of_forms"), numeric: true) %>
           <%= row.with_cell(text: t(".answer_types.table_headings.number_of_pages"), numeric: true) %>
-        <%end%>
-      <%end%>
+        <% end %>
+      <% end %>
+
+      <% answer_type_links = { selection: report_selection_questions_summary_path } %>
       <%= table.with_body do |body| %>
         <% Page::ANSWER_TYPES.map(&:to_sym).each do |answer_type| %>
           <%= body.with_row do |row| %>
             <%= row.with_cell(header: true, text: t("helpers.label.page.answer_type_options.names.#{answer_type}")) %>
-            <%= row.with_cell(text: data.live_forms_with_answer_type.attributes[answer_type] || 0, numeric: true, html_attributes: {data: {"live-forms-with-answer-type-#{answer_type.to_s.dasherize}": true}}) %>
-            <%= row.with_cell(text: data.live_pages_with_answer_type.attributes[answer_type] || 0, numeric: true, html_attributes: {data: {"live-pages-with-answer-type-#{answer_type.to_s.dasherize}": true}}) %>
-          <%end%>
-        <%end%>
-      <%end%>
-    <%end%>
+            <% if answer_type_links[answer_type].present? %>
+              <%= row.with_cell(text: govuk_link_to(data.live_forms_with_answer_type.attributes[answer_type] || 0, answer_type_links[answer_type], no_visited_state: true), numeric: true, html_attributes: { data: { "live-forms-with-answer-type-#{answer_type.to_s.dasherize}": true } }) %>
+            <% else %>
+              <%= row.with_cell(text: data.live_forms_with_answer_type.attributes[answer_type] || 0, numeric: true, html_attributes: { data: { "live-forms-with-answer-type-#{answer_type.to_s.dasherize}": true } }) %>
+            <% end %>
+            <%= row.with_cell(text: data.live_pages_with_answer_type.attributes[answer_type] || 0, numeric: true, html_attributes: { data: { "live-pages-with-answer-type-#{answer_type.to_s.dasherize}": true } }) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/reports/selection_questions/_questions.html.erb
+++ b/app/views/reports/selection_questions/_questions.html.erb
@@ -1,0 +1,21 @@
+<%= govuk_table do |table| %>
+
+  <%= table.with_head do |head| %>
+    <%= head.with_row do |row| %>
+      <%= row.with_cell(text: t("reports.selection_questions.questions.table_headings.form_name")) %>
+      <%= row.with_cell(text: t("reports.selection_questions.questions.table_headings.question")) %>
+      <%= row.with_cell(text: t("reports.selection_questions.questions.table_headings.number_of_options")) %>
+      <%= row.with_cell(text: t("reports.selection_questions.questions.table_headings.none_of_the_above")) %>
+    <% end %>
+  <% end %>
+  <%= table.with_body do |body| %>
+    <% data.questions.each do |question| %>
+      <%= body.with_row do |row| %>
+        <%= row.with_cell(text: govuk_link_to(question.form_name, form_url(question.form_id))) %>
+        <%= row.with_cell(text: question.question_text) %>
+        <%= row.with_cell(text: question.selection_options_count) %>
+        <%= row.with_cell(text: question.is_optional ? t("reports.selection_questions.questions.none_of_the_above_yes") : t("reports.selection_questions.questions.none_of_the_above_no")) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/reports/selection_questions/autocomplete.html.erb
+++ b/app/views/reports/selection_questions/autocomplete.html.erb
@@ -1,0 +1,9 @@
+<% set_page_title(t(".title")) %>
+<% content_for :back_link, govuk_back_link_to(report_selection_questions_summary_path, t("reports.selection_questions.questions.back_link")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <%= render partial: 'reports/selection_questions/questions', locals: { data: } %>
+  </div>
+</div>

--- a/app/views/reports/selection_questions/checkboxes.html.erb
+++ b/app/views/reports/selection_questions/checkboxes.html.erb
@@ -1,0 +1,9 @@
+<% set_page_title(t(".title")) %>
+<% content_for :back_link, govuk_back_link_to(report_selection_questions_summary_path, t("reports.selection_questions.questions.back_link")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <%= render partial: 'reports/selection_questions/questions', locals: { data: } %>
+  </div>
+</div>

--- a/app/views/reports/selection_questions/radios.html.erb
+++ b/app/views/reports/selection_questions/radios.html.erb
@@ -1,0 +1,9 @@
+<% set_page_title(t(".title")) %>
+<% content_for :back_link, govuk_back_link_to(report_selection_questions_summary_path, t("reports.selection_questions.questions.back_link")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <%= render partial: 'reports/selection_questions/questions', locals: { data: } %>
+  </div>
+</div>

--- a/app/views/reports/selection_questions/summary.html.erb
+++ b/app/views/reports/selection_questions/summary.html.erb
@@ -1,0 +1,58 @@
+<% set_page_title(t(".title")) %>
+<% content_for :back_link, govuk_back_link_to(report_features_path, t(".back_link")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <h2 class="govuk-heading-m"><%= t(".autocomplete.heading") %></h2>
+    <p><%= govuk_link_to t(".view_questions"), report_selection_questions_with_autocomplete_path, no_visited_state: true %></p>
+    <%= govuk_summary_list do |summary_list|%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".autocomplete.live_forms")) %>
+        <%= row.with_value(text: data.autocomplete.form_count) %>
+      <%end%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".number_of_questions")) %>
+        <%= row.with_value(text: data.autocomplete.question_count) %>
+      <%end%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".with_none_of_the_above")) %>
+        <%= row.with_value(text: data.autocomplete.optional_question_count) %>
+      <%end%>
+    <%end%>
+
+    <h2 class="govuk-heading-m"><%= t(".radios.heading") %></h2>
+    <p><%= govuk_link_to t(".view_questions"), report_selection_questions_with_radios_path, no_visited_state: true %></p>
+    <%= govuk_summary_list do |summary_list|%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".radios.live_forms")) %>
+        <%= row.with_value(text: data.radios.form_count) %>
+      <%end%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".number_of_questions")) %>
+        <%= row.with_value(text: data.radios.question_count) %>
+      <%end%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".with_none_of_the_above")) %>
+        <%= row.with_value(text: data.radios.optional_question_count) %>
+      <%end%>
+    <%end%>
+
+    <h2 class="govuk-heading-m"><%= t(".checkboxes.heading") %></h2>
+    <p><%= govuk_link_to t(".view_questions"), report_selection_questions_with_checkboxes_path, no_visited_state: true %></p>
+    <%= govuk_summary_list do |summary_list|%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".checkboxes.live_forms")) %>
+        <%= row.with_value(text: data.checkboxes.form_count) %>
+      <%end%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".number_of_questions")) %>
+        <%= row.with_value(text: data.checkboxes.question_count) %>
+      <%end%>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: t(".with_none_of_the_above")) %>
+        <%= row.with_value(text: data.checkboxes.optional_question_count) %>
+      <%end%>
+    <%end%>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1253,6 +1253,22 @@ en:
       not_since_auth0_enabled: People who last signed in before 3 November 2023
       not_since_last_signed_in_at_added: People who last signed in sometime between 3 November 2023 and 4 November 2024
       title: When users last signed in
+    selection_questions:
+      autocomplete:
+        title: Select one only - more than 30 options in live forms
+      checkboxes:
+        title: Select one or more in live forms
+      questions:
+        back_link: Back to selection from a list of options usage
+        none_of_the_above_no: 'No'
+        none_of_the_above_yes: 'Yes'
+        table_headings:
+          form_name: Form name
+          none_of_the_above: "‘None of the above’"
+          number_of_options: Number of options
+          question: Question
+      radios:
+        title: Select one only - 30 options or fewer in live forms
     users:
       heading: Number of users per organisation
       table_headings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1269,6 +1269,21 @@ en:
           question: Question
       radios:
         title: Select one only - 30 options or fewer in live forms
+      summary:
+        autocomplete:
+          heading: Select one only - more than 30 options
+          live_forms: Live forms with more than 30 options
+        back_link: Back to feature usage
+        checkboxes:
+          heading: Select one or more
+          live_forms: Live forms using one or more
+        number_of_questions: Number of questions
+        radios:
+          heading: Select one only - 30 options or fewer
+          live_forms: Live forms with 30 options or fewer
+        title: Selection from a list of options in live forms
+        view_questions: View questions
+        with_none_of_the_above: Questions with ‘None of the above’
     users:
       heading: Number of users per organisation
       table_headings:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,6 +186,9 @@ Rails.application.routes.draw do
     get "users", to: "reports#users", as: :report_users
     get "add_another_answer", to: "reports#add_another_answer", as: :report_add_another_answer
     get "last-signed-in-at", to: "reports#last_signed_in_at", as: :report_last_signed_in_at
+    get "selection-questions-with-autocomplete", to: "reports#selection_questions_with_autocomplete", as: :report_selection_questions_with_autocomplete
+    get "selection-questions-with-radios", to: "reports#selection_questions_with_radios", as: :report_selection_questions_with_radios
+    get "selection-questions-with-checkboxes", to: "reports#selection_questions_with_checkboxes", as: :report_selection_questions_with_checkboxes
   end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,6 +186,7 @@ Rails.application.routes.draw do
     get "users", to: "reports#users", as: :report_users
     get "add_another_answer", to: "reports#add_another_answer", as: :report_add_another_answer
     get "last-signed-in-at", to: "reports#last_signed_in_at", as: :report_last_signed_in_at
+    get "selection-questions-summary", to: "reports#selection_questions_summary", as: :report_selection_questions_summary
     get "selection-questions-with-autocomplete", to: "reports#selection_questions_with_autocomplete", as: :report_selection_questions_with_autocomplete
     get "selection-questions-with-radios", to: "reports#selection_questions_with_radios", as: :report_selection_questions_with_radios
     get "selection-questions-with-checkboxes", to: "reports#selection_questions_with_checkboxes", as: :report_selection_questions_with_checkboxes

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -281,4 +281,93 @@ RSpec.describe ReportsController, type: :request do
       expect(response.body).to include users.third.email
     end
   end
+
+  describe "selection question reports" do
+    let(:data) do
+      {
+        questions: [
+          {
+            form_id: 1,
+            form_name: "A form",
+            question_text: "A question",
+            is_optional: true,
+            selection_options_count: 33,
+          },
+        ],
+        count: 1,
+      }
+    end
+
+    describe "#selection_questions_with_autocomplete" do
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/reports/selection-questions-with-autocomplete", headers, data.to_json, 200
+        end
+
+        login_as_super_admin_user
+        get report_selection_questions_with_autocomplete_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the autocomplete questions report view" do
+        expect(response).to render_template("reports/selection_questions/autocomplete")
+      end
+
+      it "includes the report data" do
+        expect(response.body).to include "A form"
+        expect(response.body).to include "A question"
+      end
+    end
+
+    describe "#selection_questions_with_radios" do
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/reports/selection-questions-with-radios", headers, data.to_json, 200
+        end
+
+        login_as_super_admin_user
+        get report_selection_questions_with_radios_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the autocomplete questions report view" do
+        expect(response).to render_template("reports/selection_questions/radios")
+      end
+
+      it "includes the report data" do
+        expect(response.body).to include "A form"
+        expect(response.body).to include "A question"
+      end
+    end
+
+    describe "#selection_questions_with_checkboxes" do
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/reports/selection-questions-with-checkboxes", headers, data.to_json, 200
+        end
+
+        login_as_super_admin_user
+        get report_selection_questions_with_checkboxes_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the autocomplete questions report view" do
+        expect(response).to render_template("reports/selection_questions/checkboxes")
+      end
+
+      it "includes the report data" do
+        expect(response.body).to include "A form"
+        expect(response.body).to include "A question"
+      end
+    end
+  end
 end

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -282,6 +282,45 @@ RSpec.describe ReportsController, type: :request do
     end
   end
 
+  describe "#selection_questions_summary" do
+    let(:summary) do
+      {
+        autocomplete: {
+          form_count: 234,
+          question_count: 432,
+          optional_question_count: 20,
+        },
+        radios: {
+          form_count: 2,
+          question_count: 2,
+          optional_question_count: 1,
+        },
+        checkboxes: {
+          form_count: 1,
+          question_count: 1,
+          optional_question_count: 1,
+        },
+      }
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/reports/selection-questions-summary", headers, summary.to_json, 200
+      end
+
+      login_as_super_admin_user
+      get report_selection_questions_summary_path
+    end
+
+    it "returns http code 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the selection questions summary report view" do
+      expect(response).to render_template("reports/selection_questions/summary")
+    end
+  end
+
   describe "selection question reports" do
     let(:data) do
       {

--- a/spec/views/reports/selection_questions/autocomplete.html.erb_spec.rb
+++ b/spec/views/reports/selection_questions/autocomplete.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe "reports/selection_questions/autocomplete.html.erb" do
+  let(:data) do
+    Report.new({
+      questions: [
+        {
+          form_id: 1,
+          form_name: "A form",
+          question_text: "A question",
+          is_optional: true,
+          selection_options_count: 33,
+        },
+      ],
+      count: 1,
+    })
+  end
+
+  before do
+    render template: "reports/selection_questions/autocomplete", locals: { data: }
+  end
+
+  it "has expected page title" do
+    expect(view.content_for(:title)).to eq "Select one only - more than 30 options in live forms"
+  end
+
+  it "has a back link to the selection from a list of options usage report" do
+    expect(view.content_for(:back_link)).to have_link("Back to selection from a list of options usage", href: report_selection_questions_summary_path)
+  end
+
+  it "includes the form name" do
+    expect(rendered).to have_link("A form", href: form_url(1))
+  end
+
+  it "includes the question text" do
+    expect(rendered).to have_content("A question")
+  end
+
+  it "includes whether the options include 'None of the above'" do
+    expect(rendered).to have_css("td", text: "Yes")
+  end
+end

--- a/spec/views/reports/selection_questions/checkboxes.html.erb_spec.rb
+++ b/spec/views/reports/selection_questions/checkboxes.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe "reports/selection_questions/checkboxes.html.erb" do
+  let(:data) do
+    Report.new({
+      questions: [
+        {
+          form_id: 1,
+          form_name: "A form",
+          question_text: "A question",
+          is_optional: true,
+          selection_options_count: 33,
+        },
+      ],
+      count: 1,
+    })
+  end
+
+  before do
+    render template: "reports/selection_questions/checkboxes", locals: { data: }
+  end
+
+  it "has expected page title" do
+    expect(view.content_for(:title)).to eq "Select one or more in live forms"
+  end
+
+  it "has a back link to the selection from a list of options usage report" do
+    expect(view.content_for(:back_link)).to have_link("Back to selection from a list of options usage", href: report_selection_questions_summary_path)
+  end
+
+  it "includes the form name" do
+    expect(rendered).to have_link("A form", href: form_url(1))
+  end
+
+  it "includes the question text" do
+    expect(rendered).to have_content("A question")
+  end
+
+  it "includes whether the options include 'None of the above'" do
+    expect(rendered).to have_css("td", text: "Yes")
+  end
+end

--- a/spec/views/reports/selection_questions/radios.html.erb_spec.rb
+++ b/spec/views/reports/selection_questions/radios.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe "reports/selection_questions/radios.html.erb" do
+  let(:data) do
+    Report.new({
+      questions: [
+        {
+          form_id: 1,
+          form_name: "A form",
+          question_text: "A question",
+          is_optional: true,
+          selection_options_count: 33,
+        },
+      ],
+      count: 1,
+    })
+  end
+
+  before do
+    render template: "reports/selection_questions/radios", locals: { data: }
+  end
+
+  it "has expected page title" do
+    expect(view.content_for(:title)).to eq "Select one only - 30 options or fewer in live forms"
+  end
+
+  it "has a back link to the selection from a list of options usage report" do
+    expect(view.content_for(:back_link)).to have_link("Back to selection from a list of options usage", href: report_selection_questions_summary_path)
+  end
+
+  it "includes the form name" do
+    expect(rendered).to have_link("A form", href: form_url(1))
+  end
+
+  it "includes the question text" do
+    expect(rendered).to have_content("A question")
+  end
+
+  it "includes whether the options include 'None of the above'" do
+    expect(rendered).to have_css("td", text: "Yes")
+  end
+end

--- a/spec/views/reports/selection_questions/summary.html.erb_spec.rb
+++ b/spec/views/reports/selection_questions/summary.html.erb_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+describe "reports/selection_questions/summary.html.erb" do
+  let(:data) do
+    Report.new({
+      autocomplete: {
+        form_count: 222,
+        question_count: 444,
+        optional_question_count: 111,
+      },
+      radios: {
+        form_count: 33,
+        question_count: 77,
+        optional_question_count: 44,
+      },
+      checkboxes: {
+        form_count: 55,
+        question_count: 99,
+        optional_question_count: 88,
+      },
+    })
+  end
+
+  before do
+    render template: "reports/selection_questions/summary", locals: { data: }
+  end
+
+  it "has expected page title" do
+    expect(view.content_for(:title)).to eq "Selection from a list of options in live forms"
+  end
+
+  it "has a back link to the selection from a list of options usage report" do
+    expect(view.content_for(:back_link)).to have_link("Back to feature usage", href: report_features_path)
+  end
+
+  it "has statistics about questions with autocomplete" do
+    page = Capybara.string(rendered.html)
+    within(page.find_all(".govuk-summary-list__row").first) do
+      expect(page.find_all(".govuk-summary-list__value"[0])).to have_text "234"
+      expect(page.find_all(".govuk-summary-list__value"[1])).to have_text "444"
+      expect(page.find_all(".govuk-summary-list__value"[2])).to have_text "111"
+    end
+  end
+
+  it "has link to questions with autocomplete report" do
+    expect(rendered).to have_link("View questions", href: report_selection_questions_with_autocomplete_path)
+  end
+
+  it "has statistics about questions with radio buttons" do
+    page = Capybara.string(rendered.html)
+    within(page.find_all(".govuk-summary-list__row")[1]) do
+      expect(page.find_all(".govuk-summary-list__value"[0])).to have_text "33"
+      expect(page.find_all(".govuk-summary-list__value"[1])).to have_text "77"
+      expect(page.find_all(".govuk-summary-list__value"[2])).to have_text "44"
+    end
+  end
+
+  it "has link to questions with radio buttons report" do
+    expect(rendered).to have_link("View questions", href: report_selection_questions_with_radios_path)
+  end
+
+  it "has statistics about questions with checkboxes buttons" do
+    page = Capybara.string(rendered.html)
+    within(page.find_all(".govuk-summary-list__row")[1]) do
+      expect(page.find_all(".govuk-summary-list__value"[0])).to have_text "55"
+      expect(page.find_all(".govuk-summary-list__value"[1])).to have_text "99"
+      expect(page.find_all(".govuk-summary-list__value"[2])).to have_text "88"
+    end
+  end
+
+  it "has link to questions with checkboxes report" do
+    expect(rendered).to have_link("View questions", href: report_selection_questions_with_checkboxes_path)
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SVZMGF6m/

Adds:
- A page to show a summary of the usages of selection questions in live forms, grouped by whether they will show as an autocomplete, radios or checkoxes component in runner.
- Individual pages that show a list of all questions that will display each of autocomplete, radios or checkboxes in runner.

The summary report is linked to from the feature usage report. The summary report then has links to view the questions for each type of select from a list question: autocomplete, radios and checkboxes:

<img width="868" alt="Screenshot 2024-11-18 at 10 40 06" src="https://github.com/user-attachments/assets/025f79dd-f169-4132-a152-79def3b01f3d">

<img width="868" alt="Screenshot 2024-11-18 at 10 40 11" src="https://github.com/user-attachments/assets/4392d3b6-0a1c-4968-a881-399e76362984">

<img width="868" alt="Screenshot 2024-11-18 at 10 41 51" src="https://github.com/user-attachments/assets/3e4a05bf-6266-41b8-91a6-efcc41af01eb">

<img width="868" alt="Screenshot 2024-11-18 at 10 42 02" src="https://github.com/user-attachments/assets/6dfacd90-f0c3-4545-8cdd-5311f5ae6932">

<img width="868" alt="Screenshot 2024-11-18 at 10 42 11" src="https://github.com/user-attachments/assets/4c45d6e0-f80f-4fda-9d9d-d13b43e43805">

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
