### PR TITLE
Add file answer type

### DIFF
--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -1,6 +1,8 @@
 class Pages::TypeOfAnswerController < PagesController
+  before_action :set_answer_types
+
   def new
-    @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type)
+    @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type, answer_types:)
     @type_of_answer_path = type_of_answer_create_path(current_form)
     render :type_of_answer, locals: { current_form: }
   end
@@ -17,7 +19,7 @@ class Pages::TypeOfAnswerController < PagesController
   end
 
   def edit
-    @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type)
+    @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type, answer_types:)
     @type_of_answer_path = type_of_answer_update_path(current_form)
     render :type_of_answer, locals: { current_form: }
   end
@@ -79,10 +81,24 @@ private
   end
 
   def answer_type_form_params
-    params.require(:pages_type_of_answer_input).permit(:answer_type).merge(draft_question:)
+    params.require(:pages_type_of_answer_input).permit(:answer_type).merge(draft_question:, answer_types:)
   end
 
   def answer_type_changed?
     @type_of_answer_input.answer_type != @type_of_answer_input.draft_question.answer_type
+  end
+
+  def file_upload_enabled
+    current_form.group&.file_upload_enabled
+  end
+
+  def set_answer_types
+    @answer_types = answer_types
+  end
+
+  def answer_types
+    return Page::ANSWER_TYPES_INCLUDING_FILE if file_upload_enabled
+
+    Page::ANSWER_TYPES_EXCLUDING_FILE
   end
 end

--- a/app/input_objects/pages/type_of_answer_input.rb
+++ b/app/input_objects/pages/type_of_answer_input.rb
@@ -1,10 +1,10 @@
 class Pages::TypeOfAnswerInput < BaseInput
-  attr_accessor :answer_type, :draft_question
+  attr_accessor :answer_type, :draft_question, :answer_types
 
   SELECTION_DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }] }.freeze
 
   validates :draft_question, presence: true
-  validates :answer_type, presence: true, inclusion: { in: Page::ANSWER_TYPES }
+  validates :answer_type, presence: true, inclusion: { in: :answer_types }
 
   def submit
     return false if invalid?

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,7 +6,8 @@ class Page < ActiveResource::Base
   self.include_format_in_path = false
   headers["X-API-Token"] = Settings.forms_api.auth_key
 
-  ANSWER_TYPES = %w[name organisation_name email phone_number national_insurance_number address date selection number text].freeze
+  ANSWER_TYPES_EXCLUDING_FILE = %w[name organisation_name email phone_number national_insurance_number address date selection number text].freeze
+  ANSWER_TYPES_INCLUDING_FILE = (ANSWER_TYPES_EXCLUDING_FILE + %w[file]).freeze
 
   ANSWER_TYPES_WITHOUT_SETTINGS = %w[organisation_name email phone_number national_insurance_number number].freeze
 
@@ -16,7 +17,9 @@ class Page < ActiveResource::Base
 
   validates :hint_text, length: { maximum: 500 }
 
