### PR TITLE
Stop form creators from making repeatable checkbox questions

### DIFF
--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -34,7 +34,7 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
   <% end %>
 
-  <% if question_input.answer_settings[:only_one_option] == "true" %>
+  <% if question_input.answer_type == "selection" %>
     <%= f.hidden_field :is_repeatable, value: false %>
   <% else %>
     <%= f.govuk_collection_radio_buttons :is_repeatable, question_input.repeatable_options, :id, :name, :description, legend: { size: 'm', tag: 'h2' }, bold_labels: false %>

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -59,6 +59,14 @@ describe "pages/_form.html.erb", type: :view do
     end
   end
 
+  context "when the question is an only more than one option selection" do
+    let(:page) { build :page, :with_selections_settings, only_one_option: false, id: 2, form_id: form.id }
+
+    it "does not have the radio input for repeatable" do
+      expect(rendered).not_to have_field("pages_question_input[is_repeatable]", type: :radio)
+    end
+  end
+
   it "has a submit button with the correct text" do
     expect(rendered).to have_button(I18n.t("pages.submit_save"))
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Tq0BBEis/2498-form-creators-can-make-a-checkbox-question-repeatable-but-shouldnt-be-able-to <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We don't think it makes sense for a selection question to allow multiple answers. In PR alphagov/forms-admin#1453 we hid the option for selection questions where only one option is allowed, but we should have done it for all kinds of selection questions.

This commit changes the edit question page so that selection questions can't be repeatable.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?