### PR TITLE
Add delete actions to secondary skip controller

### DIFF
--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -1,7 +1,7 @@
 class Pages::SecondarySkipController < PagesController
   before_action :ensure_branch_routing_feature_enabled, :ensure_page_has_skip_condition
   before_action :ensure_secondary_skip_blank, only: %i[new create]
-  before_action :ensure_secondary_skip_exists, only: %i[edit update]
+  before_action :ensure_secondary_skip_exists, only: %i[edit update delete destroy]
 
   def new
     secondary_skip_input = Pages::SecondarySkipInput.new(form: current_form, page:)
@@ -46,10 +46,36 @@ class Pages::SecondarySkipController < PagesController
     end
   end
 
+  def delete
+    delete_secondary_skip_input = Pages::DeleteSecondarySkipInput.new(form: current_form, page:, record: secondary_skip_condition)
+
+    render template: "pages/secondary_skip/delete", locals: {
+      delete_secondary_skip_input:,
+      back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
+    }
+  end
+
+  def destroy
+    delete_secondary_skip_input = Pages::DeleteSecondarySkipInput.new(delete_secondary_skip_input_params.merge(record: secondary_skip_condition))
+
+    if delete_secondary_skip_input.submit
+      redirect_to show_routes_path(form_id: current_form.id, page_id: page.id)
+    else
+      render template: "pages/secondary_skip/delete", locals: {
+        delete_secondary_skip_input:,
+        back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
+      }, status: :unprocessable_entity
+    end
+  end
+
 private
 
   def secondary_skip_input_params
     params.require(:pages_secondary_skip_input).permit(:routing_page_id, :goto_page_id).merge(form: current_form, page:)
+  end
+
+  def delete_secondary_skip_input_params
+    params.require(:pages_delete_secondary_skip_input).permit(:confirm).merge(form: current_form, page:)
   end
 
   def ensure_branch_routing_feature_enabled

--- a/app/input_objects/pages/delete_secondary_skip_input.rb
+++ b/app/input_objects/pages/delete_secondary_skip_input.rb
@@ -1,0 +1,20 @@
+class Pages::DeleteSecondarySkipInput < ConfirmActionInput
+  attr_accessor :form, :page, :record
+
+  validates :confirm, presence: true
+
+  def submit
+    return false if invalid?
+
+    result = true
+
+    if confirmed?
+
+      record.prefix_options[:form_id] = form.id
+      record.prefix_options[:page_id] = record.routing_page_id
+      result = ConditionRepository.destroy(record)
+    end
+
+    result
+  end
+end

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -94,7 +94,7 @@ private
   end
 
   def delete_secondary_skip_link
-    govuk_link_to(I18n.t("page_route_card.delete"), "#")
+    govuk_link_to(I18n.t("page_route_card.delete"), delete_secondary_skip_path(form_id: form.id, page_id: page.id))
   end
 
   def secondary_skip_rows

--- a/app/views/pages/secondary_skip/delete.html.erb
+++ b/app/views/pages/secondary_skip/delete.html.erb
@@ -1,0 +1,18 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.delete_secondary_skip'), false)) %>
+<% content_for :back_link, govuk_back_link_to(back_link_url, t('secondary_skip.new.back', page_position: delete_secondary_skip_input.page.position)) %>
+
+<%= form_with(model: delete_secondary_skip_input, url: destroy_secondary_skip_path(form_id: delete_secondary_skip_input.form.id, page_id: delete_secondary_skip_input.page.id), method: :delete) do |f| %>
+  <% if delete_secondary_skip_input.errors.any? %>
+    <%= f.govuk_error_summary %>
+  <% end %>
+
+  <span class="govuk-caption-l"><%= t("secondary_skip.new.caption", page_position: delete_secondary_skip_input.page.position) %></span>
+
+  <%= f.govuk_collection_radio_buttons :confirm,
+    delete_secondary_skip_input.values, ->(option) { option },
+     ->(option) { t('helpers.label.confirm_action_input.options.' + "#{option}") },
+     legend: { text: t("page_titles.delete_secondary_skip"), size: 'l', tag: 'h1' }
+  %>
+
+  <%= f.govuk_submit t("save_and_continue") %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,10 @@ en:
             question_text:
               blank: Enter a question
               too_long: Question text must be %{count} characters or less
