### PR TITLE
Add a dry run version of the org fetch task

### DIFF
--- a/spec/lib/tasks/groups.rake_spec.rb
+++ b/spec/lib/tasks/groups.rake_spec.rb
@@ -263,6 +263,7 @@ RSpec.describe "groups.rake" do
       expect {
         task.invoke
       }.to raise_error(SystemExit)
+      .and output(/usage/).to_stderr
     end
 
     it "with invalid group id raises an error" do


### PR DESCRIPTION
Add a variant of the organisations:fetch rake task, which rolls the transaction back once it's been completed.

### What problem does this pull request solve?

Trello card: https://trello.com/c/M81WBlnp/2021-update-organisations-table-in-forms-admin-database
<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The support ticket involves rerunning our `organisations:fetch` to get an up to date list of organisations. We don't currently have a dry run variant of this task, and because it involves using an external source, it seemed sensible to make sure it can successfully do a dry run before actually updating the database. 

The second commit is to prevent this from happening: 

![image](https://github.com/user-attachments/assets/c5d50eac-4d0f-4968-89ff-2abd3683de51)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
