### PR TITLE
1994 add repository service to forms admin for form model

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,7 +110,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_form
-    @current_form ||= Form.find(params[:form_id])
+    @current_form ||= FormRepository.find(form_id: params[:form_id])
   end
 
   def groups_enabled

--- a/app/controllers/forms/archive_form_controller.rb
+++ b/app/controllers/forms/archive_form_controller.rb
@@ -15,11 +15,11 @@ module Forms
       @confirm_archive_input = ConfirmArchiveInput.new(confirm_archive_input_params)
 
       return render :archive, status: :unprocessable_entity unless @confirm_archive_input.valid?
-      return redirect_to live_form_path(current_form) unless user_wants_to_archive_form
+      return redirect_to live_form_path(current_form.id) unless user_wants_to_archive_form
 
       ArchiveFormService.new(form: current_form, current_user: @current_user).archive
 
-      redirect_to archive_form_confirmation_path(current_form)
+      redirect_to archive_form_confirmation_path(current_form.id)
     end
 
     def confirmation

--- a/app/controllers/forms/archived_controller.rb
+++ b/app/controllers/forms/archived_controller.rb
@@ -13,7 +13,7 @@ module Forms
     end
 
     def current_archived_form
-      @current_archived_form ||= Form.find_archived(params[:form_id])
+      @current_archived_form ||= FormRepository.find_archived(form_id: params[:form_id])
     end
   end
 end

--- a/app/controllers/forms/change_name_controller.rb
+++ b/app/controllers/forms/change_name_controller.rb
@@ -12,7 +12,7 @@ module Forms
       @name_input = NameInput.new(name_input_params(current_form))
 
       if @name_input.submit
-        redirect_to form_path(@name_input.form), success: t("banner.success.form.change_name")
+        redirect_to form_path(@name_input.form.id), success: t("banner.success.form.change_name")
       else
         render :edit
       end

--- a/app/controllers/forms/contact_details_controller.rb
+++ b/app/controllers/forms/contact_details_controller.rb
@@ -11,7 +11,7 @@ module Forms
       @contact_details_input = ContactDetailsInput.new(**contact_details_input_params)
 
       if @contact_details_input.submit
-        redirect_to form_path(@contact_details_input.form), success: t("banner.success.form.support_details_saved")
+        redirect_to form_path(@contact_details_input.form.id), success: t("banner.success.form.support_details_saved")
       else
         render :new, status: :unprocessable_entity
       end

--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -37,16 +37,16 @@ module Forms
     def load_page_variables
       @delete_confirmation_input = DeleteConfirmationInput.new
 
-      @url = destroy_form_path(current_form)
+      @url = destroy_form_path(current_form.id)
       @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion")
       @item_name = current_form.name
-      @back_url = form_path(current_form)
+      @back_url = form_path(current_form.id)
     end
 
     def delete_form(form)
       success_url = groups_enabled && form.group.present? ? group_path(form.group) : root_path
 
-      if form.destroy
+      if FormRepository.destroy(form)
         redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{form.name}’"
       else
         raise StandardError, "Deletion unsuccessful"

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -15,7 +15,7 @@ module Forms
   private
 
     def current_live_form
-      @current_live_form ||= Form.find_live(params[:form_id])
+      @current_live_form ||= FormRepository.find_live(form_id: params[:form_id])
     end
   end
 end

--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -14,7 +14,7 @@ module Forms
       @make_live_input = MakeLiveInput.new(**make_live_input_params)
 
       return render_new(status: :unprocessable_entity) unless @make_live_input.valid?
-      return redirect_to form_path(@make_live_input.form) unless @make_live_input.confirmed?
+      return redirect_to form_path(@make_live_input.form.id) unless @make_live_input.confirmed?
 
       @make_form_live_service = MakeFormLiveService.call(current_form:, current_user:)
       @make_form_live_service.make_live

--- a/app/controllers/forms/payment_link_controller.rb
+++ b/app/controllers/forms/payment_link_controller.rb
@@ -12,7 +12,7 @@ module Forms
       @payment_link_input = PaymentLinkInput.new(payment_link_input_params)
 
       if @payment_link_input.submit
-        redirect_to form_path(@payment_link_input.form), success: t("banner.success.form.payment_link_saved")
+        redirect_to form_path(@payment_link_input.form.id), success: t("banner.success.form.payment_link_saved")
       else
         render :new, status: :unprocessable_entity
       end

--- a/app/controllers/forms/privacy_policy_controller.rb
+++ b/app/controllers/forms/privacy_policy_controller.rb
@@ -11,7 +11,7 @@ module Forms
       @privacy_policy_input = PrivacyPolicyInput.new(privacy_policy_input_params)
 
       if @privacy_policy_input.submit
-        redirect_to form_path(@privacy_policy_input.form), success: t("banner.success.form.privacy_details_saved")
+        redirect_to form_path(@privacy_policy_input.form.id), success: t("banner.success.form.privacy_details_saved")
       else
         render :new
       end

--- a/app/controllers/forms/receive_csv_controller.rb
+++ b/app/controllers/forms/receive_csv_controller.rb
@@ -14,7 +14,7 @@ module Forms
       new_submission_type = @receive_csv_input.submission_type
 
       if @receive_csv_input.submit
-        redirect_to form_path(@receive_csv_input.form), success: success_message(previous_submission_type, new_submission_type)
+        redirect_to form_path(@receive_csv_input.form.id), success: success_message(previous_submission_type, new_submission_type)
       else
         render :new, status: :unprocessable_entity
       end

--- a/app/controllers/forms/share_preview_controller.rb
+++ b/app/controllers/forms/share_preview_controller.rb
@@ -12,7 +12,7 @@ module Forms
 
       if @share_preview_input.submit
         success_message = @share_preview_input.marked_complete? ? t("banner.success.form.share_preview_completed") : nil
-        redirect_to form_path(current_form), success: success_message
+        redirect_to form_path(current_form.id), success: success_message
       else
         render "new", status: :unprocessable_entity
       end

--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -12,7 +12,7 @@ module Forms
       @submission_email_input = SubmissionEmailInput.new(set_submission_email_input_params)
 
       if @submission_email_input.submit
-        redirect_to submission_email_code_sent_path(@submission_email_input.form)
+        redirect_to submission_email_code_sent_path(@submission_email_input.form.id)
       else
         render :new, status: :unprocessable_entity
       end
@@ -31,7 +31,7 @@ module Forms
       @submission_email_input = SubmissionEmailInput.new(set_email_code_form_params).assign_form_values
 
       if @submission_email_input.confirm_confirmation_code
-        redirect_to submission_email_confirmed_path(@submission_email_input.form)
+        redirect_to submission_email_confirmed_path(@submission_email_input.form.id)
       else
         render :submission_email_code, status: :unprocessable_entity
       end
@@ -64,7 +64,7 @@ module Forms
     end
 
     def current_live_form
-      @current_live_form ||= Form.find_live(params[:form_id])
+      @current_live_form ||= FormRepository.find_live(form_id: params[:form_id])
     end
   end
 end

--- a/app/controllers/forms/unarchive_controller.rb
+++ b/app/controllers/forms/unarchive_controller.rb
@@ -14,7 +14,7 @@ module Forms
       @make_live_input = MakeLiveInput.new(**unarchive_form_params)
 
       return render "unarchive_form", status: :unprocessable_entity, locals: { current_form: } unless @make_live_input.valid?
-      return redirect_to archived_form_path(current_form) unless @make_live_input.confirmed?
+      return redirect_to archived_form_path(current_form.id) unless @make_live_input.confirmed?
 
       @make_form_live_service = MakeFormLiveService.call(current_form:, current_user:)
       @make_form_live_service.make_live

--- a/app/controllers/forms/what_happens_next_controller.rb
+++ b/app/controllers/forms/what_happens_next_controller.rb
@@ -22,7 +22,7 @@ module Forms
         end
       when :save_and_continue
         if @what_happens_next_input.submit
-          redirect_to form_path(@what_happens_next_input.form), success: t("banner.success.form.what_happens_next_saved")
+          redirect_to form_path(@what_happens_next_input.form.id), success: t("banner.success.form.what_happens_next_saved")
         else
           render :new, status: :unprocessable_entity
         end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -20,7 +20,7 @@ class FormsController < ApplicationController
                         else
                           t("banner.success.form.pages_saved")
                         end
-      redirect_to form_path(current_form), success: success_message
+      redirect_to form_path(current_form.id), success: success_message
     else
       @mark_complete_input.mark_complete = "false"
       render "pages/index", locals: { current_form: }, status: :unprocessable_entity

--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -16,15 +16,14 @@ class GroupFormsController < ApplicationController
     @group_form = GroupForm.new(group: @group)
     authorize @group_form
 
-    @form = Form.new(creator_id: @current_user.id)
+    @name_input = Forms::NameInput.new(name_input_params)
 
-    @name_input = Forms::NameInput.new(name_input_params(@form))
-
-    if @name_input.submit
+    if @name_input.valid?
+      @form = FormRepository.create!(creator_id: @current_user.id, name: @name_input.name)
       @group_form.form_id = @form.id
       @group_form.save!
 
-      redirect_to form_path(@form)
+      redirect_to form_path(@form.id)
     else
       render :new, status: :unprocessable_entity
     end
@@ -40,7 +39,7 @@ private
     @group = Group.find_by!(external_id: params[:group_id])
   end
 
-  def name_input_params(form)
-    params.require(:forms_name_input).permit(:name).merge(form:)
+  def name_input_params
+    params.require(:forms_name_input).permit(:name)
   end
 end

--- a/app/controllers/pages/address_settings_controller.rb
+++ b/app/controllers/pages/address_settings_controller.rb
@@ -3,18 +3,18 @@ class Pages::AddressSettingsController < PagesController
     settings = draft_question.answer_settings
     @address_settings_input = Pages::AddressSettingsInput.new(uk_address: settings.dig(:input_type, :uk_address),
                                                               international_address: settings.dig(:input_type, :international_address))
-    @address_settings_path = address_settings_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @address_settings_path = address_settings_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
     render :address_settings, locals: { current_form: }
   end
 
   def create
     @address_settings_input = Pages::AddressSettingsInput.new(address_settings_input_params)
-    @address_settings_path = address_settings_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @address_settings_path = address_settings_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
 
     if @address_settings_input.submit
-      redirect_to new_question_path(current_form)
+      redirect_to new_question_path(current_form.id)
     else
       render :address_settings, locals: { current_form: }
     end
@@ -24,18 +24,18 @@ class Pages::AddressSettingsController < PagesController
     settings = draft_question.answer_settings
     @address_settings_input = Pages::AddressSettingsInput.new(uk_address: settings.dig(:input_type, :uk_address),
                                                               international_address: settings.dig(:input_type, :international_address))
-    @address_settings_path = address_settings_update_path(current_form)
-    @back_link_url = type_of_answer_edit_path(current_form)
+    @address_settings_path = address_settings_update_path(current_form.id)
+    @back_link_url = type_of_answer_edit_path(current_form.id)
     render :address_settings, locals: { current_form: }
   end
 
   def update
     @address_settings_input = Pages::AddressSettingsInput.new(address_settings_input_params)
-    @address_settings_path = address_settings_update_path(current_form)
-    @back_link_url = type_of_answer_edit_path(current_form)
+    @address_settings_path = address_settings_update_path(current_form.id)
+    @back_link_url = type_of_answer_edit_path(current_form.id)
 
     if @address_settings_input.submit
-      redirect_to edit_question_path(current_form)
+      redirect_to edit_question_path(current_form.id)
     else
       page
       render :address_settings, locals: { current_form: }

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -12,7 +12,7 @@ class Pages::ConditionsController < PagesController
 
     if routing_page_input.valid?
       routing_page = PageRepository.find(page_id: routing_page_id, form_id: current_form.id)
-      redirect_to new_condition_path(current_form, routing_page.id)
+      redirect_to new_condition_path(current_form.id, routing_page.id)
     else
       render template: "pages/conditions/routing_page", locals: { form: current_form, routing_page_input: }, status: :unprocessable_entity
     end

--- a/app/controllers/pages/date_settings_controller.rb
+++ b/app/controllers/pages/date_settings_controller.rb
@@ -1,18 +1,18 @@
 class Pages::DateSettingsController < PagesController
   def new
     @date_settings_input = Pages::DateSettingsInput.new(input_type: draft_question.answer_settings[:input_type])
-    @date_settings_path = date_settings_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @date_settings_path = date_settings_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
     render :date_settings, locals: { current_form: }
   end
 
   def create
     @date_settings_input = Pages::DateSettingsInput.new(date_settings_input_params)
-    @date_settings_path = date_settings_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @date_settings_path = date_settings_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
 
     if @date_settings_input.submit
-      redirect_to new_question_path(current_form)
+      redirect_to new_question_path(current_form.id)
     else
       render :date_settings, locals: { current_form: }
     end
@@ -20,18 +20,18 @@ class Pages::DateSettingsController < PagesController
 
   def edit
     @date_settings_input = Pages::DateSettingsInput.new(input_type: draft_question.answer_settings[:input_type])
-    @date_settings_path = date_settings_update_path(current_form)
-    @back_link_url = type_of_answer_edit_path(current_form)
+    @date_settings_path = date_settings_update_path(current_form.id)
+    @back_link_url = type_of_answer_edit_path(current_form.id)
     render :date_settings, locals: { current_form: }
   end
 
   def update
     @date_settings_input = Pages::DateSettingsInput.new(date_settings_input_params)
-    @date_settings_path = date_settings_update_path(current_form)
-    @back_link_url = type_of_answer_edit_path(current_form)
+    @date_settings_path = date_settings_update_path(current_form.id)
+    @back_link_url = type_of_answer_edit_path(current_form.id)
 
     if @date_settings_input.submit
