### PR TITLE
Add FormRepository pages method

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -11,7 +11,7 @@ class FormsController < ApplicationController
 
   def mark_pages_section_completed
     authorize current_form, :can_view_form?
-    @pages = current_form.pages
+    @pages = FormRepository.pages(current_form)
     @mark_complete_input = Forms::MarkPagesSectionCompleteInput.new(mark_complete_input_params)
 
     if @mark_complete_input.submit

--- a/app/controllers/pages/routes_controller.rb
+++ b/app/controllers/pages/routes_controller.rb
@@ -1,7 +1,7 @@
 class Pages::RoutesController < PagesController
   def show
     back_link_url = form_pages_path(current_form.id)
-    render locals: { current_form:, page:, pages: current_form.pages, back_link_url: }
+    render locals: { current_form:, page:, pages: FormRepository.pages(current_form), back_link_url: }
   end
 
   def delete

--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -97,6 +97,6 @@ private
   end
 
   def secondary_skip_condition
-    @secondary_skip_condition ||= current_form.pages.flat_map(&:routing_conditions).compact_blank.find { |c| c.secondary_skip? && c.check_page_id == page.id }
+    @secondary_skip_condition ||= FormRepository.pages(current_form).flat_map(&:routing_conditions).compact_blank.find { |c| c.secondary_skip? && c.check_page_id == page.id }
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,7 @@ class PagesController < ApplicationController
   after_action :verify_authorized
 
   def index
-    @pages = current_form.pages
+    @pages = FormRepository.pages(current_form)
     @mark_complete_input = Forms::MarkPagesSectionCompleteInput.new(form: current_form).assign_form_values
     render :index, locals: { current_form: }
   end
@@ -16,7 +16,7 @@ class PagesController < ApplicationController
     @item_name = @page.question_text
     @back_url = edit_question_path(current_form.id, @page.id)
 
-    all_form_conditions = current_form.pages.flat_map(&:routing_conditions).compact_blank
+    all_form_conditions = FormRepository.pages(current_form).flat_map(&:routing_conditions).compact_blank
     @page_goto_conditions = all_form_conditions.select { |condition| condition.goto_page_id == @page.id }
 
     if @page.routing_conditions.any? && @page.routing_conditions.first.secondary_skip?

--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -37,7 +37,7 @@ class Pages::ConditionsInput < BaseInput
   end
 
   def goto_page_options
-    page_options = pages_after_current_page(form.pages, page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
+    page_options = pages_after_current_page(FormRepository.pages(form), page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
     page_options << OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))
 
     page_options

--- a/app/input_objects/pages/delete_condition_input.rb
+++ b/app/input_objects/pages/delete_condition_input.rb
@@ -16,6 +16,6 @@ class Pages::DeleteConditionInput < ConfirmActionInput
   def goto_page_question_text
     return I18n.t("page_conditions.check_your_answers") if goto_page_id.nil? && record.skip_to_end
 
-    form.pages.filter { |p| p.id == goto_page_id }.first&.question_text
+    FormRepository.pages(form).filter { |p| p.id == goto_page_id }.first&.question_text
   end
 end

--- a/app/input_objects/pages/routes/delete_confirmation_input.rb
+++ b/app/input_objects/pages/routes/delete_confirmation_input.rb
@@ -18,7 +18,7 @@ class Pages::Routes::DeleteConfirmationInput < ConfirmActionInput
 private
 
   def delete_routes
-    all_form_routing_conditions = form.pages.flat_map(&:routing_conditions).compact_blank
+    all_form_routing_conditions = FormRepository.pages(form).flat_map(&:routing_conditions).compact_blank
     page_routes = all_form_routing_conditions.select { |rc| rc.check_page_id == page.id }
     page_routes.each do |rc|
       rc.prefix_options[:form_id] = form.id

--- a/app/input_objects/pages/secondary_skip_input.rb
+++ b/app/input_objects/pages/secondary_skip_input.rb
@@ -46,17 +46,17 @@ class Pages::SecondarySkipInput < BaseInput
 
   def goto_page_options
     [
-      *pages_after_current_page(form.pages, page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) },
+      *pages_after_current_page(FormRepository.pages(form), page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) },
       OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
     ]
   end
 
   def routing_page_options
