### PR TITLE
Update organisation fetcher with dry run version

### DIFF
--- a/lib/organisations_fetcher.rb
+++ b/lib/organisations_fetcher.rb
@@ -5,9 +5,13 @@
 # Based on similar code in Signon app:
 # https://github.com/alphagov/signon/blob/b7a53e282c55d8ef3ab6369a7cb358b6ae100d27/lib/organisations_fetcher.rb
 class OrganisationsFetcher
-  def call
+  def call(dry_run: false)
     organisations.each do |organisation_data|
-      update_or_create_organisation(organisation_data)
+      if dry_run
+        show_pending_organisation_update_or_creation(organisation_data)
+      else
+        update_or_create_organisation(organisation_data)
+      end
     end
   rescue ActiveRecord::RecordInvalid => e
     raise "Couldn't save organisation #{e.record.slug} because: #{e.record.errors.full_messages.join(',')}"
@@ -27,15 +31,24 @@ private
       Organisation.find_by(slug:) ||
       Organisation.new(govuk_content_id:)
 
-    update_data = {
-      govuk_content_id:,
-      slug:,
-      name: organisation_data[:title],
-      abbreviation: organisation_data[:details][:abbreviation],
-      closed: organisation_data[:details][:govuk_status] == "closed",
-    }
+    organisation.update!(allocate_update_data(organisation_data))
+  end
 
-    organisation.update!(update_data)
+  def show_pending_organisation_update_or_creation(organisation_data)
+    update_data = allocate_update_data(organisation_data)
+
+    unless (organisation = Organisation.find_by(govuk_content_id: update_data[:govuk_content_id]) || Organisation.find_by(slug: update_data[:slug]))
+      Rails.logger.info "Organisation Fetcher: Creating #{organisation_data[:title]} #{update_data}"
+      return
+    end
+
+    organisation_attributes = organisation.attributes.symbolize_keys.slice(*update_data.keys)
+
+    if organisation_attributes != update_data
+      organisation.assign_attributes(**update_data)
+
+      Rails.logger.info "Organisation Fetcher: Updating #{organisation_data[:title]} #{organisation.changes_to_save}"
+    end
   end
 
   def get_json_with_subsequent_pages(uri)
@@ -56,5 +69,15 @@ private
     else
       raise "error fetching organisations: #{response.code}: #{response.body}"
     end
+  end
+
+  def allocate_update_data(organisation_data)
+    {
+      govuk_content_id: organisation_data[:details][:content_id],
+      slug: organisation_data[:details][:slug],
+      name: organisation_data[:title],
+      abbreviation: organisation_data[:details][:abbreviation],
+      closed: organisation_data[:details][:govuk_status] == "closed",
+    }
   end
 end

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -5,7 +5,7 @@ namespace :organisations do
 
     Rails.logger.info("Starting organisation fetch")
 
-    run_organisation_fetch(rollback: false)
+    run_organisation_fetch(dry_run: false)
 
     Rails.logger.info("Organisation fetch complete")
   end
@@ -16,7 +16,7 @@ namespace :organisations do
 
     Rails.logger.info("Starting dry run of organisation fetch")
 
-    run_organisation_fetch(rollback: true)
+    run_organisation_fetch(dry_run: true)
 
     Rails.logger.info("Dry run of organisation fetch complete")
   end
@@ -38,12 +38,8 @@ namespace :organisations do
   end
 end
 
-def run_organisation_fetch(rollback:)
-  ActiveRecord::Base.transaction do
-    with_lock("forms-admin:organisations:fetch") do
-      OrganisationsFetcher.new.call
-    end
-
-    raise ActiveRecord::Rollback if rollback
+def run_organisation_fetch(dry_run:)
+  with_lock("forms-admin:organisations:fetch") do
+    OrganisationsFetcher.new.call(dry_run:)
   end
 end


### PR DESCRIPTION
The OrganisationFetcher now takes a `dry_run` argument, which will toggle between the dry run and actual fetch process. The dry run will not make any changes to the database, and instead will list out all the proposed changes.

When iterating over the organisations from the API, any new additions will be presented, and any changes to existing orgs will have their changes presented.

The rake task that makes use of this has also been updated to incorporate this

### What problem does this pull request solve?

Trello card: https://trello.com/c/M81WBlnp/2021-update-organisations-table-in-forms-admin-database

Modifying the `OrganisationFetcher` so that it has a dry run variation. This doesn't result in any changes, but simply lists out any changes that would happen if it weren't a dry run.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