-      redirect_to edit_question_path(current_form)
+      redirect_to edit_question_path(current_form.id)
     else
       page
       render :date_settings, locals: { current_form: }

--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -2,13 +2,13 @@ class Pages::GuidanceController < PagesController
   def new
     guidance_input = Pages::GuidanceInput.new(page_heading: draft_question.page_heading,
                                               guidance_markdown: draft_question.guidance_markdown)
-    back_link = new_question_path(current_form)
+    back_link = new_question_path(current_form.id)
     render :guidance, locals: view_locals(nil, guidance_input, back_link)
   end
 
   def create
     guidance_input = Pages::GuidanceInput.new(guidance_input_params)
-    back_link = new_question_path(current_form)
+    back_link = new_question_path(current_form.id)
 
     case route_to
     when :preview
@@ -16,7 +16,7 @@ class Pages::GuidanceController < PagesController
       render :guidance, locals: view_locals(nil, guidance_input, back_link)
     when :save_and_continue
       if guidance_input.submit
-        redirect_to new_question_path(current_form)
+        redirect_to new_question_path(current_form.id)
       else
         render :guidance, locals: view_locals(nil, guidance_input, back_link), status: :unprocessable_entity
       end
@@ -26,14 +26,14 @@ class Pages::GuidanceController < PagesController
   def edit
     guidance_input = Pages::GuidanceInput.new(page_heading: draft_question.page_heading,
                                               guidance_markdown: draft_question.guidance_markdown)
-    back_link = edit_question_path(current_form, page.id)
+    back_link = edit_question_path(current_form.id, page.id)
 
     render :guidance, locals: view_locals(page, guidance_input, back_link)
   end
 
   def update
     guidance_input = Pages::GuidanceInput.new(guidance_input_params)
-    back_link = edit_question_path(current_form, page.id)
+    back_link = edit_question_path(current_form.id, page.id)
 
     case route_to
     when :preview

--- a/app/controllers/pages/name_settings_controller.rb
+++ b/app/controllers/pages/name_settings_controller.rb
@@ -2,18 +2,18 @@ class Pages::NameSettingsController < PagesController
   def new
     @name_settings_input = Pages::NameSettingsInput.new(input_type: draft_question.answer_settings[:input_type],
                                                         title_needed: draft_question.answer_settings[:title_needed])
-    @name_settings_path = name_settings_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @name_settings_path = name_settings_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
     render :name_settings, locals: { current_form: }
   end
 
   def create
     @name_settings_input = Pages::NameSettingsInput.new(name_settings_input_params)
-    @name_settings_path = name_settings_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @name_settings_path = name_settings_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
 
     if @name_settings_input.submit
-      redirect_to new_question_path(current_form)
+      redirect_to new_question_path(current_form.id)
     else
       render :name_settings, locals: { current_form: }
     end
@@ -22,18 +22,18 @@ class Pages::NameSettingsController < PagesController
   def edit
     @name_settings_input = Pages::NameSettingsInput.new(input_type: draft_question.answer_settings[:input_type],
                                                         title_needed: draft_question.answer_settings[:title_needed])
-    @name_settings_path = name_settings_update_path(current_form)
-    @back_link_url = type_of_answer_edit_path(current_form)
+    @name_settings_path = name_settings_update_path(current_form.id)
+    @back_link_url = type_of_answer_edit_path(current_form.id)
     render :name_settings, locals: { current_form: }
   end
 
   def update
     @name_settings_input = Pages::NameSettingsInput.new(name_settings_input_params)
-    @name_settings_path = name_settings_update_path(current_form)
-    @back_link_url = type_of_answer_edit_path(current_form)
+    @name_settings_path = name_settings_update_path(current_form.id)
+    @back_link_url = type_of_answer_edit_path(current_form.id)
 
     if @name_settings_input.submit
-      redirect_to edit_question_path(current_form)
+      redirect_to edit_question_path(current_form.id)
     else
       page
       render :name_settings, locals: { current_form: }

--- a/app/controllers/pages/question_text_controller.rb
+++ b/app/controllers/pages/question_text_controller.rb
@@ -1,18 +1,18 @@
 class Pages::QuestionTextController < PagesController
   def new
     @question_text_input = Pages::QuestionTextInput.new(question_text: draft_question.question_text)
-    @question_text_path = question_text_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @question_text_path = question_text_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
     render :question_text, locals: { current_form: }
   end
 
   def create
     @question_text_input = Pages::QuestionTextInput.new(question_text_input_params)
-    @question_text_path = question_text_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @question_text_path = question_text_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
 
     if @question_text_input.submit
-      redirect_to selection_type_new_path(current_form)
+      redirect_to selection_type_new_path(current_form.id)
     else
       render :question_text, locals: { current_form: }
     end

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -20,7 +20,7 @@ class Pages::QuestionsController < PagesController
     if @question_input.valid?
       @page = @question_input.submit
       clear_draft_questions_data
-      redirect_to edit_question_path(current_form, @page.id), success: "Your changes have been saved"
+      redirect_to edit_question_path(current_form.id, @page.id), success: "Your changes have been saved"
     else
       render :new, locals: { current_form:, draft_question: }, status: :unprocessable_entity
     end
@@ -43,7 +43,7 @@ class Pages::QuestionsController < PagesController
 
     if @question_input.update_page(@page)
       clear_draft_questions_data
-      redirect_to edit_question_path(current_form, @page.id), success: "Your changes have been saved"
+      redirect_to edit_question_path(current_form.id, @page.id), success: "Your changes have been saved"
     else
       render :edit, locals: { current_form:, draft_question: }, status: :unprocessable_entity
     end

--- a/app/controllers/pages/selection/bulk_options_controller.rb
+++ b/app/controllers/pages/selection/bulk_options_controller.rb
@@ -2,40 +2,40 @@ class Pages::Selection::BulkOptionsController < PagesController
   def new
     @bulk_options_input = Pages::Selection::BulkOptionsInput.new(draft_question:)
     @bulk_options_input.assign_form_values
-    @bulk_options_path = selection_bulk_options_create_path(current_form)
-    @back_link_url = selection_type_new_path(current_form)
+    @bulk_options_path = selection_bulk_options_create_path(current_form.id)
+    @back_link_url = selection_type_new_path(current_form.id)
     render "pages/selection/bulk_options", locals: { current_form: }
   end
 
   def create
     @bulk_options_input = Pages::Selection::BulkOptionsInput.new(**bulk_options_input_params,
                                                                            draft_question:)
-    @bulk_options_path = selection_bulk_options_create_path(current_form)
-    @back_link_url = selection_type_new_path(current_form)
+    @bulk_options_path = selection_bulk_options_create_path(current_form.id)
+    @back_link_url = selection_type_new_path(current_form.id)
 
     if @bulk_options_input.submit
-      redirect_to new_question_path(current_form)
+      redirect_to new_question_path(current_form.id)
     else
       render "pages/selection/bulk_options", locals: { current_form: }
     end
   end
 
   def edit
-    @bulk_options_path = selection_bulk_options_update_path(current_form)
+    @bulk_options_path = selection_bulk_options_update_path(current_form.id)
     @bulk_options_input = Pages::Selection::BulkOptionsInput.new(draft_question:)
     @bulk_options_input.assign_form_values
-    @back_link_url = edit_question_path(current_form, page.id)
+    @back_link_url = edit_question_path(current_form.id, page.id)
     render "pages/selection/bulk_options", locals: { current_form: }
   end
 
   def update
     @bulk_options_input = Pages::Selection::BulkOptionsInput.new(**bulk_options_input_params,
                                                                            draft_question:)
-    @bulk_options_path = selection_bulk_options_update_path(current_form)
-    @back_link_url = edit_question_path(current_form, page.id)
+    @bulk_options_path = selection_bulk_options_update_path(current_form.id)
+    @back_link_url = edit_question_path(current_form.id, page.id)
 
     if @bulk_options_input.submit
-      redirect_to edit_question_path(current_form)
+      redirect_to edit_question_path(current_form.id)
     else
       render "pages/selection/bulk_options", locals: { current_form: }
     end

--- a/app/controllers/pages/selection/options_controller.rb
+++ b/app/controllers/pages/selection/options_controller.rb
@@ -4,9 +4,9 @@ class Pages::Selection::OptionsController < PagesController
                                                                                          .map { |option| { name: option[:name] } },
                                                                   include_none_of_the_above: draft_question.is_optional,
                                                                   draft_question:)
-    @selection_options_path = selection_options_create_path(current_form)
-    @back_link_url = selection_type_new_path(current_form)
-    @bulk_options_url = selection_bulk_options_new_path(current_form)
+    @selection_options_path = selection_options_create_path(current_form.id)
+    @back_link_url = selection_type_new_path(current_form.id)
+    @bulk_options_url = selection_bulk_options_new_path(current_form.id)
     render "pages/selection/options", locals: { current_form: }
   end
 
@@ -14,9 +14,9 @@ class Pages::Selection::OptionsController < PagesController
     @selection_options_input = Pages::Selection::OptionsInput.new(selection_options: selection_options_param_values,
                                                                   include_none_of_the_above: include_none_of_the_above_param_values,
                                                                   draft_question:)
-    @selection_options_path = selection_options_create_path(current_form)
-    @back_link_url = selection_type_new_path(current_form)
-    @bulk_options_url = selection_bulk_options_new_path(current_form)
+    @selection_options_path = selection_options_create_path(current_form.id)
+    @back_link_url = selection_type_new_path(current_form.id)
+    @bulk_options_url = selection_bulk_options_new_path(current_form.id)
 
     if params[:add_another]
       @selection_options_input.add_another
@@ -25,7 +25,7 @@ class Pages::Selection::OptionsController < PagesController
       @selection_options_input.remove(params[:remove].to_i)
       render "pages/selection/options", locals: { current_form: }
     elsif @selection_options_input.submit
-      redirect_to new_question_path(current_form)
+      redirect_to new_question_path(current_form.id)
     else
       render "pages/selection/options", locals: { current_form: }
     end
@@ -36,9 +36,9 @@ class Pages::Selection::OptionsController < PagesController
                                                                                                   .map { |option| { name: option[:name] } },
                                                                   include_none_of_the_above: draft_question.is_optional,
                                                                   draft_question:)
-    @selection_options_path = selection_options_update_path(current_form)
-    @back_link_url = edit_question_path(current_form)
-    @bulk_options_url = selection_bulk_options_edit_path(current_form)
+    @selection_options_path = selection_options_update_path(current_form.id)
+    @back_link_url = edit_question_path(current_form.id)
+    @bulk_options_url = selection_bulk_options_edit_path(current_form.id)
     render "pages/selection/options", locals: { current_form: }
   end
 
@@ -46,9 +46,9 @@ class Pages::Selection::OptionsController < PagesController
     @selection_options_input = Pages::Selection::OptionsInput.new(selection_options: selection_options_param_values,
                                                                   include_none_of_the_above: include_none_of_the_above_param_values,
                                                                   draft_question:)
-    @selection_options_path = selection_options_update_path(current_form)
-    @back_link_url = edit_question_path(current_form)
-    @bulk_options_url = selection_bulk_options_edit_path(current_form)
+    @selection_options_path = selection_options_update_path(current_form.id)
+    @back_link_url = edit_question_path(current_form.id)
+    @bulk_options_url = selection_bulk_options_edit_path(current_form.id)
 
     if params[:add_another]
       @selection_options_input.add_another
@@ -57,7 +57,7 @@ class Pages::Selection::OptionsController < PagesController
       @selection_options_input.remove(params[:remove].to_i)
       render "pages/selection/options", locals: { current_form: }
     elsif @selection_options_input.submit
-      redirect_to edit_question_path(current_form)
+      redirect_to edit_question_path(current_form.id)
     else
       render "pages/selection/options", locals: { current_form: }
     end

--- a/app/controllers/pages/selection/type_controller.rb
+++ b/app/controllers/pages/selection/type_controller.rb
@@ -2,15 +2,15 @@ class Pages::Selection::TypeController < PagesController
   include PagesHelper
   def new
     @selection_type_input = Pages::Selection::TypeInput.new(only_one_option:, draft_question:)
-    @selection_type_path = selection_type_create_path(current_form)
-    @back_link_url = question_text_new_path(current_form)
+    @selection_type_path = selection_type_create_path(current_form.id)
+    @back_link_url = question_text_new_path(current_form.id)
     render "pages/selection/type", locals: { current_form: }
   end
 
   def create
     @selection_type_input = Pages::Selection::TypeInput.new(type_params)
-    @selection_type_path = selection_type_create_path(current_form)
-    @back_link_url = question_text_new_path(current_form)
+    @selection_type_path = selection_type_create_path(current_form.id)
+    @back_link_url = question_text_new_path(current_form.id)
 
     if @selection_type_input.submit
       redirect_to selection_options_new_path_for_draft_question(draft_question)
@@ -21,15 +21,15 @@ class Pages::Selection::TypeController < PagesController
 
   def edit
     @selection_type_input = Pages::Selection::TypeInput.new(only_one_option:, draft_question:)
-    @selection_type_path = selection_type_update_path(current_form)
-    @back_link_url = edit_question_path(current_form)
+    @selection_type_path = selection_type_update_path(current_form.id)
+    @back_link_url = edit_question_path(current_form.id)
     render "pages/selection/type", locals: { current_form: }
   end
 
   def update
     @selection_type_input = Pages::Selection::TypeInput.new(type_params)
-    @selection_type_path = selection_type_create_path(current_form)
-    @back_link_url = edit_question_path(current_form)
+    @selection_type_path = selection_type_create_path(current_form.id)
+    @back_link_url = edit_question_path(current_form.id)
 
     if @selection_type_input.submit
       redirect_to selection_options_edit_path_for_draft_question(draft_question)

