### PR TITLE
Fix request headers for csv reports

### DIFF
--- a/app/services/reports/csv_reports_service.rb
+++ b/app/services/reports/csv_reports_service.rb
@@ -1,7 +1,10 @@
 require "csv"
 
 class Reports::CsvReportsService
-  REQUEST_HEADERS = { "X-API-Token" => Settings.forms_api.auth_key }.freeze
+  REQUEST_HEADERS = {
+    "X-API-Token" => Settings.forms_api.auth_key,
+    "Accept" => "application/json",
+  }.freeze
   FORM_DOCUMENTS_URL = "#{Settings.forms_api.base_url}/api/v2/form-documents".freeze
 
   FormDocumentsResponse = Data.define(:forms, :has_more_results?)
@@ -100,7 +103,7 @@ private
     params = { tag: "live", page:, per_page: Settings.reports.forms_api_forms_per_request_page }
     uri.query = URI.encode_www_form(params)
 
-    Net::HTTP.get_response(uri)
+    Net::HTTP.get_response(uri, REQUEST_HEADERS)
   end
 
   def write_forms_to_csv(csv, forms)

--- a/app/services/reports/csv_reports_service.rb
+++ b/app/services/reports/csv_reports_service.rb
@@ -103,7 +103,11 @@ private
     params = { tag: "live", page:, per_page: Settings.reports.forms_api_forms_per_request_page }
     uri.query = URI.encode_www_form(params)
 
-    Net::HTTP.get_response(uri, REQUEST_HEADERS)
+    response = Net::HTTP.get_response(uri, REQUEST_HEADERS)
+
+    return response if response.is_a? Net::HTTPSuccess
+
+    raise StandardError, "Forms API responded with a non-success HTTP code when retrieving form documents: status #{response.code}"
   end
 
   def write_forms_to_csv(csv, forms)

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,7 +2,7 @@ forms_api:
   # URL to form-api endpoints
   base_url: http://localhost:9292
   # Authentication key to authenticate forms-runner to forms-api
-  auth_key:
+  auth_key: an-auth-key
 
 # When set to true, All pages will render 'Maintenance mode'
 maintenance_mode_enabled: false

--- a/spec/services/reports/csv_reports_service_spec.rb
+++ b/spec/services/reports/csv_reports_service_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Reports::CsvReportsService do
   describe "#live_forms_csv" do
     it "makes request to forms-api for each page of results" do
       csv_reports_service.live_forms_csv
-      assert_requested(:get, form_documents_url, query: { page: "1", per_page: "3", tag: "live" }, times: 1)
-      assert_requested(:get, form_documents_url, query: { page: "2", per_page: "3", tag: "live" }, times: 1)
-      assert_requested(:get, form_documents_url, query: { page: "3", per_page: "3", tag: "live" }, times: 1)
+      assert_requested(:get, form_documents_url, query: { page: "1", per_page: "3", tag: "live" }, headers:, times: 1)
+      assert_requested(:get, form_documents_url, query: { page: "2", per_page: "3", tag: "live" }, headers:, times: 1)
+      assert_requested(:get, form_documents_url, query: { page: "3", per_page: "3", tag: "live" }, headers:, times: 1)
     end
 
     it "returns a CSV with 10 rows, including the header row" do
@@ -74,9 +74,9 @@ RSpec.describe Reports::CsvReportsService do
   describe "#live_forms_questions" do
     it "makes request to forms-api for each page of results" do
       csv_reports_service.live_questions_csv
-      assert_requested(:get, form_documents_url, query: { page: "1", per_page: "3", tag: "live" }, times: 1)
-      assert_requested(:get, form_documents_url, query: { page: "2", per_page: "3", tag: "live" }, times: 1)
-      assert_requested(:get, form_documents_url, query: { page: "3", per_page: "3", tag: "live" }, times: 1)
+      assert_requested(:get, form_documents_url, query: { page: "1", per_page: "3", tag: "live" }, headers:, times: 1)
+      assert_requested(:get, form_documents_url, query: { page: "2", per_page: "3", tag: "live" }, headers:, times: 1)
+      assert_requested(:get, form_documents_url, query: { page: "3", per_page: "3", tag: "live" }, headers:, times: 1)
     end
 
     it "returns a CSV with 46 rows, including the header row" do

--- a/spec/services/reports/csv_reports_service_spec.rb
+++ b/spec/services/reports/csv_reports_service_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe Reports::CsvReportsService do
         "email",
       ])
     end
+
+    context "when forms-api responds with a non-success status code" do
+      before do
+        stub_request(:get, form_documents_url)
+          .with(query: { page: "1", per_page: "3", tag: "live" })
+          .to_return(body: "There was an error", status: 400)
+      end
+
+      it "raises a StandardError" do
+        expect { csv_reports_service.live_forms_csv }.to raise_error(
+          StandardError, "Forms API responded with a non-success HTTP code when retrieving form documents: status 400"
+        )
+      end
+    end
   end
 
   describe "#live_forms_questions" do
@@ -195,6 +209,20 @@ RSpec.describe Reports::CsvReportsService do
         nil,
         "{\"only_one_option\"=>\"true\", \"selection_options\"=>[{\"name\"=>\"Once\"}, {\"name\"=>\"More than once\"}]}",
       ])
+    end
+
+    context "when forms-api responds with a non-success status code" do
+      before do
+        stub_request(:get, form_documents_url)
+          .with(query: { page: "1", per_page: "3", tag: "live" })
+          .to_return(body: "There was an error", status: 400)
+      end
+
+      it "raises a StandardError" do
+        expect { csv_reports_service.live_questions_csv }.to raise_error(
+          StandardError, "Forms API responded with a non-success HTTP code when retrieving form documents: status 400"
+        )
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/mPtJhtWq/126-investigate-improvements-for-creating-reports-about-feature-usage

We were not sending the request headers containing the API key when making a request to forms-api to retrieve form documents for creating the CSV reports.

Also send an "Accept" header.

Assert in the tests that the expected headers are sent.

Also handle a non-success response from forms-api when retrieving form documents for the CSV reports by raising a StandardError, which will be sent to Sentry.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