-    pages_after_current_page(form.pages, page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
+    pages_after_current_page(FormRepository.pages(form), page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
   end
 
   def page_name(page_id)
-    target_page = form.pages.find { |page| page.id == page_id }
+    target_page = FormRepository.pages(form).find { |page| page.id == page_id }
 
     page_name = target_page.question_text
     page_position = target_page.position
@@ -99,8 +99,8 @@ private
   def pages_in_valid_order
     if routing_page_id.present? && goto_page_id.present?
 
-      routing_page = form.pages.find { |page| page.id.to_s == routing_page_id.to_s }
-      goto_page = form.pages.find { |page| page.id.to_s == goto_page_id.to_s }
+      routing_page = FormRepository.pages(form).find { |page| page.id.to_s == routing_page_id.to_s }
+      goto_page = FormRepository.pages(form).find { |page| page.id.to_s == goto_page_id.to_s }
 
       if goto_page_id == routing_page_id
         errors.add(:goto_page_id, :equal, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.equal"))

--- a/app/policies/form_policy.rb
+++ b/app/policies/form_policy.rb
@@ -17,7 +17,7 @@ class FormPolicy
   alias_method :destroy?, :delete?
 
   def can_add_page_routing_conditions?
-    form_has_two_or_more_pages = form.pages.length >= 2
+    form_has_two_or_more_pages = FormRepository.pages(form).length >= 2
     form_has_qualifying_pages = form.qualifying_route_pages.any?
 
     form_has_two_or_more_pages && form_has_qualifying_pages

--- a/app/services/form_repository.rb
+++ b/app/services/form_repository.rb
@@ -42,5 +42,10 @@ class FormRepository
       form = Form.new(record.attributes, true)
       form.destroy # rubocop:disable Rails/SaveBang
     end
+
+    def pages(record)
+      form = Form.new(record.attributes, true)
+      form.pages
+    end
   end
 end

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -46,7 +46,7 @@ private
   end
 
   def create_form_section_tasks
-    question_path = if @form.pages.any?
+    question_path = if FormRepository.pages(@form).any?
                       form_pages_path(@form.id)
                     else
                       start_new_question_path(@form.id)
@@ -161,7 +161,7 @@ private
         task_name: share_preview_task_name,
         path: share_preview_path(@form.id),
         status: @task_statuses[:share_preview_status],
-        active: @form.pages.any?,
+        active: FormRepository.pages(@form).any?,
       },
       {
         task_name: live_task_name,

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -18,7 +18,7 @@
     <h2 class="govuk-heading-l">Your form</h2>
 
     <p>
-      <%= render PreviewLinkComponent::View.new(form.pages, link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: preview_mode)) %>
+      <%= render PreviewLinkComponent::View.new(FormRepository.pages(form), link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: preview_mode)) %>
     </p>
 
     <% if status == :live %>
@@ -31,7 +31,7 @@
     <% end %>
 
     <h3 class="govuk-heading-m"><%= t('made_live_form.questions') %></h3>
-    <p><%= govuk_link_to t('made_live_form.questions_link', count: form.pages.count), questions_path %></p>
+    <p><%= govuk_link_to t('made_live_form.questions_link', count: FormRepository.pages(form).count), questions_path %></p>
 
     <% if form.declaration_text.present? %>
       <h3 class="govuk-heading-m"><%= t('made_live_form.declaration') %></h3>

--- a/app/views/forms/_made_live_form_pages.html.erb
+++ b/app/views/forms/_made_live_form_pages.html.erb
@@ -11,8 +11,8 @@
 
     <%= render FormStatusTagDescriptionComponent::View.new(status: status) %>
 
-    <% form.pages.each_with_index do |page, index| %>
-      <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: form.pages).build_data)%>
+    <% FormRepository.pages(form).each_with_index do |page, index| %>
+      <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: FormRepository.pages(form)).build_data)%>
     <% end %>
 
     <p>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -23,7 +23,7 @@
       <p><%= flash[:message] %></p>
     <% end %>
 
-    <% preview_link = PreviewLinkComponent::View.new(current_form.pages, link_to_runner(Settings.forms_runner.url, current_form.id, current_form.form_slug)) %>
+    <% preview_link = PreviewLinkComponent::View.new(FormRepository.pages(current_form), link_to_runner(Settings.forms_runner.url, current_form.id, current_form.form_slug)) %>
     <% if preview_link.render? %>
       <p class="govuk-!-margin-bottom-9">
         <%= render preview_link %>

