### PR TITLE
Change delete button for routes to delete all routes for page

### DIFF
--- a/app/controllers/pages/routes_controller.rb
+++ b/app/controllers/pages/routes_controller.rb
@@ -3,4 +3,29 @@ class Pages::RoutesController < PagesController
     back_link_url = form_pages_path(current_form.id)
     render locals: { current_form:, page:, pages: current_form.pages, back_link_url: }
   end
+
+  def delete
+    @delete_confirmation_input = Pages::Routes::DeleteConfirmationInput.new
+    render locals: { current_form:, page:, delete_confirmation_input: @delete_confirmation_input }
+  end
+
+  def destroy
+    @delete_confirmation_input = Pages::Routes::DeleteConfirmationInput.new(delete_confirmation_input_params)
+
+    if @delete_confirmation_input.submit
+      if @delete_confirmation_input.confirmed?
+        return redirect_to form_pages_path, success: t("banner.success.page_routes_deleted", question_position: current_form.page_number(page))
+      end
+    else
+      return render :delete, locals: { current_form:, page:, delete_confirmation_input: @delete_confirmation_input }, status: :unprocessable_entity
+    end
+
+    redirect_to show_routes_path(form_id: current_form.id, page_id: page.id)
+  end
+
+private
+
+  def delete_confirmation_input_params
+    params.require(:pages_routes_delete_confirmation_input).permit(:confirm).merge(form: current_form, page: page)
+  end
 end

--- a/app/input_objects/pages/routes/delete_confirmation_input.rb
+++ b/app/input_objects/pages/routes/delete_confirmation_input.rb
@@ -1,0 +1,29 @@
+class Pages::Routes::DeleteConfirmationInput < ConfirmActionInput
+  attr_accessor :form, :page
+
+  def submit
+    return false if invalid?
+
+    if confirmed?
+      delete_routes
+    end
+
+    true
+  end
+
+  def to_partial_path
+    "input_objects/pages/routes/delete_confirmation_input"
+  end
+
+private
+
+  def delete_routes
+    all_form_routing_conditions = form.pages.flat_map(&:routing_conditions).compact_blank
+    page_routes = all_form_routing_conditions.select { |rc| rc.check_page_id == page.id }
+    page_routes.each do |rc|
+      rc.prefix_options[:form_id] = form.id
+      rc.prefix_options[:page_id] = rc.routing_page_id
+      ConditionRepository.destroy(rc)
+    end
+  end
+end

--- a/app/views/input_objects/pages/routes/_delete_confirmation_input.html.erb
+++ b/app/views/input_objects/pages/routes/_delete_confirmation_input.html.erb
@@ -1,0 +1,12 @@
+<%= form_with(model: delete_confirmation_input, url:, method: 'delete') do |f| %>
+  <% if delete_confirmation_input&.errors.any? %>
+    <%= f.govuk_error_summary %>
+  <% end %>
+  <span class="govuk-caption-l"><%= caption_text %></span>
+  <%= f.govuk_collection_radio_buttons :confirm,
+                                       delete_confirmation_input.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_action_input.options.' + "#{option}") },
+                                       legend: { text: legend_text, size: 'l', tag: 'h1' }
+                                       %>
+
+  <%= f.govuk_submit t("save_and_continue") %>
+<% end %>

