### PR TITLE
Turn on long lists feature for all users

### DIFF
--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -39,22 +39,12 @@
                     href: @change_selections_options_path,
                     visually_hidden_text: t("page_settings_summary.selection.options")) %>
     <% end %>
-    <% if @long_lists_enabled %>
-      <%= summary_list.with_row do |row| %>
-        <%= row.with_key(text: t("page_settings_summary.selection.how_many_selections")) %>
-        <%= row.with_value(text: answer_settings[:only_one_option] == "true" ? t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.true") : t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")) %>
-        <%= row.with_action(text: t("page_settings_summary.change"),
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: t("page_settings_summary.selection.how_many_selections")) %>
+      <%= row.with_value(text: answer_settings[:only_one_option] == "true" ? t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.true") : t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")) %>
+      <%= row.with_action(text: t("page_settings_summary.change"),
                             href: @change_selections_only_one_option_path,
                             visually_hidden_text: t("page_settings_summary.selection.only_one_option")) %>
-      <% end %>
-    <% else %>
-      <%= summary_list.with_row do |row| %>
-        <%= row.with_key(text: t("page_settings_summary.selection.only_one_option")) %>
-        <%= row.with_value(text: answer_settings[:only_one_option] == "true" ? t("selections_settings.yes") : t("selections_settings.no")) %>
-        <%= row.with_action(text: t("page_settings_summary.change"),
-                      href: @change_selections_only_one_option_path,
-                      visually_hidden_text: t("page_settings_summary.selection.only_one_option")) %>
-      <% end %>
     <% end %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: t("page_settings_summary.selection.include_none_of_the_above")) %>

--- a/app/components/page_settings_summary_component/view.html.erb
+++ b/app/components/page_settings_summary_component/view.html.erb
@@ -44,7 +44,7 @@
       <%= row.with_value(text: answer_settings[:only_one_option] == "true" ? t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.true") : t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")) %>
       <%= row.with_action(text: t("page_settings_summary.change"),
                             href: @change_selections_only_one_option_path,
-                            visually_hidden_text: t("page_settings_summary.selection.only_one_option")) %>
+                            visually_hidden_text: t("page_settings_summary.selection.how_many_selections")) %>
     <% end %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key(text: t("page_settings_summary.selection.include_none_of_the_above")) %>

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -8,7 +8,6 @@ module PageSettingsSummaryComponent
     def initialize(draft_question:, errors: nil, long_lists_enabled: false)
       super
       @draft_question = draft_question
-      @long_lists_enabled = long_lists_enabled
       @errors = errors
     end
 
@@ -86,42 +85,25 @@ module PageSettingsSummaryComponent
 
     def change_selections_only_one_option_path
       return unless @draft_question.answer_type == "selection"
-      return change_selections_options_path unless @long_lists_enabled
+      return long_lists_selection_type_new_path(form_id: @draft_question.form_id) if is_new_question?
 
-      if is_new_question?
-        long_lists_selection_type_new_path(form_id: @draft_question.form_id)
-      else
-        long_lists_selection_type_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
-      end
+      long_lists_selection_type_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
     end
 
     def change_selections_options_path
       return unless @draft_question.answer_type == "selection"
-      return change_selections_options_long_lists_enabled_path if @long_lists_enabled
 
-      if is_new_question?
-        selections_settings_new_path(form_id: @draft_question.form_id)
-      else
-        selections_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
-      end
-    end
+      return selection_options_new_path_for_draft_question(@draft_question) if is_new_question?
 
-    def change_selections_options_long_lists_enabled_path
-      if is_new_question?
-        selection_options_new_path_for_draft_question(@draft_question)
-      else
-        selection_options_edit_path_for_draft_question(@draft_question)
-      end
+      selection_options_edit_path_for_draft_question(@draft_question)
     end
 
     def change_text_settings_path
       return unless @draft_question.answer_type == "text"
 