--- a/app/controllers/pages/text_settings_controller.rb
+++ b/app/controllers/pages/text_settings_controller.rb
@@ -1,18 +1,18 @@
 class Pages::TextSettingsController < PagesController
   def new
     @text_settings_input = Pages::TextSettingsInput.new(input_type: draft_question.answer_settings[:input_type])
-    @text_settings_path = text_settings_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @text_settings_path = text_settings_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
     render :text_settings, locals: { current_form: }
   end
 
   def create
     @text_settings_input = Pages::TextSettingsInput.new(text_settings_input_params)
-    @text_settings_path = text_settings_create_path(current_form)
-    @back_link_url = type_of_answer_new_path(current_form)
+    @text_settings_path = text_settings_create_path(current_form.id)
+    @back_link_url = type_of_answer_new_path(current_form.id)
 
     if @text_settings_input.submit
-      redirect_to new_question_path(current_form)
+      redirect_to new_question_path(current_form.id)
     else
       render :text_settings, locals: { current_form: }
     end
@@ -20,18 +20,18 @@ class Pages::TextSettingsController < PagesController
 
   def edit
     @text_settings_input = Pages::TextSettingsInput.new(input_type: draft_question.answer_settings[:input_type])
-    @text_settings_path = text_settings_update_path(current_form)
-    @back_link_url = type_of_answer_edit_path(current_form)
+    @text_settings_path = text_settings_update_path(current_form.id)
+    @back_link_url = type_of_answer_edit_path(current_form.id)
     render :text_settings, locals: { current_form: }
   end
 
   def update
     @text_settings_input = Pages::TextSettingsInput.new(text_settings_input_params)
-    @text_settings_path = text_settings_update_path(current_form)
-    @back_link_url = type_of_answer_edit_path(current_form)
+    @text_settings_path = text_settings_update_path(current_form.id)
+    @back_link_url = type_of_answer_edit_path(current_form.id)
 
     if @text_settings_input.submit
-      redirect_to edit_question_path(current_form)
+      redirect_to edit_question_path(current_form.id)
     else
       page
       render :text_settings, locals: { current_form: }

--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -3,7 +3,7 @@ class Pages::TypeOfAnswerController < PagesController
 
   def new
     @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type, answer_types:)
-    @type_of_answer_path = type_of_answer_create_path(current_form)
+    @type_of_answer_path = type_of_answer_create_path(current_form.id)
     render :type_of_answer, locals: { current_form: }
   end
 
@@ -11,16 +11,16 @@ class Pages::TypeOfAnswerController < PagesController
     @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type_form_params)
 
     if @type_of_answer_input.submit
-      redirect_to next_page_path(current_form, @type_of_answer_input.answer_type, :create)
+      redirect_to next_page_path(current_form.id, @type_of_answer_input.answer_type, :create)
     else
-      @type_of_answer_path = type_of_answer_create_path(current_form)
+      @type_of_answer_path = type_of_answer_create_path(current_form.id)
       render :type_of_answer, locals: { current_form: }
     end
   end
 
   def edit
     @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type, answer_types:)
-    @type_of_answer_path = type_of_answer_update_path(current_form)
+    @type_of_answer_path = type_of_answer_update_path(current_form.id)
     render :type_of_answer, locals: { current_form: }
   end
 
@@ -28,55 +28,55 @@ class Pages::TypeOfAnswerController < PagesController
     @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type_form_params)
 
     if @type_of_answer_input.submit
-      redirect_to next_page_path(current_form, @type_of_answer_input.answer_type, :update)
+      redirect_to next_page_path(current_form.id, @type_of_answer_input.answer_type, :update)
     else
-      @type_of_answer_path = type_of_answer_update_path(current_form)
+      @type_of_answer_path = type_of_answer_update_path(current_form.id)
       render :type_of_answer
     end
   end
 
 private
 
-  def selection_path(form, action)
-    return question_text_new_path(form) if action == :create
+  def selection_path(form_id, action)
+    return question_text_new_path(form_id) if action == :create
 
-    selection_type_edit_path(form, page.id)
+    selection_type_edit_path(form_id, page.id)
   end
 
-  def text_path(form, action)
-    action == :create ? text_settings_new_path(form) : text_settings_edit_path(form)
+  def text_path(form_id, action)
+    action == :create ? text_settings_new_path(form_id) : text_settings_edit_path(form_id)
   end
 
-  def date_path(form, action)
-    action == :create ? date_settings_new_path(form) : date_settings_edit_path(form)
+  def date_path(form_id, action)
+    action == :create ? date_settings_new_path(form_id) : date_settings_edit_path(form_id)
   end
 
-  def address_path(form, action)
-    action == :create ? address_settings_new_path(form) : address_settings_edit_path(form)
+  def address_path(form_id, action)
+    action == :create ? address_settings_new_path(form_id) : address_settings_edit_path(form_id)
   end
 
-  def name_path(form, action)
-    action == :create ? name_settings_new_path(form) : name_settings_edit_path(form)
+  def name_path(form_id, action)
+    action == :create ? name_settings_new_path(form_id) : name_settings_edit_path(form_id)
   end
 
-  def default_path(form, action)
-    action == :create ? new_question_path(form) : edit_question_path(form)
+  def default_path(form_id, action)
+    action == :create ? new_question_path(form_id) : edit_question_path(form_id)
   end
 
-  def next_page_path(form, answer_type, action)
+  def next_page_path(form_id, answer_type, action)
     case answer_type
     when "selection"
-      selection_path(form, action)
+      selection_path(form_id, action)
     when "text"
-      text_path(form, action)
+      text_path(form_id, action)
     when "date"
-      date_path(form, action)
+      date_path(form_id, action)
     when "address"
-      address_path(form, action)
+      address_path(form_id, action)
     when "name"
-      name_path(form, action)
+      name_path(form_id, action)
     else
-      default_path(form, action)
+      default_path(form_id, action)
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,26 +11,26 @@ class PagesController < ApplicationController
 
   def delete
     @page = PageRepository.find(page_id: params[:page_id], form_id: current_form.id)
-    @url = destroy_page_path(current_form, @page.id)
+    @url = destroy_page_path(current_form.id, @page.id)
     @confirm_deletion_legend = t("forms_delete_confirmation_input.confirm_deletion_page")
     @item_name = @page.question_text
-    @back_url = edit_question_path(current_form, @page.id)
+    @back_url = edit_question_path(current_form.id, @page.id)
 
     @delete_confirmation_input = Forms::DeleteConfirmationInput.new
   end
 
   def destroy
     @page = PageRepository.find(page_id: params[:page_id], form_id: current_form.id)
-    @url = destroy_page_path(current_form, @page.id)
+    @url = destroy_page_path(current_form.id, @page.id)
     @item_name = @page.question_text
-    @back_url = edit_question_path(current_form, @page.id)
+    @back_url = edit_question_path(current_form.id, @page.id)
 
     @delete_confirmation_input = Forms::DeleteConfirmationInput.new(
       params.require(:forms_delete_confirmation_input).permit(:confirm),
     )
     if @delete_confirmation_input.valid?
       if @delete_confirmation_input.confirmed?
-        delete_page(current_form, @page)
+        delete_page(current_form.id, @page)
       else
         redirect_to @back_url
       end

--- a/app/input_objects/forms/contact_details_input.rb
+++ b/app/input_objects/forms/contact_details_input.rb
@@ -37,7 +37,7 @@ class Forms::ContactDetailsInput < BaseInput
     form.support_url = link_href if supplied(:supply_link)
     form.support_url_text = link_text if supplied(:supply_link)
 
-    form.save!
+    FormRepository.save!(form)
   end
 
   def assign_form_values

--- a/app/input_objects/forms/declaration_input.rb
+++ b/app/input_objects/forms/declaration_input.rb
@@ -8,7 +8,7 @@ class Forms::DeclarationInput < Forms::MarkCompleteInput
 
     form.declaration_text = declaration_text
     form.declaration_section_completed = mark_complete
-    form.save!
+    FormRepository.save!(form)
   end
 
   def assign_form_values

--- a/app/input_objects/forms/mark_pages_section_complete_input.rb
+++ b/app/input_objects/forms/mark_pages_section_complete_input.rb
@@ -5,7 +5,7 @@ class Forms::MarkPagesSectionCompleteInput < Forms::MarkCompleteInput
     return false if invalid?
 
     form.question_section_completed = mark_complete
-    if form.save!
+    if FormRepository.save!(form)
       true
     else
       false

--- a/app/input_objects/forms/name_input.rb
+++ b/app/input_objects/forms/name_input.rb
@@ -7,7 +7,7 @@ class Forms::NameInput < BaseInput
     return false if invalid?
 
     form.name = name
-    form.save!
+    FormRepository.save!(form)
   end
 
   def assign_form_values

--- a/app/input_objects/forms/payment_link_input.rb
+++ b/app/input_objects/forms/payment_link_input.rb
@@ -10,7 +10,7 @@ class Forms::PaymentLinkInput < BaseInput
     return false if invalid?
 
     form.payment_url = payment_url
-    form.save!
+    FormRepository.save!(form)
   end
 
   def assign_form_values

--- a/app/input_objects/forms/privacy_policy_input.rb
+++ b/app/input_objects/forms/privacy_policy_input.rb
@@ -9,7 +9,7 @@ class Forms::PrivacyPolicyInput < BaseInput
     return false if invalid?
 
     form.privacy_policy_url = privacy_policy_url
-    form.save!
+    FormRepository.save!(form)
   end
 
   def assign_form_values

--- a/app/input_objects/forms/receive_csv_input.rb
+++ b/app/input_objects/forms/receive_csv_input.rb
@@ -7,7 +7,7 @@ class Forms::ReceiveCsvInput < BaseInput
     return false if invalid?
 
     form.submission_type = submission_type
-    form.save!
+    FormRepository.save!(form)
   end
 
   def assign_form_values

--- a/app/input_objects/forms/share_preview_input.rb
+++ b/app/input_objects/forms/share_preview_input.rb
@@ -3,7 +3,7 @@ class Forms::SharePreviewInput < Forms::MarkCompleteInput
     return false if invalid?
 
     form.share_preview_completed = mark_complete
-    if form.save!
+    if FormRepository.save!(form)
       true
     else
       false

--- a/app/input_objects/forms/submission_email_input.rb
+++ b/app/input_objects/forms/submission_email_input.rb
@@ -45,7 +45,7 @@ class Forms::SubmissionEmailInput < BaseInput
 
     # Update the submission email in the form
     form.submission_email = temporary_submission_email
-    form.save!
+    FormRepository.save!(form)
     mark_submission_email_as_confirmed
   end
 

--- a/app/input_objects/forms/what_happens_next_input.rb
+++ b/app/input_objects/forms/what_happens_next_input.rb
@@ -7,7 +7,7 @@ class Forms::WhatHappensNextInput < BaseInput
     return false if invalid?
 
     form.what_happens_next_markdown = what_happens_next_markdown
-    form.save!
+    FormRepository.save!(form)
   end
 
   def assign_form_values

--- a/app/models/group_form.rb
+++ b/app/models/group_form.rb
@@ -5,6 +5,6 @@ class GroupForm < ApplicationRecord
   belongs_to :group
 
   def form
-    Form.find(form_id)
+    FormRepository.find(form_id: form_id)
   end
 end

--- a/app/services/archive_form_service.rb
+++ b/app/services/archive_form_service.rb
@@ -5,7 +5,7 @@ class ArchiveFormService
   end
 
   def archive
-    @form.archive!
+    FormRepository.archive!(@form)
     SubmissionEmailMailer.alert_processor_form_archive(processor_email: @form.submission_email,
                                                        form_name: @form.name,
                                                        archived_by_name: @current_user.name,

--- a/app/services/default_group_service.rb
+++ b/app/services/default_group_service.rb
@@ -5,7 +5,7 @@ class DefaultGroupService
   def create_user_default_trial_group!(user)
     return unless user.name.present? && user.organisation.present?
 
-    forms = Form.where(creator_id: user.id).to_h { [_1.id, _1] }
+    forms = FormRepository.where(creator_id: user.id).to_h { [_1.id, _1] }
     form_ids = forms.keys
     group_form_ids = GroupForm.where(form_id: form_ids).pluck(:form_id)
     not_group_form_ids = form_ids.to_set - group_form_ids

--- a/app/services/form_repository.rb
+++ b/app/services/form_repository.rb
@@ -42,10 +42,5 @@ class FormRepository
       form = Form.new(record.attributes, true)
       form.destroy # rubocop:disable Rails/SaveBang
     end
-
-    # todo
-    # def pages(record)
-    #   record.pages
-    # end
   end
 end

--- a/app/services/form_repository.rb
+++ b/app/services/form_repository.rb
@@ -1,0 +1,51 @@
+class FormRepository
+  class << self
+    def create!(creator_id:, name:)
+      Form.create!(creator_id:, name:)
+    end
+
+    def find(form_id:)
+      Form.find(form_id)
+    end
+
+    def find_live(form_id:)
+      Form.find_live(form_id)
+    end
+
+    def find_archived(form_id:)
+      Form.find_archived(form_id)
+    end
+
+    def where(creator_id:)
+      Form.where(creator_id:)
+    end
+
+    def save!(record)
+      form = Form.new(record.attributes, true)
+      form.save!
+      form
+    end
+
+    def make_live!(record)
+      form = Form.new(record.attributes, true)
+      form.make_live!
+      form
+    end
+
+    def archive!(record)
+      form = Form.new(record.attributes, true)
+      form.archive!
+      form
+    end
+
+    def destroy(record)
+      form = Form.new(record.attributes, true)
+      form.destroy # rubocop:disable Rails/SaveBang
+    end
+
+    # todo
+    # def pages(record)
+    #   record.pages
+    # end
+  end
+end

--- a/app/services/make_form_live_service.rb
+++ b/app/services/make_form_live_service.rb
@@ -7,12 +7,12 @@ class MakeFormLiveService
 
   def initialize(current_form:, current_user:)
     @current_form = current_form
-    @current_live_form = Form.find_live(current_form.id) if current_form.is_live?
+    @current_live_form = FormRepository.find_live(form_id: current_form.id) if current_form.is_live?
     @current_user = current_user
   end
 
   def make_live
-    @current_form.make_live!
+    FormRepository.make_live!(@current_form)
 
     if live_form_submission_email_has_changed
       SubmissionEmailMailer.alert_email_change(

--- a/app/views/forms/contact_details/new.html.erb
+++ b/app/views/forms/contact_details/new.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= form_with(model: @contact_details_input, url: contact_details_create_path(@contact_details_input.form)) do |f| %>
+    <%= form_with(model: @contact_details_input, url: contact_details_create_path(@contact_details_input.form.id)) do |f| %>
       <% if @contact_details_input&.errors.any? %>
         <%= f.govuk_error_summary %>
       <% end %>

--- a/app/views/forms/submission_email/new.html.erb
+++ b/app/views/forms/submission_email/new.html.erb
@@ -1,5 +1,5 @@
 <% set_page_title(title_with_error_prefix(t('page_titles.set_email'), @submission_email_input.errors.any?)) %>
-<% content_for :back_link, govuk_back_link_to(form_path(@submission_email_input.form), t("back_link.form_create")) %>
+<% content_for :back_link, govuk_back_link_to(form_path(@submission_email_input.form.id), t("back_link.form_create")) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @submission_email_input, url: submission_email_input_path) do |f| %>

--- a/app/views/forms/submission_email/submission_email_code.html.erb
+++ b/app/views/forms/submission_email/submission_email_code.html.erb
@@ -1,5 +1,5 @@
 <% set_page_title(title_with_error_prefix(t('page_titles.confirm_email'), @submission_email_input.errors.any?)) %>
-<% content_for :back_link, govuk_back_link_to(form_path(@submission_email_input.form), t("back_link.form_create")) %>
+<% content_for :back_link, govuk_back_link_to(form_path(@submission_email_input.form.id), t("back_link.form_create")) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @submission_email_input, url: confirm_submission_email_code_path) do |f| %>

