### PR TITLE
Reduce the max number of file upload questions to 4

### DIFF
--- a/app/input_objects/pages/type_of_answer_input.rb
+++ b/app/input_objects/pages/type_of_answer_input.rb
@@ -5,7 +5,7 @@ class Pages::TypeOfAnswerInput < BaseInput
 
   validates :draft_question, presence: true
   validates :answer_type, presence: true, inclusion: { in: :answer_types }
-  validate :not_more_than_5_file_upload_questions
+  validate :not_more_than_4_file_upload_questions
 
   def submit
     return false if invalid?
@@ -19,8 +19,8 @@ class Pages::TypeOfAnswerInput < BaseInput
 
 private
 
-  def not_more_than_5_file_upload_questions
-    if answer_type.present? && answer_type.to_sym == :file && current_form.file_upload_question_count >= 5
+  def not_more_than_4_file_upload_questions
+    if answer_type.present? && answer_type.to_sym == :file && current_form.file_upload_question_count >= 4
       errors.add(:answer_type, :cannot_add_more_file_upload_questions)
     end
   end

--- a/config/locales/input_objects/type_of_answer.yml
+++ b/config/locales/input_objects/type_of_answer.yml
@@ -7,5 +7,5 @@ en:
           attributes:
             answer_type:
               blank: Select the type of answer you need
-              cannot_add_more_file_upload_questions: You cannot have more than 5 file upload questions
+              cannot_add_more_file_upload_questions: You cannot have more than 4 file upload questions in a form
               inclusion: Select the type of answer you need

--- a/spec/input_objects/pages/type_of_answer_input_spec.rb
+++ b/spec/input_objects/pages/type_of_answer_input_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe Pages::TypeOfAnswerInput, type: :model do
       context "when file upload is enabled" do
         let(:answer_types) { Page::ANSWER_TYPES_INCLUDING_FILE }
 
-        context "when there are fewer than 5 existing file upload questions" do
+        context "when there are fewer than 4 existing file upload questions" do
           let(:pages) do
-            pages = build_list :page, 4, answer_type: :file
+            pages = build_list :page, 3, answer_type: :file
             page_with_another_answer_type = build(:page, answer_type: :text)
             pages.push(page_with_another_answer_type)
           end
@@ -68,23 +68,23 @@ RSpec.describe Pages::TypeOfAnswerInput, type: :model do
           end
         end
 
-        context "when there are already 5 file upload questions" do
+        context "when there are already 4 file upload questions" do
+          let(:pages) { build_list :page, 4, answer_type: :file }
+          let(:current_form) { build :form, id: 1, pages: }
+
+          it "is invalid" do
+            expect(type_of_answer_input).to be_invalid
+            expect(type_of_answer_input.errors[:answer_type]).to include "You cannot have more than 4 file upload questions in a form"
+          end
+        end
+
+        context "when there are already more than 4 file upload questions" do
           let(:pages) { build_list :page, 5, answer_type: :file }
           let(:current_form) { build :form, id: 1, pages: }
 
           it "is invalid" do
             expect(type_of_answer_input).to be_invalid
-            expect(type_of_answer_input.errors[:answer_type]).to include "You cannot have more than 5 file upload questions"
-          end
-        end
-
-        context "when there are already more than 5 file upload questions" do
-          let(:pages) { build_list :page, 6, answer_type: :file }
-          let(:current_form) { build :form, id: 1, pages: }
-
-          it "is invalid" do
-            expect(type_of_answer_input).to be_invalid
-            expect(type_of_answer_input.errors[:answer_type]).to include "You cannot have more than 5 file upload questions"
+            expect(type_of_answer_input.errors[:answer_type]).to include "You cannot have more than 4 file upload questions in a form"
           end
         end
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/7qrLP1gH/2067-restrict-file-uploads-to-5-questions-of-7mb-each

File attachments sent using SES are base64 encoded. The size limit for an email is 40MB after base64 encoding. Base64 encoding causes an overhead of 33–37% relative to the size of the original binary data. Therefore we are reducing the maximum number of file upload questions allowed in a form to 4. If there are 4 file upload questions with files uploaded with the maximum 7MB size, this will have a maximum total size after encoding of 1.37 x 4 x 7MB = 38.36MB.

Also update the content with a small tweak.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