-      if is_new_question?
-        text_settings_new_path(form_id: @draft_question.form_id)
-      else
-        text_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
-      end
+      return text_settings_new_path(form_id: @draft_question.form_id) if is_new_question?
+
+      text_settings_edit_path(form_id: @draft_question.form_id, page_id: @draft_question.page_id)
     end
 
     def is_new_question?

--- a/app/components/page_settings_summary_component/view.rb
+++ b/app/components/page_settings_summary_component/view.rb
@@ -5,7 +5,7 @@ module PageSettingsSummaryComponent
     include Rails.application.routes.url_helpers
     include PagesHelper
 
-    def initialize(draft_question:, errors: nil, long_lists_enabled: false)
+    def initialize(draft_question:, errors: nil)
       super
       @draft_question = draft_question
       @errors = errors

--- a/app/controllers/pages/question_text_controller.rb
+++ b/app/controllers/pages/question_text_controller.rb
@@ -12,11 +12,7 @@ class Pages::QuestionTextController < PagesController
     @back_link_url = type_of_answer_new_path(current_form)
 
     if @question_text_input.submit
-      if current_form.group.long_lists_enabled
-        redirect_to long_lists_selection_type_new_path(current_form)
-      else
-        redirect_to selections_settings_new_path(current_form)
-      end
+      redirect_to long_lists_selection_type_new_path(current_form)
     else
       render :question_text, locals: { current_form: }
     end

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -37,9 +37,8 @@ private
 
   def selection_path(form, action)
     return question_text_new_path(form) if action == :create
-    return long_lists_selection_type_edit_path(form, page) if form.group.long_lists_enabled
 
-    selections_settings_edit_path(form)
+    long_lists_selection_type_edit_path(form, page)
   end
 
   def text_path(form, action)

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -43,7 +43,7 @@
   <% end %>
 
   <h2 class="govuk-heading-m"><%= t("pages.answer_settings") %></h2>
-  <%= render PageSettingsSummaryComponent::View.new(draft_question:, errors: question_input.errors, long_lists_enabled: form_object.group.long_lists_enabled) %>
+  <%= render PageSettingsSummaryComponent::View.new(draft_question:, errors: question_input.errors) %>
 
   <ul class="govuk-list govuk-list--spaced">
     <li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1058,7 +1058,6 @@ en:
     selection:
       how_many_selections: How many options can people select
       include_none_of_the_above: Include an option for ‘None of the above’
-      only_one_option: People can only select one option
       options: Options
       options_count: "%{number_of_options} options:"
       options_summary: Show %{number_of_options} options

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -56,31 +56,19 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
 
   context "when the draft question is a 'select from a list'" do
     context "when editing an existing question" do
-      let(:draft_question) { build :selection_draft_question }
+      let(:only_one_option) { "false" }
+      let(:is_optional) { false }
+      let(:draft_question) do
+        build :selection_draft_question,
+              is_optional:,
+              answer_settings: {
+                only_one_option:,
+                selection_options: [{ name: "Option 1" }, { name: "Option 2" }],
+              }
+      end
 
       it "has a link to change the answer type" do
         expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: edit_answer_type_path)
-      end
-
-      it "has links to change the selection options" do
-        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.options')}", href: edit_selections_setting_path)
-        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: edit_selections_setting_path)
-        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.include_none_of_the_above')}", href: edit_selections_setting_path)
-      end
-
-      it "renders the selection settings" do
-        rows = page.find_all(".govuk-summary-list__row")
-
-        expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
-        expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
-        expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
-        expect(rows[1].find(".govuk-summary-list__value")).to have_text "2 options:"
-        expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 1")
-        expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 2")
-        expect(rows[2].find(".govuk-summary-list__key")).to have_text "People can only select one option"
-        expect(rows[2].find(".govuk-summary-list__value")).to have_text "Yes"
-        expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
-        expect(rows[3].find(".govuk-summary-list__value")).to have_text "No"
       end
 
       context "when there are 10 or more selection options" do
@@ -156,74 +144,60 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         end
       end
 