--- a/spec/features/account/complete_user_account_spec.rb
+++ b/spec/features/account/complete_user_account_spec.rb
@@ -7,11 +7,7 @@ feature "Add account organisation to user without organisation", type: :feature 
   let(:form) { build :form, id: 1, name: "a form I created when I didn't have an organisation", created_at: "2024-10-08T07:31:15.762Z" }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/pages", headers, [].to_json, 200
-    end
-
-    allow(FormRepository).to receive_messages(where: [form], find: form)
+    allow(FormRepository).to receive_messages(where: [form], find: form, pages: form.pages)
 
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:auth0] = Faker::Omniauth.auth0(

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -6,11 +6,7 @@ feature "Add/editing a single question", type: :feature do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-    end
-
-    allow(FormRepository).to receive_messages(find: form, save!: form)
+    allow(FormRepository).to receive_messages(find: form, save!: form, pages: form.pages)
     allow(PageRepository).to receive_messages(find: fake_page, create!: fake_page)
 
     GroupForm.create!(group:, form_id: form.id)

--- a/spec/features/form/create_or_edit_a_form_spec.rb
+++ b/spec/features/form/create_or_edit_a_form_spec.rb
@@ -12,11 +12,7 @@ feature "Create or edit a form", type: :feature do
     let(:pages) { [] }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
-      allow(FormRepository).to receive_messages(create!: form, find: form)
+      allow(FormRepository).to receive_messages(create!: form, find: form, pages: form.pages)
     end
 
     context "when the user is a member of a group" do
@@ -44,11 +40,7 @@ feature "Create or edit a form", type: :feature do
     before do
       form.name = "Another form of juggling"
 
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
-      allow(FormRepository).to receive_messages(save!: form, find: form)
+      allow(FormRepository).to receive_messages(save!: form, find: form, pages: form.pages)
     end
 
     context "when the user is a member of a group with a form" do

--- a/spec/features/form/make_changes_live_spec.rb
+++ b/spec/features/form/make_changes_live_spec.rb
@@ -8,11 +8,7 @@ feature "Make changes live", type: :feature do
   let(:group) { create(:group, name: "Group 1", organisation:, status: "active") }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-    end
-
-    allow(FormRepository).to receive_messages(find: form, find_live: form, make_live!: form)
+    allow(FormRepository).to receive_messages(find: form, find_live: form, make_live!: form, pages: pages)
 
     GroupForm.create!(form_id: form.id, group_id: group.id)
     Membership.create!(user:, group:, added_by: user, role: :group_admin)

--- a/spec/features/form/share_a_preview_spec.rb
+++ b/spec/features/form/share_a_preview_spec.rb
@@ -4,14 +4,9 @@ feature "Share a preview", type: :feature do
   let(:form) { build :form, :with_pages, id: 1 }
   let(:group) { create(:group, organisation: standard_user.organisation, status: "active") }
   let(:fake_page) { build :page, form_id: form.id, id: 2 }
-  let(:pages) { [fake_page] }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-    end
-
-    allow(FormRepository).to receive_messages(find: form, save!: form)
+    allow(FormRepository).to receive_messages(find: form, save!: form, pages: form.pages)
     allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(fake_page)
     allow(PageRepository).to receive(:create!).with(hash_including(form_id: 1))
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe ApplicationController, type: :request do
   let(:logger) { ActiveSupport::Logger.new(output) }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/pages", headers, form.pages.to_json, 200
-    end
-
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form)
 
     login_as_standard_user
   end

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -18,10 +18,6 @@ RSpec.describe FormsController, type: :request do
       let(:params) { {} }
 
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2/pages", headers, form.pages.to_json, 200
-        end
-
         allow(FormRepository).to receive(:find).and_return(form)
 
         get form_path(2, params)
@@ -38,11 +34,7 @@ RSpec.describe FormsController, type: :request do
 
     context "with a non-live form" do
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2/pages", headers, form.pages.to_json, 200
-        end
-
-        allow(FormRepository).to receive(:find).and_return(form)
+        allow(FormRepository).to receive_messages(find: form, pages: form.pages)
 
         get form_path(2)
       end
@@ -116,10 +108,6 @@ RSpec.describe FormsController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
-      end
-
       allow(FormRepository).to receive_messages(find: form, save!: form)
 
       login_as user
