### PR TITLE
Add a form for setting the "secondary skip" route of a question

### DIFF
--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -22,6 +22,28 @@ class Pages::SecondarySkipController < PagesController
     end
   end
 
+  def edit
+    secondary_skip_input = Pages::SecondarySkipInput.new(form: current_form, page:, record: secondary_skip_condition).assign_values
+
+    render template: "pages/secondary_skip/edit", locals: {
+      secondary_skip_input:,
+      back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
+    }
+  end
+
+  def update
+    secondary_skip_input = Pages::SecondarySkipInput.new(secondary_skip_input_params.merge(record: secondary_skip_condition)).assign_values
+
+    if secondary_skip_input.submit
+      redirect_to show_routes_path(form_id: current_form.id, page_id: page.id)
+    else
+      render template: "pages/secondary_skip/edit", locals: {
+        secondary_skip_input:,
+        back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
+      }, status: :unprocessable_entity
+    end
+  end
+
 private
 
   def secondary_skip_input_params
@@ -30,5 +52,9 @@ private
 
   def ensure_branch_routing_feature_enabled
     raise ActionController::RoutingError, "branch_routing feature not enabled" unless Settings.features.branch_routing
+  end
+
+  def secondary_skip_condition
+    @secondary_skip_condition ||= current_form.pages.flat_map(&:conditions).compact_blank.find(&:secondary_skip?)
   end
 end

--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -8,7 +8,25 @@ class Pages::SecondarySkipController < PagesController
       back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
     }
   end
+
+  def create
+    secondary_skip_input = Pages::SecondarySkipInput.new(secondary_skip_input_params)
+
+    if secondary_skip_input.submit
+      redirect_to show_routes_path(form_id: current_form.id, page_id: page.id)
+    else
+      render template: "pages/secondary_skip/new", locals: {
+        secondary_skip_input:,
+        back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
+      }, status: :unprocessable_entity
+    end
+  end
+
 private
+
+  def secondary_skip_input_params
+    params.require(:pages_secondary_skip_input).permit(:routing_page_id, :goto_page_id).merge(form: current_form, page:)
+  end
 
   def ensure_branch_routing_feature_enabled
     raise ActionController::RoutingError, "branch_routing feature not enabled" unless Settings.features.branch_routing

--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -1,0 +1,16 @@
+class Pages::SecondarySkipController < PagesController
+  before_action :ensure_branch_routing_feature_enabled
+
+  def new
+    secondary_skip_input = Pages::SecondarySkipInput.new(form: current_form, page:)
+    render locals: {
+      secondary_skip_input:,
+      back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
+    }
+  end
+private
+
+  def ensure_branch_routing_feature_enabled
+    raise ActionController::RoutingError, "branch_routing feature not enabled" unless Settings.features.branch_routing
+  end
+end