-      context "when long_lists_enabled is true for the group" do
-        let(:long_lists_enabled) { true }
-        let(:only_one_option) { "false" }
-        let(:is_optional) { false }
-        let(:draft_question) do
-          build :selection_draft_question,
-                is_optional:,
-                answer_settings: {
-                  only_one_option:,
-                  selection_options: [{ name: "Option 1" }, { name: "Option 2" }],
-                }
-        end
+      it "renders the selection settings" do
+        rows = page.find_all(".govuk-summary-list__row")
 
-        it "renders the selection settings" do
+        expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
+        expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
+        expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
+        expect(rows[1].find(".govuk-summary-list__value")).to have_text "2 options:"
+        expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 1")
+        expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 2")
+        expect(rows[2].find(".govuk-summary-list__key")).to have_text I18n.t("page_settings_summary.selection.how_many_selections")
+        expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")
+        expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
+        expect(rows[3].find(".govuk-summary-list__value")).to have_text "No"
+      end
+
+      context "when only_one_option is true" do
+        let(:only_one_option) { "true" }
+
+        it "says people can select one or more options in the summary table" do
           rows = page.find_all(".govuk-summary-list__row")
+          expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.true")
+        end
+      end
 
-          expect(rows[0].find(".govuk-summary-list__key")).to have_text "Answer type"
-          expect(rows[0].find(".govuk-summary-list__value")).to have_text "Selection from a list"
-          expect(rows[1].find(".govuk-summary-list__key")).to have_text "Options"
-          expect(rows[1].find(".govuk-summary-list__value")).to have_text "2 options:"
-          expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 1")
-          expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 2")
-          expect(rows[2].find(".govuk-summary-list__key")).to have_text I18n.t("page_settings_summary.selection.how_many_selections")
+      # This ensures there is backwards compatibility for existing questions as we previously set "only_one_option" to
+      # "0" rather than "false"
+      context "when only_one_option has value '0'" do
+        let(:only_one_option) { "0" }
+
+        it "says people can select only one option in the summary table" do
+          rows = page.find_all(".govuk-summary-list__row")
           expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")
-          expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
-          expect(rows[3].find(".govuk-summary-list__value")).to have_text "No"
         end
+      end
 
-        context "when only_one_option is true" do
-          let(:only_one_option) { "true" }
+      context "when is_optional is true" do
+        let(:is_optional) { "true" }
 
-          it "says people can select one or more options in the summary table" do
-            rows = page.find_all(".govuk-summary-list__row")
-            expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.true")
-          end
+        it "says an option for None of the above will be included" do
+          rows = page.find_all(".govuk-summary-list__row")
+          expect(rows[3].find(".govuk-summary-list__value")).to have_text "Yes"
         end
+      end
 
-        # This ensures there is backwards compatibility for existing questions as we previously set "only_one_option" to
-        # "0" rather than "false"
-        context "when only_one_option has value '0'" do
-          let(:only_one_option) { "0" }
+      it "the change button for only one option links to the long lists type page" do
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: edit_long_lists_selection_type_path)
+      end
 
-          it "says people can select only one option in the summary table" do
-            rows = page.find_all(".govuk-summary-list__row")
-            expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.false")
-          end
-        end
+      it "the change button for the options links to the long lists options page" do
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.options')}", href: edit_long_lists_selection_options_path)
+      end
 
-        context "when is_optional is true" do
-          let(:is_optional) { "true" }
-
-          it "says an option for None of the above will be included" do
-            rows = page.find_all(".govuk-summary-list__row")
-            expect(rows[3].find(".govuk-summary-list__value")).to have_text "Yes"
-          end
-        end
-
-        it "the change button for only one option links to the long lists type page" do
-          expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: edit_long_lists_selection_type_path)
-        end
-
-        it "the change button for the options links to the long lists options page" do
-          expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.options')}", href: edit_long_lists_selection_options_path)
-        end
-
-        it "the change button for include none of the above links to the longs lists options page" do
-          expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.include_none_of_the_above')}", href: edit_long_lists_selection_options_path)
-        end
+      it "the change button for include none of the above links to the longs lists options page" do
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.include_none_of_the_above')}", href: edit_long_lists_selection_options_path)
       end
     end
 
