### PR TITLE
Update file upload content

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,6 +59,12 @@ module ApplicationHelper
     t("helpers.hint.page.#{field}.#{key}", default: t("helpers.hint.page.#{field}.default"))
   end
 
+  def question_text_label(answer_type, answer_settings)
+    key = translation_key_for_answer_type(answer_type, answer_settings)
+    translation_path = "helpers.label.pages_question_input.question_text"
+    t("#{translation_path}.#{key}", default: t("#{translation_path}.default"))
+  end
+
   def govuk_assets_path
     "/node_modules/govuk-frontend/dist/govuk/assets"
   end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -5,7 +5,10 @@
     <p class="govuk-body"><%=t('helpers.label.pages_question_input.file_body_html')%></p>
   <% end %>
 
-  <%= f.govuk_text_field :question_text , label: { size: 'm', text: question_input.answer_type == "file" ? t('helpers.label.pages_question_input.file_question_text') : t("helpers.label.pages_question_input.question_text") }, hint: { text: hint_for_edit_page_field("question_text", draft_question.answer_type, draft_question.answer_settings) } %>
+  <%= f.govuk_text_field :question_text,
+    label: { size: 'm', text: question_text_label(draft_question.answer_type, draft_question.answer_settings) },
+    hint: { text: hint_for_edit_page_field("question_text", draft_question.answer_type, draft_question.answer_settings) }
+  %>
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -18,7 +18,7 @@
     <%= govuk_summary_list(**PageSummaryData::GuidanceService.call(form: form_object, draft_question:).build_data) %>
 
   <% else %>
-    <p><%= t("guidance.instructions") %></p>
+    <p><%= hint_for_edit_page_field("guidance", draft_question.answer_type, draft_question.answer_settings) %></p>
 
     <p>
       <% guidance_link = unless is_new_page

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_with model: [form_object, question_input], url: action_path do |f| %>
   <%= f.govuk_error_summary %>
 
+  <% if question_input.answer_type == "file" %>
+    <p class="govuk-body"><%=t('helpers.label.pages_question_input.file_body_html')%></p>
+  <% end %>
+
   <%= f.govuk_text_field :question_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("question_text", draft_question.answer_type, draft_question.answer_settings) } %>
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -5,7 +5,7 @@
     <p class="govuk-body"><%=t('helpers.label.pages_question_input.file_body_html')%></p>
   <% end %>
 
-  <%= f.govuk_text_field :question_text, label: { size: 'm' }, hint: { text: hint_for_edit_page_field("question_text", draft_question.answer_type, draft_question.answer_settings) } %>
+  <%= f.govuk_text_field :question_text , label: { size: 'm', text: question_input.answer_type == "file" ? t('helpers.label.pages_question_input.file_question_text') : t("helpers.label.pages_question_input.question_text") }, hint: { text: hint_for_edit_page_field("question_text", draft_question.answer_type, draft_question.answer_settings) } %>
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -38,7 +38,7 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
   <% end %>
 
-  <% if question_input.answer_type == "selection" %>
+  <% if question_input.answer_type == "selection" || question_input.answer_type == "file" %>
     <%= f.hidden_field :is_repeatable, value: false %>
   <% else %>
     <%= f.govuk_collection_radio_buttons :is_repeatable, question_input.repeatable_options, :id, :name, :description, legend: { size: 'm', tag: 'h2' }, bold_labels: false %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -620,6 +620,7 @@ en:
           phone_number: Ask the question the way you would in person. For example, ‘What’s your phone number?’
           radio: Ask the question the way you would in person. For example, ‘What country do you live in?’
           single_line: Ask the question the way you would in person. For example, ‘What’s your reference number?’
+          file: Be specific about the file you want to receive. For example ’Upload your annual report’.
       pages_question_input:
         is_optional_options:
           'true': We’ll add ‘(optional)’ to the end of the question text.
@@ -747,6 +748,7 @@ en:
         file_body_html: |
           <p>People will be able to upload one image or document up to 7MB in size.</p>
           <p>You can have up to 4 file upload questions in a form.</p>
