### PR TITLE
Use PageRepository in specs where appropriate

### DIFF
--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -26,7 +26,7 @@ class Pages::GuidanceController < PagesController
   def edit
     guidance_input = Pages::GuidanceInput.new(page_heading: draft_question.page_heading,
                                               guidance_markdown: draft_question.guidance_markdown)
-    back_link = edit_question_path(current_form, page)
+    back_link = edit_question_path(current_form, page.id)
 
     render :guidance, locals: view_locals(page, guidance_input, back_link)
   end

--- a/app/controllers/pages/selection/bulk_options_controller.rb
+++ b/app/controllers/pages/selection/bulk_options_controller.rb
@@ -24,7 +24,7 @@ class Pages::Selection::BulkOptionsController < PagesController
     @bulk_options_path = selection_bulk_options_update_path(current_form)
     @bulk_options_input = Pages::Selection::BulkOptionsInput.new(draft_question:)
     @bulk_options_input.assign_form_values
-    @back_link_url = edit_question_path(current_form, page)
+    @back_link_url = edit_question_path(current_form, page.id)
     render "pages/selection/bulk_options", locals: { current_form: }
   end
 
@@ -32,7 +32,7 @@ class Pages::Selection::BulkOptionsController < PagesController
     @bulk_options_input = Pages::Selection::BulkOptionsInput.new(**bulk_options_input_params,
                                                                            draft_question:)
     @bulk_options_path = selection_bulk_options_update_path(current_form)
-    @back_link_url = edit_question_path(current_form, page)
+    @back_link_url = edit_question_path(current_form, page.id)
 
     if @bulk_options_input.submit
       redirect_to edit_question_path(current_form)

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -40,7 +40,7 @@ private
   def selection_path(form, action)
     return question_text_new_path(form) if action == :create
 
-    selection_type_edit_path(form, page)
+    selection_type_edit_path(form, page.id)
   end
 
   def text_path(form, action)

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -9,10 +9,11 @@ feature "Add/editing a single question", type: :feature do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      mock.get "/api/v1/forms/1/pages/2", headers, fake_page.to_json, 200
-      mock.post "/api/v1/forms/1/pages", post_headers, fake_page.to_json, 200
       mock.put "/api/v1/forms/1", post_headers, form.to_json, 200
     end
+
+    allow(PageRepository).to receive(:create!).with(hash_including(form_id: 1)).and_return(fake_page)
+    allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(fake_page)
 
     GroupForm.create!(group:, form_id: form.id)
     create(:membership, group:, user: standard_user, added_by: standard_user)

--- a/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
+++ b/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
@@ -8,11 +8,12 @@ feature "Editing answer_settings for existing question", type: :feature do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      mock.post "/api/v1/forms/1/pages", post_headers
-      pages.each do |page|
-        mock.get "/api/v1/forms/1/pages/#{page.id}", headers, page.to_json, 200
-      end
     end
+
+    pages.each do |page|
+      allow(PageRepository).to receive(:find).with(page_id: page.id.to_s, form_id: 1).and_return(page)
+    end
+    allow(PageRepository).to receive(:create!).with(hash_including(form_id: 1))
 
     GroupForm.create! group:, form_id: form.id
     create(:membership, group:, user: standard_user, added_by: standard_user)

--- a/spec/features/form/share_a_preview_spec.rb
+++ b/spec/features/form/share_a_preview_spec.rb
@@ -10,10 +10,11 @@ feature "Share a preview", type: :feature do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      mock.get "/api/v1/forms/1/pages/2", headers, fake_page.to_json, 200
-      mock.post "/api/v1/forms/1/pages", post_headers, fake_page.to_json, 200
       mock.put "/api/v1/forms/1", post_headers, form.to_json, 200
     end
+
+    allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(fake_page)
+    allow(PageRepository).to receive(:create!).with(hash_including(form_id: 1))
 
     GroupForm.create!(group:, form_id: form.id)
     create(:membership, group:, user: standard_user, added_by: standard_user, role: :group_admin)

--- a/spec/requests/pages/address_settings_controller_spec.rb
+++ b/spec/requests/pages/address_settings_controller_spec.rb
@@ -107,8 +107,10 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+
       draft_question
       get address_settings_edit_path(form_id: page.form_id, page_id: page.id)
     end
@@ -144,9 +146,10 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
-        mock.put "/api/v1/forms/1/pages/2", post_headers
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+      allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end
 
     context "when form is valid and ready to update in the DB" do

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -100,8 +100,9 @@ RSpec.describe Pages::ConditionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/1", headers, selected_page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "1", form_id: 1).and_return(selected_page)
 
       get new_condition_path(form_id: 1, page_id: 1)
     end
@@ -134,8 +135,9 @@ RSpec.describe Pages::ConditionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/1", headers, selected_page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "1", form_id: 1).and_return(selected_page)
 
       conditions_input = Pages::ConditionsInput.new(form:, page: selected_page, answer_value: "Yes", goto_page_id: 3)
 
@@ -195,8 +197,9 @@ RSpec.describe Pages::ConditionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: selected_page.id.to_s, form_id: 1).and_return(selected_page)
 
       allow(ConditionRepository).to receive(:find).and_return(condition)
 
@@ -245,8 +248,9 @@ RSpec.describe Pages::ConditionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: selected_page.id.to_s, form_id: 1).and_return(selected_page)
 
       conditions_input = Pages::ConditionsInput.new(form:, page: selected_page, record: condition, answer_value: "Yes", goto_page_id: 3)
 
