### PR TITLE
Improve SecondarySkip request tests

### DIFF
--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -2,26 +2,7 @@ require "rails_helper"
 
 RSpec.describe Pages::SecondarySkipController, type: :request do
   let(:form) { build :form, id: 2, pages: }
-  let(:pages) do
-    pages = build_list(:page, 5).each_with_index do |page, index|
-      page.id = index + 1
-    end
-
-    pages.first.answer_settings =
-      DataStruct.new(
-        only_one_option: true,
-        selection_options: [
-          OpenStruct.new(attributes: { name: "Option 1" }),
-          OpenStruct.new(attributes: { name: "Option 2" }),
-        ],
-      )
-
-    pages.first.routing_conditions = [
-      build(:condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false),
-    ]
-
-    pages
-  end
+  let(:pages) { build_pages_with_skip_condition }
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
@@ -382,5 +363,26 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
       end
     end
+  end
+
+  def build_pages_with_skip_condition
+    pages = build_list(:page, 5).each_with_index do |page, index|
+      page.id = index + 1
+    end
+
+    pages.first.answer_settings =
+      DataStruct.new(
+        only_one_option: true,
+        selection_options: [
+          OpenStruct.new(attributes: { name: "Option 1" }),
+          OpenStruct.new(attributes: { name: "Option 2" }),
+        ],
+      )
+
+    pages.first.routing_conditions = [
+      build(:condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false),
+    ]
+
+    pages
   end
 end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -38,16 +38,18 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
   end
 
   describe "#new" do
+    subject(:get_new) { get new_secondary_skip_path(form_id: 2, page_id: 1) }
+
     context "when the branch_routing feature is not enabled", feature_branch_routing: false do
       it "returns a 404" do
-        get new_secondary_skip_path(form_id: 2, page_id: 1)
+        get_new
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
       it "returns 200" do
-        get new_secondary_skip_path(form_id: 2, page_id: 1)
+        get_new
         expect(response).to have_http_status(:success)
       end
 
@@ -59,7 +61,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the page list" do
-          get new_secondary_skip_path(form_id: 2, page_id: 1)
+          get_new
           expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
@@ -87,7 +89,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the show routes page" do
-          get new_secondary_skip_path(form_id: 2, page_id: 1)
+          get_new
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
@@ -95,6 +97,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
   end
 
   describe "#create" do
