### PR TITLE
Fix DefaultGroupService to handle trial users with the same name as another

### DIFF
--- a/app/services/default_group_service.rb
+++ b/app/services/default_group_service.rb
@@ -29,6 +29,7 @@ class DefaultGroupService
       end
     rescue ActiveRecord::RecordInvalid => e
       raise unless e.record.errors.added? :name, :taken, value: default_trial_group_name
+      raise if Group.exists?(creator_id: user.id, name: default_trial_group_name, organisation_id: user.organisation_id, status: :active)
 
       # Make a number to disambiguate, starting at 2, and increasing by one if that is also already taken
       attempt ||= 1

--- a/app/services/default_group_service.rb
+++ b/app/services/default_group_service.rb
@@ -17,13 +17,27 @@ class DefaultGroupService
 
     Rails.logger.info "DefaultGroupService: User '#{user.name}' default group creation starting"
 
-    default_trial_group = Group.find_or_create_by!(
-      creator_id: user.id,
-      name: "#{user.name}’s trial group",
-      organisation_id: user.organisation_id,
-      status: :trial,
-    ) do |new_group|
-      Rails.logger.info "DefaultGroupService: Created default group '#{new_group.name}', with creator '#{new_group.creator.email}'"
+    default_trial_group_name = "#{user.name}’s trial group"
+    begin
+      default_trial_group = Group.find_or_create_by!(
+        creator_id: user.id,
+        name: default_trial_group_name,
+        organisation_id: user.organisation_id,
+        status: :trial,
+      ) do |new_group|
+        Rails.logger.info "DefaultGroupService: Created default group '#{new_group.name}', with creator '#{new_group.creator.email}'"
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      raise unless e.record.errors.added? :name, :taken, value: default_trial_group_name
+
+      # Make a number to disambiguate, starting at 2, and increasing by one if that is also already taken
+      attempt ||= 1
+      attempt += 1
+      raise "DefaultGroupService: Aborted, possible infinite loop" if attempt > 100
+
+      default_trial_group_name = "#{user.name} #{attempt}’s trial group"
+      Rails.logger.info "DefaultGroupService: Group with name '#{e.record.name}' already exists, trying with '#{default_trial_group_name}"
+      retry
     end
 
     default_trial_group.memberships.find_or_create_by!(


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Qe0UuexS/2019-handle-legacy-trial-users-who-have-created-accounts-twice <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

In PR alphagov/forms-admin#1236 we added DefaultGroupService to help with migrating users with trial accounts who had not set a name or organisation but had created forms to standard accounts with groups. The `DefaultGroupService#create_user_default_trial_group!` method creates a group in the chosen organisation of the user named after the chosen name of the user.

At around the same time in PR alphagov/forms-admin#1206 we added a constraint that more than one group could not have exist with the same organisation and name.

At the time we did not account for the possibility that the default group service would interact with this constraint, partly because the set of users who would be affected is small. However, we have now had an incident where two users who have two user accounts each have run into this issue; see the incident report [[1]] and Sentry issue [[2]] for more details.

To fix this we've added logic to append an incrementing number to the user's name in the name of the group to be created. This will work for the users who are currently unable to sign in due to this issue, and any new cases. We still consider it unlikely to happen again, but at least now we're covered if it does.

[1]: https://docs.google.com/document/d/1BZhgaNGaeV4dyZGkEmmDywoceEEegtxzjDkmULc5Npk/edit
[2]: https://govuk-forms.sentry.io/issues/6089472300



### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?