--- a/app/views/forms/submission_email/submission_email_code_sent.html.erb
+++ b/app/views/forms/submission_email/submission_email_code_sent.html.erb
@@ -7,7 +7,7 @@
 
     <%= t("email_code_sent.what_happens_next_body_html") %>
 
-    <p><%= govuk_link_to "Enter the email address confirmation code", submission_email_code_path( @submission_email_input.form) %></p>
+    <p><%= govuk_link_to "Enter the email address confirmation code", submission_email_code_path(@submission_email_input.form.id) %></p>
 
     <p><%= govuk_link_to(t('email_code_sent.continue'), form_path) %></p>
   </div>

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -1,10 +1,10 @@
 <% set_page_title(title_with_error_prefix(t("page_titles.what_happens_next"), @what_happens_next_input.errors.present?)) %>
-<% content_for :back_link, govuk_back_link_to(form_path(@what_happens_next_input.form), t("back_link.form_create")) %>
+<% content_for :back_link, govuk_back_link_to(form_path(@what_happens_next_input.form.id), t("back_link.form_create")) %>
 
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @what_happens_next_input, url: what_happens_next_create_path(@what_happens_next_input.form)) do |f| %>
+    <%= form_with(model: @what_happens_next_input, url: what_happens_next_create_path(@what_happens_next_input.form.id)) do |f| %>
       <% if @what_happens_next_input&.errors&.present? %>
         <%= f.govuk_error_summary %>
       <% end %>
@@ -30,7 +30,7 @@
 
       <%= render MarkdownEditorComponent::View.new(:what_happens_next_markdown,
         form_builder: f,
-        render_preview_path: what_happens_next_render_preview_path(@what_happens_next_input.form),
+        render_preview_path: what_happens_next_render_preview_path(@what_happens_next_input.form.id),
         preview_html: @preview_html,
         form_model: @what_happens_next_input,
         label: "Enter some information to tell people what will happen next",

--- a/app/views/pages/address_settings.html.erb
+++ b/app/views/pages/address_settings.html.erb
@@ -13,7 +13,7 @@
     <% end %>
 
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/date_settings.html.erb
+++ b/app/views/pages/date_settings.html.erb
@@ -17,7 +17,7 @@
     <% end %>
 
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -1,5 +1,5 @@
 <% set_page_title(title_with_error_prefix(@question_input.question_text, @question_input.errors.any?)) %>
-<% content_for :back_link, govuk_back_link_to(form_pages_path(current_form)) %>
+<% content_for :back_link, govuk_back_link_to(form_pages_path(current_form.id)) %>
 <% content_for :notification_banner_content do %>
   <ul class="govuk-list govuk-list--spaced">
     <% if @page.has_next_page? %>
@@ -8,11 +8,11 @@
       </li>
     <% else %>
       <li>
-        <%= govuk_button_link_to t("pages.index.add_question"), start_new_question_path(current_form), class: "govuk-!-margin-bottom-0" %>
+        <%= govuk_button_link_to t("pages.index.add_question"), start_new_question_path(current_form.id), class: "govuk-!-margin-bottom-0" %>
       </li>
     <% end %>
     <li>
-      <%= govuk_link_to t("pages.go_to_your_questions"), form_pages_path(current_form) %>
+      <%= govuk_link_to t("pages.go_to_your_questions"), form_pages_path(current_form.id) %>
     </li>
   </ul>
 <% end%>

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -18,7 +18,7 @@
 
       <%= render MarkdownEditorComponent::View.new(:guidance_markdown,
         form_builder: f,
-        render_preview_path: guidance_render_preview_path(current_form),
+        render_preview_path: guidance_render_preview_path(current_form.id),
         preview_html:,
         form_model: guidance_input,
         label: t("helpers.label.pages_guidance_input.guidance_markdown"),
@@ -39,7 +39,7 @@
 
     <% end %>
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,6 +1,6 @@
 <% set_page_title(t("pages.index.title")) %>
 
-<% content_for :back_link, govuk_back_link_to(form_path(current_form), t("back_link.form_create")) %>
+<% content_for :back_link, govuk_back_link_to(form_path(current_form.id), t("back_link.form_create")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -20,7 +20,7 @@
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), start_new_question_path(form_id: current_form.id), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
-      <%= govuk_button_link_to t("pages.index.add_a_question_route"), routing_page_path(current_form), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
+      <%= govuk_button_link_to t("pages.index.add_a_question_route"), routing_page_path(current_form.id), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
 
       <%= render PreviewLinkComponent::View.new(@pages, link_to_runner(Settings.forms_runner.url, current_form.id, current_form.form_slug)) %>
     </div>
@@ -28,7 +28,7 @@
     <% if @pages.any? %>
       <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0"><%= t("forms.form_overview.your_questions") %></h2>
       <%= render PageListComponent::View.new(pages: @pages, form_id: current_form.id) %>
-      <%= render MarkCompleteComponent::View.new(form_model: @mark_complete_input, path: form_pages_path(current_form), legend: t("pages.index.mark_complete.legend")) %>
+      <%= render MarkCompleteComponent::View.new(form_model: @mark_complete_input, path: form_pages_path(current_form.id), legend: t("pages.index.mark_complete.legend")) %>
     <% end %>
 
   </div>

--- a/app/views/pages/name_settings.html.erb
+++ b/app/views/pages/name_settings.html.erb
@@ -32,7 +32,7 @@
     <% end %>
 
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/question_text.html.erb
+++ b/app/views/pages/question_text.html.erb
@@ -10,7 +10,7 @@
     <% end %>
 
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/selection/bulk_options.html.erb
+++ b/app/views/pages/selection/bulk_options.html.erb
@@ -33,7 +33,7 @@
     <% end %>
 
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/selection/options.html.erb
+++ b/app/views/pages/selection/options.html.erb
@@ -57,7 +57,7 @@
     <% end %>
 
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/selection/type.html.erb
+++ b/app/views/pages/selection/type.html.erb
@@ -8,7 +8,7 @@
       <% if @selection_type_input.need_to_reduce_options? %>
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
           <% banner.with_heading(text: t("selection_type.routing_and_reduce_your_options_combined_warning.heading"), tag: "h3") %>
-          <p><%= t("selection_type.routing_and_reduce_your_options_combined_warning.body", pages_link_url: form_pages_path(current_form)) %></p>
+          <p><%= t("selection_type.routing_and_reduce_your_options_combined_warning.body", pages_link_url: form_pages_path(current_form.id)) %></p>
         <% end %>
       <% else %>
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
@@ -18,7 +18,7 @@
     <% elsif @selection_type_input.need_to_reduce_options? %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("selection_type.reduce_your_options_warning.heading"), tag: "h3") %>
-        <p><%= t("selection_type.reduce_your_options_warning.body", pages_link_url: form_pages_path(current_form)) %></p>
+        <p><%= t("selection_type.reduce_your_options_warning.body", pages_link_url: form_pages_path(current_form.id)) %></p>
       <% end %>
     <% end %>
 
@@ -39,7 +39,7 @@
     <% end %>
 
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/text_settings.html.erb
+++ b/app/views/pages/text_settings.html.erb
@@ -17,7 +17,7 @@
     <% end %>
 
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -1,12 +1,12 @@
 <% set_page_title(title_with_error_prefix(t("page_titles.new_page"), @type_of_answer_input.errors.any?)) %>
-<% content_for :back_link, govuk_back_link_to(form_pages_path(current_form)) %>
+<% content_for :back_link, govuk_back_link_to(form_pages_path(current_form.id)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @page.present? && @page.routing_conditions.any?  %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("type_of_answer.routing_warning_about_change_answer_type_heading"), tag: "h3") %>
-        <%= t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(current_form)) %>
+        <%= t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(current_form.id)) %>
       <% end %>
     <% end %>
 
@@ -28,7 +28,7 @@
     <% end %>
 
     <p>
-      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form) %>
+      <%= govuk_link_to t('pages.go_to_your_questions'), form_pages_path(current_form.id) %>
     </p>
   </div>
 </div>

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -32,12 +32,12 @@ namespace :forms do
       abort usage_message if args[:form_id].blank? || args[:submission_email].blank?
       raise "'#{args[:submission_email]}' is not an email address" unless args[:submission_email].match?(/.*@.*/)
 
-      form = Form.find(args[:form_id])
+      form = FormRepository.find(form_id: args[:form_id])
       form.submission_email = args[:submission_email]
 
       Rails.logger.info "forms:submission_email:update: setting #{fmt_form(form)} submission email to \'#{form.submission_email}\'"
 
-      form.save!
+      FormRepository.save!(form)
 
       form.form_submission_email&.destroy!
     end
@@ -48,7 +48,7 @@ def move_forms(form_ids, group_id)
   group = Group.find_by! external_id: group_id
 
   form_ids.each do |form_id|
-    form = Form.find(form_id)
+    form = FormRepository.find(form_id: form_id)
     group_form = GroupForm.find_or_initialize_by(form_id:)
 
     if group_form.group == group

--- a/spec/features/account/complete_user_account_spec.rb
+++ b/spec/features/account/complete_user_account_spec.rb
@@ -4,14 +4,14 @@ feature "Add account organisation to user without organisation", type: :feature 
   let(:user) { create :user, :with_no_org, name: nil, terms_agreed_at: nil }
   let!(:organisation) { create :organisation }
 
-  let(:form) { build :form, :with_active_resource, id: 1, name: "a form I created when I didn't have an organisation", created_at: "2024-10-08T07:31:15.762Z" }
+  let(:form) { build :form, id: 1, name: "a form I created when I didn't have an organisation", created_at: "2024-10-08T07:31:15.762Z" }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?creator_id=#{user.id}", headers, [form].to_json, 200
-      mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, [].to_json, 200
     end
