### PR TITLE
Fix association between pages and routing conditions

### DIFF
--- a/app/components/page_list_component/error_summary/view.rb
+++ b/app/components/page_list_component/error_summary/view.rb
@@ -15,7 +15,7 @@ module PageListComponent
       end
 
       def conditions_with_page_indexes
-        @pages.map { |page| page.conditions.map { |condition| OpenStruct.new(condition:, page_index: page.position) } }
+        @pages.map { |page| page.routing_conditions.map { |condition| OpenStruct.new(condition:, page_index: page.position) } }
           .flatten
       end
 

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -75,7 +75,7 @@ module PageListComponent
     # where index is the index of the condition in the array of conditions for
     # the page referenced by check_page_id
     def process_routing_conditions
-      all_form_conditions = @pages.flat_map(&:conditions).compact_blank
+      all_form_conditions = @pages.flat_map(&:routing_conditions).compact_blank
 
       all_form_conditions
         .group_by(&:check_page_id)

--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -83,7 +83,7 @@ private
   end
 
   def ensure_page_has_skip_condition
-    unless page.conditions.any? { |c| c.answer_value.present? }
+    unless page.routing_conditions.any? { |c| c.answer_value.present? }
       redirect_to form_pages_path(current_form.id)
     end
   end
@@ -97,6 +97,6 @@ private
   end
 
   def secondary_skip_condition
-    @secondary_skip_condition ||= current_form.pages.flat_map(&:conditions).compact_blank.find { |c| c.secondary_skip? && c.check_page_id == page.id }
+    @secondary_skip_condition ||= current_form.pages.flat_map(&:routing_conditions).compact_blank.find { |c| c.secondary_skip? && c.check_page_id == page.id }
   end
 end

--- a/app/input_objects/pages/secondary_skip_input.rb
+++ b/app/input_objects/pages/secondary_skip_input.rb
@@ -69,7 +69,7 @@ class Pages::SecondarySkipInput < BaseInput
   end
 
   def answer_value
-    page.conditions.find { |rc| rc.answer_value.present? }.answer_value
+    page.routing_conditions.find { |rc| rc.answer_value.present? }.answer_value
   end
 
   def continue_to

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -113,7 +113,7 @@ class Form < ActiveResource::Base
 private
 
   def has_routing_conditions
-    pages.filter { |p| p.conditions.any? }.any?
+    pages.filter { |p| p.routing_conditions.any? }.any?
   end
 
   def email_task_status_service

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,6 +14,7 @@ class Page < ActiveResource::Base
   ANSWER_TYPES_WITH_SETTINGS = %w[selection text date address name].freeze
 
   belongs_to :form
+  has_many :routing_conditions, class_name: :Condition
 
   validates :hint_text, length: { maximum: 500 }
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -51,6 +51,7 @@ class Page < ActiveResource::Base
   end
 
   def conditions
+    ActiveSupport::Deprecation.new.warn("Prefer Page#routing_conditions to Page#conditions")
     routing_conditions.map { |routing_condition| Condition.new(routing_condition.attributes) }
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -66,7 +66,7 @@ class Page < ActiveResource::Base
   def self.qualifying_route_pages(pages)
     pages.filter do |page|
       page.answer_type == "selection" && page.answer_settings.only_one_option == "true" &&
-        page.position != pages.length && page.conditions.empty?
+        page.position != pages.length && page.routing_conditions.empty?
     end
   end
 end

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -23,7 +23,7 @@ class RouteSummaryCardDataPresenter
   end
 
   def all_routes
-    all_form_routing_conditions = pages.flat_map(&:conditions).compact_blank
+    all_form_routing_conditions = pages.flat_map(&:routing_conditions).compact_blank
     all_form_routing_conditions.select { |rc| rc.check_page_id == page.id }
   end
 

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -20,10 +20,10 @@
           <%= govuk_summary_list(**card) %>
       <% end %>
 
-      <% if page.conditions.present? %>
+      <% if page.routing_conditions.present? %>
           <ul class="govuk-list govuk-list--spaced">
               <li>