@@ -133,10 +121,6 @@ RSpec.describe FormsController, type: :request do
 
     context "when the mark completed form is invalid" do
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
-        end
-
         allow(FormRepository).to receive_messages(find: form, save!: nil)
 
         post form_pages_path(2), params: { forms_mark_pages_section_complete_input: { mark_complete: nil } }

--- a/spec/requests/pages/address_settings_controller_spec.rb
+++ b/spec/requests/pages/address_settings_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -31,10 +31,6 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       get address_settings_new_path(form_id: form.id)
     end
 
@@ -53,12 +49,6 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
   end
 
   describe "#create" do
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-    end
-
     context "when form is invalid" do
       before do
         post address_settings_create_path form_id: form.id, params: { pages_address_settings_input: { input_type: nil } }
@@ -104,10 +94,6 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).and_return(page)
 
       draft_question
@@ -142,9 +128,6 @@ RSpec.describe Pages::AddressSettingsController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
       allow(PageRepository).to receive_messages(find: page, save!: page)
     end
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
   let(:user) { standard_user }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -31,10 +31,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
   describe "#routing_page" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       get routing_page_path(form_id: form.id)
     end
 
@@ -52,9 +48,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     before do
       selected_page.id = 1
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
 
       allow(PageRepository).to receive(:find).with(page_id: "1", form_id: 1).and_return(selected_page)
 
@@ -97,9 +90,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
   describe "#new" do
     before do
       selected_page.id = 1
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
 
       allow(PageRepository).to receive(:find).and_return(selected_page)
 
@@ -131,9 +121,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
   describe "#create" do
     before do
       selected_page.id = 1
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
 
       allow(PageRepository).to receive(:find).and_return(selected_page)
 
@@ -192,9 +179,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
     before do
       selected_page.routing_conditions = [condition]
       selected_page.position = 1
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
 
       allow(PageRepository).to receive(:find).and_return(selected_page)
       allow(ConditionRepository).to receive(:find).and_return(condition)
@@ -241,9 +225,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
     before do
       selected_page.routing_conditions = [condition]
       selected_page.position = 1
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
 
       allow(PageRepository).to receive(:find).and_return(selected_page)
       allow(ConditionRepository).to receive(:find).and_return(condition)
@@ -304,9 +285,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
     before do
       selected_page.routing_conditions = [condition]
       selected_page.position = 1
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
 
       allow(PageRepository).to receive(:find).and_return(selected_page)
 
@@ -350,9 +328,6 @@ RSpec.describe Pages::ConditionsController, type: :request do
     before do
       selected_page.routing_conditions = [condition]
       selected_page.position = 1
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
 
       allow(PageRepository).to receive(:find).and_return(selected_page)
       allow(ConditionRepository).to receive_messages(find: condition, destroy: nil)