+
+    allow(FormRepository).to receive_messages(where: [form], find: form)
 
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:auth0] = Faker::Omniauth.auth0(

--- a/spec/features/analytics/analytics_spec.rb
+++ b/spec/features/analytics/analytics_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 
 feature "Google analytics", type: :feature do
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=1", headers, [].to_json, 200
-    end
-
     allow(Settings).to receive(:analytics_enabled).and_return(analytics_enabled)
   end
 

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -1,19 +1,17 @@
 require "rails_helper"
 
 feature "Add/editing a single question", type: :feature do
-  let(:form) { build :form, :with_active_resource, id: 1 }
+  let(:form) { build :form, id: 1, pages: }
   let(:fake_page) { build :page, form_id: 1, id: 2 }
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      mock.put "/api/v1/forms/1", post_headers, form.to_json, 200
     end
 
-    allow(PageRepository).to receive(:create!).with(hash_including(form_id: 1)).and_return(fake_page)
-    allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(fake_page)
+    allow(FormRepository).to receive_messages(find: form, save!: form)
+    allow(PageRepository).to receive_messages(find: fake_page, create!: fake_page)
 
     GroupForm.create!(group:, form_id: form.id)
     create(:membership, group:, user: standard_user, added_by: standard_user)

--- a/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
+++ b/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
@@ -1,14 +1,16 @@
 require "rails_helper"
 
 feature "Editing answer_settings for existing question", type: :feature do
-  let(:form) { build :form, :with_active_resource, id: 1, pages: }
+  let(:form) { build :form, id: 1, pages: }
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
     end
+
+    allow(FormRepository).to receive_messages(find: form)
+    allow(PageRepository).to receive_messages(create!: true)
 
     pages.each do |page|
       allow(PageRepository).to receive(:find).with(page_id: page.id.to_s, form_id: 1).and_return(page)

--- a/spec/features/form/archive_a_form_spec.rb
+++ b/spec/features/form/archive_a_form_spec.rb
@@ -2,17 +2,10 @@ require "rails_helper"
 
 feature "Archive a form", type: :feature do
   let(:form) { build(:form, :live, id: 1) }
-  let(:org_forms) { [form] }
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=1", headers, org_forms.to_json, 200
-      mock.get "/api/v1/forms/1", headers, form.to_json, 200
-      mock.get "/api/v1/forms/1/live", headers, form.to_json, 200
-      mock.get "/api/v1/forms/1/archived", headers, form.to_json, 200
-      mock.post "/api/v1/forms/1/archive", post_headers, {}, 200
-    end
+    allow(FormRepository).to receive_messages(find: form, find_live: form, find_archived: form, archive!: {})
 
     GroupForm.create! group:, form_id: form.id
     create(:membership, group:, user: standard_user, added_by: standard_user)

--- a/spec/features/form/create_or_edit_a_form_spec.rb
+++ b/spec/features/form/create_or_edit_a_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Create or edit a form", type: :feature do
-  let(:form) { build :form, :with_active_resource, id: 1, name: "Apply for a juggling license", created_at: "2024-10-08T07:31:15.762Z" }
+  let(:form) { build :form, id: 1, name: "Apply for a juggling license", created_at: "2024-10-08T07:31:15.762Z" }
   let(:group) { create :group, name: "Group 1" }
 
   before do
@@ -13,10 +13,10 @@ feature "Create or edit a form", type: :feature do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.post "/api/v1/forms", post_headers, { id: 1 }.to_json
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
+
+      allow(FormRepository).to receive_messages(create!: form, find: form)
     end
 
     context "when the user is a member of a group" do
@@ -45,11 +45,10 @@ feature "Create or edit a form", type: :feature do
       form.name = "Another form of juggling"
 
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.put "/api/v1/forms/1", post_headers
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
-        mock.get "/api/v1/forms/1", headers, updated_form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
+
+      allow(FormRepository).to receive_messages(save!: form, find: form)
     end
 
     context "when the user is a member of a group with a form" do

--- a/spec/features/form/make_changes_live_spec.rb
+++ b/spec/features/form/make_changes_live_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 feature "Make changes live", type: :feature do
-  let(:form) { build :form, :live, :with_active_resource, id: 1, name: "Apply for a juggling license" }
-  let(:org_forms) { [form] }
+  let(:form) { build :form, :live, id: 1, name: "Apply for a juggling license" }
   let(:pages) { build_list :page, 5, form_id: form.id }
   let(:organisation) { build :organisation, id: 1 }
   let(:user) { create :user, organisation: }
@@ -10,12 +9,10 @@ feature "Make changes live", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=1", headers, org_forms.to_json, 200
-      mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      mock.get "/api/v1/forms/1/live", headers, form.to_json(include: [:pages]), 200
-      mock.post "/api/v1/forms/1/make-live", post_headers, form.to_json(include: [:pages]), 200
     end
+
+    allow(FormRepository).to receive_messages(find: form, find_live: form, make_live!: form)
 
     GroupForm.create!(form_id: form.id, group_id: group.id)
     Membership.create!(user:, group:, added_by: user, role: :group_admin)

--- a/spec/features/form/share_a_preview_spec.rb
+++ b/spec/features/form/share_a_preview_spec.rb
@@ -1,18 +1,17 @@
 require "rails_helper"
 
 feature "Share a preview", type: :feature do
-  let(:form) { build :form, :with_active_resource, id: 1 }
-  let(:fake_page) { build :page, form_id: 1, id: 2 }
-  let(:pages) { [fake_page] }
+  let(:form) { build :form, :with_pages, id: 1 }
   let(:group) { create(:group, organisation: standard_user.organisation, status: "active") }
+  let(:fake_page) { build :page, form_id: form.id, id: 2 }
+  let(:pages) { [fake_page] }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      mock.put "/api/v1/forms/1", post_headers, form.to_json, 200
     end
 
+    allow(FormRepository).to receive_messages(find: form, save!: form)
     allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(fake_page)
     allow(PageRepository).to receive(:create!).with(hash_including(form_id: 1))
 

--- a/spec/features/mou/upgrade_user_changes_mou_spec.rb
+++ b/spec/features/mou/upgrade_user_changes_mou_spec.rb
@@ -2,15 +2,11 @@ require "rails_helper"
 
 describe "Assign an organisation to a user with a signed MOU", type: :feature do
   let(:user) { create :user, name: "Test User", organisation: nil }
-  let(:mou_signature) { create(:mou_signature, user:, organisation: nil, created_at: Time.zone.parse("September 1, 2023")) }
+  let!(:mou_signature) { create(:mou_signature, user:, organisation: nil, created_at: Time.zone.parse("September 1, 2023")) }
   let(:organisation) { create :organisation }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?creator_id=#{super_admin_user.id}", headers, [].to_json, 200
-    end
-
-    mou_signature
+    allow(FormRepository).to receive(:where).and_return([])
   end
 
   it "a logged in user can sign an MOU" do

--- a/spec/features/mou/view_signed_mous_spec.rb
+++ b/spec/features/mou/view_signed_mous_spec.rb
@@ -2,18 +2,13 @@ require "rails_helper"
 
 describe "Check which MOUs have been signed", type: :feature do
   let(:user) { super_admin_user }
-  let(:mou_signatures) do
+  let!(:mou_signatures) do
     [create(:mou_signature, created_at: Time.zone.parse("October 12, 2023")),
      create(:mou_signature, created_at: Time.zone.parse("September 1, 2023"))]
   end
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=#{user.organisation.id}", headers, [].to_json, 200
-      mock.get "/api/v1/forms?creator_id=#{user.id}", headers, [].to_json, 200
-    end
-
-    mou_signatures
+    allow(FormRepository).to receive(:where).and_return([])
 
     login_as_super_admin_user
   end

--- a/spec/input_objects/forms/contact_details_input_spec.rb
+++ b/spec/input_objects/forms/contact_details_input_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Forms::ContactDetailsInput, type: :model do
       subject(:contact_details_input) { build :contact_details_input, contact_details_supplied: [:supply_email], email: "invalid_email" }
 
       before do
-        allow(contact_details_input.form).to receive(:save!)
+        allow(FormRepository).to receive(:save!)
       end
 
       it "returns false" do
@@ -232,7 +232,7 @@ RSpec.describe Forms::ContactDetailsInput, type: :model do
 
       it "does not save form" do
         contact_details_input.submit
-        expect(contact_details_input.form).not_to have_received(:save!)
+        expect(FormRepository).not_to have_received(:save!)
       end
     end
 
@@ -240,7 +240,7 @@ RSpec.describe Forms::ContactDetailsInput, type: :model do
       subject(:contact_details_input) { build :contact_details_input }
 
       before do
-        allow(contact_details_input.form).to receive(:save!).and_return(true)
+        allow(FormRepository).to receive(:save!).and_return(true)
       end
 
       it "not be false" do
@@ -249,7 +249,7 @@ RSpec.describe Forms::ContactDetailsInput, type: :model do
 
       it "saves the form" do
         contact_details_input.submit
-        expect(contact_details_input.form).to have_received(:save!)
+        expect(FormRepository).to have_received(:save!)
       end
 
       it "sets the form values" do

--- a/spec/input_objects/forms/declaration_input_spec.rb
+++ b/spec/input_objects/forms/declaration_input_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe Forms::DeclarationInput, type: :model do
   end
 
   describe "#submit" do
+    before do
+      allow(FormRepository).to receive(:save!).and_return(true)
+    end
+
     it "returns false if the data is invalid" do
       form = described_class.new(declaration_text: ("abc" * 2001), form: { declaration_text: "" })
       expect(form.submit).to be false

--- a/spec/input_objects/forms/mark_pages_section_complete_input_spec.rb
+++ b/spec/input_objects/forms/mark_pages_section_complete_input_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Forms::MarkPagesSectionCompleteInput, type: :model do
   describe "#save" do
     context "when mark_complete_input is valid" do
       before do
-        allow(form).to receive(:save).and_return(true)
+        allow(FormRepository).to receive(:save!).and_return(true)
         allow(mark_complete_input).to receive_messages(invalid?: false, form:)
       end
 
@@ -62,14 +62,14 @@ RSpec.describe Forms::MarkPagesSectionCompleteInput, type: :model do
     end
 
     it "returns true if valid and form is updated" do
-      allow(form).to receive(:save!).and_return(true)
+      allow(FormRepository).to receive(:save!).and_return(true)
       allow(mark_complete_input).to receive_messages(invalid?: false, form:)
       expect(mark_complete_input.submit).to be true
     end
 
     context "when mark_complete_input form does not save" do
       before do
-        allow(form).to receive(:save!).and_return(false)
+        allow(FormRepository).to receive(:save!).and_return(false)
         allow(mark_complete_input).to receive_messages(invalid?: false, form:)
       end
 

--- a/spec/input_objects/forms/name_input_spec.rb
+++ b/spec/input_objects/forms/name_input_spec.rb
@@ -20,15 +20,11 @@ RSpec.describe Forms::NameInput, type: :model do
         form = build :form
         name_input = described_class.new(form:, name: "New Form")
 
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms", post_headers, { id: 1, name: "New Form" }.to_json, 200
-        end
+        allow(FormRepository).to receive(:save!).and_return({ id: 1, name: "New Form" })
 
         expect {
           name_input.submit
         }.to change(form, :name).to("New Form")
-
-        expect(form).to be_persisted
       end
     end
 
@@ -40,8 +36,6 @@ RSpec.describe Forms::NameInput, type: :model do
         expect {
           name_input.submit
         }.not_to change(form, :name)
-
-        expect(form).not_to be_persisted
       end
     end
   end

--- a/spec/input_objects/forms/share_preview_input_spec.rb
+++ b/spec/input_objects/forms/share_preview_input_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Forms::SharePreviewInput, type: :model do
   describe "#save" do
     context "when valid" do
       before do
-        allow(form).to receive(:save).and_return(true)
+        allow(FormRepository).to receive(:save!).and_return(true)
         allow(mark_complete_input).to receive_messages(invalid?: false, form:)
       end
 

--- a/spec/input_objects/forms/submission_email_input_spec.rb
+++ b/spec/input_objects/forms/submission_email_input_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Forms::SubmissionEmailInput, type: :model do
     end
 
     it "returns true and updates form if confirmation code does not match" do
-      allow(form).to receive(:save!).and_return(true)
+      allow(FormRepository).to receive(:save!).and_return(true)
       create :form_submission_email, form_id: form.id, confirmation_code: "123456", temporary_submission_email: "test@test.gov.uk"
 
       submission_email_input_with_user.assign_form_values

--- a/spec/input_objects/forms/what_happens_next_input_spec.rb
+++ b/spec/input_objects/forms/what_happens_next_input_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Forms::WhatHappensNextInput, type: :model do
     end
 
     describe "#submit" do
+      before do
+        allow(FormRepository).to receive(:save!).and_return(true)
+      end
+
       it "returns false if the data is invalid" do
         what_happens_next_input.what_happens_next_markdown = "# abc"
         expect(what_happens_next_input.submit).to be false
@@ -61,6 +65,10 @@ RSpec.describe Forms::WhatHappensNextInput, type: :model do
     end
 
     describe "#submit" do
+      before do
+        allow(FormRepository).to receive(:save!).and_return(true)
+      end
+
       it "returns false if the data is invalid" do
         what_happens_next_input = described_class.new(form:, what_happens_next_markdown: "# a level one heading")
         expect(what_happens_next_input.submit).to be false

--- a/spec/integration/auth0_spec.rb
+++ b/spec/integration/auth0_spec.rb
@@ -143,13 +143,6 @@ RSpec.describe "usage of omniauth-auth0 gem" do
 
   describe "Google workspace integration" do
     let(:form) { build :form, :with_active_resource, id: 1, name: "Apply for a juggling license" }
-    let(:org_forms) { [] }
-
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms?organisation_id=1", api_get_request_headers, org_forms.to_json, 200
-      end
-    end
 
     context "when a super-admin user is logged in" do
       let(:user) { super_admin_user }

--- a/spec/integration/basic_auth_spec.rb
+++ b/spec/integration/basic_auth_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "using basic auth" do
       "Accept" => "application/json",
     }
 
+    # TODO: Remove this stub when we shift over from API to ActiveRecord
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms?creator_id=#{basic_auth_user.id}", api_headers, [].to_json, 200
     end

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "forms.rake" do
     end
     let(:form_ids) { forms.map(&:id) }
 
-    # TODO, it's a bit too closely linked to the API
+    # TODO: Refactor this when we move over from API to ActiveRecord
     before do
       ActiveResource::HttpMock.respond_to do |mock|
         forms.each do |form|

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "forms.rake" do
     end
     let(:form_ids) { forms.map(&:id) }
 
+    # TODO, it's a bit too closely linked to the API
     before do
       ActiveResource::HttpMock.respond_to do |mock|
         forms.each do |form|

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -189,10 +189,7 @@ RSpec.describe Group, type: :model do
     it "is associated with a form through the form ID" do
       form = build :form, id: 1
 
-      ActiveResource::HttpMock.respond_to do |mock|
-        request_headers = { "Accept" => "application/json", "X-API-Token" => Settings.forms_api.auth_key }
-        mock.get "/api/v1/forms/1", request_headers, form.to_json, 200
-      end
+      allow(FormRepository).to receive(:find).with(form_id: form.id).and_return(form)
 
       group = build(:group, id: 1)
       group.group_forms.build(form_id: 1)

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe ApplicationController, type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms?organisation_id=1", headers, [form].to_json, 200
-      mock.get "/api/v1/forms/1", headers, form.to_json, 200
       mock.get "/api/v1/forms/1/pages", headers, form.pages.to_json, 200
     end
+
+    allow(FormRepository).to receive(:find).and_return(form)
 
     login_as_standard_user
   end

