### PR TITLE
SPIKE: Delete users with no name/organisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem "omniauth-auth0"
 gem "omniauth-rails_csrf_protection"
 gem "warden"
 
+# used for calling auth0 API to delete users
+gem "auth0"
+
 # Used for handling authorisation policies
 gem "pundit"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,12 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    auth0 (5.17.0)
+      addressable (~> 2.8)
+      jwt (~> 2.7)
+      rest-client (~> 2.1)
+      retryable (~> 3.0)
+      zache (~> 0.12)
     aws-eventstream (1.3.0)
     aws-partitions (1.1013.0)
     aws-sdk-cloudwatch (1.107.0)
@@ -174,6 +180,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.1)
     docile (1.4.0)
+    domain_name (0.6.20240107)
     drb (2.2.1)
     dry-cli (1.2.0)
     dumb_delegator (1.0.0)
@@ -217,6 +224,9 @@ GEM
     highline (3.0.1)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
+    http-accept (1.7.0)
+    http-cookie (1.0.7)
+      domain_name (~> 0.5)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.0.14)
@@ -256,6 +266,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.1105)
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.2)
@@ -272,6 +286,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
@@ -385,6 +400,12 @@ GEM
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    retryable (3.0.5)
     rexml (3.3.9)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
@@ -505,6 +526,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    zache (0.13.2)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -521,6 +543,7 @@ PLATFORMS
 DEPENDENCIES
   MailchimpMarketing (~> 3.0)
   activeresource (~> 6.1)
+  auth0
   aws-sdk-cloudwatch (~> 1.107)
   aws-sdk-codepipeline (~> 1.91)
   axe-core-rspec

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,4 +1,6 @@
 namespace :users do
+  require "auth0"
+
   desc "Update all trial and editor users to be standard users - dry run"
   task update_user_roles_to_standard_dry_run: :environment do
     ActiveRecord::Base.transaction do
@@ -11,6 +13,49 @@ namespace :users do
   desc "Update all trial and editor users to be standard users"
   task update_user_roles_to_standard: :environment do
     update_user_roles
+  end
+
+  desc "Delete user accounts with no name or organisation"
+  task delete_users_with_no_name_or_org: :environment do
+    auth0_client = Auth0Client.new(
+      client_id: Settings.auth0.client_id,
+      client_secret: Settings.auth0.client_secret,
+      domain: Settings.auth0.domain,
+    )
+
+    deleted_count = 0
+    skipped_count = 0
+
+    User.where(name: nil).or(User.where(organisation: nil)).find_each do |user|
+      Rails.logger.info("Deleting user #{user.email} with uid #{user.uid}")
+
+      if user.memberships.present?
+        group_ids = user.memberships.map { |membership| membership.group.external_id }
+        Rails.logger.info("Skipping deleting user #{user.email} as they are a member of a group. Group IDs: #{group_ids}")
+        skipped_count += 1
+        next
+      end
+
+      Form.where(creator_id: user.id).find_all do |form|
+        Rails.logger.info("Deleting form with id #{form.id} for user #{user.email}")
+        # rubocop:disable Rails/SaveBang
+        form.destroy
+        # rubocop:enable Rails/SaveBang
+      end
+
+      if user.provider == "auth0" && user.uid.present?
+        auth0_client.delete_user(user.uid)
+        Rails.logger.info("Deleted auth0 account for user #{user.email} with auth0 uid #{user.uid}")
+      else
+        Rails.logger.info("User #{user.email} does not have an auth0 account")
+      end
+
+      user.delete
+      deleted_count += 1
+      Rails.logger.info("Deleted user #{user.email} with uid #{user.uid}")
+    end
+
+    Rails.logger.info("Finished deleting users, deleted #{deleted_count} users, skipped #{skipped_count} users that are in groups")
   end
 end
 


### PR DESCRIPTION

### What problem does this pull request solve?

Trello card: https://trello.com/c/B7dPRWtc/

This tests deleting users that have not set their organisation or name along with deleting their forms.

Users are skipped if they are a member of a group - as we do not expect any users who have not set their organisation or name to be a member of a group, as groups were introduced after we started asking for the organisation and name, and we only put people's forms in a default group once they have entered their organisation.

If users do have a group, it probably makes sense to double check that they are the only member of the group and run the dedicated task to remove that group first.

We delete the user's account in auth0 - which requires the "Auth0 Management API" to be enabled for the application in the Auth0 tenant with the `delete:users` permission enabled.

### Testing

You can test this locally by connecting to the dev tenant in Auth0 using the credentials for the `forms-admin-local-dev` auth0 application. Start forms-admin using 
```
SETTINGS__AUTH_PROVIDER=auth0 SETTINGS__AUTH0__CLIENT_ID=<app-client-id> SETTINGS__AUTH0__CLIENT_SECRET=<client-secret> SETTINGS__AUTH0__DOMAIN=<auth-domain> bundle exec rails s
```

You can then use plus addressing to create additional users with your email as this application doesn't have Google Workspaces enabled. You can't do this on a remote environment because our email addresses will always use Google Workplaces to log in.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
