### PR TITLE
Fix secondary skip display pagelist

### DIFF
--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -18,7 +18,7 @@ module PageListComponent
 
     def condition_description(condition)
       if condition.secondary_skip?
-        I18n.t("page_conditions.secondary_skip_description", check_page_text: skip_condition_check_page_text(condition), goto_page_text: goto_page_text_for_condition(condition))
+        I18n.t("page_conditions.secondary_skip_description", check_page_text: skip_condition_route_page_text(condition), goto_page_text: goto_page_text_for_condition(condition))
       else
         I18n.t("page_conditions.condition_description", check_page_text: condition_check_page_text(condition), goto_page_text: goto_page_text_for_condition(condition), answer_value: answer_value_text_for_condition(condition))
       end
@@ -66,9 +66,9 @@ module PageListComponent
       @routing_conditions_with_index ||= process_routing_conditions
     end
 
-    def skip_condition_check_page_text(condition)
-      check_page = @pages.find { |page| page.id == condition.check_page_id }
-      I18n.t("page_conditions.skip_condition_check_page_text", check_page_text: check_page.question_text, check_page_position: check_page.position)
+    def skip_condition_route_page_text(condition)
+      routing_page = @pages.find { |page| page.id == condition.routing_page_id }
+      I18n.t("page_conditions.skip_condition_route_page_text", route_page_text: routing_page.question_text, route_page_position: routing_page.position)
     end
 
     # Create hash of page_id => [condition, index]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1015,7 +1015,7 @@ en:
     none_of_the_above: None of the above
     route: Route
     secondary_skip_description: After %{check_page_text} go to %{goto_page_text}
-    skip_condition_check_page_text: "%{check_page_position}, “%{check_page_text}”"
+    skip_condition_route_page_text: "%{route_page_position}, “%{route_page_text}”"
   page_options_service:
     answer_type: Answer type
     date: Date

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -187,6 +187,7 @@ RSpec.describe PageListComponent::View, type: :component do
           (build :page, id: 1, position: 1, question_text: "What country do you live in?", routing_conditions:),
           (build :page, id: 2, position: 2, question_text: "What is your name?", routing_conditions:),
           (build :page, id: 3, position: 3, question_text: "What is your pet's name?", routing_conditions:),
+          (build :page, id: 4, position: 4, question_text: "What is your email address?", routing_conditions:),
         ]
       end
 
@@ -270,6 +271,23 @@ RSpec.describe PageListComponent::View, type: :component do
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
         end
       end
+
+      context "when showing a secondary_skip" do
+        let(:condition) do
+          build(:condition,
+                id: 1,
+                routing_page_id: 2,
+                check_page_id: 1,
+                answer_value: nil,
+                goto_page_id: 4,
+                secondary_skip: true)
+        end
+
+        it "returns correct description" do
+          expected_text = "After 2, “What is your name?” go to 4, “What is your email address?”"
+          expect(page_list_component.condition_description(condition)).to eq(expected_text)
+        end
+      end
     end
 
     describe "#conditions_for_page_with_index" do
@@ -301,6 +319,7 @@ RSpec.describe PageListComponent::View, type: :component do
         let(:pages) do
           [(build :page, id: 1, position: 1, question_text: "What country do you live in?", routing_conditions:)]
         end
+
         let(:routing_conditions) do
           [
             build(:condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3),


### PR DESCRIPTION
### Fix the text for secondary skip's in the pagelist component

Trello card: https://trello.com/c/faPNxjxY/2517-update-routing-pages-to-match-designs-snags-ticket

The text used when showing secondary skips in the pagelist is referencing the wrong question.

This commit fixes it.

## Wrong, before this commit
<img width="690" alt="image" src="https://github.com/user-attachments/assets/4cdcba87-684d-4a4c-bc0d-6015d8101ae7">

## Right, after this commit
<img width="693" alt="image" src="https://github.com/user-attachments/assets/0430ce80-fead-4b05-9de8-25e9160bd204">

See the designs for more info.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