--- a/spec/requests/forms/archive_form_controller_spec.rb
+++ b/spec/requests/forms/archive_form_controller_spec.rb
@@ -14,15 +14,13 @@ RSpec.describe Forms::ArchiveFormController, type: :request do
 
   describe "#archive" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{id}", headers, form.to_json, 200
-      end
+      allow(FormRepository).to receive(:find).and_return(form)
 
       get archive_form_path(id)
     end
 
-    it "reads the form from the APi" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns 200" do
@@ -46,18 +44,14 @@ RSpec.describe Forms::ArchiveFormController, type: :request do
     let(:confirm) { :yes }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{id}", headers, form.to_json, 200
-        mock.post "/api/v1/forms/#{id}/archive", post_headers
-      end
+      allow(FormRepository).to receive_messages(find: form, archive!: form)
 
       post archive_form_update_path(id), params: { forms_confirm_archive_input: { confirm:, form: } }
     end
 
     context "when 'Yes' is selected" do
       it "archives the form" do
-        archive_post = ActiveResource::Request.new(:post, "/api/v1/forms/#{id}/archive", {}, post_headers)
-        expect(ActiveResource::HttpMock.requests).to include archive_post
+        expect(FormRepository).to have_received(:archive!)
       end
 
       it "redirects to the success page" do
@@ -90,8 +84,7 @@ RSpec.describe Forms::ArchiveFormController, type: :request do
       let(:form) { build(:form, :archived, id:) }
 
       it "doesn't archive the form" do
-        archive_post = ActiveResource::Request.new(:post, "/api/v1/forms/#{id}/archive", {}, post_headers)
-        expect(ActiveResource::HttpMock.requests).not_to include archive_post
+        expect(FormRepository).not_to have_received(:archive!)
       end
 
       it "redirects to archived form page" do
@@ -102,9 +95,7 @@ RSpec.describe Forms::ArchiveFormController, type: :request do
 
   describe "#confirmation" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{id}", headers, form.to_json, 200
-      end
+      allow(FormRepository).to receive(:find).and_return(form)
 
       get archive_form_confirmation_path(id)
     end

--- a/spec/requests/forms/archived_controller_spec.rb
+++ b/spec/requests/forms/archived_controller_spec.rb
@@ -11,10 +11,7 @@ RSpec.describe Forms::ArchivedController, type: :request do
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
 
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/#{id}", headers, form.to_json, 200
-      mock.get "/api/v1/forms/#{id}/archived", headers, form.to_json, 200
-    end
+    allow(FormRepository).to receive_messages(find: form, find_archived: form)
   end
 
   describe "#show_form" do
@@ -22,11 +19,8 @@ RSpec.describe Forms::ArchivedController, type: :request do
       get archived_form_path(id)
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
-
-      pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{id}", {}, headers)
-      expect(ActiveResource::HttpMock.requests).to include pages_request
+    it "Reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "renders the show archived form template" do

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -1,24 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Forms::ChangeNameController, type: :request do
-  let(:form_response_data) do
-    {
-      id: 2,
-      name: "Form name",
-      creator_id: 123,
-    }.to_json
-  end
-
+  let(:form) { build(:form, id: 2, name: "Form name", creator_id: 123) }
   let(:organisation) { build :organisation, id: 1, slug: "test-org" }
   let(:user) { build :user, id: 1, organisation: }
   let(:group) { create(:group, organisation: user.organisation) }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2", headers, form_response_data, 200
-      mock.post "/api/v1/forms", post_headers, { id: 2 }.to_json, 200
-      mock.put "/api/v1/forms/2", post_headers
-    end
+    allow(FormRepository).to receive_messages(find: form, create!: form, save!: form)
 
     Membership.create!(group_id: group.id, user:, added_by: user)
     GroupForm.create!(form_id: 2, group_id: group.id)
@@ -30,18 +19,16 @@ RSpec.describe Forms::ChangeNameController, type: :request do
       get change_form_name_path(form_id: 2)
     end
 
-    it "fetches the from from the API" do
-      expected_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
-      expect(ActiveResource::HttpMock.requests).to include expected_request
+    it "fetches the form" do
+      expect(FormRepository).to have_received(:find)
     end
   end
 
   describe "#update" do
     it "renames form" do
       post change_form_name_path(form_id: 2), params: { forms_name_input: { name: "new_form_name", creator_id: 123 } }
-      expected_request = ActiveResource::Request.new(:put, "/api/v1/forms/2", { "id": 2, "name": "new_form_name", creator_id: 123 }.to_json, post_headers)
-      expect(ActiveResource::HttpMock.requests).to include expected_request
-      expect(ActiveResource::HttpMock.requests[1].body).to eq expected_request.body
+
+      expect(FormRepository).to have_received(:save!)
       expect(response).to redirect_to(form_path(form_id: 2))
     end
   end

--- a/spec/requests/forms/live_controller_spec.rb
+++ b/spec/requests/forms/live_controller_spec.rb
@@ -17,19 +17,14 @@ RSpec.describe Forms::LiveController, type: :request do
     before do
       allow(CloudWatchService).to receive_messages(week_submissions: 501, week_starts: 1305)
 
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2", headers, form.to_json, 200
-        mock.get "/api/v1/forms/2/live", headers, form.to_json, 200
-      end
+      allow(FormRepository).to receive_messages(find: form, find_live: form)
 
       get live_form_path(2)
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
-
-      pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
-      expect(ActiveResource::HttpMock.requests).to include pages_request
+    it "Reads the form" do
+      expect(FormRepository).to have_received(:find)
+      expect(FormRepository).to have_received(:find_live)
     end
 
     it "renders the live template" do
@@ -58,10 +53,7 @@ RSpec.describe Forms::LiveController, type: :request do
   describe "#show_pages" do
     context "with a live form" do
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", headers, form.to_json, 200
-          mock.get "/api/v1/forms/2/live", headers, form.to_json, 200
-        end
+        allow(FormRepository).to receive_messages(find: form, find_live: form)
 
         get live_form_pages_path(2)
       end

--- a/spec/requests/forms/privacy_policy_controller_spec.rb
+++ b/spec/requests/forms/privacy_policy_controller_spec.rb
@@ -14,16 +14,7 @@ RSpec.describe Forms::PrivacyPolicyController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2", headers, form.to_json, 200
-      mock.put "/api/v1/forms/2", headers
-    end
-
-    ActiveResourceMock.mock_resource(form,
-                                     {
-                                       read: { response: form, status: 200 },
-                                       update: { response: updated_form, status: 200 },
-                                     })
+    allow(FormRepository).to receive_messages(find: form, save!: updated_form)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -33,33 +24,25 @@ RSpec.describe Forms::PrivacyPolicyController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.put "/api/v1/forms/2", post_headers
-        mock.get "/api/v1/forms/2", headers, form.to_json, 200
-      end
       get privacy_policy_path(form_id: 2)
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "Reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
   end
 
   describe "#create" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2", headers, form.to_json, 200
-        mock.put "/api/v1/forms/2", post_headers
-      end
       post privacy_policy_path(form_id: 2), params: { forms_privacy_policy_input: { privacy_policy_url: "https://www.example.gov.uk/privacy-policy" } }
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "Reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
-    it "Updates the form on the API" do
-      expect(form).to have_been_updated_to(updated_form)
+    it "Updates the form" do
+      expect(FormRepository).to have_received(:save!)
     end
 
     it "Redirects you to the form overview page" do

--- a/spec/requests/forms/share_preview_controller_spec.rb
+++ b/spec/requests/forms/share_preview_controller_spec.rb
@@ -16,14 +16,13 @@ RSpec.describe Forms::SharePreviewController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{id}", headers, form.to_json, 200
-        get share_preview_path(id)
-      end
+      allow(FormRepository).to receive(:find).and_return(form)
+
+      get share_preview_path(id)
     end
 
-    it "reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns 200" do
@@ -47,15 +46,13 @@ RSpec.describe Forms::SharePreviewController, type: :request do
     let(:mark_complete) { "true" }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{id}", headers, form.to_json, 200
-        mock.put "/api/v1/forms/#{id}", post_headers
-        post share_preview_create_path(id), params: { forms_share_preview_input: { form:, mark_complete: } }
-      end
+      allow(FormRepository).to receive_messages(find: form, save!: form)
+
+      post share_preview_create_path(id), params: { forms_share_preview_input: { form:, mark_complete: } }
     end
 
-    it "reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     context "when 'Yes' is selected" do
@@ -65,8 +62,8 @@ RSpec.describe Forms::SharePreviewController, type: :request do
         end
       end
 
-      it "updates the form on the API" do
-        expect(form).to have_been_updated_to(updated_form)
+      it "updates the form" do
+        expect(FormRepository).to have_received(:save!)
       end
 
       it "redirects to the form" do
@@ -86,8 +83,8 @@ RSpec.describe Forms::SharePreviewController, type: :request do
         end
       end
 
-      it "updates the form on the API" do
-        expect(form).to have_been_updated_to(updated_form)
+      it "updates the form" do
+        expect(FormRepository).to have_received(:save!)
       end
 
       it "redirects to the form" do
@@ -102,8 +99,8 @@ RSpec.describe Forms::SharePreviewController, type: :request do
     context "when no value is selected" do
       let(:mark_complete) { "" }
 
-      it "does not update the form on the API" do
-        expect(form).not_to have_been_updated
+      it "does not update the form" do
+        expect(FormRepository).not_to have_received(:save!)
       end
 
       it "returns an 422" do

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -18,12 +18,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms", headers, [form].to_json, 200
-      mock.get "/api/v1/forms/1", headers, form.to_json, 200
-      mock.get "/api/v1/forms/1/live", headers, form.to_json, 200
-      mock.put "/api/v1/forms/1", post_headers, form.to_json, 200
-    end
+    allow(FormRepository).to receive_messages(find: form, save!: form, find_live: form)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -220,10 +215,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
         previous_live_version
         form.submission_email = Faker::Internet.email(domain: "example.gov.uk")
 
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/1", headers, form.to_json, 200
-          mock.get "/api/v1/forms/1/live", headers, previous_live_version.to_json, 200
-        end
+        allow(FormRepository).to receive_messages(find: form, find_live: previous_live_version)
 
         get submission_email_confirmed_path(form.id)
       end

--- a/spec/requests/forms/unarchive_controller_spec.rb
+++ b/spec/requests/forms/unarchive_controller_spec.rb
@@ -26,16 +26,7 @@ RSpec.describe Forms::UnarchiveController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.put "/api/v1/forms/2", post_headers
-        mock.get "/api/v1/forms/2", headers, form.to_json, 200
-      end
-
-      ActiveResourceMock.mock_resource(form,
-                                       {
-                                         read: { response: form, status: 200 },
-                                         update: { response: updated_form, status: 200 },
-                                       })
+      allow(FormRepository).to receive_messages(find: form, save!: updated_form)
 
       Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user, role: :group_admin)
       GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -45,8 +36,8 @@ RSpec.describe Forms::UnarchiveController, type: :request do
       get unarchive_path(form_id: 2)
     end
 
-    it "reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns 200" do
@@ -68,11 +59,7 @@ RSpec.describe Forms::UnarchiveController, type: :request do
 
   describe "#create" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.post "/api/v1/forms/2/make-live", post_headers
-        mock.get "/api/v1/forms/2", headers, form.to_json, 200
-        mock.get "/api/v1/forms/2/live", headers, form.to_json, 200
-      end
+      allow(FormRepository).to receive_messages(find: form, make_live!: form, find_live: form)
 
       Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user, role: :group_admin)
       GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -85,13 +72,12 @@ RSpec.describe Forms::UnarchiveController, type: :request do
     context "when making a form live again" do
       let(:form_params) { { forms_make_live_input: { confirm: :yes, form: } } }
 
-      it "reads the form from the API" do
-        expect(form).to have_been_read
+      it "reads the form" do
+        expect(FormRepository).to have_received(:find)
       end
 
-      it "makes form live on the API" do
-        make_live_post = ActiveResource::Request.new(:post, "/api/v1/forms/2/make-live", {}, post_headers)
-        expect(ActiveResource::HttpMock.requests).to include make_live_post
+      it "makes form live" do
+        expect(FormRepository).to have_received(:make_live!)
       end
 
       it "renders the confirmation page" do
@@ -106,12 +92,12 @@ RSpec.describe Forms::UnarchiveController, type: :request do
     context "when deciding not to make a form live again" do
       let(:form_params) { { forms_make_live_input: { confirm: :no } } }
 
-      it "reads the form from the API" do
-        expect(form).to have_been_read
+      it "reads the form" do
+        expect(FormRepository).to have_received(:find)
       end
 
-      it "does not update the form on the API" do
-        expect(form).not_to have_been_updated
+      it "does not make the form live" do
+        expect(FormRepository).not_to have_received(:make_live!)
       end
 
       it "redirects you to the archived form page" do
@@ -126,8 +112,8 @@ RSpec.describe Forms::UnarchiveController, type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it "does not update the form on the API" do
-        expect(form).not_to have_been_updated
+      it "does not make the form live" do
+        expect(FormRepository).not_to have_received(:make_live!)
       end
 
       it "re-renders the page with an error" do

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe FormsController, type: :request do
       }
     end
 
-    # TODO: will need to change to the activerecord version later
+    # TODO: Refactor this when we move from API to ActiveRecord
     before do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/api/v1/forms/999", headers, no_data_found_response, 404

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -66,21 +66,7 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
       let(:new_form_id) { 1 }
 
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms", post_headers, { id: new_form_id }.to_json, 200
-        end
-      end
-
-      it "creates a new form" do
-        post group_forms_url(group), params: { forms_name_input: valid_attributes }
-
-        expected_request = ActiveResource::Request.new(:post, "/api/v1/forms", nil, post_headers)
-
-        expect(ActiveResource::HttpMock.requests).to include expected_request
-        expect(JSON(ActiveResource::HttpMock.requests.first.body, symbolize_names: true)).to eq({
-          name: "Test form",
-          creator_id: standard_user.id,
-        })
+        allow(FormRepository).to receive(:create!).and_return(OpenStruct.new(id: new_form_id))
       end
 
       it "associates the new form with the group" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -156,11 +156,9 @@ RSpec.describe "/groups", type: :request do
 
       it "assigns a list of forms in the group to present" do
         forms = build_list(:form, 3, created_at: "2024-10-08T07:31:15.762Z") { |form, i| form.id = i }
