### PR TITLE
Fix secondary_skip #update and add before_actions to prevent errors

### DIFF
--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -1,5 +1,5 @@
 class Pages::SecondarySkipController < PagesController
-  before_action :ensure_branch_routing_feature_enabled
+  before_action :ensure_branch_routing_feature_enabled, :ensure_page_has_skip_condition
 
   def new
     secondary_skip_input = Pages::SecondarySkipInput.new(form: current_form, page:)
@@ -52,6 +52,12 @@ private
 
   def ensure_branch_routing_feature_enabled
     raise ActionController::RoutingError, "branch_routing feature not enabled" unless Settings.features.branch_routing
+  end
+
+  def ensure_page_has_skip_condition
+    unless page.conditions.any? { |c| c.answer_value.present? }
+      redirect_to form_pages_path(current_form.id)
+    end
   end
 
   def secondary_skip_condition

--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -32,7 +32,7 @@ class Pages::SecondarySkipController < PagesController
   end
 
   def update
-    secondary_skip_input = Pages::SecondarySkipInput.new(secondary_skip_input_params.merge(record: secondary_skip_condition)).assign_values
+    secondary_skip_input = Pages::SecondarySkipInput.new(secondary_skip_input_params.merge(record: secondary_skip_condition))
 
     if secondary_skip_input.submit
       redirect_to show_routes_path(form_id: current_form.id, page_id: page.id)

--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -1,5 +1,7 @@
 class Pages::SecondarySkipController < PagesController
   before_action :ensure_branch_routing_feature_enabled, :ensure_page_has_skip_condition
+  before_action :ensure_secondary_skip_blank, only: %i[new create]
+  before_action :ensure_secondary_skip_exists, only: %i[edit update]
 
   def new
     secondary_skip_input = Pages::SecondarySkipInput.new(form: current_form, page:)
@@ -58,6 +60,14 @@ private
     unless page.conditions.any? { |c| c.answer_value.present? }
       redirect_to form_pages_path(current_form.id)
     end
+  end
+
+  def ensure_secondary_skip_exists
+    redirect_to show_routes_path(form_id: current_form.id, page_id: page.id) if secondary_skip_condition.blank?
+  end
+
+  def ensure_secondary_skip_blank
+    redirect_to show_routes_path(form_id: current_form.id, page_id: page.id) if secondary_skip_condition.present?
   end
 
   def secondary_skip_condition

--- a/app/input_objects/pages/secondary_skip_input.rb
+++ b/app/input_objects/pages/secondary_skip_input.rb
@@ -13,7 +13,7 @@ class Pages::SecondarySkipInput < BaseInput
     #
     # If the user has changed the routing_page_id, we need to remove the old
     # Condition and create a new one
-    if record.present? && record.routing_page_id == routing_page_id
+    if record.present? && record.routing_page_id.to_s == routing_page_id
       record.routing_page_id = routing_page_id
       record.goto_page_id = skip_to_end? ? nil : goto_page_id
       record.skip_to_end = skip_to_end?

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -108,4 +108,138 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       end
     end
   end
+
+  describe "#edit" do
+    let(:condition) do
+      build(:condition, id: 2, routing_page_id: pages[2].id, goto_page_id: pages[4].id)
+    end
+
+    before do
+      pages[2].routing_conditions = [condition]
+
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2", headers, form.to_json, 200
+        mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
+        mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
+      end
+    end
+
+    context "when the branch_routing feature is not enabled", feature_branch_routing: false do
+      it "returns a 404" do
+        get edit_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the branch_routing feature is enabled", :feature_branch_routing do
+      it "returns 200" do
+        get edit_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to have_http_status(:success)
+      end
+
+      it "renders the edit template" do
+        get edit_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to render_template("pages/secondary_skip/edit")
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:condition) do
+      build(
+        :condition,
+        id: 2,
+        routing_page_id: pages[2].id,
+        goto_page_id: pages[4].id,
+        secondary_skip: true,
+      )
+    end
+
+    let(:valid_params) do
+      {
+        form_id: "2",
+        page_id: "1",
+        pages_secondary_skip_input: {
+          routing_page_id: "3",
+          goto_page_id: "5",
+        },
+      }
+    end
+
+    before do
+      pages[2].routing_conditions = [condition]
+
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2", headers, form.to_json, 200
+        mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
+        mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
+      end
+    end
+
+    context "when the branch_routing feature is not enabled", feature_branch_routing: false do
+      it "returns a 404" do
+        patch update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the branch_routing feature is enabled", :feature_branch_routing do
+      context "when the submission is successful without changing the routing_page_id" do
+        before do
+          ActiveResource::HttpMock.respond_to(false) do |mock|
+            mock.put "/api/v1/forms/2/pages/3/conditions/2", post_headers, {}.to_json, 200
+          end
+        end
+
+        it "redirects to the show routes page" do
+          post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        end
+      end
+
+      context "when the submission is successful and changes the routing_page_id" do
+        let(:valid_params) do
+          {
+            form_id: "2",
+            page_id: "1",
+            pages_secondary_skip_input: {
+              routing_page_id: "2",
+              goto_page_id: "5",
+            },
+          }
+        end
+
+        before do
+          ActiveResource::HttpMock.respond_to(false) do |mock|
+            mock.delete "/api/v1/forms/2/pages/3/conditions/2", headers, {}.to_json, 200
+            mock.post "/api/v1/forms/2/pages/2/conditions", post_headers, {}.to_json, 200
+          end
+        end
+
+        it "redirects to the show routes page" do
+          post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        end
+      end
+
+      context "when the submission fails" do
+        let(:invalid_params) do
+          {
+            form_id: "2",
+            page_id: "1",
+            pages_secondary_skip_input: {
+              routing_page_id: "3",
+              goto_page_id: "3",
+            },
+          }
+        end
+
+        it "renders the edit template" do
+          post update_secondary_skip_path(form_id: 2, page_id: 1), params: invalid_params
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to render_template("pages/secondary_skip/edit")
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -66,6 +66,34 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         expect(response).to redirect_to(form_pages_path(form.id))
       end
     end