+    subject(:post_create) { post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params }
+
     let(:valid_params) do
       {
         form_id: "2",
@@ -108,7 +112,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
     context "when the branch_routing feature is not enabled", feature_branch_routing: false do
       it "returns a 404" do
-        post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+        post_create
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -122,7 +126,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the show routes page" do
-          post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          post_create
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
@@ -135,7 +139,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the page list" do
-          post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          post_create
           expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
@@ -163,12 +167,14 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the show routes page" do
-          post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          post_create
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
 
       context "when the submission fails" do
+        subject(:post_create) { post create_secondary_skip_path(form_id: 2, page_id: 1), params: invalid_params }
+
         let(:invalid_params) do
           {
             form_id: "2",
@@ -181,7 +187,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "renders the new template" do
-          post create_secondary_skip_path(form_id: 2, page_id: pages.first.id), params: invalid_params
+          post_create
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response).to render_template("pages/secondary_skip/new")
         end
@@ -190,6 +196,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
   end
 
   describe "#edit" do
+    subject(:get_edit) { get edit_secondary_skip_path(form_id: 2, page_id: 1) }
+
     let(:condition) do
       build(:condition, id: 2, check_page_id: 1, routing_page_id: pages[2].id, goto_page_id: pages[4].id)
     end
@@ -206,19 +214,19 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
     context "when the branch_routing feature is not enabled", feature_branch_routing: false do
       it "returns a 404" do
-        get edit_secondary_skip_path(form_id: 2, page_id: 1)
+        get_edit
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
       it "returns 200" do
-        get edit_secondary_skip_path(form_id: 2, page_id: 1)
+        get_edit
         expect(response).to have_http_status(:success)
       end
 
       it "renders the edit template" do
-        get edit_secondary_skip_path(form_id: 2, page_id: 1)
+        get_edit
         expect(response).to render_template("pages/secondary_skip/edit")
       end
 
@@ -230,7 +238,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the page list" do
-          get edit_secondary_skip_path(form_id: 2, page_id: 1)
+          get_edit
           expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
@@ -247,7 +255,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the page list" do
-          get edit_secondary_skip_path(form_id: 2, page_id: 1)
+          get_edit
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
@@ -255,6 +263,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
   end
 
   describe "#update" do
+    subject(:post_update) { post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params }
+
     let(:condition) do
       build(
         :condition,
@@ -288,7 +298,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
     context "when the branch_routing feature is not enabled", feature_branch_routing: false do
       it "returns a 404" do
-        patch update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+        post_update
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -302,7 +312,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the show routes page" do
-          post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          post_update
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
@@ -315,7 +325,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the page list" do
-          post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          post_update
           expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
@@ -332,7 +342,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the page list" do
-          post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          post_update
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
@@ -343,7 +353,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
             form_id: "2",
             page_id: "1",
             pages_secondary_skip_input: {
-              routing_page_id: "2",
+              routing_page_id: "3",
               goto_page_id: "5",
             },
           }
@@ -357,12 +367,14 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "redirects to the show routes page" do
-          post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          post_update
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
 
       context "when the submission fails" do
+        subject(:post_update) { post update_secondary_skip_path(form_id: 2, page_id: 1), params: invalid_params }
+
         let(:invalid_params) do
           {
             form_id: "2",
@@ -375,7 +387,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         end
 
         it "renders the edit template" do
-          post update_secondary_skip_path(form_id: 2, page_id: 1), params: invalid_params
+          post_update
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response).to render_template("pages/secondary_skip/edit")
         end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Pages::SecondarySkipController, type: :request do
   let(:form) { build :form, id: 2, pages: }
-  let(:pages) { build_pages_with_skip_condition }
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
@@ -29,6 +28,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
   describe "#new" do
     subject(:get_new) { get new_secondary_skip_path(form_id: 2, page_id: 1) }
+
+    let(:pages) { build_pages_with_skip_condition }
 
     it_behaves_like "feature flag protected endpoint", :subject
 
@@ -83,6 +84,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
   describe "#create" do
     subject(:post_create) { post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params }
+
+    let(:pages) { build_pages_with_skip_condition }
 
     let(:valid_params) do
       {
@@ -178,6 +181,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
   describe "#edit" do
     subject(:get_edit) { get edit_secondary_skip_path(form_id: 2, page_id: 1) }
 
+    let(:pages) { build_pages_with_skip_condition }
+
     let(:condition) do
       build(:condition, id: 2, check_page_id: 1, routing_page_id: pages[2].id, goto_page_id: pages[4].id)
     end
@@ -239,6 +244,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
   describe "#update" do
     subject(:post_update) { post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params }
+
+    let(:pages) { build_pages_with_skip_condition }
 
     let(:condition) do
       build(

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
+  RSpec.shared_examples "feature flag protected endpoint" do |action|
+    context "when the branch_routing feature is disabled" do
+      it "returns 404", feature_branch_routing: false do
+        send(action)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   before do
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -40,12 +49,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
   describe "#new" do
     subject(:get_new) { get new_secondary_skip_path(form_id: 2, page_id: 1) }
 
-    context "when the branch_routing feature is not enabled", feature_branch_routing: false do
-      it "returns a 404" do
-        get_new
-        expect(response).to have_http_status(:not_found)
-      end
-    end
+    it_behaves_like "feature flag protected endpoint", :subject
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
       it "returns 200" do
@@ -110,12 +114,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       }
     end
 
-    context "when the branch_routing feature is not enabled", feature_branch_routing: false do
-      it "returns a 404" do
-        post_create
-        expect(response).to have_http_status(:not_found)
-      end
-    end
+    it_behaves_like "feature flag protected endpoint", :subject
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
       context "when the submission is successful" do
@@ -212,12 +211,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       end
     end
 
-    context "when the branch_routing feature is not enabled", feature_branch_routing: false do
-      it "returns a 404" do
-        get_edit
-        expect(response).to have_http_status(:not_found)
-      end
-    end
+    it_behaves_like "feature flag protected endpoint", :subject
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
       it "returns 200" do
@@ -296,12 +290,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       end
     end
 
-    context "when the branch_routing feature is not enabled", feature_branch_routing: false do
-      it "returns a 404" do
-        post_update
-        expect(response).to have_http_status(:not_found)
-      end
-    end
+    it_behaves_like "feature flag protected endpoint", :subject
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
       context "when the submission is successful without changing the routing_page_id" do

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -137,20 +137,16 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     context "when the branch_routing feature is enabled", :feature_branch_routing do
       it_behaves_like "requires condition", :subject
 
-      it "returns 200" do
-        get_edit
-        expect(response).to have_http_status(:success)
-      end
-
       it "renders the edit template" do
         get_edit
+        expect(response).to have_http_status(:success)
         expect(response).to render_template("pages/secondary_skip/edit")
       end
 
       context "when no secondary_skip exists on the page" do
         let(:pages) { build_pages_with_skip_condition }
 
-        it "redirects to the page list" do
+        it "redirects to the show routes page" do
           get_edit
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
@@ -195,7 +191,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       context "when no secondary_skip exists on the page" do
         let(:pages) { build_pages_with_skip_condition }
 
-        it "redirects to the page list" do
+        it "redirects to the show routes page" do
           post_update
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     end
   end
 
+  RSpec.shared_examples "requires condition" do |action|
+    let(:pages) { build_pages }
+
+    it "redirects to the page list" do
+      send(action)
+      expect(response).to redirect_to(form_pages_path(form.id))
+    end
+  end
+
   before do
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -34,18 +43,11 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     it_behaves_like "feature flag protected endpoint", :subject
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
+      it_behaves_like "requires condition", :subject
+
       it "returns 200" do
         get_new
         expect(response).to have_http_status(:success)
-      end
-
-      context "when no condition exists on the page" do
-        let(:pages) { build_pages }
-
-        it "redirects to the page list" do
-          get_new
-          expect(response).to redirect_to(form_pages_path(form.id))
-        end
       end
 
       context "when a secondary skip condition already exists on the page" do
@@ -78,6 +80,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     it_behaves_like "feature flag protected endpoint", :subject
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
+      it_behaves_like "requires condition", :subject
+
       context "when the submission is successful" do
         before do
           ActiveResource::HttpMock.respond_to(false) do |mock|
@@ -88,15 +92,6 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         it "redirects to the show routes page" do
           post_create
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
-        end
-      end
-
-      context "when no condition exists on the page" do
-        let(:pages) { build_pages }
-
-        it "redirects to the page list" do
-          post_create
-          expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
 
@@ -140,6 +135,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     it_behaves_like "feature flag protected endpoint", :subject
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
+      it_behaves_like "requires condition", :subject
+
       it "returns 200" do
         get_edit
         expect(response).to have_http_status(:success)
@@ -148,15 +145,6 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       it "renders the edit template" do
         get_edit
         expect(response).to render_template("pages/secondary_skip/edit")
-      end
-
-      context "when no condition exists on the page" do
-        let(:pages) { build_pages }
-
-        it "redirects to the page list" do
-          get_edit
-          expect(response).to redirect_to(form_pages_path(form.id))
-        end
       end
 
       context "when no secondary_skip exists on the page" do
@@ -189,6 +177,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     it_behaves_like "feature flag protected endpoint", :subject
 
     context "when the branch_routing feature is enabled", :feature_branch_routing do
+      it_behaves_like "requires condition", :subject
+
       context "when the submission is successful without changing the routing_page_id" do
         before do
           ActiveResource::HttpMock.respond_to(false) do |mock|
@@ -199,15 +189,6 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         it "redirects to the show routes page" do
           post_update
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
-        end
-      end
-
-      context "when no condition exists on the page" do
-        let(:pages) { build_pages }
-
-        it "redirects to the page list" do
-          post_update
-          expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
 

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -372,24 +372,17 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     end
   end
 
-  def build_pages_with_skip_condition
-    pages = build_list(:page, 5).each_with_index do |page, index|
+  def build_pages
+    build_list(:page, 5).each_with_index do |page, index|
       page.id = index + 1
     end
+  end
 
-    pages.first.answer_settings =
-      DataStruct.new(
-        only_one_option: true,
-        selection_options: [
-          OpenStruct.new(attributes: { name: "Option 1" }),
-          OpenStruct.new(attributes: { name: "Option 2" }),
-        ],
-      )
-
-    pages.first.routing_conditions = [
-      build(:condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false),
-    ]
-
-    pages
+  def build_pages_with_skip_condition
+    build_pages.tap do |pages|
+      pages[0] = build :page, :with_selections_settings, id: 1, routing_conditions: [
+        build(:condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false),
+      ]
+    end
   end
 end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -37,61 +37,59 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     end
   end
 
-  context "when the branch_routing feature is not enabled", feature_branch_routing: false do
-    describe "#new" do
+  describe "#new" do
+    context "when the branch_routing feature is not enabled", feature_branch_routing: false do
       it "returns a 404" do
         get new_secondary_skip_path(form_id: 2, page_id: 1)
         expect(response).to have_http_status(:not_found)
       end
     end
-  end
 
-  context "when the branch_routing feature is enabled", :feature_branch_routing do
-    describe "#new" do
+    context "when the branch_routing feature is enabled", :feature_branch_routing do
       it "returns 200" do
         get new_secondary_skip_path(form_id: 2, page_id: 1)
         expect(response).to have_http_status(:success)
       end
-    end
 
-    context "when no condition exists on the page" do
-      let(:pages) do
-        build_list(:page, 5).each_with_index do |page, index|
-          page.id = index + 1
+      context "when no condition exists on the page" do
+        let(:pages) do
+          build_list(:page, 5).each_with_index do |page, index|
+            page.id = index + 1
+          end
+        end
+
+        it "redirects to the page list" do
+          get new_secondary_skip_path(form_id: 2, page_id: 1)
+          expect(response).to redirect_to(form_pages_path(form.id))
         end
       end
 
-      it "redirects to the page list" do
-        get new_secondary_skip_path(form_id: 2, page_id: 1)
-        expect(response).to redirect_to(form_pages_path(form.id))
-      end
-    end
-
-    context "when a secondary skip condition already exists on the page" do
-      let(:existing_secondary_skip) do
-        build(
-          :condition,
-          id: 2,
-          routing_page_id: pages[2].id,
-          check_page_id: pages[0].id,
-          goto_page_id: pages[4].id,
-          secondary_skip: true,
-        )
-      end
-
-      before do
-        pages[2].routing_conditions = [existing_secondary_skip]
-
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", headers, form.to_json, 200
-          mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
-          mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
+      context "when a secondary skip condition already exists on the page" do
+        let(:existing_secondary_skip) do
+          build(
+            :condition,
+            id: 2,
+            routing_page_id: pages[2].id,
+            check_page_id: pages[0].id,
+            goto_page_id: pages[4].id,
+            secondary_skip: true,
+          )
         end
-      end
 
-      it "redirects to the show routes page" do
-        get new_secondary_skip_path(form_id: 2, page_id: 1)
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        before do
+          pages[2].routing_conditions = [existing_secondary_skip]
+
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v1/forms/2", headers, form.to_json, 200
+            mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
+            mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
+          end
+        end
+
+        it "redirects to the show routes page" do
+          get new_secondary_skip_path(form_id: 2, page_id: 1)
+          expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        end
       end
     end
   end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         form_id: "2",
         page_id: "1",
         pages_secondary_skip_input: {
-          routing_page_id: "3",
+          routing_page_id: "2",
           goto_page_id: "5",
         },
       }
@@ -178,7 +178,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       context "when the submission is successful without changing the routing_page_id" do
         before do
           ActiveResource::HttpMock.respond_to(false) do |mock|
-            mock.put "/api/v1/forms/2/pages/3/conditions/2", post_headers, {}.to_json, 200
+            mock.put "/api/v1/forms/2/pages/2/conditions/2", post_headers, {}.to_json, 200
           end
         end
 
@@ -211,8 +211,8 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
         before do
           ActiveResource::HttpMock.respond_to(false) do |mock|
-            mock.delete "/api/v1/forms/2/pages/3/conditions/2", headers, {}.to_json, 200
-            mock.post "/api/v1/forms/2/pages/2/conditions", post_headers, {}.to_json, 200
+            mock.delete "/api/v1/forms/2/pages/2/conditions/2", headers, {}.to_json, 200
+            mock.post "/api/v1/forms/2/pages/3/conditions", post_headers, {}.to_json, 200
           end
         end
 
@@ -270,40 +270,6 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
         secondary_skip: true,
       )
       pages[1].routing_conditions = [existing_secondary_skip]
