### PR TITLE
1967 add link to set questions to skip page behind feature flag in forms admin

### DIFF
--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -45,7 +45,7 @@ private
         title: I18n.t("page_route_card.route_title", index:),
         classes: "app-summary-card",
         actions: [
-          govuk_link_to("Edit", edit_condition_path(form_id: form.id, page_id: page.id, condition_id: routing_condition.id)),
+          govuk_link_to(I18n.t("page_route_card.edit"), edit_condition_path(form_id: form.id, page_id: page.id, condition_id: routing_condition.id)),
         ],
       },
       rows: [
@@ -68,6 +68,9 @@ private
       card: {
         title: I18n.t("page_route_card.route_title", index:),
         classes: "app-summary-card",
+        actions: [
+          edit_secondary_skip_link,
+        ],
       },
       rows: [
         {
@@ -79,10 +82,27 @@ private
     }
   end
 
+  def edit_secondary_skip_link
+    if FeatureService.enabled?(:branch_routing) && all_routes.find(&:secondary_skip?).present?
+      govuk_link_to(I18n.t("page_route_card.edit"), edit_secondary_skip_path(form_id: form.id, page_id: page.id))
+    end
+  end
+
   def secondary_skip_rows
     secondary_skip = all_routes.find(&:secondary_skip?)
 
-    return [] if secondary_skip.blank?
+    if secondary_skip.blank?
+      if FeatureService.enabled?(:branch_routing)
+        return [
+          {
+            key: { text: I18n.t("page_route_card.then") },
+            value: { text: govuk_link_to(I18n.t("page_route_card.set_secondary_skip"), new_secondary_skip_path(form_id: form.id, page_id: page.id)) },
+          },
+        ]
+      else
+        return []
+      end
+    end
 
     goto_page_name = secondary_skip.skip_to_end ? end_page_name : page_name(secondary_skip.goto_page_id)
     routing_page_name = page_name(secondary_skip.routing_page_id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1034,13 +1034,16 @@ en:
     conditional_answer_value: "%{answer_value}"
     continue_to: For any other answer, continue to
     delete_route: Delete routes
+    edit: Edit
     if_answer_is: If the answer is
     page_name: "%{page_position}. %{page_name}"
     question_title: Question %{position}
     route_title: Route %{index}
     secondary_skip_after: Then after the person answers
     secondary_skip_then: take them to
+    set_secondary_skip: Set one or more questions to skip later in the form (optional)
     take_the_person_to: take the person to
+    then: Then
   page_settings_summary:
     address:
       address_type: Address type

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -46,8 +46,15 @@ describe RouteSummaryCardDataPresenter do
 
         # default route
         expect(result[1][:card][:title]).to eq("Route 2")
-        expect(result[1][:card][:actions]).to be_nil
+        expect(result[1][:card][:actions][0]).to be_nil
         expect(result[1][:rows][0][:value][:text]).to eq("2. Next Question")
+      end
+
+      context "with branch_routing enabled", :feature_branch_routing do
+        it "has the link to create a secondary skip" do
+          result = service.summary_card_data
+          expect(result[1][:rows][1][:value][:text]).to have_link("Set one or more questions to skip later in the form (optional)", href: "/forms/99/pages/1/routes/any-other-answer/questions-to-skip/new")
+        end
       end
     end
 
@@ -78,6 +85,13 @@ describe RouteSummaryCardDataPresenter do
         expect(result[1][:rows][0][:value][:text]).to eq("2. Next Question")
         expect(result[1][:rows][1][:value][:text]).to eq("2. Next Question")
         expect(result[1][:rows][2][:value][:text]).to eq("Check your answers before submitting")
+      end
+
+      context "with branch_routing enabled", :feature_branch_routing do
+        it "shows the edit secondary skip link" do
+          result = service.summary_card_data
+          expect(result[1][:card][:actions].first).to have_link("Edit", href: "/forms/99/pages/1/routes/any-other-answer/questions-to-skip")
+        end
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/pNKOqQ1j/1967-add-link-to-set-questions-to-skip-page-behind-feature-flag-in-forms-admin

Adds links to the routing summary cards for secondary routes. These show up only when the `branch_routing` flag is on. 

When creating a route, you can see a link to create a secondary skip on the secondary route card. 

![image](https://github.com/user-attachments/assets/37e0f607-7170-4ae8-82ba-5dbaf33f211b)

Once a secondary route has been created, you will get an `Edit` action at the top of the summary card.

![image](https://github.com/user-attachments/assets/f39383c6-d067-4c4c-8e9d-e24e25cb0d04)


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