-  validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
+  # we validate that users can't choose file if file upload isn't enabled for their group when creating the draft_question
+  validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES_INCLUDING_FILE }
+
   before_validation :convert_boolean_fields
 
   def has_next_page?

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -15,7 +15,7 @@
 
       <%= f.govuk_collection_radio_buttons(
             :answer_type,
-            Page::ANSWER_TYPES,
+            @answer_types,
             ->(option) { option },
             ->(option) { t('helpers.label.page.answer_type_options.names.' + option) },
             ->(option) { t('helpers.label.page.answer_type_options.descriptions.' + option) },

--- a/app/views/reports/features.html.erb
+++ b/app/views/reports/features.html.erb
@@ -42,7 +42,7 @@
 
       <% answer_type_links = { selection: report_selection_questions_summary_path } %>
       <%= table.with_body do |body| %>
-        <% Page::ANSWER_TYPES.map(&:to_sym).each do |answer_type| %>
+        <% Page::ANSWER_TYPES_INCLUDING_FILE.map(&:to_sym).each do |answer_type| %>
           <%= body.with_row do |row| %>
             <%= row.with_cell(header: true, text: t("helpers.label.page.answer_type_options.names.#{answer_type}")) %>
             <% if answer_type_links[answer_type].present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -681,6 +681,7 @@ en:
             address: ''
             date: ''
             email: ''
+            file: ''
             name: ''
             national_insurance_number: ''
             number: People will only be able to enter whole or decimal numbers
@@ -693,6 +694,7 @@ en:
             address: Address
             date: Date
             email: Email address
+            file: File
             name: Person’s name
             national_insurance_number: National Insurance number
             number: Number

--- a/config/locales/input_objects/type_of_answer.yml
+++ b/config/locales/input_objects/type_of_answer.yml
@@ -7,3 +7,4 @@ en:
           attributes:
             answer_type:
               blank: Select the type of answer you need
+              inclusion: Select the type of answer you need

--- a/db/migrate/20241129152103_add_file_upload_enabled_to_groups.rb
+++ b/db/migrate/20241129152103_add_file_upload_enabled_to_groups.rb
@@ -1,0 +1,5 @@
+class AddFileUploadEnabledToGroups < ActiveRecord::Migration[7.2]
+  def change
+    add_column :groups, :file_upload_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_31_082440) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_29_152103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_31_082440) do
     t.bigint "creator_id"
     t.bigint "upgrade_requester_id"
     t.boolean "long_lists_enabled", default: false
+    t.boolean "file_upload_enabled", default: false
     t.index ["creator_id"], name: "index_groups_on_creator_id"
     t.index ["external_id"], name: "index_groups_on_external_id", unique: true
     t.index ["name", "organisation_id"], name: "index_groups_on_name_and_organisation_id", unique: true

--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -71,6 +71,24 @@ namespace :groups do
     Group.find_by(external_id: args[:group_id]).update!(long_lists_enabled: false)
     Rails.logger.info("Updated long_lists_enabled to false for group #{args[:group_id]}")
   end