--- a/app/input_objects/pages/secondary_skip_input.rb
+++ b/app/input_objects/pages/secondary_skip_input.rb
@@ -1,0 +1,86 @@
+class Pages::SecondarySkipInput < BaseInput
+  attr_accessor :form, :page, :routing_page_id, :goto_page_id, :record
+
+  validates :routing_page_id, :goto_page_id, presence: true
+  validate :pages_in_valid_order
+
+  def submit
+    return false if invalid?
+
+    ConditionRepository.create!(form_id: form.id,
+                                page_id: routing_page_id,
+                                check_page_id: page.id,
+                                routing_page_id:,
+                                answer_value: nil,
+                                goto_page_id: skip_to_end? ? nil : goto_page_id,
+                                skip_to_end: skip_to_end?)
+  end
+
+  def goto_page_options
+    [
+      *pages_after_current_page(form.pages, page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) },
+      OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
+    ]
+  end
+
+  def routing_page_options
+    pages_after_current_page(form.pages, page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
+  end
+
+  def page_name(page_id)
+    target_page = form.pages.find { |page| page.id == page_id }
+
+    page_name = target_page.question_text
+    page_position = target_page.position
+
+    I18n.t("page_route_card.page_name", page_position:, page_name:)
+  end
+
+  def end_page_name
+    I18n.t("page_route_card.check_your_answers")
+  end
+
+  def answer_value
+    page.conditions.find { |rc| rc.answer_value.present? }.answer_value
+  end
+
+  def continue_to
+    page.has_next_page? ? page_name(page.next_page) : end_page_name
+  end
+
+private
+
+  def pages_after_current_page(all_pages, current_page)
+    all_pages.filter { |page| page.position > current_page.position }
+  end
+
+  def skip_to_end?
+    goto_page_id == "check_your_answers"
+  end
+
+  def goto_question_page?
+    !skip_to_end?
+  end
+
+  def pages_in_valid_order
+    if routing_page_id.present? && goto_page_id.present?
+
+      routing_page = form.pages.find { |page| page.id.to_s == routing_page_id }
+      goto_page = form.pages.find { |page| page.id.to_s == goto_page_id }
+
+      if goto_page_id == routing_page_id
+        errors.add(:goto_page_id, :equal, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.equal"))
+      end
+
+      if goto_question_page?
+        if routing_page.position > goto_page.position
+          errors.add(:goto_page_id, :routing_page_after, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.routing_page_after"))
+        end
+
+        if routing_page.position + 1 == goto_page.position
+          errors.add(:goto_page_id, :already_consecutive, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.already_consecutive"))
+        end
+      end
+    end
+  end
+end

--- a/app/views/pages/secondary_skip/_form.html.erb
+++ b/app/views/pages/secondary_skip/_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_with(model: secondary_skip_input, url: submit_path) do |f| %>
+  <% if  secondary_skip_input&.errors.any? %>
+    <%= f.govuk_error_summary %>
+  <% end %>
+
+  <%= content_for :heading %>
+
+  <%= govuk_summary_list(actions: false, classes: "govuk-summary-list--no-border") do |summary_list|
+    summary_list.with_row do |row|
+      row.with_key { t("secondary_skip.new.primary_route_question_key") }
+      row.with_value { secondary_skip_input.page.question_text }
+    end;
+    summary_list.with_row do |row|
+      row.with_key { t("secondary_skip.new.primary_route_answer_key") }
+      row.with_value { secondary_skip_input.answer_value }
+    end;
+    summary_list.with_row do |row|
+      row.with_key { t("secondary_skip.new.primary_route_continue_key") }
+      row.with_value { secondary_skip_input.continue_to }
+    end;
+  end %>
+
+  <%= f.govuk_collection_select :routing_page_id, secondary_skip_input.routing_page_options, :id, :question_text, options: { include_blank: t("helpers.label.pages_secondary_skip_input.default_routing_page_id") } %>
+  <%= f.govuk_collection_select :goto_page_id, secondary_skip_input.goto_page_options, :id, :question_text, options: { include_blank: t("helpers.label.pages_secondary_skip_input.default_goto_page_id") } %>
+
+  <%= govuk_details(summary_text: t("secondary_skip.new.details_summary")) do
+    t("secondary_skip.new.details_html")
+  end %>
+
+  <%= f.govuk_submit t("save_and_continue") do
+    govuk_link_to(I18n.t("cancel"), show_routes_path(form_id: secondary_skip_input.form.id, page_id: secondary_skip_input.page.id))
+  end %>
+<% end %>

--- a/app/views/pages/secondary_skip/edit.html.erb
+++ b/app/views/pages/secondary_skip/edit.html.erb
@@ -1,0 +1,19 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.new_secondary_skip', route_index: 2), false)) %>
+<% content_for :back_link, govuk_back_link_to(back_link_url, t('secondary_skip.new.back', page_position: secondary_skip_input.page.position)) %>
+
+<% content_for :heading do %>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= t("secondary_skip.new.caption", page_position: secondary_skip_input.page.position) %></span>
+    <%= t("page_titles.new_secondary_skip", route_index: 2) %>
+    <%# TODO: route_index is hardcoded as 2 here because we know there are only two conditions. It will need to change in the future %>
+  </h1>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'form', locals: {
+      secondary_skip_input:,
+      submit_path: update_secondary_skip_path(form_id: secondary_skip_input.form.id, page_id: secondary_skip_input.page.id),
+    } %>
+  </div>
+</div>

--- a/app/views/pages/secondary_skip/new.html.erb
+++ b/app/views/pages/secondary_skip/new.html.erb
@@ -1,0 +1,19 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.new_secondary_skip', route_index: 2), false)) %>
+<% content_for :back_link, govuk_back_link_to(back_link_url, t('secondary_skip.new.back', page_position: secondary_skip_input.page.position)) %>
+
+<% content_for :heading do %>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= t("secondary_skip.new.caption", page_position: secondary_skip_input.page.position) %></span>
+    <%= t("page_titles.new_secondary_skip", route_index: 2) %>
+    <%# TODO: route_index is hardcoded as 2 here because we know there are only two conditions. It will need to change in the future %>
+  </h1>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'form', locals: {
+      secondary_skip_input:,
+      submit_path: create_secondary_skip_path(form_id: secondary_skip_input.form.id, page_id: secondary_skip_input.page.id),
+    } %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1094,6 +1094,7 @@ en:
     mou_signatures: Memorandum of Understanding agreements
     name_settings: Ask for a person’s name
     new_page: Edit question
+    new_secondary_skip: 'Route %{route_index}: set questions to skip'
     not_found: Page not found
     payment_link: Add a link to a payment page on GOV.UK Pay
     privacy_policy: Provide a link to privacy information for this form
@@ -1322,6 +1323,17 @@ en:
         You can only add one route from each question.
       </p>
   save_and_continue: Save and continue
+  secondary_skip:
+    new:
+      back: Back to question %{page_position}’s routes
+      caption: Question %{page_position}’s routes
+      details_html: |
+        <p>People who select an answer that does not have a route assigned to it will continue to the next question.</p>
+        <p>If you need to, you can make these people skip one or more questions later in the form. For example, you might want them to skip route 1’s questions. This allows you to create 2 different ‘branches’ of questions.</p>
+      details_summary: Why set question to skip?
+      primary_route_answer_key: is not
+      primary_route_continue_key: continue to
+      primary_route_question_key: If the answer to
   selection_options:
     add_another: Add another option
     add_options: Add options to your list

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,15 @@ en:
               too_long: Question text must be %{count} characters or less
             selection_options:
               too_many_selection_options: You cannot have more than 30 options in a list when people can select more than one option
+        pages/secondary_skip_input:
+          attributes:
+            goto_page_id:
+              already_consecutive: The question you want to skip to is already straight after the question you want to skip from
+              blank: Select the question or page you want to take the person to
+              equal: The question you want to skip from cannot be the same question you want to take them to
+              routing_page_after: The question you want to skip from must be before the question you want to take the person to
+            routing_page_id:
+              blank: Select the question you want to skip from
   activerecord:
     errors:
       models:
@@ -750,6 +759,11 @@ en:
           'false': No - this question can only be answered once
           'true': 'Yes'
         question_text: Question text
+      pages_secondary_skip_input:
+        default_goto_page_id: Select a question or page
+        default_routing_page_id: Select a question
+        goto_page_id: take them to
+        routing_page_id: Then after the person answers
     legend:
       account_terms_of_use_input:
         agreed: Do you agree to these terms?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,8 +114,10 @@ Rails.application.routes.draw do
 
         scope "/routes" do
           get "/" => "pages/routes#show", as: :show_routes
-          get "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#new", as: :new_secondary_skip
-          post "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#create", as: :create_secondary_skip
+          get "/any-other-answer/questions-to-skip/new" => "pages/secondary_skip_#new", as: :new_secondary_skip
+          post "/any-other-answer/questions-to-skip/new" => "pages/secondary_skip_#create", as: :create_secondary_skip
+          get "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#edit", as: :edit_secondary_skip
+          post "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#update", as: :update_secondary_skip
         end
 
         scope "/edit" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Rails.application.routes.draw do
         scope "/routes" do
           get "/" => "pages/routes#show", as: :show_routes
           get "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#new", as: :new_secondary_skip
+          post "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#create", as: :create_secondary_skip
         end
 
         scope "/edit" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,7 +112,10 @@ Rails.application.routes.draw do
           delete "/:condition_id/delete" => "pages/conditions#destroy", as: :destroy_condition
         end
 
-        get "/routes" => "pages/routes#show", as: :show_routes
+        scope "/routes" do
+          get "/" => "pages/routes#show", as: :show_routes
+          get "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#new", as: :new_secondary_skip
+        end
 
         scope "/edit" do
           get "/type-of-answer" => "pages/type_of_answer#edit", as: :type_of_answer_edit

--- a/spec/input_objects/pages/secondary_skip_input_spec.rb
+++ b/spec/input_objects/pages/secondary_skip_input_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Pages::SecondarySkipInput, type: :model do
+  let(:secondary_skip_input) { described_class.new(form:, page:) }
+
+  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:pages) { form.pages }
+  let(:is_optional) { false }
+  let(:page) do
+    pages.second.tap do |second_page|
+      second_page.is_optional = is_optional
+      second_page.answer_type = "selection"
+      second_page.answer_settings = DataStruct.new(
+        only_one_option: true,
+        selection_options: [OpenStruct.new(attributes: { name: "Option 1" }), OpenStruct.new(attributes: { name: "Option 2" })],
+      )
+    end
+  end
+  let(:condition) { nil }
+
+  describe "validations" do
+    it "is valid given valid params" do
+      secondary_skip_input.routing_page_id = form.pages.first.id.to_s
+      secondary_skip_input.goto_page_id = form.pages[3].id.to_s
+      expect(secondary_skip_input).to be_valid
+    end
+
+    it "is invalid if goto_page_id is nil" do
+      error_message = I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.blank")
+      secondary_skip_input.goto_page_id = nil
+      expect(secondary_skip_input).to be_invalid
+      expect(secondary_skip_input.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
+    end
+
+    it "is invalid if routing_page_id is nil" do
+      error_message = I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.routing_page_id.blank")
+      secondary_skip_input.routing_page_id = nil
+      expect(secondary_skip_input).to be_invalid
+      expect(secondary_skip_input.errors.full_messages_for(:routing_page_id)).to include("Routing page #{error_message}")
+    end
+
+    it "is invalid if routing_page is after the goto_page" do
+      error_message = I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.routing_page_after")
+      secondary_skip_input.routing_page_id = form.pages[2].id.to_s
+      secondary_skip_input.goto_page_id = form.pages.first.id.to_s
+      expect(secondary_skip_input).to be_invalid
+      expect(secondary_skip_input.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
+    end
+
+    it "is invalid if routing_page and goto_page are already consecutive" do
+      error_message = I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.already_consecutive")
+      secondary_skip_input.routing_page_id = form.pages.first.id.to_s
+      secondary_skip_input.goto_page_id = form.pages.second.id.to_s
+      expect(secondary_skip_input).to be_invalid
+      expect(secondary_skip_input.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
+    end
+
+    it "is invalid if routing_page and goto_page are the same" do
+      error_message = I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.equal")
+      secondary_skip_input.routing_page_id = form.pages.first.id.to_s
+      secondary_skip_input.goto_page_id = form.pages.first.id.to_s
+      expect(secondary_skip_input).to be_invalid
+      expect(secondary_skip_input.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
+    end
+  end
+end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Pages::SecondarySkipController, type: :request do
+  let(:form) { build :form, id: 2, pages: }
+  let(:pages) do
+    pages = build_list(:page, 5).each_with_index do |page, index|
+      page.id = index + 1
+    end
+
+    pages.first.answer_settings =
+      DataStruct.new(
+        only_one_option: true,
+        selection_options: [
+          OpenStruct.new(attributes: { name: "Option 1" }),
+          OpenStruct.new(attributes: { name: "Option 2" }),
+        ],
+      )
+
+    pages.first.routing_conditions = [
+      build(:condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false),
+    ]
+
+    pages
+  end
+
+  let(:group) { create(:group, organisation: standard_user.organisation) }
+
+  before do
+    Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
+    GroupForm.create!(form_id: form.id, group_id: group.id)
+    login_as_standard_user
+
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/2", headers, form.to_json, 200
+      mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
+      mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
+    end
+  end
+
+  context "when the branch_routing feature is not enabled", feature_branch_routing: false do
+    describe "#new" do
+      it "returns a 404" do
+        get new_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  context "when the branch_routing feature is enabled", :feature_branch_routing do
+    describe "#new" do
+      it "returns 200" do
+        get new_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end

--- a/spec/views/pages/secondary_skip/new.html.erb_spec.rb
+++ b/spec/views/pages/secondary_skip/new.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe "pages/secondary_skip/new.html.erb" do
+  let(:form) { build :form, id: 1, pages: [page] }
+  let(:page) do
+    build(:page,
+          :with_selections_settings,
+          id: 1,
+          position: 1,
+          answer_settings: DataStruct.new(
+            only_one_option: true,
+            selection_options: [
+              OpenStruct.new(attributes: { name: "Option 1" }),
+              OpenStruct.new(attributes: { name: "Option 2" }),
+            ],
+          ),
+          routing_conditions: [
+            build(:condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Yes", goto_page_id: 2, skip_to_end: false),
+          ])
+  end
+
+  let(:secondary_skip_input) { Pages::SecondarySkipInput.new(form:, page:) }
+
+  before do
+    render template: "pages/secondary_skip/new", locals: { back_link_url: "/back", secondary_skip_input: }
+  end
+
+  it "has the correct title" do
+    expect(view.content_for(:title)).to have_content(I18n.t("page_titles.new_secondary_skip", route_index: 2))
+  end
+
+  it "has the correct back link" do
+    expect(view.content_for(:back_link)).to have_link(I18n.t("secondary_skip.new.back", page_position: 1), href: "/back")
+  end
+
+  it "has the correct heading and caption" do
+    expect(rendered).to have_selector("h1", text: "Question 1’s routes")
+    expect(rendered).to have_selector("h1", text: I18n.t("page_titles.new_secondary_skip", route_index: 2))
+  end
+end


### PR DESCRIPTION
### Add a form for setting the "secondary skip" route of a question

Trello card: https://trello.com/c/Ubj0HU4s/1966-allow-form-creators-to-add-a-secondary-route-to-a-question-route-for-up-to-2-branches

<img width="753" alt="image" src="https://github.com/user-attachments/assets/bd31c43d-d777-44ce-83b9-6f47865f6908">

This PR is adds the input model, view, controller and route for creating new "secondary_skip" conditions.

This feature is behind the flag "branch_routing".

The following features haven't been done yet:
- redirecting the user if the user is trying to create a skip for question which doesn't have a route
- preventing the user adding more than one skip using /new(!)

These will be added soon.

Also not included from the ticket is JS code to manipulate the select options of the "take them to" field based on the answer to the first select. That will be done separately too. 

There are more tests to be added too for example request tests for the edit/create routes.

I think a few other things can also be cleaned up and refactored but I think it's safe to do those later.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
