### PR TITLE
Update question text error messages for file upload

### DIFF
--- a/app/input_objects/pages/question_input.rb
+++ b/app/input_objects/pages/question_input.rb
@@ -1,6 +1,4 @@
 class Pages::QuestionInput < BaseInput
-  include QuestionTextValidation
-
   attr_accessor :question_text, :hint_text, :is_optional, :answer_type, :draft_question, :is_repeatable, :form_id
 
   # TODO: We could lose these attributes once we have a Check your answers page
@@ -9,6 +7,8 @@ class Pages::QuestionInput < BaseInput
   attr_reader :selection_options # only used for displaying error
 
   validates :draft_question, presence: true
+  validate :validate_question_text_presence
+  validate :validate_question_text_length
   validates :hint_text, length: { maximum: 500 }
   validates :is_optional, inclusion: { in: %w[false true] }
   validates :is_repeatable, inclusion: { in: %w[false true] }
@@ -67,5 +67,19 @@ class Pages::QuestionInput < BaseInput
       @draft_question.answer_settings[:selection_options].length > 30
 
     errors.add(:selection_options, :too_many_selection_options)
+  end
+
+  def validate_question_text_presence
+    return if question_text.present?
+
+    translation_key = answer_type == "file" ? :blank_file : :blank
+    errors.add(:question_text, translation_key)
+  end
+
+  def validate_question_text_length
+    return if question_text.blank? || question_text.length <= QuestionTextValidation::QUESTION_TEXT_MAX_LENGTH
+
+    translation_key = answer_type == "file" ? :too_long_file : :too_long
+    errors.add(:question_text, translation_key, count: QuestionTextValidation::QUESTION_TEXT_MAX_LENGTH)
   end
 end

--- a/app/models/concerns/question_text_validation.rb
+++ b/app/models/concerns/question_text_validation.rb
@@ -1,8 +1,10 @@
 module QuestionTextValidation
   extend ActiveSupport::Concern
 
+  QUESTION_TEXT_MAX_LENGTH = 250
+
   included do
     validates :question_text, presence: true
-    validates :question_text, length: { maximum: 250 }
+    validates :question_text, length: { maximum: QUESTION_TEXT_MAX_LENGTH }
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,9 @@ en:
               inclusion: Select ‘Yes’ if someone can add more than one answer
             question_text:
               blank: Enter a question
+              blank_file: Enter text to ask for a file
               too_long: Question text must be %{count} characters or less
+              too_long_file: Your text to ask for a file must be %{count} characters or less
             selection_options:
               too_many_selection_options: You cannot have more than 30 options in a list when people can select more than one option
         pages/routes/delete_confirmation_input:


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/gg7uqjma/2069-update-content-in-production-for-muscle-version-v2

For file upload questions, we have changed the label for the question text input on the edit question page to be "Ask for a file". As a result, we also need to update the error messages if the input is blank or contains too many characters.

To accomplish this, add custom validation methods and use these instead of the `QuestionTextValidation` concern. Define a shared constant for the maximum length so that this is common between all the places we validate the question text length.

<img width="1192" alt="Screenshot 2025-01-17 at 14 32 05" src="https://github.com/user-attachments/assets/936c08af-6190-4ca1-87f6-f8c20eeccc2a" />

<img width="1192" alt="Screenshot 2025-01-17 at 14 31 50" src="https://github.com/user-attachments/assets/e8e4a2f9-13ff-4b3a-aa54-b8d8dfa1921e" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