-    end
-  end
-
-  def build_pages_with_two_skip_conditions
-    build_pages.tap do |pages|
-      pages[0] = build :page, :with_selections_settings, id: 1, routing_conditions: [
-        build(:condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false),
-      ]
-
-      first_secondary_skip = build(
-        :condition,
-        id: 2,
-        routing_page_id: pages[1].id,
-        check_page_id: pages[0].id,
-        goto_page_id: pages[4].id,
-        secondary_skip: true,
-      )
-
-      pages[1].routing_conditions = [first_secondary_skip]
-
-      pages[5] = build :page, :with_selections_settings, id: 6, routing_conditions: [
-        build(:condition, id: 3, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages[7].id, skip_to_end: false),
-      ]
-
-      second_secondary_skip = build(
-        :condition,
-        id: 4,
-        routing_page_id: pages[6].id,
-        check_page_id: pages[5].id,
-        goto_page_id: nil,
-        skip_to_end: true,
-      )
-
-      pages[6].routing_conditions = [second_secondary_skip]
     end
   end
 end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -40,11 +40,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       end
 
       context "when no condition exists on the page" do
-        let(:pages) do
-          build_list(:page, 5).each_with_index do |page, index|
-            page.id = index + 1
-          end
-        end
+        let(:pages) { build_pages }
 
         it "redirects to the page list" do
           get_new
