### PR TITLE
Add task to delete users with no name or org set

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -107,7 +107,8 @@ def delete_users_with_no_name_or_org(dry_run: false)
       if dry_run || form.destroy
         Rails.logger.info "#{task_name}: Deleted form #{form.id} (\"#{form.name}\") created by user #{user.id} (#{user.email})"
       else
-        Rails.logger.info "#{task_name}: Unable to delete form #{form.id} (\"#{form.name}\") created by user #{user.id}"
+        Rails.logger.info "#{task_name}: Unable to delete form #{form.id} (\"#{form.name}\") created by user, skipping deleting user #{user.id} (#{user.email})"
+        next
       end
     end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -24,6 +24,18 @@ namespace :users do
     # Before running the task, remove the user from any groups and reassign their forms to another user.
     run_deletion_task("delete_user", args, rollback: false)
   end
+
+  desc "Delete users with no name or organisation set"
+  task delete_users_with_no_name_or_org: :environment do
+    delete_users_with_no_name_or_org
+  end
+
+  namespace :delete_users_with_no_name_or_org do
+    desc "Delete users with no name or organisation set - dry run"
+    task dry_run: :environment do
+      delete_users_with_no_name_or_org(dry_run: true)
+    end
+  end
 end
 
 def update_user_roles
@@ -53,4 +65,60 @@ def run_deletion_task(task_name, args, rollback:)
     Rails.logger.info("users:delete_user_dry_run: rollback deletion of user #{args[:user_id]}") if rollback
     raise ActiveRecord::Rollback if rollback
   end
+end
+
+def delete_users_with_no_name_or_org(dry_run: false)
+  task_name = "users:#{__method__}"
+  task_name = "#{task_name}:dry_run" if dry_run
+
+  users = User.where(name: nil).or(User.where(organisation: nil))
+  users_count = users.count
+  deleted_count = 0
+
+  Rails.logger.info "#{task_name}: Found #{users.count} users without a name or organisation set"
+
+  users.find_each do |user|
+    Rails.logger.info "#{task_name}: Found user #{user.id} (#{user.email}) without a name or organisation set"
+
+    if user.last_signed_in_at && (Time.zone.now - user.last_signed_in_at) < 20.hours
+      Rails.logger.info "#{task_name}: User could still have active session, skipping deleting user #{user.id} (#{user.email})"
+      next
+    end
+
+    if user.memberships.present?
+      Rails.logger.info "#{task_name}: Found user in groups #{user.memberships.pluck(:group_id)}, skipping deleting user #{user.id} (#{user.email})"
+      next
+    end
+
+    forms = Form.where(creator_id: user.id).find_all
+
+    if forms.any?(&:is_live?)
+      Rails.logger.info "#{task_name}: Found live forms #{forms.select(&:is_live?).map(&:id)} created by user, skipping deleting user #{user.id} (#{user.email})"
+      next
+    end
+
+    forms_in_groups = GroupForm.where(form_id: forms.map(&:id)).pluck(:form_id)
+    if forms_in_groups.any?
+      Rails.logger.info "#{task_name}: Found forms #{forms_in_groups} created by user in groups, skipping deleting user #{user.id} (#{user.email})"
+      next
+    end
+
+    forms.each do |form|
+      if dry_run || form.destroy
+        Rails.logger.info "#{task_name}: Deleted form #{form.id} (\"#{form.name}\") created by user #{user.id} (#{user.email})"
+      else
+        Rails.logger.info "#{task_name}: Unable to delete form #{form.id} (\"#{form.name}\") created by user #{user.id}"
+      end
+    end
+
+    if dry_run || user.destroy
+      Rails.logger.info "#{task_name}: Deleted user #{user.id} (#{user.email})"
+      deleted_count += 1
+    else
+      Rails.logger.info "#{task_name}: Unable to delete user #{user.id} (#{user.email})"
+    end
+  end
+
+  Rails.logger.info "#{task_name}: Deleted #{deleted_count} users, skipped deleting #{users_count - deleted_count} users"
+  Rails.logger.info "#{task_name}: Finished dry run, no changes persisted" if dry_run
 end

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     role { :standard }
     has_access { true }
     created_at { Faker::Time.between(from: Time.zone.local(2022, 3, 8), to: Time.zone.now) }
+    updated_at { created_at }
+    last_signed_in_at { created_at }
     terms_agreed_at { Time.zone.now }
 
     factory :basic_auth_user do
@@ -50,6 +52,15 @@ FactoryBot.define do
 
     trait :with_no_name do
       name { nil }
