### PR TITLE
Remove inspect config added in error

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,9 +83,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [:id]
-
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Removes the `config.active_record.attributes_for_inspect` item set by the Rails app:update script - we use inspect in production for one of the organisation rake tasks, so this config change doesn't work for us.

I added this in error when making the update to Rails 8.0.1 - it was a change from an earlier Rails update.

Thanks @chao-xian for spotting this!

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
