### PR TITLE
Add delete link to summary card for any other answers route

### DIFF
--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -70,7 +70,8 @@ private
         classes: "app-summary-card",
         actions: [
           edit_secondary_skip_link,
-        ],
+          delete_secondary_skip_link,
+        ]
       },
       rows: [
         {
@@ -85,6 +86,12 @@ private
   def edit_secondary_skip_link
     if FeatureService.enabled?(:branch_routing) && all_routes.find(&:secondary_skip?).present?
       govuk_link_to(I18n.t("page_route_card.edit"), edit_secondary_skip_path(form_id: form.id, page_id: page.id))
+    end
+  end
+
+  def delete_secondary_skip_link
+    if FeatureService.enabled?(:branch_routing) && all_routes.find(&:secondary_skip?).present?
+      govuk_link_to(I18n.t("page_route_card.delete"), "#")
     end
   end
 

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -64,14 +64,20 @@ private
   def default_route_card(index)
     continue_to_name = page.has_next_page? ? page_name(page.next_page) : end_page_name
 
+    actions = if FeatureService.enabled?(:branch_routing) && all_routes.find(&:secondary_skip?).present?
+                [
+                  edit_secondary_skip_link,
+                  delete_secondary_skip_link,
+                ]
+              else
+                []
+              end
+
     {
       card: {
         title: I18n.t("page_route_card.route_title", index:),
         classes: "app-summary-card",
-        actions: [
-          edit_secondary_skip_link,
-          delete_secondary_skip_link,
-        ]
+        actions:,
       },
       rows: [
         {
@@ -84,15 +90,11 @@ private
   end
 
   def edit_secondary_skip_link
-    if FeatureService.enabled?(:branch_routing) && all_routes.find(&:secondary_skip?).present?
-      govuk_link_to(I18n.t("page_route_card.edit"), edit_secondary_skip_path(form_id: form.id, page_id: page.id))
-    end
+    govuk_link_to(I18n.t("page_route_card.edit"), edit_secondary_skip_path(form_id: form.id, page_id: page.id))
   end
 
   def delete_secondary_skip_link
-    if FeatureService.enabled?(:branch_routing) && all_routes.find(&:secondary_skip?).present?
-      govuk_link_to(I18n.t("page_route_card.delete"), "#")
-    end
+    govuk_link_to(I18n.t("page_route_card.delete"), "#")
   end
 
   def secondary_skip_rows

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1033,6 +1033,7 @@ en:
     check_your_answers: Check your answers before submitting
     conditional_answer_value: "%{answer_value}"
     continue_to: For any other answer, continue to
+    delete: Delete
     delete_route: Delete routes
     edit: Edit
     if_answer_is: If the answer is

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -92,6 +92,11 @@ describe RouteSummaryCardDataPresenter do
           result = service.summary_card_data
           expect(result[1][:card][:actions].first).to have_link("Edit", href: "/forms/99/pages/1/routes/any-other-answer/questions-to-skip")
         end
+
+        it "shows the delete secondary skip link" do
+          result = service.summary_card_data
+          expect(result[1][:card][:actions].second).to have_link("Delete", href: "#")
+        end
       end
     end
 

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -87,6 +87,13 @@ describe RouteSummaryCardDataPresenter do
         expect(result[1][:rows][2][:value][:text]).to eq("Check your answers before submitting")
       end
 
+      context "when branch routing is not enabled", feature_branch_routing: false do
+        it "has no actions" do
+          result = service.summary_card_data
+          expect(result[1][:card][:actions]).to be_empty
+        end
+      end
+
       context "with branch_routing enabled", :feature_branch_routing do
         it "shows the edit secondary skip link" do
           result = service.summary_card_data


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/RU21t6Gn/1988-add-link-to-delete-route-2-route-in-forms-admin <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Add a link to the actions for the any other answers route summary card that will lead to a page to confirm deletion of the route condition.

Currently the link goes nowhere, but we want to add it now so we can put it in front of users in testing and see how well it works.

This link should not appear if the branch routing feature flag is not enabled.

### Screenshot

![Screenshot of the route summary card for the any other answers route, with the delete action link](https://github.com/user-attachments/assets/7f18951e-3a8c-49ce-a819-0a640f52746b)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?