+
+  desc "Enable file upload feature"
+  task :enable_file_upload, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:enable_file_upload[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+
+    Group.find_by(external_id: args[:group_id]).update!(file_upload_enabled: true)
+    Rails.logger.info("Updated file_upload_enabled to true for group #{args[:group_id]}")
+  end
+
+  desc "Disable file upload feature"
+  task :disable_file_upload, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:disable_file_upload[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+
+    Group.find_by(external_id: args[:group_id]).update!(file_upload_enabled: false)
+    Rails.logger.info("Updated file_upload_enabled to false for group #{args[:group_id]}")
+  end
 end
 
 def run_task(task_name, args, rollback:)

--- a/spec/factories/input_objects/pages/type_of_answer_input.rb
+++ b/spec/factories/input_objects/pages/type_of_answer_input.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :type_of_answer_input, class: "Pages::TypeOfAnswerInput" do
-    answer_type { Page::ANSWER_TYPES.sample }
+    answer_type { Page::ANSWER_TYPES_EXCLUDING_FILE.sample }
     draft_question { build :draft_question, answer_type: }
+    answer_types { Page::ANSWER_TYPES_EXCLUDING_FILE }
 
     trait :with_simple_answer_type do
       answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }

--- a/spec/input_objects/pages/type_of_answer_input_spec.rb
+++ b/spec/input_objects/pages/type_of_answer_input_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Pages::TypeOfAnswerInput, type: :model do
-  let(:type_of_answer_input) { build :type_of_answer_input, draft_question: }
+  let(:type_of_answer_input) { build :type_of_answer_input, draft_question:, answer_types: }
   let(:draft_question) { build :draft_question, form_id: 1 }
+  let(:answer_types) { Page::ANSWER_TYPES_EXCLUDING_FILE }
 
   it "has a valid factory" do
-    type_of_answer_input = build(:type_of_answer_input, draft_question:)
+    type_of_answer_input = build(:type_of_answer_input, draft_question:, answer_types:)
     expect(type_of_answer_input).to be_valid
   end
 
@@ -18,10 +19,11 @@ RSpec.describe Pages::TypeOfAnswerInput, type: :model do
     it "is invalid given an empty string answer_type" do
       type_of_answer_input.answer_type = ""
       expect(type_of_answer_input).to be_invalid
+      expect(type_of_answer_input.errors.full_messages_for(:answer_type)).to include("Answer type Select the type of answer you need")
     end
 
     it "is valid if answer type is a valid page answer type" do
-      Page::ANSWER_TYPES.each do |answer_type|
+      Page::ANSWER_TYPES_EXCLUDING_FILE.each do |answer_type|
         type_of_answer_input.answer_type = answer_type
         expect(type_of_answer_input).to be_valid "#{answer_type} is not a Page answer type"
       end
@@ -32,6 +34,24 @@ RSpec.describe Pages::TypeOfAnswerInput, type: :model do
 
       it "is invalid" do
         expect(type_of_answer_input).to be_invalid
+      end
+    end
+
+    context "when file upload is disabled" do
+      let(:answer_types) { Page::ANSWER_TYPES_EXCLUDING_FILE }
+
+      it "does not allow file answer type" do
+        type_of_answer_input.answer_type = "file"
+        expect(type_of_answer_input).to be_invalid
+      end
+    end
+
+    context "when file upload is enabled" do
+      let(:answer_types) { Page::ANSWER_TYPES_INCLUDING_FILE }
+
+      it "allows file answer type" do
+        type_of_answer_input.answer_type = "file"
+        expect(type_of_answer_input).to be_valid
       end
     end
   end

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
   let(:type_of_answer_input) { build :type_of_answer_input }
 
-  let(:group) { create(:group, organisation: standard_user.organisation) }
+  let(:file_upload_enabled) { false }
+  let(:group) { create(:group, organisation: standard_user.organisation, file_upload_enabled:) }
 
   before do
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -35,6 +36,20 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
     it "renders the template" do
       expect(response).to have_rendered(:type_of_answer)
+    end
+
+    context "when file upload is disabled for the group" do
+      it "does not show the file answer type option" do
+        expect(response.body).not_to include("File")
+      end
+    end
+
+    context "when file upload is enabled for the group" do
+      let(:file_upload_enabled) { true }
+
+      it "shows the file answer type option" do
+        expect(response.body).to include("File")
+      end
     end
   end
 
@@ -175,6 +190,20 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
     it "renders the template" do
       expect(response).to have_rendered(:type_of_answer)
+    end
+
+    context "when file upload is disabled for the group" do
+      it "does not show the file answer type option" do
+        expect(response.body).not_to include("File")
+      end
+    end
+
+    context "when file upload is enabled for the group" do
+      let(:file_upload_enabled) { true }
+
+      it "shows the file answer type option" do
+        expect(response.body).to include("File")
+      end
     end
   end
 

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "pages/type_of_answer.html.erb", type: :view do
   let(:form) { build :form, id: 1 }
   let(:type_of_answer_input) { build :type_of_answer_input }
-  let(:answer_types) { Page::ANSWER_TYPES }
+  let(:answer_types) { Page::ANSWER_TYPES_EXCLUDING_FILE }
   let(:page) { OpenStruct.new(conditions: [], answer_type: "number") }
   let(:question_number) { 1 }
   let(:is_new_page) { true }

--- a/spec/views/reports/features.html.erb_spec.rb
+++ b/spec/views/reports/features.html.erb_spec.rb
@@ -51,7 +51,7 @@ describe "reports/features.html.erb" do
     expect(rendered).to have_css(".govuk-summary-list__row", text: "Total live forms#{report.total_live_forms}")
   end
 
-  Page::ANSWER_TYPES.map(&:to_sym).each do |answer_type|
+  Page::ANSWER_TYPES_INCLUDING_FILE.map(&:to_sym).each do |answer_type|
     it "contains a heading for #{answer_type}" do
       expect(rendered).to have_css("th", text: I18n.t("helpers.label.page.answer_type_options.names.#{answer_type}"))
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/icJPiPHn/

Adds a column `file_upload_enabled` to the `groups` table so that we can enable creating file upload questions just for specific groups while we are developing the feature.

Allow creating questions with answer type "file" if the flag is enabled.

Relies on https://github.com/alphagov/forms-api/pull/644

![Screenshot 2024-12-03 at 10 18 14](https://github.com/user-attachments/assets/441195a3-6218-4e09-bf2b-3ef8db77ef92)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
