### PR TITLE
Refactor controller actions and views for page delete confirmation

### DIFF
--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -61,7 +61,6 @@ module Forms
       else
         @url = destroy_form_path(current_form)
         @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion")
-        @confirm_deletion_live_form = t("forms_delete_confirmation_input.confirm_deletion_live_form") if current_form.live?
         @item_name = current_form.name
         @back_url = form_path(current_form)
       end

--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -16,11 +16,7 @@ module Forms
 
       if @delete_confirmation_input.valid?
         if @delete_confirmation_input.confirmed?
-          if params[:page_id].present?
-            delete_page(current_form, @page)
-          else
-            delete_form(current_form)
-          end
+          delete_form(current_form)
         else
           redirect_to @back_url
         end
@@ -52,18 +48,10 @@ module Forms
     def load_page_variables
       @delete_confirmation_input = DeleteConfirmationInput.new
 
-      if params[:page_id].present?
-        @page = PageRepository.find(page_id: params[:page_id], form_id: current_form.id)
-        @url = destroy_page_path(current_form, @page.id)
-        @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion_page")
-        @item_name = @page.question_text
-        @back_url = edit_question_path(current_form, @page.id)
-      else
-        @url = destroy_form_path(current_form)
-        @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion")
-        @item_name = current_form.name
-        @back_url = form_path(current_form)
-      end
+      @url = destroy_form_path(current_form)
+      @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion")
+      @item_name = current_form.name
+      @back_url = form_path(current_form)
     end
 
     def delete_form(form)
@@ -71,16 +59,6 @@ module Forms
 
       if form.destroy
         redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{form.name}’"
-      else
-        raise StandardError, "Deletion unsuccessful"
-      end
-    end
-
-    def delete_page(form, page)
-      success_url = form_pages_path(form)
-
-      if PageRepository.destroy(page)
-        redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{page.question_text}’"
       else
         raise StandardError, "Deletion unsuccessful"
       end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -35,7 +35,7 @@ private
   end
 
   def check_user_has_permission
-    authorize current_form, :can_view_form?
+    authorize current_form, :can_edit_form?
   end
 
   def page

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,6 +9,40 @@ class PagesController < ApplicationController
     render :index, locals: { current_form: }
   end
 
+  def delete
+    @page = PageRepository.find(page_id: params[:page_id], form_id: current_form.id)
+    @url = destroy_page_path(current_form, @page.id)
+    @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion_page")
+    @item_name = @page.question_text
+    @back_url = edit_question_path(current_form, @page.id)
+
+    @delete_confirmation_input = Forms::DeleteConfirmationInput.new
+  end
+
+  def destroy
+    @page = PageRepository.find(page_id: params[:page_id], form_id: current_form.id)
+    @url = destroy_page_path(current_form, @page.id)
+    @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion_page")
+    @item_name = @page.question_text
+    @back_url = edit_question_path(current_form, @page.id)
+
+    @delete_confirmation_input = Forms::DeleteConfirmationInput.new(
+      params.require(:forms_delete_confirmation_input).permit(:confirm),
+    )
+    if @delete_confirmation_input.valid?
+      if @delete_confirmation_input.confirmed?
+        delete_page(current_form, @page)
+      else
+        redirect_to @back_url
+      end
+    else
+      render :delete
+    end
+  rescue StandardError
+    flash[:message] = "Deletion unsuccessful"
+    redirect_to @back_url
+  end
+
   def start_new_question
     clear_draft_questions_data
     redirect_to type_of_answer_create_path(form_id: current_form.id)
@@ -69,5 +103,15 @@ private
       edit_draft_question.save!(validate: false)
     end
     edit_draft_question
+  end
+
+  def delete_page(form, page)
+    success_url = form_pages_path(form)
+
+    if PageRepository.destroy(page)
+      redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{page.question_text}’"
+    else
+      raise StandardError, "Deletion unsuccessful"
+    end
   end
 end

--- a/app/input_objects/forms/delete_confirmation_input.rb
+++ b/app/input_objects/forms/delete_confirmation_input.rb
@@ -1,2 +1,5 @@
 class Forms::DeleteConfirmationInput < ConfirmActionInput
