### PR TITLE
Log entry method for selection options

### DIFF
--- a/app/helpers/logging_helper.rb
+++ b/app/helpers/logging_helper.rb
@@ -1,0 +1,9 @@
+module LoggingHelper
+  def log_selection_question_options_submitted(is_bulk_entry:, options_count:, only_one_option:)
+    Rails.logger.info("Submitted selection options for a selection question", {
+      is_bulk_entry:,
+      options_count:,
+      only_one_option:,
+    })
+  end
+end

--- a/app/input_objects/pages/long_lists_selection/bulk_options_input.rb
+++ b/app/input_objects/pages/long_lists_selection/bulk_options_input.rb
@@ -1,4 +1,6 @@
 class Pages::LongListsSelection::BulkOptionsInput < BaseInput
+  include LoggingHelper
+
   MAXIMUM_CHOOSE_ONLY_ONE_OPTION = 1000
   MAXIMUM_CHOOSE_MORE_THAN_ONE_OPTION = 30
 
@@ -21,7 +23,10 @@ class Pages::LongListsSelection::BulkOptionsInput < BaseInput
       .assign_attributes({ answer_settings:,
                            is_optional: include_none_of_the_above })
 
-    draft_question.save!(validate: false)
+    success = draft_question.save!(validate: false)
+    log_submission if success
+
+    success
   end
 
   def none_of_the_above_options
@@ -62,5 +67,9 @@ private
 
   def maximum_options
     only_one_option? ? MAXIMUM_CHOOSE_ONLY_ONE_OPTION : MAXIMUM_CHOOSE_MORE_THAN_ONE_OPTION
+  end
+
+  def log_submission
+    log_selection_question_options_submitted(is_bulk_entry: true, options_count: selection_options.length, only_one_option: only_one_option?)
   end
 end

--- a/app/input_objects/pages/long_lists_selection/options_input.rb
+++ b/app/input_objects/pages/long_lists_selection/options_input.rb
@@ -1,4 +1,6 @@
 class Pages::LongListsSelection::OptionsInput < BaseInput
+  include LoggingHelper
+
   DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }] }.freeze
   INCLUDE_NONE_OF_THE_ABOVE_OPTIONS = %w[true false].freeze
   MAXIMUM_CHOOSE_ONLY_ONE_OPTION = 1000
@@ -29,7 +31,10 @@ class Pages::LongListsSelection::OptionsInput < BaseInput
       .assign_attributes({ answer_settings:,
                            is_optional: include_none_of_the_above })
 
-    draft_question.save!(validate: false)
+    success = draft_question.save!(validate: false)
+    log_submission if success
+
+    success
   end
 
   def selection_options_form_objects
@@ -65,5 +70,9 @@ private
 
   def maximum_error_type
     draft_question.answer_settings[:only_one_option] == "true" ? :maximum_choose_only_one_option : :maximum_choose_more_than_one_option
+  end
+
+  def log_submission
+    log_selection_question_options_submitted(is_bulk_entry: false, options_count: selection_options.length, only_one_option: only_one_option?)
   end
 end

--- a/spec/input_objects/pages/long_lists_selection/bulk_options_input_spec.rb
+++ b/spec/input_objects/pages/long_lists_selection/bulk_options_input_spec.rb
@@ -99,6 +99,20 @@ RSpec.describe Pages::LongListsSelection::BulkOptionsInput, type: :model do
       expect(bulk_options_input.draft_question.answer_settings[:selection_options]).to eq([{ name: "1" }, { name: "2" }])
     end
 
+    it "logs submission" do
+      allow(Rails.logger).to receive(:info)
+
+      bulk_options_input.bulk_selection_options = (1..2).to_a.join("\n")
+      bulk_options_input.include_none_of_the_above = "true"
+      bulk_options_input.submit
+
+      expect(Rails.logger).to have_received(:info).with("Submitted selection options for a selection question", {
+        "is_bulk_entry": true,
+        "options_count": 2,
+        "only_one_option": true,
+      })
+    end
+
     context "when only one option is allowed" do
       let(:only_one_option) { "true" }
 

--- a/spec/input_objects/pages/long_lists_selection/options_input_spec.rb
+++ b/spec/input_objects/pages/long_lists_selection/options_input_spec.rb
@@ -117,6 +117,19 @@ RSpec.describe Pages::LongListsSelection::OptionsInput do
       expect { input.submit }.to change(draft_question, :is_optional).to true
     end
 
+    it "logs submission" do
+      allow(Rails.logger).to receive(:info)
+
+      input = described_class.new(draft_question:, include_none_of_the_above: "true", selection_options:)
+      input.submit
+
+      expect(Rails.logger).to have_received(:info).with("Submitted selection options for a selection question", {
+        "is_bulk_entry": false,
+        "options_count": 2,
+        "only_one_option": true,
+      })
+    end
+
     context "when there are existing answer settings" do
       before do
         draft_question.answer_settings = { foo: "bar" }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SVZMGF6m

We want to know how many people are using the text box or individual fields to enter their options when creating a "Select from a list of options" question. We want to know whether this depends on how many options they are entering.

Log when options are submitted, with:
- The input method (is_bulk_entry)
- The number of options (options_count)
- Whether people can select more than one option (only_one_option)

We will use this log line to create a report in Splunk.

Example log line:

```json
{
  "level": "INFO",
  "time": "2024-11-19T17:19:54.191+00:00",
  "message": "Submitted selection options for a selection question",
  "is_bulk_entry": true,
  "options_count": 5,
  "only_one_option": false,
  "host": "localhost",
  "request_id": "b2754d29-0ecf-41ba-b08d-38387f9a01e3",
  "session_id_hash": "1d58c47c593c22b10014f124ada9d0de46e4f1b2386c2fb5fe5ab63e6597c6d5",
  "user_id": 1,
  "user_email": "example@example.com",
  "user_organisation_slug": "government-digital-service",
  "form_id": "8",
  "page_id": "32"
}
```

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