+        file_question_text: Ask for a file
         hint_text: Hint text (optional)
         is_optional_options:
           'false': Mandatory

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -604,6 +604,7 @@ en:
           phone_number: You can add a short hint to help people answer the question. For example, ‘You can provide either a home or mobile phone number.’
           radio: You can add a short hint to help people answer the question. For a question where people can only select one answer you might want to use ‘Select one option’.
           single_line: You can add a short hint to help people answer the question. For example, you could say what format the answer should be in or where to find it.
+          file: You can add a short hint to help people upload the file you need. For example, you might need the file to contain specific information.
         question_text:
           address: Ask the question the way you would in person. For example, ‘What’s your address?’
           checkbox: Ask the question the way you would in person. For example, ‘Which of these countries have you lived in?’

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -744,6 +744,9 @@ en:
         default_answer_value: Select an answer
         default_goto_page_id: Select a question or page
       pages_question_input:
+        file_body_html: |
+          <p>People will be able to upload one image or document up to 7MB in size.</p>
+          <p>You can have up to 4 file upload questions in a form.</p>
         hint_text: Hint text (optional)
         is_optional_options:
           'false': Mandatory

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,7 +751,6 @@ en:
         file_body_html: |
           <p>People will be able to upload one image or document up to 7MB in size.</p>
           <p>You can have up to 4 file upload questions in a form.</p>
-        file_question_text: Ask for a file
         hint_text: Hint text (optional)
         is_optional_options:
           'false': Mandatory
@@ -759,7 +758,9 @@ en:
         is_repeatable_options:
           'false': No - this question can only be answered once
           'true': 'Yes'
-        question_text: Question text
+        question_text:
+          default: Question text
+          file: Ask for a file
       pages_secondary_skip_input:
         default_goto_page_id: Select a question or page
         default_routing_page_id: Select a question

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -551,7 +551,6 @@ en:
   guidance:
     add_guidance: Add guidance
     guidance: Guidance
-    instructions: Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content with paragraphs, headings, lists or links.
     markdown_editor:
       edit_markdown_link: Edit guidance text
       preview:
@@ -588,6 +587,9 @@ en:
         organisation_id: Currently, GOV.UK Forms is only available for central government organisations that publish content on the GOV.UK website.
       page:
         answer_type: The answer will be checked to make sure it’s in the selected format.
+        guidance:
+          default: Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content with paragraphs, headings, lists or links.
+          file: Only add guidance if you need to give a longer explanation of what the uploaded file needs to contain, or to format your content with paragraphs, headings, lists or links.
         hint_text:
           address: You can add a short hint to help people answer the question. For example, you could tell people how you’ll use their address.
           checkbox: You can add a short hint to help people answer the question. For a question where people can select more than one answer you might want to use ‘Select all that apply’.
@@ -595,6 +597,7 @@ en:
           date_of_birth: You can add a short hint to help people answer the question. For a date of birth question you could use ‘For example, 27 3 1998’.
           default: You can add a short hint to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for.
           email: You could add a short hint to tell people how you’ll use their email address. For example, ‘We’ll only use your email address to contact you about your application.’
+          file: You can add a short hint to help people upload the file you need. For example, you might need the file to contain specific information.
           long_text: You can add a short hint to help people answer the question. For example, you could give a bit more detail about the information you need.
           name: You can add a short hint to help people answer the question. For example, you might need to ask people to enter their name as it’s written on an official document such as a passport or driving licence.
           national_insurance_number: You can add a short hint to help people answer the question. For example, ‘It’s on your National Insurance card, benefit letter, payslip or P60. For example, QQ 12 34 56 C.’
@@ -604,7 +607,6 @@ en:
           phone_number: You can add a short hint to help people answer the question. For example, ‘You can provide either a home or mobile phone number.’
           radio: You can add a short hint to help people answer the question. For a question where people can only select one answer you might want to use ‘Select one option’.
           single_line: You can add a short hint to help people answer the question. For example, you could say what format the answer should be in or where to find it.
-          file: You can add a short hint to help people upload the file you need. For example, you might need the file to contain specific information.
         question_text:
           address: Ask the question the way you would in person. For example, ‘What’s your address?’
           checkbox: Ask the question the way you would in person. For example, ‘Which of these countries have you lived in?’