@@ -234,26 +208,16 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
         expect(page).to have_link("Change #{I18n.t('page_settings_summary.answer_type')}", href: new_answer_type_path)
       end
 
-      it "has links to change the selection options" do
-        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.options')}", href: new_selections_setting_path)
-        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: new_selections_setting_path)
-        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.include_none_of_the_above')}", href: new_selections_setting_path)
+      it "the change button for only one option links to the long lists type page" do
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: new_long_lists_selection_type_path)
       end
 
-      context "when long_lists_enabled is true for the group" do
-        let(:long_lists_enabled) { true }
+      it "the change button for the options links to the long lists options page" do
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.options')}", href: new_long_lists_selection_options_path)
+      end
 
-        it "the change button for only one option links to the long lists type page" do
-          expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: new_long_lists_selection_type_path)
-        end
-
-        it "the change button for the options links to the long lists options page" do
-          expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.options')}", href: new_long_lists_selection_options_path)
-        end
-
-        it "the change button for include none of the above links to the longs lists options page" do
-          expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.include_none_of_the_above')}", href: new_long_lists_selection_options_path)
-        end
+      it "the change button for include none of the above links to the longs lists options page" do
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.include_none_of_the_above')}", href: new_long_lists_selection_options_path)
       end
     end
   end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
   include Rails.application.routes.url_helpers
 
   let(:draft_question) { build :draft_question }
-  let(:long_lists_enabled) { false }
   let(:errors) { instance_double(ActiveModel::Errors) }
   let(:selection_options_error_messages) { nil }
   let(:question_input) { Pages::QuestionInput.new(draft_question:, is_optional: "false", is_repeatable: "false") }
@@ -34,7 +33,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
   before do
     allow(errors).to receive(:has_key?).with(:selection_options).and_return(selection_options_error_messages.present?)
     allow(errors).to receive(:messages_for).with(:selection_options).and_return(selection_options_error_messages)
-    render_inline(described_class.new(draft_question:, errors:, long_lists_enabled:))
+    render_inline(described_class.new(draft_question:, errors:))
   end
 
   context "when the page is not a selection page" do
@@ -137,8 +136,8 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
           expect(rows[1].find(".govuk-summary-list__value")).to have_text "2 options:"
           expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 1")
           expect(rows[1].find(".govuk-summary-list__value")).to have_css("li", text: "Option 2")
-          expect(rows[2].find(".govuk-summary-list__key")).to have_text "People can only select one option"
-          expect(rows[2].find(".govuk-summary-list__value")).to have_text "Yes"
+          expect(rows[2].find(".govuk-summary-list__key")).to have_text I18n.t("page_settings_summary.selection.how_many_selections")
+          expect(rows[2].find(".govuk-summary-list__value")).to have_text I18n.t("helpers.label.pages_long_lists_selection_type_input.only_one_option_options.true")
           expect(rows[3].find(".govuk-summary-list__key")).to have_text "Include an option for ‘None of the above’"
           expect(rows[3].find(".govuk-summary-list__value")).to have_text "Yes"
         end

--- a/spec/components/page_settings_summary_component/view_spec.rb
+++ b/spec/components/page_settings_summary_component/view_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       end
 
       it "the change button for only one option links to the long lists type page" do
-        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: edit_long_lists_selection_type_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.how_many_selections')}", href: edit_long_lists_selection_type_path)
       end
 
       it "the change button for the options links to the long lists options page" do
@@ -208,7 +208,7 @@ RSpec.describe PageSettingsSummaryComponent::View, type: :component do
       end
 
       it "the change button for only one option links to the long lists type page" do
-        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.only_one_option')}", href: new_long_lists_selection_type_path)
+        expect(page).to have_link("Change #{I18n.t('page_settings_summary.selection.how_many_selections')}", href: new_long_lists_selection_type_path)
       end
 
       it "the change button for the options links to the long lists options page" do

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -150,7 +150,7 @@ private
     select_people_can_choose_one_or_more_options
     configure_the_selection_options
 