--- a/app/views/pages/routes/delete.html.erb
+++ b/app/views/pages/routes/delete.html.erb
@@ -1,0 +1,15 @@
+<% page_number = current_form.page_number(page) %>
+<% set_page_title(title_with_error_prefix(t(".title", page_number: page_number), delete_confirmation_input.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(show_routes_path(form_id: current_form.id, page_id: page.id), t("pages.routes.delete.back", page_number: page_number)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+      delete_confirmation_input,
+      url: destroy_routes_path(current_form.id, page.id),
+      caption_text: t("pages.routes.delete.caption", page_number: page_number),
+      legend_text: t("pages.routes.delete.title", page_number: page_number),
+      hint_text: nil,
+    ) %>
+  </div>
+</div>

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -23,7 +23,7 @@
       <% if page.routing_conditions.present? %>
           <ul class="govuk-list govuk-list--spaced">
               <li>
-                  <%= govuk_button_link_to t("page_route_card.delete_route"), destroy_condition_path(form_id: current_form.id, page_id: page.id, condition_id: page.routing_conditions.first.id), warning: true %>
+                  <%= govuk_button_link_to t("page_route_card.delete_route"), delete_routes_path(current_form.id, page.id), warning: true %>
               </li>
               <li>
                   <%= govuk_link_to t("pages.go_to_your_questions"), form_pages_path(current_form.id) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,6 +194,7 @@ en:
         share_preview_completed: The preview task has been completed
         support_details_saved: Your contact details for support have been saved
         what_happens_next_saved: Your information about what happens next has been saved
+      page_routes_deleted: Question %{question_position}’s routes have been deleted
       route_created: Question %{question_position}’s route has been created
       route_deleted: Question %{question_position}’s route has been deleted
       route_updated: Question %{question_position}’s route has been updated
@@ -1158,6 +1159,11 @@ en:
       title: Add and edit your questions
     optional: "%{question_text} (optional)"
     question: Question
+    routes:
+      delete:
+        back: Back to question %{page_number}’s routes
+        caption: Question %{page_number}’s routes
+        title: Are you sure you want to delete all question %{page_number}’s routes?
     submit_save: Save question
   payment_link_input:
     body_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,10 @@ en:
               too_long: Question text must be %{count} characters or less
             selection_options:
               too_many_selection_options: You cannot have more than 30 options in a list when people can select more than one option
+        pages/routes/delete_confirmation_input:
+          attributes:
+            confirm:
+              blank: Select ‘Yes’ to delete this question’s routes
         pages/secondary_skip_input:
           attributes:
             goto_page_id:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,8 @@ Rails.application.routes.draw do
 
         scope "/routes" do
           get "/" => "pages/routes#show", as: :show_routes
+          get "/delete" => "pages/routes#delete", as: :delete_routes
+          delete "/delete" => "pages/routes#destroy", as: :destroy_routes
           get "/any-other-answer/questions-to-skip/new" => "pages/secondary_skip_#new", as: :new_secondary_skip
           post "/any-other-answer/questions-to-skip/new" => "pages/secondary_skip_#create", as: :create_secondary_skip
           get "/any-other-answer/questions-to-skip" => "pages/secondary_skip_#edit", as: :edit_secondary_skip

--- a/spec/input_objects/pages/routes/delete_confirmation_input_spec.rb
+++ b/spec/input_objects/pages/routes/delete_confirmation_input_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe Pages::Routes::DeleteConfirmationInput, type: :model do
+  subject(:delete_confirmation_input) { described_class.new }
+
+  describe "validations" do
+    it "is invalid if confirm is nil" do
+      delete_confirmation_input.confirm = nil
+      expect(delete_confirmation_input).to be_invalid
+      expect(delete_confirmation_input.errors.full_messages_for(:confirm)).to include("Confirm Select ‘Yes’ to delete this question’s routes")
+    end
+
+    it "is invalid if given invalid input" do
+      delete_confirmation_input.confirm = "invalid"
+      expect(delete_confirmation_input).to be_invalid
+      expect(delete_confirmation_input.errors.full_messages_for(:confirm)).to include("Confirm is not included in the list")
+    end
+
+    it "is valid given valid input" do
+      delete_confirmation_input.confirm = "yes"
+      expect(delete_confirmation_input).to be_valid
+    end
+  end
+
+  describe "#submit" do
+    it "returns false if invalid" do
+      delete_confirmation_input.confirm = "invalid"
+      expect(delete_confirmation_input.submit).to be false
+    end
+
+    context "when valid" do
+      subject(:delete_confirmation_input) { described_class.new(form:, page: form.pages[0]) }
+
+      let(:form) { build :form, id: 1, pages: build_pages }
+
+      def build_pages
+        pages = build_list(:page, 5).each_with_index do |page, index|
+          page.id = index
+        end
+
+        # primary route
+        pages[0].routing_conditions = [build(:condition, routing_page_id: 0, check_page_id: 0, goto_page_id: 4)]
+        # secondary skip
+        pages[3].routing_conditions = [build(:condition, routing_page_id: 3, check_page_id: 0, goto_page_id: 4)]
+
+        # unrelated condition
+        pages[2].routing_conditions = [build(:condition, routing_page_id: 2, check_page_id: 2, goto_page_id: 5)]
+
+        pages
+      end
+
+      before do
+        allow(ConditionRepository).to receive(:destroy)
+      end
+
+      it "returns true" do
+        delete_confirmation_input.confirm = "no"
+        expect(delete_confirmation_input.submit).to be true
+      end
+
+      it "does not delete routes when not confirmed" do
+        delete_confirmation_input.confirm = "no"
+
+        delete_confirmation_input.submit
+
+        expect(ConditionRepository).not_to have_received(:destroy)
+      end
+
+      it "deletes routes when confirmed" do
+        delete_confirmation_input.confirm = "yes"
+        delete_confirmation_input.submit
+
+        expect(ConditionRepository).to have_received(:destroy).with(form.pages[0].routing_conditions.first)
+        expect(ConditionRepository).to have_received(:destroy).with(form.pages[3].routing_conditions.first)
+        expect(ConditionRepository).not_to have_received(:destroy).with(form.pages[2].routing_conditions.first)
+      end
+    end
+  end
+end

--- a/spec/views/pages/routes/delete.html.erb_spec.rb
+++ b/spec/views/pages/routes/delete.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe "pages/routes/delete.html.erb" do
+  let(:form) { build :form, id: 1, pages: [page] }
+  let(:page) { build :page, id: 1, position: 1 }
+
+  before do
+    render template: "pages/routes/delete", locals: { current_form: form, page:, delete_confirmation_input: Pages::Routes::DeleteConfirmationInput.new }
+  end
+
+  it "has the correct title" do
+    expect(view.content_for(:title)).to have_content(I18n.t("pages.routes.delete.title", page_number: 1))
+  end
+
+  it "has the correct back link" do
+    expect(view.content_for(:back_link)).to have_link(I18n.t("pages.routes.delete.back", page_number: form.page_number(page)), href: show_routes_path(form_id: form.id, page_id: page.id))
+  end
+
+  it "has the correct heading" do
+    expect(rendered).to have_selector("h1", text: I18n.t("pages.routes.delete.title", page_number: 1))
+  end
+
+  it "posts the confirm value to the destroy action" do
+    expect(rendered).to have_element "form", action: destroy_routes_path(form.id, page.id), method: "post"
+  end
+
+  it "has radio buttons to set confirmation to yes or no" do
+    expect(rendered).to have_field "Yes", type: "radio", name: "pages_routes_delete_confirmation_input[confirm]"
+    expect(rendered).to have_field "No", type: "radio", name: "pages_routes_delete_confirmation_input[confirm]"
+  end
+
+  it "has a legend for the radio buttons" do
+    expect(rendered).to have_css "fieldset legend:has(~ .govuk-radios)", text: I18n.t("pages.routes.delete.title", page_number: 1)
+  end
+
+  it "has a submit button" do
+    expect(rendered).to have_button I18n.t("save_and_continue"), type: "submit"
+  end
+end

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -52,8 +52,8 @@ describe "pages/routes/show.html.erb" do
   context "when the page has routing conditions" do
     let(:page) { build :page, id: 1, position: 1, routing_conditions: [build(:condition, id: 101)] }
 
-    it "has a delete link" do
-      expect(rendered).to have_link(I18n.t("page_route_card.delete_route", href: destroy_condition_path(form_id: form.id, page_id: page.id, condition_id: page.routing_conditions.first.id)))
+    it "has a link to delete all routes" do
+      expect(rendered).to have_link(I18n.t("page_route_card.delete_route"), href: delete_routes_path(form.id, page.id))
     end
   end
 end


### PR DESCRIPTION
## Let form creators delete all routes for a question

https://trello.com/c/KA2MdRKW/2036-change-delete-routes-button-to-delete-all-routes-for-a-page

https://app.mural.co/t/gaap0347/m/gaap0347/1728478914347/6a7e0b709f50f00f81cab37414fdf44ec8601a70

The delete button on the routes#show page now takes the user to a confirmation screen for removing all the routes associated with the page, not just the primary route.

# screenshots
![image](https://github.com/user-attachments/assets/c202aba2-82c7-4257-b3e0-8e99c301b0df)

![image](https://github.com/user-attachments/assets/9f29ba45-a100-46eb-88e1-b495412478db)

![image](https://github.com/user-attachments/assets/caaeaa10-9f64-4a22-845e-0e64387c48f6)