--- a/spec/requests/pages/date_settings_controller_spec.rb
+++ b/spec/requests/pages/date_settings_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pages::DateSettingsController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive_messages(find: page, save!: page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -20,10 +20,6 @@ RSpec.describe Pages::DateSettingsController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       get date_settings_new_path(form_id: form.id)
     end
 
@@ -42,12 +38,6 @@ RSpec.describe Pages::DateSettingsController, type: :request do
   end
 
   describe "#create" do
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-    end
-
     context "when form is invalid" do
       before do
         post date_settings_create_path form_id: form.id, params: { pages_date_settings_input: { input_type: nil } }
@@ -90,10 +80,6 @@ RSpec.describe Pages::DateSettingsController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       draft_question
       get date_settings_edit_path(form_id: page.form_id, page_id: page.id)
     end
@@ -125,10 +111,6 @@ RSpec.describe Pages::DateSettingsController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
       allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Pages::GuidanceController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive(:find).and_return(page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -27,10 +27,6 @@ RSpec.describe Pages::GuidanceController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       get guidance_new_path(form_id: form.id)
     end
 
@@ -59,10 +55,6 @@ RSpec.describe Pages::GuidanceController, type: :request do
     let(:route_to) { "preview" }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(controller_spy).to receive(:draft_question).and_return(draft_question)
       post guidance_new_path(form_id: form.id), params: { pages_guidance_input: { page_heading:, guidance_markdown: }, route_to: }
     end
@@ -147,10 +139,6 @@ RSpec.describe Pages::GuidanceController, type: :request do
 
   describe "#edit" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: page.id.to_s, form_id: 1).and_return(page)
 
       get guidance_edit_path(form_id: form.id, page_id: page.id)
@@ -182,10 +170,6 @@ RSpec.describe Pages::GuidanceController, type: :request do
     let(:route_to) { "preview" }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(controller_spy).to receive(:draft_question).and_return(draft_question)
       post guidance_update_path(form_id: form.id, page_id: page.id), params: { pages_guidance_input: { page_heading:, guidance_markdown: }, route_to: }
     end

--- a/spec/requests/pages/name_settings_controller_spec.rb
+++ b/spec/requests/pages/name_settings_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pages::NameSettingsController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive_messages(find: page, save!: page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -20,10 +20,6 @@ RSpec.describe Pages::NameSettingsController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       get name_settings_new_path(form_id: form.id)
     end
 
@@ -42,12 +38,6 @@ RSpec.describe Pages::NameSettingsController, type: :request do
   end
 
   describe "#create" do
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-    end
-
     context "when form is invalid" do
       before do
         post name_settings_create_path form_id: form.id, params: { pages_name_settings_input: { input_type: nil } }
@@ -91,10 +81,6 @@ RSpec.describe Pages::NameSettingsController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
 
       draft_question
@@ -128,10 +114,6 @@ RSpec.describe Pages::NameSettingsController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
       allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end

--- a/spec/requests/pages/question_text_controller_spec.rb
+++ b/spec/requests/pages/question_text_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Pages::QuestionTextController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -18,10 +18,6 @@ RSpec.describe Pages::QuestionTextController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       get question_text_new_path(form_id: form.id)
     end
 
@@ -40,12 +36,6 @@ RSpec.describe Pages::QuestionTextController, type: :request do
   end
 
   describe "#create" do
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-    end
-
     context "when form is invalid" do
       before do
         post question_text_create_path form_id: form.id, params: { pages_question_text_input: { question_text: nil } }

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -68,17 +68,13 @@ RSpec.describe Pages::QuestionsController, type: :request do
   end
 
   let(:form_pages_response) do
-    [page_response].to_json
+    [page_response]
   end
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2/pages", headers, form_pages_response, 200
-    end
-
-    allow(FormRepository).to receive(:find).and_return(form_response)
+    allow(FormRepository).to receive_messages(find: form_response, pages: form_pages_response)
     allow(PageRepository).to receive_messages(create!: page, find: page, save!: updated_page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)

--- a/spec/requests/pages/routes_controller_spec.rb
+++ b/spec/requests/pages/routes_controller_spec.rb
@@ -22,7 +22,7 @@ describe Pages::RoutesController, type: :request do
   let(:user) { standard_user }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive(:find).and_return(page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -32,10 +32,6 @@ describe Pages::RoutesController, type: :request do
 
   describe "#show" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "101", form_id: 1).and_return(selected_page)
 
       get show_routes_path(form_id: form.id, page_id: selected_page.id)
@@ -52,7 +48,6 @@ describe Pages::RoutesController, type: :request do
 
   describe "#delete" do
     before do
-      allow(FormRepository).to receive(:find).and_return(form)
       allow(PageRepository).to receive(:find).with(page_id: "101", form_id: 1).and_return(selected_page)
 
       get delete_routes_path(form_id: form.id, page_id: selected_page.id)
@@ -70,7 +65,6 @@ describe Pages::RoutesController, type: :request do
     let(:secondary_skip) { build :condition, routing_page_id: secondary_skip_page.id, check_page_id: selected_page.id, goto_page_id: pages[3].id }
 
     before do
-      allow(FormRepository).to receive(:find).and_return(form)
       allow(PageRepository).to receive(:find).with(page_id: "101", form_id: 1).and_return(selected_page)
       allow(ConditionRepository).to receive(:find).and_return(condition)
       allow(ConditionRepository).to receive(:destroy)

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -28,11 +28,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
 
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
-    end
-
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive(:find).and_return(pages.first)
     allow(ConditionRepository).to receive_messages(create!: {}, find: {}, save!: {}, destroy: {})
   end

--- a/spec/requests/pages/selection/bulk_options_controller_spec.rb
+++ b/spec/requests/pages/selection/bulk_options_controller_spec.rb
@@ -20,7 +20,7 @@ describe Pages::Selection::BulkOptionsController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive_messages(find: page, save!: page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -30,9 +30,6 @@ describe Pages::Selection::BulkOptionsController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
       draft_question
       get selection_bulk_options_new_path(form_id: form.id)
     end
@@ -78,9 +75,6 @@ describe Pages::Selection::BulkOptionsController, type: :request do
 
   describe "#create" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
       draft_question
     end
 
@@ -121,9 +115,6 @@ describe Pages::Selection::BulkOptionsController, type: :request do
     let(:page_id) { page.id }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
       draft_question
       get selection_bulk_options_edit_path(form_id: page.form_id, page_id: page.id)
@@ -161,10 +152,6 @@ describe Pages::Selection::BulkOptionsController, type: :request do
     let(:selection_options) { [{ name: "Option 1" }, { name: "Option 2" }] }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
       allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end

--- a/spec/requests/pages/selection/options_controller_spec.rb
+++ b/spec/requests/pages/selection/options_controller_spec.rb
@@ -20,7 +20,7 @@ describe Pages::Selection::OptionsController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive_messages(find: page, save!: page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -30,9 +30,6 @@ describe Pages::Selection::OptionsController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
       draft_question
       get selection_options_new_path(form_id: form.id)
     end
@@ -78,9 +75,6 @@ describe Pages::Selection::OptionsController, type: :request do
 
   describe "#create" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
       draft_question
     end
 
@@ -137,10 +131,6 @@ describe Pages::Selection::OptionsController, type: :request do
     let(:page_id) { page.id }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
 
       draft_question
@@ -178,10 +168,6 @@ describe Pages::Selection::OptionsController, type: :request do
     let(:page_id) { page.id }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
       allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
 

--- a/spec/requests/pages/selection/type_controller_spec.rb
+++ b/spec/requests/pages/selection/type_controller_spec.rb
@@ -24,7 +24,7 @@ describe Pages::Selection::TypeController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive_messages(find: page, save!: page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -34,9 +34,6 @@ describe Pages::Selection::TypeController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
       draft_question
       get selection_type_new_path(form_id: form.id)
     end
@@ -72,12 +69,6 @@ describe Pages::Selection::TypeController, type: :request do
   end
 
   describe "#create" do
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-    end
-
     context "when form is valid and ready to store" do
       before do
         post selection_type_create_path form_id: form.id, params: { pages_selection_type_input: { only_one_option: true } }
@@ -111,10 +102,6 @@ describe Pages::Selection::TypeController, type: :request do
     let(:page_id) { page.id }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
 
       draft_question
@@ -155,10 +142,6 @@ describe Pages::Selection::TypeController, type: :request do
     let(:page) { build :page, id: 2, form_id: form.id }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
       allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end

--- a/spec/requests/pages/text_settings_controller_spec.rb
+++ b/spec/requests/pages/text_settings_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pages::TextSettingsController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive_messages(find: page, save!: page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -20,10 +20,6 @@ RSpec.describe Pages::TextSettingsController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       get text_settings_new_path(form_id: form.id)
     end
 
@@ -42,12 +38,6 @@ RSpec.describe Pages::TextSettingsController, type: :request do
   end
 
   describe "#create" do
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-    end
-
     context "when form is invalid" do
       before do
         post text_settings_create_path form_id: form.id, params: { pages_text_settings_input: { input_type: nil } }
@@ -90,10 +80,6 @@ RSpec.describe Pages::TextSettingsController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
 
       draft_question
@@ -123,10 +109,6 @@ RSpec.describe Pages::TextSettingsController, type: :request do
     let(:page) { build :page, :with_text_settings, id: 2, form_id: form.id }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
       allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation, file_upload_enabled:) }
 
   before do
-    allow(FormRepository).to receive(:find).and_return(form)
+    allow(FormRepository).to receive_messages(find: form, pages: pages)
     allow(PageRepository).to receive_messages(find: page, save!: page)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -20,10 +20,6 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
 
   describe "#new" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       get type_of_answer_new_path(form_id: form.id)
     end
 
@@ -56,12 +52,6 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
   end
 
   describe "#create" do
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-    end
-
     context "when form is valid and ready to store" do
       before do
         post type_of_answer_create_path form_id: form.id, params: { pages_type_of_answer_input: { answer_type: type_of_answer_input.answer_type } }
@@ -166,10 +156,6 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
     let(:page) { build :page, :with_simple_answer_type, id: 2, form_id: form.id }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
 
       get type_of_answer_edit_path(form_id: page.form_id, page_id: page.id)
@@ -212,10 +198,6 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
     let(:page) { build :page, :with_simple_answer_type, id: 2, form_id: form.id, answer_type: "email" }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
       allow(PageRepository).to receive(:find).with(page_id: "2", form_id: 1).and_return(page)
       allow(PageRepository).to receive(:save!).with(hash_including(page_id: "2", form_id: 1))
     end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -22,11 +22,7 @@ RSpec.describe PagesController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
-      end
-
-      allow(FormRepository).to receive(:find).and_return(form)
+      allow(FormRepository).to receive_messages(find: form, pages: pages)
 
       get form_pages_path(2)
     end
@@ -97,11 +93,7 @@ RSpec.describe PagesController, type: :request do
       let(:pages) { [page] }
 
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
-        end
-
-        allow(FormRepository).to receive(:find).and_return(form_response)
+        allow(FormRepository).to receive_messages(find: form_response, pages: pages)
 
         pages.each do |page|
           allow(PageRepository).to receive(:find).with(page_id: page.id.to_s, form_id: 2).and_return(page)
@@ -307,11 +299,7 @@ RSpec.describe PagesController, type: :request do
       end
 
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/2/pages", headers, form_pages_response, 200
-        end
-
-        allow(FormRepository).to receive(:find).and_return(form_response)
+        allow(FormRepository).to receive_messages(find: form_response, pages: form_pages_response)
         allow(PageRepository).to receive_messages(find: page, destroy: true)
 
         GroupForm.create!(form_id: 2, group_id: group.id)
@@ -352,11 +340,7 @@ RSpec.describe PagesController, type: :request do
     end
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-      end
-
-      allow(FormRepository).to receive(:find).and_return(form)
+      allow(FormRepository).to receive_messages(find: form, pages: pages)
       allow(PageRepository).to receive_messages(find: pages[1], move_page: true)
 
       GroupForm.create!(form_id: 2, group_id: group.id)

--- a/spec/services/form_repository_spec.rb
+++ b/spec/services/form_repository_spec.rb
@@ -145,4 +145,21 @@ describe FormRepository do
       expect(Form.new(id: 2)).to have_been_deleted
     end
   end
+
+  describe "#pages" do
+    let(:form) { build(:form, id: 2) }
+    let(:pages) { build_list(:page, 5) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2/pages", headers, pages.to_json, 200
+      end
+    end
+
+    it "gets a form's pages through ActiveResource" do
+      pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/2/pages", pages, headers)
+      described_class.pages(form)
+      expect(ActiveResource::HttpMock.requests).to include pages_request
+    end
+  end
 end

--- a/spec/views/pages/conditions/new.html.erb_spec.rb
+++ b/spec/views/pages/conditions/new.html.erb_spec.rb
@@ -10,6 +10,7 @@ describe "pages/conditions/new.html.erb" do
   let(:condition_input) { Pages::ConditionsInput.new(form:, page: pages.first) }
 
   before do
+    allow(FormRepository).to receive(:pages).and_return(pages)
     allow(view).to receive(:set_routing_page_path).with(routing_page_id: condition_input.page.id).and_return("/forms/1/new-condition?routing-page_id=#{condition_input.page.id}")
     allow(view).to receive_messages(form_pages_path: "/forms/1/pages", routing_page_path: "/forms/1/new-condition", create_condition_path: "/forms/1/pages/1/conditions/new")
     allow(form).to receive(:qualifying_route_pages).and_return(pages)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/XJVoEeTw/2075-add-form-pages-to-form-repository

Adds a FormRepository `pages` method, which requests a form's pages via the form model. This is then used throughout the app to replace any requests for form pages that we're currently making.

### Things to consider when reviewing

It was a little fiddly to find all the places we're getting form pages, and the way activeresource works makes testing that we're actually stubbing out a request is also quite fiddly. 

There may be some tests where technically we could have removed the stubbing, and they still would have worked, as the way we factory build forms means they come with pages already, so a call for `.pages` wouldn't result in an API request. I've tried to still replace any possible circumstances where we could have made an API request with the FormRepository version. 

I'm also not sure if there'll be a performance hit with some of this, mainly around the conditions stuff. There are a few places where we're looking at a form's pages, and if each of those hits the API, we might (big might) see some slowdown. I've tried testing locally which was fine, but I'm very tempted to test on dev to see if it's fine.

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