-    click_link "Change People can only select one option"
+    click_link "Change How many options can people select"
 
     select_people_can_only_choose_one_option
     configure_the_selection_options

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -40,32 +40,6 @@ feature "Add/editing a single question", type: :feature do
         and_i_add_another_question
       end
     end
-
-    context "when the form is in a group which has long lists enabled" do
-      let(:group) { create(:group, organisation: standard_user.organisation, long_lists_enabled: true) }
-      let(:options) { 10.times.map { Faker::Name.unique.name } }
-
-      scenario "add a selection question which the user can answer more than once" do
-        when_i_am_viewing_an_existing_form
-        and_i_want_to_create_or_edit_a_page
-        and_i_select_selection_type_question
-        and_i_select_people_can_choose_one_or_more_options
-        and_i_configure_the_selection_options(options)
-        and_i_make_the_question_not_repeatable
-        and_i_click_save
-        and_i_add_another_question
-      end
-
-      scenario "add a selection question which the user can answer once" do
-        when_i_am_viewing_an_existing_form
-        and_i_want_to_create_or_edit_a_page
-        and_i_select_selection_type_question
-        and_i_select_people_can_only_choose_one_option
-        and_i_configure_the_selection_options(options)
-        and_i_click_save
-        and_i_add_another_question
-      end
-    end
   end
 
   context "when a form has existing pages" do
@@ -173,23 +147,13 @@ private
   end
 
   def fill_in_selection_settings
-    expect(page.find("h1")).to have_text "Create a list of options"
-    expect_page_to_have_no_axe_errors(page)
-    check "Include an option for ‘None of the above’"
-    fill_in "Option 1", with: "Checkbox option 1"
-    fill_in "Option 2", with: "Checkbox option 2"
-    click_button "Add another option"
-    fill_in "Option 3", with: "Checkbox option 3"
-    click_button "Continue"
-    click_link "Change Options"
-    expect(page.find("h1")).to have_text "Create a list of options"
-    expect_page_to_have_no_axe_errors(page)
-    check "People can only select one option"
-    uncheck "Include an option for ‘None of the above’"
-    click_button "Remove option 3"
-    fill_in "Option 1", with: "Radio option 1"
-    fill_in "Option 2", with: "Radio option 2"
-    click_button "Continue"
+    select_people_can_choose_one_or_more_options
+    configure_the_selection_options
+
+    click_link "Change People can only select one option"
+
+    select_people_can_only_choose_one_option
+    configure_the_selection_options
   end
 
   def fill_in_text_settings
@@ -237,21 +201,23 @@ private
     fill_in_question_text
   end
 
-  def and_i_select_people_can_only_choose_one_option
+  def select_people_can_only_choose_one_option
     expect(page.find("h1")).to have_text "How many options should people be able to select?"
     expect_page_to_have_no_axe_errors(page)
     choose "One option only"
     click_button "Continue"
   end
 
-  def and_i_select_people_can_choose_one_or_more_options
+  def select_people_can_choose_one_or_more_options
     expect(page.find("h1")).to have_text "How many options should people be able to select?"
     expect_page_to_have_no_axe_errors(page)
     choose "One or more options"
     click_button "Continue"
   end
 
-  def and_i_configure_the_selection_options(options)
+  def configure_the_selection_options
+    options = 10.times.map { Faker::Name.unique.name }
+
     fill_in_selection_options(options)
     fill_in_bulk_options(options)
   end

--- a/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
+++ b/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
@@ -77,7 +77,7 @@ private
     when :name
       name_settings_edit_path(form_id: form.id, page_id: question.id)
     when :selection
-      selections_settings_edit_path(form_id: form.id, page_id: question.id)
+      long_lists_selection_options_edit_path(form_id: form.id, page_id: question.id)
     when :text
       text_settings_edit_path(form_id: form.id, page_id: question.id)
     end
