### PR TITLE
Fix deleting users when they have one or more draft questions

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -103,6 +103,9 @@ def delete_users_with_no_name_or_org(dry_run: false)
       next
     end
 
+    # we need to delete all draft questions for this user or else PostgreSQL will complain
+    DraftQuestion.destroy_by(user:)
+
     forms.each do |form|
       if dry_run || form.destroy
         Rails.logger.info "#{task_name}: Deleted form #{form.id} (\"#{form.name}\") created by user #{user.id} (#{user.email})"

--- a/spec/lib/tasks/users.rake_spec.rb
+++ b/spec/lib/tasks/users.rake_spec.rb
@@ -259,6 +259,18 @@ RSpec.describe "users.rake" do
         expect(Rails.logger).to have_received(:info).with(/delete_users_with_no_name_or_org: Deleted form 3/)
       end
 
+      context "and there is a draft question for one of those forms" do
+        before do
+          create_list :draft_question, 2, user: users.last
+        end
+
+        it "deletes the draft questions" do
+          expect {
+            task.invoke
+          }.to change(DraftQuestion, :count).by(-2)
+        end
+      end
+
       context "and one or more of the forms have been made live" do
         let(:user_with_live_form) { users.second_to_last }
         let(:forms) do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/qmQcoMsO/2061-7-jan-delete-the-accounts-with-no-name-or-organisation <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When running the task to delete users with no name or organisation set we saw errors when a user has some draft questions, because of a database constrain, see Sentry issue https://govuk-forms.sentry.io/issues/6220836647.

This commit fixes the error by making sure draft questions are deleted before the user.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?