### PR TITLE
Allow a maximum of 5 file upload questions

### DIFF
--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -81,7 +81,7 @@ private
   end
 
   def answer_type_form_params
-    params.require(:pages_type_of_answer_input).permit(:answer_type).merge(draft_question:, answer_types:)
+    params.require(:pages_type_of_answer_input).permit(:answer_type).merge(draft_question:, answer_types:, current_form:)
   end
 
   def answer_type_changed?

--- a/app/input_objects/pages/type_of_answer_input.rb
+++ b/app/input_objects/pages/type_of_answer_input.rb
@@ -1,10 +1,11 @@
 class Pages::TypeOfAnswerInput < BaseInput
-  attr_accessor :answer_type, :draft_question, :answer_types
+  attr_accessor :answer_type, :draft_question, :answer_types, :current_form
 
   SELECTION_DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }] }.freeze
 
   validates :draft_question, presence: true
   validates :answer_type, presence: true, inclusion: { in: :answer_types }
+  validate :not_more_than_5_file_upload_questions
 
   def submit
     return false if invalid?
@@ -17,6 +18,12 @@ class Pages::TypeOfAnswerInput < BaseInput
   end
 
 private
+
+  def not_more_than_5_file_upload_questions
+    if answer_type.present? && answer_type.to_sym == :file && current_form.file_upload_question_count >= 5
+      errors.add(:answer_type, :cannot_add_more_file_upload_questions)
+    end
+  end
 
   def answer_type_changed?
     answer_type != draft_question.answer_type

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -106,6 +106,10 @@ class Form < ActiveResource::Base
     nil
   end
 
+  def file_upload_question_count
+    pages.count { |p| p.answer_type.to_sym == :file }
+  end
+
   after_destroy do
     group_form&.destroy
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -680,7 +680,7 @@ en:
             address: ''
             date: ''
             email: ''
-            file: ''
+            file: People will be able to upload an image or a document
             name: ''
             national_insurance_number: ''
             number: People will only be able to enter whole or decimal numbers
@@ -693,7 +693,7 @@ en:
             address: Address
             date: Date
             email: Email address
-            file: File
+            file: File upload
             name: Person’s name
             national_insurance_number: National Insurance number
             number: Number

--- a/config/locales/input_objects/type_of_answer.yml
+++ b/config/locales/input_objects/type_of_answer.yml
@@ -7,4 +7,5 @@ en:
           attributes:
             answer_type:
               blank: Select the type of answer you need
+              cannot_add_more_file_upload_questions: You cannot have more than 5 file upload questions
               inclusion: Select the type of answer you need

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -115,7 +115,7 @@ describe Form, type: :model do
     let(:completed_form) { build :form, :live }
 
     context "with an existing page" do
-      let(:page)  { completed_form.pages.first }
+      let(:page) { completed_form.pages.first }
 
       it "returns the page position" do
         expect(completed_form.page_number(page)).to eq(1)
@@ -123,7 +123,7 @@ describe Form, type: :model do
     end
 
     context "with an new page" do
-      let(:page)  { build :page }
+      let(:page) { build :page }
 
       it "returns the position for a new page" do
         expect(completed_form.page_number(page)).to eq(completed_form.pages.count + 1)
@@ -340,6 +340,21 @@ describe Form, type: :model do
       group = create :group
       GroupForm.create!(form_id: form.id, group_id: group.id)
       expect(form.group).to eq group
+    end
+  end
+
+  describe "#file_upload_question_count" do
+    let(:pages) do
+      pages = build_list :page, 3, answer_type: :file
+      Page::ANSWER_TYPES_INCLUDING_FILE.each do |answer_type|
+        pages.push(build(:page, answer_type:))
+      end
+      pages
+    end
+    let(:form) { build :form, pages: }
+
+    it "returns the number of file upload questions" do
+      expect(form.file_upload_question_count).to eq(4)
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/7qrLP1gH/2067-restrict-file-uploads-to-5-questions-of-7mb-each

Display a validation error if a form creator attempts to add a 6th file upload question.

There is a 40GB limit for sending emails using SES version 2. We currently allow uploaded files to be a maximum of 7GB. Allowing 5 questions means that there will be a maximum of 35GB of uploaded files. We need the total size of all files to be below 40GB, as the content of the email will take up some of this size limit.

<img width="830" alt="Screenshot 2025-01-09 at 17 00 32" src="https://github.com/user-attachments/assets/01d5bfaa-18d5-4fba-9b2f-773b992e2c80" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