+        pages/delete_secondary_skip_input:
+          attributes:
+            confirm:
+              blank: Select ‘Yes’ to delete route 2
         pages/question_input:
           attributes:
             hint_text:
@@ -1080,6 +1084,7 @@ en:
     contact_details: Provide contact details for support
     date_settings: Are you asking for someone’s date of birth?
     declaration: Add a declaration for people to agree to
+    delete_secondary_skip: Are you sure you want to delete route 2?
     email_code_sent: Confirmation code sent
     error_prefix: 'Error: '
     forbidden: You cannot view this page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,8 @@ Rails.application.routes.draw do
           post "/any-other-answer/questions-to-skip/new" => "pages/secondary_skip_#create", as: :create_secondary_skip
           get "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#edit", as: :edit_secondary_skip
           post "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#update", as: :update_secondary_skip
+          get "/any-other-answer/questions-to-skip/delete" => "pages/secondary_skip_#delete", as: :delete_secondary_skip
+          delete "/any-other-answer/questions-to-skip/delete" => "pages/secondary_skip_#destroy", as: :destroy_secondary_skip
         end
 
         scope "/edit" do

--- a/spec/input_objects/pages/delete_secondary_skip_input_spec.rb
+++ b/spec/input_objects/pages/delete_secondary_skip_input_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Pages::DeleteSecondarySkipInput, type: :model do
+  let(:delete_secondary_skip_input) { described_class.new(form:, page:, record: condition) }
+  let(:form) { build :form, :ready_for_routing }
+  let(:page) { form.pages.first }
+  let(:condition) { build :condition, routing_page_id: page.id }
+
+  describe "validations" do
+    it "is invalid if confirm is nil" do
+      delete_secondary_skip_input.confirm = nil
+      expect(delete_secondary_skip_input).to be_invalid
+      expect(delete_secondary_skip_input.errors.full_messages_for(:confirm)).to include("Confirm Select ‘Yes’ to delete route 2")
+    end
+  end
+
+  describe "#submit" do
+    context "when no confirm value is given" do
+      it "returns false" do
+        delete_secondary_skip_input.confirm = nil
+        expect(delete_secondary_skip_input.submit).to be(false)
+      end
+    end
+
+    context "when confirm is 'no'" do
+      it "returns true" do
+        delete_secondary_skip_input.confirm = "no"
+        expect(delete_secondary_skip_input.submit).to be(true)
+      end
+    end
+
+    context "when confirm is 'yes'" do
+      before { allow(ConditionRepository).to receive(:destroy) }
+
+      it "destroys the condition" do
+        delete_secondary_skip_input.confirm = "yes"
+        delete_secondary_skip_input.submit
+        expect(ConditionRepository).to have_received(:destroy)
+      end
+    end
+  end
+end

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -113,7 +113,7 @@ describe RouteSummaryCardDataPresenter do
 
         it "shows the delete secondary skip link" do
           result = service.summary_card_data
-          expect(result[1][:card][:actions].second).to have_link("Delete", href: "#")
+          expect(result[1][:card][:actions].second).to have_link("Delete", href: "/forms/99/pages/1/routes/any-other-answer/questions-to-skip/delete")
         end
       end
     end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/2", headers, form.to_json, 200
       mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
-      mock.get "/api/v1/forms/2/pages/1", headers, pages.first.to_json, 200
     end
+
+    allow(PageRepository).to receive(:find).and_return(pages.first)
+    allow(ConditionRepository).to receive_messages(create!: {}, find: {}, save!: {}, destroy: {})
   end
 
   describe "#new" do
@@ -83,12 +85,6 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       it_behaves_like "requires condition", :subject
 
       context "when the submission is successful" do
-        before do
-          ActiveResource::HttpMock.respond_to(false) do |mock|
-            mock.post "/api/v1/forms/2/pages/3/conditions", post_headers, {}.to_json, 200
-          end
-        end
-
         it "redirects to the show routes page" do
           post_create
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
@@ -176,12 +172,6 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
       it_behaves_like "requires condition", :subject
 
       context "when the submission is successful without changing the routing_page_id" do