-        ActiveResource::HttpMock.respond_to do |mock|
-          headers = { "X-API-Token" => Settings.forms_api.auth_key, "Accept" => "application/json" }
-          forms.each do |form|
-            mock.get "/api/v1/forms/#{form.id}", headers, form.to_json, 200
-          end
+
+        forms.each do |form|
+          allow(FormRepository).to receive(:find).with(form_id: form.id).and_return(form)
         end
 
         member_group.group_forms << forms.map { |form| GroupForm.create! form_id: form.id, group_id: member_group.id }

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
   let(:user) { standard_user }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as user
@@ -30,15 +32,14 @@ RSpec.describe Pages::ConditionsController, type: :request do
   describe "#routing_page" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
       get routing_page_path(form_id: form.id)
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "renders the routing page template" do
@@ -52,7 +53,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
     before do
       selected_page.id = 1
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -61,8 +61,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
       post routing_page_path(form_id: 1, params:)
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "redirects the user to the new conditions page" do
@@ -98,17 +98,16 @@ RSpec.describe Pages::ConditionsController, type: :request do
     before do
       selected_page.id = 1
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
-      allow(PageRepository).to receive(:find).with(page_id: "1", form_id: 1).and_return(selected_page)
+      allow(PageRepository).to receive(:find).and_return(selected_page)
 
       get new_condition_path(form_id: 1, page_id: 1)
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "renders the new condition page template" do
@@ -133,11 +132,10 @@ RSpec.describe Pages::ConditionsController, type: :request do
     before do
       selected_page.id = 1
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
-      allow(PageRepository).to receive(:find).with(page_id: "1", form_id: 1).and_return(selected_page)
+      allow(PageRepository).to receive(:find).and_return(selected_page)
 
       conditions_input = Pages::ConditionsInput.new(form:, page: selected_page, answer_value: "Yes", goto_page_id: 3)
 
@@ -148,8 +146,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
       post create_condition_path(form_id: form.id, page_id: selected_page.id, params: { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: 3, answer_value: "Wales" } })
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "redirects to the page list" do
@@ -195,12 +193,10 @@ RSpec.describe Pages::ConditionsController, type: :request do
       selected_page.routing_conditions = [condition]
       selected_page.position = 1
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
-      allow(PageRepository).to receive(:find).with(page_id: selected_page.id.to_s, form_id: 1).and_return(selected_page)
-
+      allow(PageRepository).to receive(:find).and_return(selected_page)
       allow(ConditionRepository).to receive(:find).and_return(condition)
 
       allow(Pages::ConditionsInput).to receive(:new).and_return(conditions_input)
@@ -210,8 +206,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
       get edit_condition_path(form_id: 1, page_id: selected_page.id, condition_id: condition.id)
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "Checks the errors from the API response" do
@@ -246,15 +242,13 @@ RSpec.describe Pages::ConditionsController, type: :request do
       selected_page.routing_conditions = [condition]
       selected_page.position = 1
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
-      allow(PageRepository).to receive(:find).with(page_id: selected_page.id.to_s, form_id: 1).and_return(selected_page)
+      allow(PageRepository).to receive(:find).and_return(selected_page)
+      allow(ConditionRepository).to receive(:find).and_return(condition)
 
       conditions_input = Pages::ConditionsInput.new(form:, page: selected_page, record: condition, answer_value: "Yes", goto_page_id: 3)
-
-      allow(ConditionRepository).to receive(:find).and_return(condition)
 
       allow(conditions_input).to receive(:update_condition).and_return(submit_result)
 
@@ -266,8 +260,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
                                 params: { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: 3, answer_value: "Wales" } })
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "redirects to the page list" do
@@ -311,11 +305,10 @@ RSpec.describe Pages::ConditionsController, type: :request do
       selected_page.routing_conditions = [condition]
       selected_page.position = 1
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
-      allow(PageRepository).to receive(:find).with(page_id: selected_page.id.to_s, form_id: 1).and_return(selected_page)
+      allow(PageRepository).to receive(:find).and_return(selected_page)
 
       allow(ConditionRepository).to receive(:find).and_return(condition)
 
@@ -328,8 +321,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
       get delete_condition_path(form_id: 1, page_id: selected_page.id, condition_id: condition.id)
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "renders the delete condition page template" do
@@ -358,14 +351,11 @@ RSpec.describe Pages::ConditionsController, type: :request do
       selected_page.routing_conditions = [condition]
       selected_page.position = 1
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
-      allow(PageRepository).to receive(:find).with(page_id: selected_page.id.to_s, form_id: 1).and_return(selected_page)
-
-      allow(ConditionRepository).to receive(:find).and_return(condition)
-      allow(ConditionRepository).to receive(:destroy)
+      allow(PageRepository).to receive(:find).and_return(selected_page)
+      allow(ConditionRepository).to receive_messages(find: condition, destroy: nil)
 
       delete_condition_input = Pages::DeleteConditionInput.new(form:, page: selected_page, record: condition, answer_value: "Wales", goto_page_id: 3, confirm:)
 
@@ -379,8 +369,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
                                     params: { pages_delete_condition_input: { confirm:, goto_page_id: 3, answer_value: "Wales" } })
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "redirects to the page list" do

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe Pages::GuidanceController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+    allow(PageRepository).to receive(:find).and_return(page)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
@@ -25,15 +28,14 @@ RSpec.describe Pages::GuidanceController, type: :request do
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
       get guidance_new_path(form_id: form.id)
     end
 
-    it "reads the existing form" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "renders the template" do
@@ -58,7 +60,6 @@ RSpec.describe Pages::GuidanceController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -69,8 +70,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
     context "when previewing markdown" do
       let(:route_to) { "preview" }
 
-      it "reads the existing form" do
-        expect(form).to have_been_read
+      it "reads the form" do
+        expect(FormRepository).to have_received(:find)
       end
 
       it "renders the template" do
@@ -96,8 +97,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
       context "when markdown is blank" do
         let(:guidance_markdown) { "" }
 
-        it "reads the existing form" do
-          expect(form).to have_been_read
+        it "reads the form" do
+          expect(FormRepository).to have_received(:find)
         end
 
         it "renders the template" do
@@ -117,8 +118,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
     context "when saving markdown" do
       let(:route_to) { "save_and_continue" }
 
-      it "reads the existing form" do
-        expect(form).to have_been_read
+      it "reads the form" do
+        expect(FormRepository).to have_received(:find)
       end
 
       it "saves the page_heading and guidance_markdown to session" do
@@ -147,7 +148,6 @@ RSpec.describe Pages::GuidanceController, type: :request do
   describe "#edit" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -156,8 +156,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
       get guidance_edit_path(form_id: form.id, page_id: page.id)
     end
 
-    it "reads the existing form" do
-      expect(form).to have_been_read
+    it "reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "renders the template" do
@@ -183,10 +183,9 @@ RSpec.describe Pages::GuidanceController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
-      allow(PageRepository).to receive(:find).with(page_id: page.id.to_s, form_id: 1).and_return(page)
+
       allow(controller_spy).to receive(:draft_question).and_return(draft_question)
       post guidance_update_path(form_id: form.id, page_id: page.id), params: { pages_guidance_input: { page_heading:, guidance_markdown: }, route_to: }
     end
@@ -194,8 +193,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
     context "when previewing markdown" do
       let(:route_to) { "preview" }
 
-      it "reads the existing form" do
-        expect(form).to have_been_read
+      it "reads the form" do
+        expect(FormRepository).to have_received(:find)
       end
 
       it "renders the template" do
@@ -221,8 +220,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
       context "when markdown is blank" do
         let(:guidance_markdown) { "" }
 
-        it "reads the existing form" do
-          expect(form).to have_been_read
+        it "reads the form" do
+          expect(FormRepository).to have_received(:find)
         end
 
         it "renders the template" do
@@ -242,8 +241,8 @@ RSpec.describe Pages::GuidanceController, type: :request do
     context "when saving markdown" do
       let(:route_to) { "save_and_continue" }
 
-      it "reads the existing form" do
-        expect(form).to have_been_read
+      it "reads the form" do
+        expect(FormRepository).to have_received(:find)
       end
 
       it "saves the page_heading and guidance_markdown to session" do

--- a/spec/requests/pages/name_settings_controller_spec.rb
+++ b/spec/requests/pages/name_settings_controller_spec.rb
@@ -3,12 +3,16 @@ require "rails_helper"
 RSpec.describe Pages::NameSettingsController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
+  let(:page) { pages.first }
 
   let(:name_settings_input) { build :name_settings_input }
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+    allow(PageRepository).to receive_messages(find: page, save!: page)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
@@ -17,7 +21,6 @@ RSpec.describe Pages::NameSettingsController, type: :request do
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -25,7 +28,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "sets an instance variable for name_settings_path" do
@@ -41,7 +44,6 @@ RSpec.describe Pages::NameSettingsController, type: :request do
   describe "#create" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
     end
@@ -90,7 +92,6 @@ RSpec.describe Pages::NameSettingsController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -101,7 +102,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns the existing input type" do
@@ -128,7 +129,6 @@ RSpec.describe Pages::NameSettingsController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 

--- a/spec/requests/pages/question_text_controller_spec.rb
+++ b/spec/requests/pages/question_text_controller_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Pages::QuestionTextController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
@@ -17,7 +19,6 @@ RSpec.describe Pages::QuestionTextController, type: :request do
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -25,7 +26,7 @@ RSpec.describe Pages::QuestionTextController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "sets an instance variable for question_text_path" do
@@ -41,7 +42,6 @@ RSpec.describe Pages::QuestionTextController, type: :request do
   describe "#create" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
     end

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe Pages::QuestionsController, type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2", headers, form_response.to_json, 200
       mock.get "/api/v1/forms/2/pages", headers, form_pages_response, 200
     end
 