+  def to_partial_path
+    "input_objects/forms/delete_confirmation_input"
+  end
 end

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -12,7 +12,8 @@ class FormPolicy
     user.groups.include?(form.group) || user.is_organisations_admin?(form.group&.organisation)
   end
 
-  alias_method :delete?, :can_view_form?
+  alias_method :can_edit_form?, :can_view_form?
+  alias_method :delete?, :can_edit_form?
   alias_method :destroy?, :delete?
 
   def can_add_page_routing_conditions?

--- a/app/views/forms/delete_confirmation/delete.html.erb
+++ b/app/views/forms/delete_confirmation/delete.html.erb
@@ -1,14 +1,9 @@
 <% set_page_title(title_with_error_prefix(@confirm_deletion_legend, @delete_confirmation_input.errors.any?)) %>
 <% content_for :back_link, govuk_back_link_to(@back_url) %>
-<%= form_with(model: @delete_confirmation_input, url: @url, method: 'delete') do |f| %>
-  <% if @delete_confirmation_input&.errors.any? %>
-    <%= f.govuk_error_summary %>
-  <% end %>
-  <span class="govuk-caption-l"><%= @item_name %></span>
-  <%= f.govuk_collection_radio_buttons :confirm,
-                                       @delete_confirmation_input.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_action_input.options.' + "#{option}") },
-                                       legend: { text: @confirm_deletion_legend, size: 'l', tag: 'h1' }
-                                       %>
 
-  <%= f.govuk_submit %>
-<% end %>
+<%= render(
+  @delete_confirmation_input,
+  url: @url,
+  caption_text: @item_name,
+  legend_text: @confirm_deletion_legend,
+) %>

--- a/app/views/forms/delete_confirmation/delete.html.erb
+++ b/app/views/forms/delete_confirmation/delete.html.erb
@@ -7,8 +7,8 @@
   <span class="govuk-caption-l"><%= @item_name %></span>
   <%= f.govuk_collection_radio_buttons :confirm,
                                        @delete_confirmation_input.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_action_input.options.' + "#{option}") },