-        before do
-          ActiveResource::HttpMock.respond_to(false) do |mock|
-            mock.put "/api/v1/forms/2/pages/2/conditions/2", post_headers, {}.to_json, 200
-          end
-        end
-
         it "redirects to the show routes page" do
           post_update
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
@@ -209,13 +199,6 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
           }
         end
 
-        before do
-          ActiveResource::HttpMock.respond_to(false) do |mock|
-            mock.delete "/api/v1/forms/2/pages/2/conditions/2", headers, {}.to_json, 200
-            mock.post "/api/v1/forms/2/pages/3/conditions", post_headers, {}.to_json, 200
-          end
-        end
-
         it "redirects to the show routes page" do
           post_update
           expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
@@ -240,6 +223,103 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
           post_update
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response).to render_template("pages/secondary_skip/edit")
+        end
+      end
+    end
+  end
+
+  describe "#delete" do
+    let(:condition) do
+      build(:condition, id: 2, check_page_id: 1, routing_page_id: pages[2].id, goto_page_id: pages[4].id)
+    end
+
+    let(:pages) { build_pages_with_existing_secondary_skip }
+
+    context "when the branch_routing feature is not enabled", feature_branch_routing: false do
+      it "returns a 404" do
+        get delete_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the branch_routing feature is enabled", :feature_branch_routing do
+      it "returns 200" do
+        get delete_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to have_http_status(:success)
+      end
+
+      it "renders the delete template" do
+        get delete_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to render_template("pages/secondary_skip/delete")
+      end
+
+      context "when no condition exists on the page" do
+        let(:pages) { build_pages }
+
+        it "redirects to the page list" do
+          get delete_secondary_skip_path(form_id: 2, page_id: 1)
+          expect(response).to redirect_to(form_pages_path(form.id))
+        end
+      end
+
+      context "when no secondary_skip exists on the page" do
+        let(:pages) { build_pages_with_skip_condition }
+
+        it "redirects to the page list" do
+          get delete_secondary_skip_path(form_id: 2, page_id: 1)
+          expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        end
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let(:condition) do
+      build(:condition, id: 2, check_page_id: 1, routing_page_id: pages[2].id, goto_page_id: pages[4].id)
+    end
+
+    let(:pages) { build_pages_with_existing_secondary_skip }
+
+    context "when the branch_routing feature is not enabled", feature_branch_routing: false do
+      it "returns a 404" do
+        post destroy_secondary_skip_path(form_id: 2, page_id: 1)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the branch_routing feature is enabled", :feature_branch_routing do
+      context "when the submission is successful and deletes the secondary skip condition" do
+        let(:valid_params) do
+          {
+            form_id: "2",
+            page_id: "1",
+            pages_delete_secondary_skip_input: {
+              confirm: "yes",
+            },
+          }
+        end
+
+        it "redirects to the show routes page" do
+          delete destroy_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
+          expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        end
+      end
+
+      context "when no condition exists on the page" do
+        let(:pages) { build_pages }
+
+        it "redirects to the page list" do
+          delete destroy_secondary_skip_path(form_id: 2, page_id: 1)
+          expect(response).to redirect_to(form_pages_path(form.id))
+        end
+      end
+
+      context "when no secondary_skip exists on the page" do
+        let(:pages) { build_pages_with_skip_condition }
+
+        it "redirects to the page list" do
+          delete destroy_secondary_skip_path(form_id: 2, page_id: 1)
+          expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
         end
       end
     end


### PR DESCRIPTION
This adds delete and destroy actions to the secondary skip controller. These are used to remove a secondary skip from a question's routing, to complete the full CRUD functionality.

A separate delete_secondary_skip_input object has also been created, to handle the validations and submission for the delete page.

### What problem does this pull request solve?

Trello card: https://trello.com/c/xMToaz6H/1992-add-page-to-delete-route-2-route-in-forms-admin

This activates the delete link that we added to the secondary route card. It now goes to a delete confirmation page, which has its own input and controller actions etc.

<img width="995" alt="image" src="https://github.com/user-attachments/assets/06bc1dd1-8e87-4165-883b-9cf034e58bf9">


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