-                  <%= govuk_button_link_to t("page_route_card.delete_route"), destroy_condition_path(form_id: current_form.id, page_id: page.id, condition_id: page.conditions.first.id), warning: true %>
+                  <%= govuk_button_link_to t("page_route_card.delete_route"), destroy_condition_path(form_id: current_form.id, page_id: page.id, condition_id: page.routing_conditions.first.id), warning: true %>
               </li>
               <li>
                   <%= govuk_link_to t("pages.go_to_your_questions"), form_pages_path(current_form.id) %>

--- a/app/views/pages/selection/type.html.erb
+++ b/app/views/pages/selection/type.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @page.present? && @page.conditions.any? %>
+    <% if @page.present? && @page.routing_conditions.any? %>
       <% if @selection_type_input.need_to_reduce_options? %>
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
           <% banner.with_heading(text: t("selection_type.routing_and_reduce_your_options_combined_warning.heading"), tag: "h3") %>

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @page.present? && @page.conditions.any?  %>
+    <% if @page.present? && @page.routing_conditions.any?  %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("type_of_answer.routing_warning_about_change_answer_type_heading"), tag: "h3") %>
         <%= t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(current_form)) %>

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -5,6 +5,34 @@ describe Page, type: :model do
     let(:page) { build :page, question_text: }
     let(:question_text) { "What is your address?" }
 
+    describe "associations" do
+      describe "#routing_conditions" do
+        let(:page) { build :page, id: 10, routing_conditions: build_list(:condition, 3, routing_page_id: 10) }
+
+        it "has many routing conditions" do
+          expect(page.routing_conditions.length).to eq 3
+          expect(page.routing_conditions).to all be_a Condition
+          expect(page.routing_conditions).to all have_attributes(routing_page_id: 10)
+        end
+
+        context "when accessing a page through ActiveResource" do
+          let(:page_resource) { described_class.find(10, params: { form_id: 1 }) }
+
+          before do
+            ActiveResource::HttpMock.respond_to do |mock|
+              mock.get "/api/v1/forms/1/pages/10", headers, page.to_json, 200
+            end
+          end
+
+          it "has many routing conditions" do
+            expect(page_resource.routing_conditions.length).to eq 3
+            expect(page_resource.routing_conditions).to all be_a Condition
+            expect(page_resource.routing_conditions).to all have_attributes(routing_page_id: 10)
+          end
+        end
+      end
+    end
+
     describe "#question_text" do
       [nil, ""].each do |question_text|
         it "is invalid given {question_text} question text" do

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
   let(:form) { build :form, id: 1 }
   let(:type_of_answer_input) { build :type_of_answer_input }
   let(:answer_types) { Page::ANSWER_TYPES_EXCLUDING_FILE }
-  let(:page) { OpenStruct.new(conditions: [], answer_type: "number") }
+  let(:page) { OpenStruct.new(routing_conditions: [], answer_type: "number") }
   let(:question_number) { 1 }
   let(:is_new_page) { true }
 
@@ -69,9 +69,9 @@ describe "pages/type_of_answer.html.erb", type: :view do
   end
 
   context "when editing an existing" do
-    let(:page) { OpenStruct.new(conditions:, answer_type:) }
+    let(:page) { OpenStruct.new(routing_conditions:, answer_type:) }
     let(:answer_type) { "selection" }
-    let(:conditions) { [(build :condition)] }
+    let(:routing_conditions) { [(build :condition)] }
 
     it "displays a warning about routes being deleted if answer type changes" do
       expect(Capybara.string(rendered.html).find(".govuk-notification-banner__content").text(normalize_ws: true))
@@ -80,7 +80,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
     end
 
     context "when no routing conditions set" do
-      let(:conditions) { [] }
+      let(:routing_conditions) { [] }
 
       it "does not display a warning about routes being deleted if answer type changes" do
         expect(rendered).not_to have_selector(".govuk-notification-banner__content")


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

I noticed while working on a ticket that the `Page#routing_conditions` method returns a list of `Page::RoutingCondition` objects, rather than a list of `Condition` objects like we'd expect.

This PR fixes that by adding a `has_many` association to the `Page` model with the correct class name. We then clean up the current uses of `Page#conditions` and add a deprecation warning to prevent future uses, so that maybe one day we can use the name of that method for something else.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?