+
+    context "when a secondary skip condition already exists on the page" do
+      let(:existing_secondary_skip) do
+        build(
+          :condition,
+          id: 2,
+          routing_page_id: pages[2].id,
+          check_page_id: pages[0].id,
+          goto_page_id: pages[4].id,
+          secondary_skip: true,
+        )
+      end
+
+      before do
+        pages[2].routing_conditions = [existing_secondary_skip]
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms/2", headers, form.to_json, 200
+          mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
+          mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
+        end
+      end
+
+      it "redirects to the show routes page" do
+        get new_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+      end
+    end
   end
 
   describe "#create" do
@@ -111,6 +139,34 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         it "redirects to the page list" do
           post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
           expect(response).to redirect_to(form_pages_path(form.id))
+        end
+      end
+
+      context "when a secondary skip condition already exists on the page" do
+        let(:existing_secondary_skip) do
+          build(
+            :condition,
+            id: 2,
+            routing_page_id: pages[2].id,
+            check_page_id: pages[0].id,
+            goto_page_id: pages[4].id,
+            secondary_skip: true,
+          )
+        end
+
+        before do
+          pages[2].routing_conditions = [existing_secondary_skip]
+
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v1/forms/2", headers, form.to_json, 200
+            mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
+            mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
+          end
+        end
+
+        it "redirects to the show routes page" do
+          post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
 
@@ -180,6 +236,23 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
           expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
+
+      context "when no secondary_skip exists on the page" do
+        before do
+          pages[2].routing_conditions = []
+
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v1/forms/2", headers, form.to_json, 200
+            mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
+            mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
+          end
+        end
+
+        it "redirects to the page list" do
+          get edit_secondary_skip_path(form_id: 2, page_id: 1)
+          expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        end
+      end
     end
   end
 
@@ -246,6 +319,23 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         it "redirects to the page list" do
           post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
           expect(response).to redirect_to(form_pages_path(form.id))
+        end
+      end
+
+      context "when no secondary_skip exists on the page" do
+        before do
+          pages[2].routing_conditions = []
+
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v1/forms/2", headers, form.to_json, 200
+            mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
+            mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
+          end
+        end
+
+        it "redirects to the page list" do
+          post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
 

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         expect(response).to have_http_status(:success)
       end
     end
+
+    context "when no condition exists on the page" do
+      let(:pages) do
+        build_list(:page, 5).each_with_index do |page, index|
+          page.id = index + 1
+        end
+      end
+
+      it "redirects to the page list" do
+        get new_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to redirect_to(form_pages_path(form.id))
+      end
+    end
   end
 
   describe "#create" do
@@ -85,6 +98,19 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         it "redirects to the show routes page" do
           post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        end
+      end
+
+      context "when no condition exists on the page" do
+        let(:pages) do
+          build_list(:page, 5).each_with_index do |page, index|
+            page.id = index + 1
+          end
+        end
+
+        it "redirects to the page list" do
+          post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
 
@@ -141,6 +167,19 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         get edit_secondary_skip_path(form_id: 2, page_id: 1)
         expect(response).to render_template("pages/secondary_skip/edit")
       end
+
+      context "when no condition exists on the page" do
+        let(:pages) do
+          build_list(:page, 5).each_with_index do |page, index|
+            page.id = index + 1
+          end
+        end
+
+        it "redirects to the page list" do
+          get edit_secondary_skip_path(form_id: 2, page_id: 1)
+          expect(response).to redirect_to(form_pages_path(form.id))
+        end
+      end
     end
   end
 
@@ -194,6 +233,19 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         it "redirects to the show routes page" do
           post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        end
+      end
+
+      context "when no condition exists on the page" do
+        let(:pages) do
+          build_list(:page, 5).each_with_index do |page, index|
+            page.id = index + 1
+          end
+        end
+
+        it "redirects to the page list" do
+          post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
 


### PR DESCRIPTION
# Fix errors in editing secondary skip routes

This PR combines two things:
- fixes an issue which prevents secondary skips being updated correctly
- adds before actions to prevent secondary skips being added when they shouldn't be

They could be separate PRs but are combined because they cover very similar parts of the code and the updates to the tests reveal them.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