@@ -115,11 +111,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       end
 
       context "when no condition exists on the page" do
-        let(:pages) do
-          build_list(:page, 5).each_with_index do |page, index|
-            page.id = index + 1
-          end
-        end
+        let(:pages) { build_pages }
 
         it "redirects to the page list" do
           post_create
@@ -211,11 +203,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       end
 
       context "when no condition exists on the page" do
-        let(:pages) do
-          build_list(:page, 5).each_with_index do |page, index|
-            page.id = index + 1
-          end
-        end
+        let(:pages) { build_pages }
 
         it "redirects to the page list" do
           get_edit
@@ -295,11 +283,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       end
 
       context "when no condition exists on the page" do
-        let(:pages) do
-          build_list(:page, 5).each_with_index do |page, index|
-            page.id = index + 1
-          end
-        end
+        let(:pages) { build_pages }
 
         it "redirects to the page list" do
           post_update


### PR DESCRIPTION
### Refactor the request tests for the secondary skip controller.

This is a slightly overly-chopped PR to refactor the request specs for the secondary_skip feature introduced behind a feature flag last week.

The overall aim is to make the intention of the tests clearer and make it easier understand the setup for each test.

The tests currently use a mix of setup and API mocks spread throughout the file. The changes here hopefully make everything a bit more regular and easier to reason about.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