@@ -612,6 +614,7 @@ en:
           date_of_birth: Ask the question the way you would in person. For example, ‘What’s your date of birth?’
           default: Ask a question the way you would in person. For example ‘What is your address?’
           email: Ask the question the way you would in person. For example, ‘What’s your email address?’
+          file: Be specific about the file you want to receive. For example ’Upload your annual report’.
           long_text: Ask the question the way you would in person. For example, ‘Why do you want to apply for this role?’
           name: Ask the question the way you would in person. For example, ‘What’s your name?’
           national_insurance_number: Ask the question the way you would in person. For example, ‘What’s your National Insurance number?’
@@ -621,7 +624,6 @@ en:
           phone_number: Ask the question the way you would in person. For example, ‘What’s your phone number?’
           radio: Ask the question the way you would in person. For example, ‘What country do you live in?’
           single_line: Ask the question the way you would in person. For example, ‘What’s your reference number?’
-          file: Be specific about the file you want to receive. For example ’Upload your annual report’.
       pages_question_input:
         is_optional_options:
           'true': We’ll add ‘(optional)’ to the end of the question text.

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -158,6 +158,15 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(helper.hint_for_edit_page_field("hint_text", answer_type, answer_settings)).to eq(I18n.t("helpers.hint.page.hint_text.default"))
       end
     end
+
+    context "with the file answer type" do
+      let(:answer_type) { "file" }
+      let(:answer_settings) { {} }
+
+      it "returns the hint text for the file answer type" do
+        expect(helper.hint_for_edit_page_field("question_text", answer_type, answer_settings)).to eq(I18n.t("helpers.hint.page.question_text.file"))
+      end
+    end
   end
 
   describe "#govuk_assets_path" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "hint_for_edit_page_field" do
+  describe "#hint_for_edit_page_field" do
     context "with an answer type that has custom text" do
       let(:answer_type) { "email" }
       let(:answer_settings) { {} }
@@ -165,6 +165,26 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it "returns the hint text for the file answer type" do
         expect(helper.hint_for_edit_page_field("question_text", answer_type, answer_settings)).to eq(I18n.t("helpers.hint.page.question_text.file"))
+      end
+    end
+  end
+
+  describe "#question_text_label" do
+    context "with an answer type that does not have custom text" do
+      let(:answer_type) { "some_random_string" }
+      let(:answer_settings) { {} }
+
+      it "returns the default question text label" do
+        expect(helper.question_text_label(answer_type, answer_settings)).to eq(I18n.t("helpers.label.pages_question_input.question_text.default"))
+      end
+    end
+
+    context "with the file answer type" do
+      let(:answer_type) { "file" }
+      let(:answer_settings) { {} }
+
+      it "returns the question text label for the file answer type" do
+        expect(helper.question_text_label(answer_type, answer_settings)).to eq(I18n.t("helpers.label.pages_question_input.question_text.file"))
       end
     end
   end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -128,4 +128,16 @@ describe "pages/_form.html.erb", type: :view do
       expect(rendered).to have_text(draft_question.guidance_markdown)
     end
   end
+
+  it "does not display the file body text" do
+    expect(rendered).not_to have_text(I18n.t("helpers.label.pages_question_input.file_body_html"))
+  end
+
+  context "when the answer type is file" do
+    let(:page) { build :page, :with_hints, answer_type: "file", id: 2, form_id: form.id }
+
+    it "displays the file body text" do
+      expect(rendered).to include(I18n.t("helpers.label.pages_question_input.file_body_html"))
+    end
+  end
 end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -140,13 +140,14 @@ describe "pages/_form.html.erb", type: :view do
 
   context "when the answer type is file" do
     let(:page) { build :page, :with_hints, answer_type: "file", id: 2, form_id: form.id }
-    let(:draft_question) { question_input.draft_question }
+    let(:draft_question) { build :draft_question, answer_type: "file" }
     let(:question_input) do
       build :question_input,
             answer_type: page.answer_type,
             question_text: page.question_text,
             hint_text: page.hint_text,
-            answer_settings: page.answer_settings
+            answer_settings: page.answer_settings,
+            draft_question:
     end
 
     it "displays the file body text" do