+    allow(FormRepository).to receive(:find).and_return(form_response)
     allow(PageRepository).to receive_messages(create!: page, find: page, save!: updated_page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -100,13 +100,8 @@ RSpec.describe Pages::QuestionsController, type: :request do
       get new_question_path(form_id: 2)
     end
 
-    it "Reads the form from the API" do
-      expect(form_response).to have_been_read
-    end
-
-    it "Reads the pages from the API" do
-      form_pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
-      expect(ActiveResource::HttpMock.requests).to include form_pages_request
+    it "Reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns 200" do

--- a/spec/requests/pages/routes_controller_spec.rb
+++ b/spec/requests/pages/routes_controller_spec.rb
@@ -22,6 +22,9 @@ describe Pages::RoutesController, type: :request do
   let(:user) { standard_user }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+    allow(PageRepository).to receive(:find).and_return(page)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as user
@@ -30,7 +33,6 @@ describe Pages::RoutesController, type: :request do
   describe "#show" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -39,8 +41,8 @@ describe Pages::RoutesController, type: :request do
       get show_routes_path(form_id: form.id, page_id: selected_page.id)
     end
 
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
+    it "Reads the form" do
+      expect(FormRepository).to have_received(:find)
     end
 
     it "renders the routing page template" do

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     login_as_standard_user
 
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2", headers, form.to_json, 200
       mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
     end
 
+    allow(FormRepository).to receive(:find).and_return(form)
     allow(PageRepository).to receive(:find).and_return(pages.first)
     allow(ConditionRepository).to receive_messages(create!: {}, find: {}, save!: {}, destroy: {})
   end

--- a/spec/requests/pages/selection/bulk_options_controller_spec.rb
+++ b/spec/requests/pages/selection/bulk_options_controller_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe Pages::Selection::BulkOptionsController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
+  let(:page) { pages.first }
 
   let(:draft_question) do
     create :draft_question,
@@ -19,6 +20,9 @@ describe Pages::Selection::BulkOptionsController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+    allow(PageRepository).to receive_messages(find: page, save!: page)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
@@ -27,7 +31,6 @@ describe Pages::Selection::BulkOptionsController, type: :request do
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
       draft_question
@@ -35,7 +38,7 @@ describe Pages::Selection::BulkOptionsController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "sets an instance variable for back_link_url" do
@@ -76,7 +79,6 @@ describe Pages::Selection::BulkOptionsController, type: :request do
   describe "#create" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
       draft_question
@@ -120,7 +122,6 @@ describe Pages::Selection::BulkOptionsController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
@@ -129,7 +130,7 @@ describe Pages::Selection::BulkOptionsController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns the existing draft question answer settings" do
@@ -161,7 +162,6 @@ describe Pages::Selection::BulkOptionsController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 

--- a/spec/requests/pages/selection/options_controller_spec.rb
+++ b/spec/requests/pages/selection/options_controller_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe Pages::Selection::OptionsController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
+  let(:page) { pages.first }
 
   let(:draft_question) do
     create :draft_question,
@@ -19,6 +20,9 @@ describe Pages::Selection::OptionsController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+    allow(PageRepository).to receive_messages(find: page, save!: page)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
@@ -27,7 +31,6 @@ describe Pages::Selection::OptionsController, type: :request do
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
       draft_question
@@ -35,7 +38,7 @@ describe Pages::Selection::OptionsController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "sets an instance variable for selection_options_path" do
@@ -76,7 +79,6 @@ describe Pages::Selection::OptionsController, type: :request do
   describe "#create" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
       draft_question
@@ -136,7 +138,6 @@ describe Pages::Selection::OptionsController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -147,7 +148,7 @@ describe Pages::Selection::OptionsController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns the existing draft question answer settings" do
@@ -178,7 +179,6 @@ describe Pages::Selection::OptionsController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 

--- a/spec/requests/pages/selection/type_controller_spec.rb
+++ b/spec/requests/pages/selection/type_controller_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe Pages::Selection::TypeController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
+  let(:page) { pages.first }
 
   let(:only_one_option) { "true" }
   let(:answer_settings) do
@@ -23,6 +24,9 @@ describe Pages::Selection::TypeController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+    allow(PageRepository).to receive_messages(find: page, save!: page)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
@@ -31,7 +35,6 @@ describe Pages::Selection::TypeController, type: :request do
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
       draft_question
@@ -39,7 +42,7 @@ describe Pages::Selection::TypeController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "sets an instance variable for selection_type_path" do
@@ -71,7 +74,6 @@ describe Pages::Selection::TypeController, type: :request do
   describe "#create" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
     end
@@ -110,7 +112,6 @@ describe Pages::Selection::TypeController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -121,7 +122,7 @@ describe Pages::Selection::TypeController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns the existing draft question answer settings" do
@@ -155,7 +156,6 @@ describe Pages::Selection::TypeController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 

--- a/spec/requests/pages/text_settings_controller_spec.rb
+++ b/spec/requests/pages/text_settings_controller_spec.rb
@@ -3,12 +3,16 @@ require "rails_helper"
 RSpec.describe Pages::TextSettingsController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
+  let(:page) { pages.first }
 
   let(:text_settings_input) { build :text_settings_input }
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+    allow(PageRepository).to receive_messages(find: page, save!: page)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
@@ -17,7 +21,6 @@ RSpec.describe Pages::TextSettingsController, type: :request do
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -25,7 +28,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "sets an instance variable for text_settings_path" do
@@ -41,7 +44,6 @@ RSpec.describe Pages::TextSettingsController, type: :request do
   describe "#create" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
     end
@@ -89,7 +91,6 @@ RSpec.describe Pages::TextSettingsController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -100,7 +101,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns the existing page input type" do
@@ -123,7 +124,6 @@ RSpec.describe Pages::TextSettingsController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -3,13 +3,16 @@ require "rails_helper"
 RSpec.describe Pages::TypeOfAnswerController, type: :request do
   let(:form) { build :form, id: 1 }
   let(:pages) { build_list :page, 5, form_id: form.id }
-
+  let(:page) { pages.first }
   let(:type_of_answer_input) { build :type_of_answer_input }
 
   let(:file_upload_enabled) { false }
   let(:group) { create(:group, organisation: standard_user.organisation, file_upload_enabled:) }
 
   before do
+    allow(FormRepository).to receive(:find).and_return(form)
+    allow(PageRepository).to receive_messages(find: page, save!: page)
+
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
@@ -18,7 +21,6 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
   describe "#new" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -26,7 +28,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "sets an instance variable for type_of_answer_path" do
@@ -56,7 +58,6 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
   describe "#create" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
     end
@@ -166,7 +167,6 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
@@ -176,7 +176,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
     end
 
     it "reads the existing form" do
-      expect(form).to have_been_read
+      expect(FormRepository).to have_received(:find)
     end
 
     it "returns the existing page answer type" do
@@ -213,7 +213,6 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -23,18 +23,12 @@ RSpec.describe PagesController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2", headers, form.to_json, 200
         mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
       end
 
+      allow(FormRepository).to receive(:find).and_return(form)
+
       get form_pages_path(2)
-    end
-
-    it "Reads the form from the API" do
-      expect(form).to have_been_read
-
-      pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/2", {}, headers)
-      expect(ActiveResource::HttpMock.requests).to include pages_request
     end
 
     context "with a form in a group that the user is not a member of" do
@@ -61,9 +55,7 @@ RSpec.describe PagesController, type: :request do
     let(:original_draft_question) { create :draft_question, form_id: 1, user: standard_user }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, current_form.to_json, 200
-      end
+      allow(FormRepository).to receive(:find).and_return(current_form)
 
       GroupForm.create!(form_id: current_form.id, group_id: group.id)
     end
@@ -102,10 +94,7 @@ RSpec.describe PagesController, type: :request do
       end
 
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", headers, form_response.to_json, 200
-        end
-
+        allow(FormRepository).to receive(:find).and_return(form_response)
         allow(PageRepository).to receive_messages(find: page, destroy: true)
 
         GroupForm.create!(form_id: 2, group_id: group.id)
@@ -150,11 +139,10 @@ RSpec.describe PagesController, type: :request do
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2", headers, form_response.to_json, 200
           mock.get "/api/v1/forms/2/pages", headers, form_pages_response, 200
-          mock.put "/api/v1/forms/2", post_headers
         end
 
+        allow(FormRepository).to receive(:find).and_return(form_response)
         allow(PageRepository).to receive_messages(find: page, destroy: true)
 
         GroupForm.create!(form_id: 2, group_id: group.id)
@@ -196,10 +184,10 @@ RSpec.describe PagesController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1", headers, form.to_json, 200
         mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
       end
 
+      allow(FormRepository).to receive(:find).and_return(form)
       allow(PageRepository).to receive_messages(find: pages[1], move_page: true)
 
       GroupForm.create!(form_id: 2, group_id: group.id)

--- a/spec/services/archive_form_service_spec.rb
+++ b/spec/services/archive_form_service_spec.rb
@@ -12,7 +12,7 @@ describe ArchiveFormService do
 
   describe "#archive" do
     before do
-      allow(form).to receive(:archive!)
+      allow(FormRepository).to receive(:archive!)
       allow(SubmissionEmailMailer).to receive(:alert_processor_form_archive)
                                         .with(anything)
                                         .and_return(delivery)
@@ -20,7 +20,7 @@ describe ArchiveFormService do
     end
 
     it "calls archive! on the form" do
-      expect(form).to receive(:archive!)
+      expect(FormRepository).to receive(:archive!)
       archive_form_service.archive
     end
 

--- a/spec/services/default_group_service_spec.rb
+++ b/spec/services/default_group_service_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe DefaultGroupService do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms?creator_id=#{user.id}", headers, forms_response.to_json, 200
-      end
+      allow(FormRepository).to receive(:where).with(creator_id: user.id).and_return(forms_response)
     end
 
     context "when the user does not already have a trial group" do
@@ -115,9 +113,7 @@ RSpec.describe DefaultGroupService do
       before do
         another_user = create :user, name: "Batman", email: "batsignal@example.gov.uk", organisation: user.organisation
 
-        ActiveResource::HttpMock.respond_to(false) do |mock|
-          mock.get "/api/v1/forms?creator_id=#{another_user.id}", headers, [build(:form, id: 10)].to_json, 200
-        end
+        allow(FormRepository).to receive(:where).with(creator_id: another_user.id).and_return([build(:form, id: 10)])
 
         default_group_service.create_user_default_trial_group!(another_user)
       end
@@ -137,9 +133,7 @@ RSpec.describe DefaultGroupService do
         before do
           yet_another_user = create :user, name: "Batman", email: "batman@joker.example.com", organisation: user.organisation
 
-          ActiveResource::HttpMock.respond_to(false) do |mock|
-            mock.get "/api/v1/forms?creator_id=#{yet_another_user.id}", headers, [build(:form, id: 100)].to_json, 200
-          end
+          allow(FormRepository).to receive(:where).with(creator_id: yet_another_user.id).and_return([build(:form, id: 100)])
 
           default_group_service.create_user_default_trial_group!(yet_another_user)
         end

--- a/spec/services/form_repository_spec.rb
+++ b/spec/services/form_repository_spec.rb
@@ -1,0 +1,148 @@
+require "rails_helper"
+
+describe FormRepository do
+  describe "#create!" do
+    let(:form_params) { { creator_id: 1, name: "asdf" } }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms", post_headers, Form.new(form_params).to_json, 200
+      end
+    end
+
+    it "creates a form through ActiveResource" do
+      described_class.create!(**form_params)
+      expect(Form.new(form_params)).to have_been_created
+    end
+  end
+
+  describe "#find" do
+    let(:form) { build(:form, id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2", headers, form.to_json, 200
+      end
+    end
+
+    it "finds the form through ActiveResource" do
+      described_class.find(form_id: 2)
+      expect(Form.new(id: 2)).to have_been_read
+    end
+  end
+
+  describe "#find_live" do
+    let(:form) { build(:form, id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2/live", headers, form.to_json, 200
+      end
+    end
+
+    it "calls the find_live endpoint through ActiveResource" do
+      find_live_request = ActiveResource::Request.new(:get, "/api/v1/forms/2/live", form, headers)
+      described_class.find_live(form_id: 2)
+      expect(ActiveResource::HttpMock.requests).to include find_live_request
+    end
+  end
+
+  describe "#find_archived" do
+    let(:form) { build(:form, id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2/archived", headers, form.to_json, 200
+      end
+    end
+
+    it "calls the find_archived endpoint through ActiveResource" do
+      find_archived_request = ActiveResource::Request.new(:get, "/api/v1/forms/2/archived", form, headers)
+      described_class.find_archived(form_id: 2)
+      expect(ActiveResource::HttpMock.requests).to include find_archived_request
+    end
+  end
+
+  describe "#where" do
+    let(:form) { build(:form, id: 2, creator_id: 3) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms?creator_id=3", headers, [form].to_json, 200
+      end
+    end
+
+    it "calls the where endpoint through ActiveResource" do
+      where_request = ActiveResource::Request.new(:get, "/api/v1/forms?creator_id=3", [form], headers)
+      described_class.where(creator_id: 3)
+      expect(ActiveResource::HttpMock.requests).to include where_request
+    end
+  end
+
+  describe "#save!" do
+    let(:form) { build(:form, id: 2, name: "original name") }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2", headers, form.to_json, 200
+        mock.put "/api/v1/forms/2", post_headers
+      end
+    end
+
+    it "updates the form through ActiveResource" do
+      form = described_class.find(form_id: 2)
+      form.name = "new name"
+      described_class.save!(form)
+      expect(Form.new(id: 2, name: "new name")).to have_been_updated
+    end
+  end
+
+  describe "#make_live!" do
+    let(:form) { build(:form, id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms/2/make-live", post_headers, form.to_json, 200
+      end
+    end
+
+    it "calls the make-live endpoint through ActiveResource" do
+      make_live_request = ActiveResource::Request.new(:post, "/api/v1/forms/2/make-live", {}, post_headers)
+      described_class.make_live!(form)
+      expect(ActiveResource::HttpMock.requests).to include make_live_request
+    end
+  end
+
+  describe "#archive!" do
+    let(:form) { build(:form, id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms/2/archive", post_headers, form.to_json, 200
+      end
+    end
+
+    it "calls the archive endpoint through ActiveResource" do
+      archive_request = ActiveResource::Request.new(:post, "/api/v1/forms/2/archive", {}, post_headers)
+      described_class.archive!(form)
+      expect(ActiveResource::HttpMock.requests).to include archive_request
+    end
+  end
+
+  describe "#destroy" do
+    let(:form) { build(:form, id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2", headers, form.to_json, 200
+        mock.delete "/api/v1/forms/2", delete_headers, nil, 204
+      end
+    end
+
+    it "destroys the form through ActiveResource" do
+      form = described_class.find(form_id: 2)
+      described_class.destroy(form)
+      expect(Form.new(id: 2)).to have_been_deleted
+    end
+  end
+end

--- a/spec/services/make_form_live_service_spec.rb
+++ b/spec/services/make_form_live_service_spec.rb
@@ -8,11 +8,11 @@ describe MakeFormLiveService do
 
   describe "#make_live" do
     before do
-      allow(current_form).to receive(:make_live!).and_return(true)
+      allow(FormRepository).to receive_messages(make_live!: true, find_live: live_form)
     end
 
-    it "calls make_live! on the current form" do
-      expect(current_form).to receive(:make_live!)
+    it "calls make_live! on the Form Repository with the current form" do
+      expect(FormRepository).to receive(:make_live!).with(current_form)
       make_form_live_service.make_live
     end
 
@@ -25,12 +25,6 @@ describe MakeFormLiveService do
       let(:live_form) { build :form, :live }
       let(:current_form) do
         live_form.clone
-      end
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{live_form.id}/live", headers, live_form.to_json, 200
-        end
       end
 
       context "when submission email has not been changed" do
@@ -72,9 +66,7 @@ describe MakeFormLiveService do
       end
 
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{live_form.id}/live", headers, live_form.to_json, 200
-        end
+        allow(FormRepository).to receive(:find_live).and_return(live_form)
       end
 
       it "returns a different page title" do
@@ -95,9 +87,7 @@ describe MakeFormLiveService do
       end
 
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{live_form.id}/live", headers, live_form.to_json, 200
-        end
+        allow(FormRepository).to receive(:find_live).and_return(live_form)
       end
 
       it "returns different confirmation page body" do


### PR DESCRIPTION
### What problem does this pull request solve?
https://trello.com/c/eL8l9JU1/1994-add-repository-service-to-forms-admin-for-form-model

Adds the `forms_repository` as a service, and tries to replace any and all uses of the Form model with calls to the repo instead. There are a couple of spots where it will be difficult to separate the model from ActiveResource, and it will probably be easier to do it later once we've shifted the data across. I've left a few todos in place to identify these spots, I'm just double checking to make sure. 

I'll need to do a followup PR to cover uses of `form.pages` as we do use this a lot, but it was going to get messy trying to do this as part of this main PR. 

### Things to consider when reviewing

There are quite a lot of changes, and I've segmented them into commits by the sort of file being changed - controllers, views etc, as well as the corresponding tests. There may be some underlap, where some commits change tests that won't pass without subsequent commits but I think for review purposes it's less confusing to change things in this pattern. I'm happy to shift things around though for clarity.

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