@@ -132,15 +132,14 @@ private
   def check_selection_answer_settings
     expect(page.find("h1")).to have_text "Create a list of options"
     expect_page_to_have_no_axe_errors(page)
-    expect(page).to have_checked_field("People can only select one option", visible: :all)
-    expect(page).to have_checked_field("Include an option for ‘None of the above’", visible: :all)
+    expect(page.find("fieldset", text: "Should the list include an option for ‘None of the above’?")).to have_checked_field("Yes", visible: :all)
     expect(find_field("Option 1").value).to eq "Option 1"
     expect(find_field("Option 2").value).to eq "Option 2"
     click_button "Continue"
     expect(page.find_all(".govuk-summary-list__value")[1]).to have_text "2 options:"
     expect(page.find_all(".govuk-summary-list__value")[1]).to have_css("li", text: "Option 1")
     expect(page.find_all(".govuk-summary-list__value")[1]).to have_css("li", text: "Option 2")
-    expect(page.find_all(".govuk-summary-list__value")[2]).to have_text "Yes"
+    expect(page.find_all(".govuk-summary-list__value")[2]).to have_text "One option only"
     expect(page.find_all(".govuk-summary-list__value")[3]).to have_text "Yes"
   end
 

--- a/spec/requests/pages/question_text_controller_spec.rb
+++ b/spec/requests/pages/question_text_controller_spec.rb
@@ -68,16 +68,8 @@ RSpec.describe Pages::QuestionTextController, type: :request do
         expect(form.draft_question.question_text).to eq "Are you a higher rate taxpayer?"
       end
 
-      it "redirects the user to the selection settings page" do
-        expect(response).to redirect_to selections_settings_new_path(form.id)
-      end
-
-      context "when long_lists_enabled is enabled for the group" do
-        let(:group) { create(:group, organisation: standard_user.organisation, long_lists_enabled: true) }
-
-        it "redirects the user to the page to choose whether only one option can be selected" do
-          expect(response).to redirect_to long_lists_selection_type_new_path(form.id)
-        end
+      it "redirects the user to the page to choose whether only one option can be selected" do
+        expect(response).to redirect_to long_lists_selection_type_new_path(form.id)
       end
     end
   end

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -3,11 +3,10 @@ require "rails_helper"
 RSpec.describe Pages::TypeOfAnswerController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
-  let(:long_lists_enabled) { false }
 
   let(:type_of_answer_input) { build :type_of_answer_input }
 
-  let(:group) { create(:group, organisation: standard_user.organisation, long_lists_enabled:) }
+  let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -215,20 +214,8 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
           expect(form.draft_question.answer_type).to eq "selection"
         end
 
-        context "when long_lists_enabled is set to true" do
-          let(:long_lists_enabled) { true }
-
-          it "redirects the user to the selection type page" do
-            expect(response).to redirect_to long_lists_selection_type_edit_path(form.id, page.id)
-          end
-        end
-
-        context "when long_lists_enabled is set to false" do
-          let(:long_lists_enabled) { false }
-
-          it "redirects the user to the selection settings page" do
-            expect(response).to redirect_to selections_settings_edit_path(form.id, page.id)
-          end
+        it "redirects the user to the selection type page" do
+          expect(response).to redirect_to long_lists_selection_type_edit_path(form.id, page.id)
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/v9BZe6or/1998-release-long-lists-with-autocomplete-for-all-departments?filter=label:Feature%20team%20one,label:Tech%20Support,label:X%20feature%20teams

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Includes:
- removing any use of the long_lists_enabled flag on groups
- updating and cleaning up the tests
- A tiny content fix for some visually hidden text that had the wrong translation in it

See individual commit messages for details.

There are some cleanup tasks that this PR does not include:
- removing the `long_lists_enabled` database column and the task for setting it. That will be done separately, once we're happy that this PR hasn't broken anything and won't need to be reverted.
- removing the old selection type files and translations, since we don't need them any more
- renaming references to 'long list selection' (since we now only have one type of selection)

These will need to be done in one or more subsequent PRs once we're confident in the changes.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