@@ -159,6 +160,10 @@ describe "pages/_form.html.erb", type: :view do
 
     it "contains a hint for guidance" do
       expect(rendered).to have_text(I18n.t("helpers.hint.page.guidance.file"))
+    end
+
+    it "does not have the radio input for repeatable" do
+      expect(rendered).not_to have_field("pages_question_input[is_repeatable]", type: :radio)
     end
   end
 end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -33,6 +33,7 @@ describe "pages/_form.html.erb", type: :view do
 
   it "has a field with the question text" do
     expect(rendered).to have_field(type: "text", with: question_input.question_text)
+    expect(rendered).to have_text(I18n.t("helpers.label.pages_question_input.question_text"))
   end
 
   it "has a field with the hint text" do
@@ -138,6 +139,10 @@ describe "pages/_form.html.erb", type: :view do
 
     it "displays the file body text" do
       expect(rendered).to include(I18n.t("helpers.label.pages_question_input.file_body_html"))
+    end
+
+    it "has a field with the file question text" do
+      expect(rendered).to have_text(I18n.t("helpers.label.pages_question_input.file_question_text"))
     end
   end
 end

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -33,7 +33,7 @@ describe "pages/_form.html.erb", type: :view do
 
   it "has a field with the question text" do
     expect(rendered).to have_field(type: "text", with: question_input.question_text)
-    expect(rendered).to have_text(I18n.t("helpers.label.pages_question_input.question_text"))
+    expect(rendered).to have_text(I18n.t("helpers.label.pages_question_input.question_text.default"))
   end
 
   it "has a field with the hint text" do
@@ -155,7 +155,7 @@ describe "pages/_form.html.erb", type: :view do
     end
 
     it "has a field with the file question text" do
-      expect(rendered).to have_text(I18n.t("helpers.label.pages_question_input.file_question_text"))
+      expect(rendered).to have_text(I18n.t("helpers.label.pages_question_input.question_text.file"))
     end
 
     it "contains a hint for guidance" do

--- a/spec/views/pages/_forms.html.erb_spec.rb
+++ b/spec/views/pages/_forms.html.erb_spec.rb
@@ -80,6 +80,10 @@ describe "pages/_form.html.erb", type: :view do
     expect(rendered).to have_link(text: I18n.t("guidance.add_guidance"), href: guidance_new_path(form_id: form.id))
   end
 
+  it "contains a hint for guidance" do
+    expect(rendered).to have_text(I18n.t("helpers.hint.page.guidance.default"))
+  end
+
   context "when it is not a new page" do
     let(:is_new_page) { false }
 
@@ -136,6 +140,14 @@ describe "pages/_form.html.erb", type: :view do
 
   context "when the answer type is file" do
     let(:page) { build :page, :with_hints, answer_type: "file", id: 2, form_id: form.id }
+    let(:draft_question) { question_input.draft_question }
+    let(:question_input) do
+      build :question_input,
+            answer_type: page.answer_type,
+            question_text: page.question_text,
+            hint_text: page.hint_text,
+            answer_settings: page.answer_settings
+    end
 
     it "displays the file body text" do
       expect(rendered).to include(I18n.t("helpers.label.pages_question_input.file_body_html"))
@@ -143,6 +155,10 @@ describe "pages/_form.html.erb", type: :view do
 
     it "has a field with the file question text" do
       expect(rendered).to have_text(I18n.t("helpers.label.pages_question_input.file_question_text"))
+    end
+
+    it "contains a hint for guidance" do
+      expect(rendered).to have_text(I18n.t("helpers.hint.page.guidance.file"))
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/gg7uqjma/2069-update-content-in-production-for-muscle-version-v2

Adds file upload specific content to the edit question page when the answer type is "File upload". We still need to update the error messages for the question text field to match the new label, but this will be done in a subsequent PR.

Adds additional information about file upload questions at the top of the page.

Removes the ability to specify that the question can be answered more than once, as this is not currently supported for file upload questions.

<img width="1192" alt="Screenshot 2025-01-17 at 12 58 13" src="https://github.com/user-attachments/assets/99c333b1-71b7-4fd0-b2f7-f24f7e694f13" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