+    end
+
+    trait :old do
+      created_at { Faker::Time.between(from: Time.zone.local(2022, 3, 8), to: Time.zone.local(2022, 4, 11)) }
+      last_signed_in_at { nil }
+    end
+
+    trait :new do
+      created_at { Faker::Time.between(from: 18.hours.ago, to: Time.zone.now) }
     end
   end
 end

--- a/spec/lib/tasks/users.rake_spec.rb
+++ b/spec/lib/tasks/users.rake_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "users.rake" do
           task.invoke(user_to_delete.id)
 
           user_to_delete.reload
-        }.not_to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
 
       it "logs the deletion and the rollback" do

--- a/spec/lib/tasks/users.rake_spec.rb
+++ b/spec/lib/tasks/users.rake_spec.rb
@@ -96,4 +96,370 @@ RSpec.describe "users.rake" do
       end
     end
   end
+
+  describe "users:delete_users_with_no_name_or_org" do
+    subject(:task) do
+      Rake::Task["users:delete_users_with_no_name_or_org"]
+        .tap(&:reenable) # make sure task is invoked every time
+    end
+
+    let(:users) do
+      [].concat(
+        create_list(:user, 3, :old),
+        create_list(:user, 3, :old, :with_no_name),
+        create_list(:user, 3, :old, :with_no_org),
+        create_list(:user, 3, :old, :with_no_name, :with_no_org),
+      )
+    end
+
+    let(:forms) { [] }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        forms_by_user_id = forms.group_by(&:creator_id)
+        users.each do |user|
+          mock.get "/api/v1/forms?creator_id=#{user.id}", headers, forms_by_user_id.fetch(user.id, []).to_json, 200
+        end
+
+        forms.each do |form|
+          mock.delete "/api/v1/forms/#{form.id}", delete_headers, nil, 204
+        end
+      end
+
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it "deletes users with no name or organisation set" do
+      expect {
+        task.invoke
+      }.to change(User, :count).to(3)
+    end
+
+    it "logs deleting each user" do
+      task.invoke
+
+      expect(Rails.logger).to have_received(:info).with(/delete_users_with_no_name_or_org: Deleted user \d+ \(.+@.+\)/).exactly(9)
+    end
+
+    it "logs the number of users deleted" do
+      task.invoke
+
+      expect(Rails.logger).to have_received(:info).with(/delete_users_with_no_name_or_org: Deleted 9 users/)
+    end
+
+    context "when the user has only just started using the service" do
+      let!(:new_user) do
+        users[8].update!(attributes_for(:user, :new, :with_no_org))
+        users[8]
+      end
+
+      it "does not delete that user" do
+        task.invoke
+
+        expect(User.exists?(new_user.id)).to be true
+      end
+
+      it "deletes other users not in a group" do
+        expect {
+          task.invoke
+        }.to change(User, :count).to(4)
+      end
+
+      it "logs that the user is being skipped" do
+        task.invoke
+
+        expect(Rails.logger).to have_received(:info).with(
+          /delete_users_with_no_name_or_org: User could still have active session, skipping deleting user \d+/,
+        )
+      end
+
+      it "counts the user as being skipped" do
+        task.invoke
+
+        expect(Rails.logger).to have_received(:info).with(
+          /delete_users_with_no_name_or_org: Deleted 8 users, skipped deleting 1 users/,
+        )
+      end
+    end
+
+    context "when user is in one or more groups" do
+      let(:user_in_group) { users.fifth }
+
+      let(:forms) do
+        build_list :form, 3, creator_id: user_in_group.id
+      end
+
+      before do
+        group = create :group, creator: users.first
+        create :membership, group:, user: user_in_group, added_by: users.first
+      end
+
+      it "does not delete that user" do
+        task.invoke
+
+        expect(User.exists?(user_in_group.id)).to be true
+      end
+
+      it "does not delete any of that user's forms" do
+        task.invoke
+
+        forms
+          .select { |form| form.creator_id == user_in_group.id }
+          .each do |form|
+            expect(form).not_to have_been_deleted
+          end
+      end
+
+      it "deletes other users not in a group" do
+        expect {
+          task.invoke
+        }.to change(User, :count).to(4)
+      end
+
+      it "logs that the user is being skipped" do
+        task.invoke
+
+        expect(Rails.logger).to have_received(:info).with(
+          /delete_users_with_no_name_or_org: Found user in groups \[\d+\], skipping deleting user \d+/,
+        )
+      end
+
+      it "counts the user as being skipped" do
+        task.invoke
+
+        expect(Rails.logger).to have_received(:info).with(
+          /delete_users_with_no_name_or_org: Deleted 8 users, skipped deleting 1 users/,
+        )
+      end
+    end
+
+    context "when user has created one or more forms" do
+      let(:forms) do
+        [
+          build(:form, id: 99, creator_id: users.first.id),
+          build(:form, id: 1, creator_id: users.last.id),
+          build(:form, id: 2, creator_id: users.second_to_last.id),
+          build(:form, id: 3, creator_id: users.second_to_last.id),
+        ]
+      end
+
+      it "deletes the forms" do
+        task.invoke
+
+        expect(ActiveResource::HttpMock
+          .requests.count { |request| request.method == :delete })
+          .to eq 3
+      end
+
+      it "logs deleting each form" do
+        task.invoke
+
+        expect(Rails.logger).to have_received(:info).with(/delete_users_with_no_name_or_org: Deleted form 1/)
+        expect(Rails.logger).to have_received(:info).with(/delete_users_with_no_name_or_org: Deleted form 2/)
+        expect(Rails.logger).to have_received(:info).with(/delete_users_with_no_name_or_org: Deleted form 3/)
+      end
+
+      context "and one or more of the forms have been made live" do
+        let(:user_with_live_form) { users.second_to_last }
+        let(:forms) do
+          [
+            build(:form, id: 99, creator_id: users.first.id),
+            build(:form, id: 1, creator_id: users.last.id),
+            build(:form, id: 2, creator_id: user_with_live_form.id),
+            build(:form, :live, id: 3, creator_id: user_with_live_form.id),
+          ]
+        end
+
+        it "does not delete that user" do
+          task.invoke
+
+          expect(User.exists?(user_with_live_form.id)).to be true
+        end
+
+        it "does not delete any of that user's forms" do
+          task.invoke
+
+          forms
+            .select { |form| form.creator_id == user_with_live_form.id }
+            .each do |form|
+              expect(form).not_to have_been_deleted
+            end
+        end
+
+        it "deletes other users without live forms" do
+          expect {
+            task.invoke
+          }.to change(User, :count).to(4)
+        end
+
+        it "logs that the user is being skipped" do
+          task.invoke
+
+          expect(Rails.logger).to have_received(:info).with(
+            /delete_users_with_no_name_or_org: Found live forms \[3\] created by user, skipping deleting user \d+/,
+          )
+        end
+
+        it "counts the user as being skipped" do
+          task.invoke
+
+          expect(Rails.logger).to have_received(:info).with(
+            /delete_users_with_no_name_or_org: Deleted 8 users, skipped deleting 1 users/,
+          )
+        end
+      end
+
+      context "and one or more of the forms are in a group" do
+        let(:user_with_form_in_group) { users.last }
+
+        let(:form_in_group) { forms.last }
+
+        let(:forms) do
+          [
+            build(:form, id: 99, creator_id: users.first.id),
+            build(:form, id: 1, creator_id: user_with_form_in_group.id),
+            build(:form, id: 2, creator_id: users.second_to_last.id),
+            build(:form, id: 3, creator_id: users.second_to_last.id),
+            build(:form, id: 4, creator_id: user_with_form_in_group.id),
+          ]
+        end
+
+        before do
+          GroupForm.create!(
+            form_id: form_in_group.id,
+            group: create(:group, creator: users.first),
+          )
+        end
+
+        it "does not delete that user" do
+          task.invoke
+
+          expect(User.exists?(user_with_form_in_group.id)).to be true
+        end
+
+        it "does not delete any of that user's forms" do
+          task.invoke
+
+          forms
+            .select { |form| form.creator_id == user_with_form_in_group.id }
+            .each do |form|
+              expect(form).not_to have_been_deleted
+            end
+        end
+
+        it "deletes other users without forms in groups" do
+          expect {
+            task.invoke
+          }.to change(User, :count).to(4)
+        end
+
+        it "logs that the user is being skipped" do
+          task.invoke
+
+          expect(Rails.logger).to have_received(:info).with(
+            /delete_users_with_no_name_or_org: Found forms \[4\] created by user in groups, skipping deleting user \d+/,
+          )
+        end
+
+        it "counts the user as being skipped" do
+          task.invoke
+
+          expect(Rails.logger).to have_received(:info).with(
+            /delete_users_with_no_name_or_org: Deleted 8 users, skipped deleting 1 users/,
+          )
+        end
+      end
+    end
+
+    describe ":dry_run" do
+      subject(:dry_run_task) do
+        Rake::Task["users:delete_users_with_no_name_or_org:dry_run"]
+          .tap(&:reenable) # make sure task is invoked every time
+      end
+
+      let(:user_in_group) { users.fifth }
+      let(:user_with_live_form) { users.second_to_last }
+      let(:user_with_form_in_group) { users.last }
+
+      let(:group_with_user) { create :group, creator: users.first }
+      let(:form_in_group) { forms.last }
+
+      let(:forms) do
+        [
+          build(:form, id: 99, creator_id: users.first.id),
+          build(:form, id: 1, creator_id: user_with_form_in_group.id),
+          build(:form, id: 2, creator_id: user_with_live_form.id),
+          build(:form, :live, id: 3, creator_id: user_with_live_form.id),
+          build(:form, id: 5, creator_id: users[5].id),
+          build(:form, id: 7, creator_id: users[7].id),
+          build(:form, id: 4, creator_id: user_with_form_in_group.id),
+        ]
+      end
+
+      before do
+        create :membership, group: group_with_user, user: user_in_group, added_by: users.first
+
+        GroupForm.create!(
+          form_id: form_in_group.id,
+          group: create(:group, creator: users.first),
+        )
+      end
+
+      it "logs the changes that would be made" do
+        dry_run_task.invoke
+
+        [
+          "users:delete_users_with_no_name_or_org:dry_run: Found 9 users without a name or organisation set",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Found user #{users[3].id} (#{users[3].email}) without a name or organisation set",
+          "users:delete_users_with_no_name_or_org:dry_run: Deleted user #{users[3].id} (#{users[3].email})",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Found user #{user_in_group.id} (#{user_in_group.email}) without a name or organisation set",
+          "users:delete_users_with_no_name_or_org:dry_run: Found user in groups [#{group_with_user.id}], skipping deleting user #{user_in_group.id} (#{user_in_group.email})",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Found user #{users[5].id} (#{users[5].email}) without a name or organisation set",
+          /users:delete_users_with_no_name_or_org:dry_run: Deleted form 5 \(".+"\) created by user #{users[5].id} \(#{users[5].email}\)/,
+          "users:delete_users_with_no_name_or_org:dry_run: Deleted user #{users[5].id} (#{users[5].email})",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Found user #{users[6].id} (#{users[6].email}) without a name or organisation set",
+          "users:delete_users_with_no_name_or_org:dry_run: Deleted user #{users[6].id} (#{users[6].email})",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Found user #{users[7].id} (#{users[7].email}) without a name or organisation set",
+          /users:delete_users_with_no_name_or_org:dry_run: Deleted form 7 \(".+"\) created by user #{users[7].id} \(#{users[7].email}\)/,
+          "users:delete_users_with_no_name_or_org:dry_run: Deleted user #{users[7].id} (#{users[7].email})",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Found user #{users[8].id} (#{users[8].email}) without a name or organisation set",
+          "users:delete_users_with_no_name_or_org:dry_run: Deleted user #{users[8].id} (#{users[8].email})",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Found user #{users[9].id} (#{users[9].email}) without a name or organisation set",
+          "users:delete_users_with_no_name_or_org:dry_run: Deleted user #{users[9].id} (#{users[9].email})",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Found user #{user_with_live_form.id} (#{user_with_live_form.email}) without a name or organisation set",
+          "users:delete_users_with_no_name_or_org:dry_run: Found live forms [3] created by user, skipping deleting user #{user_with_live_form.id} (#{user_with_live_form.email})",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Found user #{user_with_form_in_group.id} (#{users[11].email}) without a name or organisation set",
+          "users:delete_users_with_no_name_or_org:dry_run: Found forms [4] created by user in groups, skipping deleting user #{user_with_form_in_group.id} (#{user_with_form_in_group.email})",
+
+          "users:delete_users_with_no_name_or_org:dry_run: Deleted 6 users, skipped deleting 3 users",
+          "users:delete_users_with_no_name_or_org:dry_run: Finished dry run, no changes persisted",
+        ].each do |line|
+          expect(Rails.logger).to have_received(:info).with(a_string_matching(line))
+        end
+      end
+
+      it "does not delete any users" do
+        expect {
+          dry_run_task.invoke
+        }.not_to change(User, :count)
+      end
+
+      it "does not delete any forms" do
+        dry_run_task.invoke
+
+        expect(ActiveResource::HttpMock
+          .requests.select { |request| request.method == :delete })
+          .to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/qmQcoMsO <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to delete users accounts that haven't been used since we moved over from having trial accounts to having trial groups, so we can delete some old code.

To do this we've decided to start with deleting users that haven't got an organisation or a name set. This means that they haven't signed in since we started asking users for their name and organisation and they weren't one of the trial users manually onboarded by the team.

This logic does also catch users who have signed in, seen that they were asked for a name or organisation, and decided not to proceed, but we think this is okay because they won't have lost any forms if we delete them at that point.

To avoid a possible race condition where a user could have just signed in for the first time as this task is run, we check whether the user last signed in less than the time it would take for their session cookie to expire.

This code is largely based on the spike in #1627 by @stephencdaly.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?