@@ -309,8 +313,9 @@ RSpec.describe Pages::ConditionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: selected_page.id.to_s, form_id: 1).and_return(selected_page)
 
       allow(ConditionRepository).to receive(:find).and_return(condition)
 
@@ -355,8 +360,9 @@ RSpec.describe Pages::ConditionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{selected_page.id}", headers, selected_page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: selected_page.id.to_s, form_id: 1).and_return(selected_page)
 
       allow(ConditionRepository).to receive(:find).and_return(condition)
       allow(ConditionRepository).to receive(:destroy)

--- a/spec/requests/pages/date_settings_controller_spec.rb
+++ b/spec/requests/pages/date_settings_controller_spec.rb
@@ -91,8 +91,10 @@ RSpec.describe Pages::DateSettingsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+
       draft_question
       get date_settings_edit_path(form_id: page.form_id, page_id: page.id)
     end
@@ -127,9 +129,10 @@ RSpec.describe Pages::DateSettingsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
-        mock.put "/api/v1/forms/1/pages/2", post_headers
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+      allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end
 
     context "when form is valid and ready to update in the DB" do

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -149,8 +149,9 @@ RSpec.describe Pages::GuidanceController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{page.id}", headers, page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: page.id.to_s, form_id: 1).and_return(page)
 
       get guidance_edit_path(form_id: form.id, page_id: page.id)
     end
@@ -184,8 +185,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/#{page.id}", headers, page.to_json, 200
       end
+      allow(PageRepository).to receive(:find).with(page_id: page.id.to_s, form_id: 1).and_return(page)
       allow(controller_spy).to receive(:draft_question).and_return(draft_question)
       post guidance_update_path(form_id: form.id, page_id: page.id), params: { pages_guidance_input: { page_heading:, guidance_markdown: }, route_to: }
     end

--- a/spec/requests/pages/name_settings_controller_spec.rb
+++ b/spec/requests/pages/name_settings_controller_spec.rb
@@ -92,8 +92,10 @@ RSpec.describe Pages::NameSettingsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+
       draft_question
       get name_settings_edit_path(form_id: page.form_id, page_id: page.id)
     end
@@ -128,9 +130,10 @@ RSpec.describe Pages::NameSettingsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
-        mock.put "/api/v1/forms/1/pages/2", post_headers
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+      allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end
 
     context "when form is valid and ready to update in the DB" do

--- a/spec/requests/pages/routes_controller_spec.rb
+++ b/spec/requests/pages/routes_controller_spec.rb
@@ -32,8 +32,9 @@ describe Pages::RoutesController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/101", headers, selected_page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "101", form_id: 1).and_return(selected_page)
 
       get show_routes_path(form_id: form.id, page_id: selected_page.id)
     end

--- a/spec/requests/pages/selection/bulk_options_controller_spec.rb
+++ b/spec/requests/pages/selection/bulk_options_controller_spec.rb
@@ -122,8 +122,8 @@ describe Pages::Selection::BulkOptionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
       end
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
       draft_question
       get selection_bulk_options_edit_path(form_id: page.form_id, page_id: page.id)
     end
@@ -163,9 +163,10 @@ describe Pages::Selection::BulkOptionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
-        mock.put "/api/v1/forms/1/pages/2", post_headers
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+      allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end
 
     context "when form is valid and ready to update in the DB" do

--- a/spec/requests/pages/selection/options_controller_spec.rb
+++ b/spec/requests/pages/selection/options_controller_spec.rb
@@ -138,8 +138,10 @@ describe Pages::Selection::OptionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+
       draft_question
       get selection_options_edit_path(form_id: page.form_id, page_id: page.id)
     end
@@ -178,9 +180,11 @@ describe Pages::Selection::OptionsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
-        mock.put "/api/v1/forms/1/pages/2", post_headers
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+      allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
+
       draft_question
     end
 

--- a/spec/requests/pages/selection/type_controller_spec.rb
+++ b/spec/requests/pages/selection/type_controller_spec.rb
@@ -112,8 +112,10 @@ describe Pages::Selection::TypeController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+
       draft_question
       get selection_type_edit_path(form_id: page.form_id, page_id: page.id)
     end
@@ -155,9 +157,10 @@ describe Pages::Selection::TypeController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
-        mock.put "/api/v1/forms/1/pages/2", post_headers
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+      allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end
 
     context "when form is valid and ready to update in the DB" do

--- a/spec/requests/pages/text_settings_controller_spec.rb
+++ b/spec/requests/pages/text_settings_controller_spec.rb
@@ -91,8 +91,10 @@ RSpec.describe Pages::TextSettingsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+
       draft_question
       get text_settings_edit_path(form_id: page.form_id, page_id: page.id)
     end
@@ -123,9 +125,10 @@ RSpec.describe Pages::TextSettingsController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
-        mock.put "/api/v1/forms/1/pages/2", post_headers
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+      allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end
 
     context "when form is valid and ready to update in the DB" do

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -168,8 +168,9 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
 
       get type_of_answer_edit_path(form_id: page.form_id, page_id: page.id)
     end
@@ -214,9 +215,10 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-        mock.get "/api/v1/forms/1/pages/2", headers, page.to_json, 200
-        mock.put "/api/v1/forms/1/pages/2", post_headers
       end
+
+      allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
+      allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end
 
     context "when form is valid and ready to update in the DB" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/QuEeu8uI/2417-add-repository-service-to-forms-admin-for-form-page-model <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to mock repositories instead of forms-api requests in our specs as much as possible; this will make it easier to change the source of the model data in future.

This commit changes specs that were mocking HTTP requests to `/api/v1/forms/:form_id/pages/:page_id` so that they mock the corresponding PageRepository methods instead.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?