-                                       legend: { text: @confirm_deletion_legend, size: 'l', tag: 'h1' },
-                                       hint: {text: @confirm_deletion_live_form} %>
+                                       legend: { text: @confirm_deletion_legend, size: 'l', tag: 'h1' }
+                                       %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/input_objects/forms/_delete_confirmation_input.html.erb
+++ b/app/views/input_objects/forms/_delete_confirmation_input.html.erb
@@ -1,0 +1,12 @@
+<%= form_with(model: delete_confirmation_input, url:, method: 'delete') do |f| %>
+  <% if delete_confirmation_input&.errors.any? %>
+    <%= f.govuk_error_summary %>
+  <% end %>
+  <span class="govuk-caption-l"><%= caption_text %></span>
+  <%= f.govuk_collection_radio_buttons :confirm,
+                                       delete_confirmation_input.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_action_input.options.' + "#{option}") },
+                                       legend: { text: legend_text, size: 'l', tag: 'h1' }
+                                       %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/pages/delete.html.erb
+++ b/app/views/pages/delete.html.erb
@@ -1,0 +1,10 @@
+<% set_page_title(title_with_error_prefix(@confirm_deletion_legend, @delete_confirmation_input.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(@back_url) %>
+
+<%= render(
+  @delete_confirmation_input,
+  url: @url,
+  caption_text: @item_name,
+  legend_text: @confirm_deletion_legend,
+  hint_text: nil,
+) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,7 +398,6 @@ en:
         title: Optional task
   forms_delete_confirmation_input:
     confirm_deletion: Are you sure you want to delete this draft?
-    confirm_deletion_live_form: Deleting this draft will not remove the live form.
     confirm_deletion_page: Are you sure you want to delete this page?
   group_members:
     create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,8 +144,8 @@ Rails.application.routes.draw do
         end
 
         scope "/delete" do
-          get "/" => "forms/delete_confirmation#delete", as: :delete_page
-          delete "/" => "forms/delete_confirmation#destroy", as: :destroy_page
+          get "/" => "pages#delete", as: :delete_page
+          delete "/" => "pages#destroy", as: :destroy_page
         end
       end
     end

--- a/spec/requests/forms/delete_confirmation_controller_spec.rb
+++ b/spec/requests/forms/delete_confirmation_controller_spec.rb
@@ -35,30 +35,6 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
         end
       end
     end
-
-    describe "Given a valid page" do
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", headers, form.to_json, 200
-        end
-
-        allow(PageRepository).to receive(:find).and_return(page)
-
-        get delete_page_path(form_id: form.id, page_id: page.id)
-      end
-
-      it "Reads the form through the page repository" do
-        expect(PageRepository).to have_received(:find)
-      end
-
-      context "when current user is not in group for form the page is in" do
-        let(:membership) { nil }
-
-        it "returns an error" do
-          expect(response).to have_http_status :forbidden
-        end
-      end
-    end
   end
 
   describe "#destroy" do
@@ -111,34 +87,6 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
 
       it "does not delete the form on the API" do
         expect(form).not_to have_been_deleted
-      end
-    end
-
-    describe "Given a valid page" do
-      before do
-        allow(PageRepository).to receive_messages(find: page, destroy: true)
-
-        delete destroy_page_path(form_id: form.id, page_id: page.id, forms_delete_confirmation_input: { confirm: "yes" })
-      end
-
-      it "destroys the page through the page repository" do
-        expect(PageRepository).to have_received(:destroy)
-      end
-
-      it "redirects you to the page" do
-        expect(response).to redirect_to(form_pages_path(form.id))
-      end
-
-      context "when current user is not in group for form" do
-        let(:membership) { nil }
-
-        it "returns an error" do
-          expect(response).to have_http_status :forbidden
-        end
-
-        it "does not call destroy through the page repository" do
-          expect(PageRepository).not_to have_received(:destroy)
-        end
       end
     end
   end

--- a/spec/views/forms/delete_confirmation/delete.html.erb_spec.rb
+++ b/spec/views/forms/delete_confirmation/delete.html.erb_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "forms/delete_confirmation/delete" do
+  let(:form) { build :form, id: 1, name: "Test form" }
+
+  before do
+    assign(:back_url, form_path(form_id: 1))
+    assign(:confirm_deletion_legend, "Are you sure you want to delete this draft?")
+    assign(:delete_confirmation_input, Forms::DeleteConfirmationInput.new)
+    assign(:item_name, form.name)
+    assign(:url, destroy_form_path(form_id: 1))
+
+    render
+  end
+
+  it "has a page title" do
+    expect(view.content_for(:title)).to include "Are you sure you want to delete this draft?"
+  end
+
+  it "has a heading" do
+    expect(rendered).to have_css "h1", text: "Are you sure you want to delete this draft?"
+  end
+
+  it "has a heading caption with the question text" do
+    expect(rendered).to have_css ".govuk-caption-l", text: "Test form"
+  end
+
+  it "has a back link to the form page" do
+    expect(view.content_for(:back_link)).to have_link "Back", href: "/forms/1"
+  end
+
+  describe "delete confirmation input" do
+    it "posts the confirm value to the destroy action" do
+      expect(rendered).to have_element "form", action: "/forms/1/delete", method: "post"
+    end
+
+    it "has radio buttons to set confirmation to yes or no" do
+      expect(rendered).to have_field "Yes", type: "radio", name: "forms_delete_confirmation_input[confirm]"
+      expect(rendered).to have_field "No", type: "radio", name: "forms_delete_confirmation_input[confirm]"
+    end
+
+    it "has a legend for the radio buttons" do
+      expect(rendered).to have_css "fieldset legend:has(~ .govuk-radios)", text: "Are you sure you want to delete this draft?"
+    end
+
+    it "has a submit button" do
+      expect(rendered).to have_button "Continue", class: "govuk-button"
+    end
+  end
+end

--- a/spec/views/forms/delete_confirmation/delete.html.erb_spec.rb
+++ b/spec/views/forms/delete_confirmation/delete.html.erb_spec.rb
@@ -29,22 +29,13 @@ RSpec.describe "forms/delete_confirmation/delete" do
     expect(view.content_for(:back_link)).to have_link "Back", href: "/forms/1"
   end
 
+  it "has a delete confirmation input to confirm deletion of the form" do
+    expect(rendered).to render_template "input_objects/forms/_delete_confirmation_input"
+  end
+
   describe "delete confirmation input" do
     it "posts the confirm value to the destroy action" do
       expect(rendered).to have_element "form", action: "/forms/1/delete", method: "post"
-    end
-
-    it "has radio buttons to set confirmation to yes or no" do
-      expect(rendered).to have_field "Yes", type: "radio", name: "forms_delete_confirmation_input[confirm]"
-      expect(rendered).to have_field "No", type: "radio", name: "forms_delete_confirmation_input[confirm]"
-    end
-
-    it "has a legend for the radio buttons" do
-      expect(rendered).to have_css "fieldset legend:has(~ .govuk-radios)", text: "Are you sure you want to delete this draft?"
-    end
-
-    it "has a submit button" do
-      expect(rendered).to have_button "Continue", class: "govuk-button"
     end
   end
 end

--- a/spec/views/input_objects/forms/_delete_confirmation_input.html.erb_spec.rb
+++ b/spec/views/input_objects/forms/_delete_confirmation_input.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "input_objects/forms/_delete_confirmation_input" do
+  before do
+    delete_confirmation_input = Forms::DeleteConfirmationInput.new
+    url = delete_form_path(form_id: 1)
+    caption_text = "Test form"
+    legend_text = "Are you sure you want to delete this draft?"
+
+    render locals: { delete_confirmation_input:, url:, caption_text:, legend_text: }
+  end
+
+  it "posts the confirm value to the destroy action" do
+    expect(rendered).to have_element "form", action: "/forms/1/delete", method: "post"
+  end
+
+  it "has radio buttons to set confirmation to yes or no" do
+    expect(rendered).to have_field "Yes", type: "radio", name: "forms_delete_confirmation_input[confirm]"
+    expect(rendered).to have_field "No", type: "radio", name: "forms_delete_confirmation_input[confirm]"
+  end
+
+  it "has a legend for the radio buttons" do
+    expect(rendered).to have_css "fieldset legend:has(~ .govuk-radios)", text: "Are you sure you want to delete this draft?"
+  end
+
+  it "has a submit button" do
+    expect(rendered).to have_button "Continue", class: "govuk-button"
+  end
+end

--- a/spec/views/pages/delete.html.erb_spec.rb
+++ b/spec/views/pages/delete.html.erb_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "pages/delete" do
+  before do
+    assign(:back_url, edit_question_path(form_id: 1, page_id: 1))
+    assign(:confirm_deletion_legend, "Are you sure you want to delete this page?")
+    assign(:delete_confirmation_input, Forms::DeleteConfirmationInput.new)
+    assign(:item_name, "What’s your name?")
+    assign(:url, destroy_page_path(form_id: 1, page_id: 1))
+
+    render
+  end
+
+  it "has a page title" do
+    expect(view.content_for(:title)).to include "Are you sure you want to delete this page?"
+  end
+
+  it "has a heading" do
+    expect(rendered).to have_css "h1", text: "Are you sure you want to delete this page?"
+  end
+
+  it "has a heading caption with the question text" do
+    expect(rendered).to have_css ".govuk-caption-l", text: "What’s your name?"
+  end
+
+  it "has a back link to the edit question page" do
+    expect(view.content_for(:back_link)).to have_link "Back", href: "/forms/1/pages/1/edit/question"
+  end
+
+  it "has a delete confirmation input to confirm deletion of the page" do
+    expect(rendered).to render_template "input_objects/forms/_delete_confirmation_input"
+  end
+
+  describe "delete confirmation input" do
+    it "posts to the destroy action" do
+      expect(rendered).to have_element "form", action: "/forms/1/pages/1/delete", method: "post"
+    end
+
+    it "does not have a hint" do
+      expect(rendered).not_to have_css ".govuk-hint"
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UThSZ8ga/2037-fix-behaviour-of-deleting-page-with-secondary-skip-route <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be able to add some extra warnings and information to the confirmation page shown to users when they try to delete a question in a form.

However, to do this, we need to do some refactoring first, because currently the code for deleting pages is tangled up with the code for deleting forms.

This PR refactors the forms delete confirmation controller to deal with forms only, and moves the code for deleting pages to the pages controller; it is more idiomatic Rails to have the destroy and delete actions for a model in the controller for that model.

While working on this change I also noticed that there's an extra bit of hint text which is supposed to be shown to users when deleting a live form. It currently is not due to a typo, but it's also inaccurate as we haven't yet fully implemented deleting a form draft. So this PR just removes that hint text completely.

The changes in this PR should be purely refactors and not result in any user facing changes.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?