### PR TITLE
Fix error in routes#show for missing goto_page

### DIFF
--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -131,10 +131,14 @@ private
   def page_name(page_id)
     target_page = pages.find { |page| page.id == page_id }
 
-    page_name = target_page.question_text
-    page_position = target_page.position
+    if target_page.present?
+      page_name = target_page.question_text
+      page_position = target_page.position
 
-    I18n.t("page_route_card.page_name", page_position:, page_name:)
+      I18n.t("page_route_card.page_name", page_position:, page_name:)
+    else
+      I18n.t("page_route_card.page_name_not_exist")
+    end
   end
 
   def end_page_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1038,6 +1038,7 @@ en:
     edit: Edit
     if_answer_is: If the answer is
     page_name: "%{page_position}. %{page_name}"
+    page_name_not_exist: Edit this route to select a question or page you want to take the person to, or delete the route
     question_title: Question %{position}
     route_title: Route %{index}
     secondary_skip_after: Then after the person answers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1038,7 +1038,7 @@ en:
     edit: Edit
     if_answer_is: If the answer is
     page_name: "%{page_position}. %{page_name}"
-    page_name_not_exist: Edit this route to select a question or page you want to take the person to, or delete the route
+    page_name_not_exist: Edit this route to select the question or page you want to take the person to, or delete the route
     question_title: Question %{position}
     route_title: Route %{index}
     secondary_skip_after: Then after the person answers

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -56,6 +56,17 @@ describe RouteSummaryCardDataPresenter do
           expect(result[1][:rows][1][:value][:text]).to have_link("Set one or more questions to skip later in the form (optional)", href: "/forms/99/pages/1/routes/any-other-answer/questions-to-skip/new")
         end
       end
+
+      context "when the goto_page does not exist" do
+        let(:routing_condition) do
+          build(:condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Yes", goto_page_id: 999, skip_to_end: false)
+        end
+
+        it "uses placeholder text instead of question text" do
+          result = service.summary_card_data
+          expect(result[0][:rows][1][:value][:text]).to eq(I18n.t("page_route_card.page_name_not_exist"))
+        end
+      end
     end
 
     context "with skip to end condition" do


### PR DESCRIPTION
When a user has created a "basic route" and then deletes the page the condition points to with it's "goto_page_id", the show route throws an exception when the question_text cannot be accessed.

This commit fixes this error by using placeholder text when the goto_page cannot be found.

This is a short term fix intended to stop an error being raised, rather than a considered design fix.

## To recreate the original issue

1. create a selection question suitable for routing
2. create two questions of any type for the route to point to
3. add a route from the selection question to a page
4. delete that page
5. use the edit link on the route (which should be highlighted with an error "The question you’re taking the person to no longer exists")

The replacement text within the routes#show page:

<img width="687" alt="image" src="https://github.com/user-attachments/assets/7dd63f2b-db5d-4782-86d6-983b6f8eb8ec">

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
