### PR TITLE
Add Rake task to run DefaultGroupService#create_user_default_trial_group!

### DIFF
--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -9,6 +9,15 @@ namespace :groups do
     run_task("groups:change_organisation_dry_run", args, rollback: true)
   end
 
+  desc "Create default trial group for user who has forms not in a group"
+  task :create_user_default_trial_group, %i[user_id] => :environment do |_, args|
+    usage_message = "usage: rake create_user_default_trial_group[<user_id>]".freeze
+    abort usage_message if args[:user_id].blank?
+
+    user = User.find(args[:user_id])
+    DefaultGroupService.new.create_user_default_trial_group!(user)
+  end
+
   desc "Move all groups in one organisation to another"
   task :move_all_groups_between_organisations, %i[source_organisation_id target_organisation_id] => :environment do |_, args|
     task_name = "groups:move_all_groups_between_organisations"


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Qe0UuexS/2019-handle-legacy-trial-users-who-have-created-accounts-twice <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We have some users in production who have created forms that are not in a group, and they have already set their name and organisation. This task lets us create default trial groups for them manually.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?