### PR TITLE
Re-add linux-musl to Bundler platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,11 +276,15 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.1-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.18.1-aarch64-linux-musl)
+      racc (~> 1.4)
     nokogiri (1.18.1-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.1-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.1-x86_64-linux-musl)
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
@@ -511,6 +515,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-gnu
+  aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
@@ -520,6 +525,7 @@ PLATFORMS
   x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   MailchimpMarketing (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.1-aarch64-linux-musl)
       racc (~> 1.4)
+    nokogiri (1.18.1-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.1-arm-linux-musl)
+      racc (~> 1.4)
     nokogiri (1.18.1-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.1-x86_64-darwin)
@@ -516,14 +520,10 @@ GEM
 PLATFORMS
   aarch64-linux-gnu
   aarch64-linux-musl
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-23
-  arm64-darwin-24
-  x86_64-darwin-20
-  x86_64-darwin-21
-  x86_64-darwin-22
-  x86_64-darwin-23
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
   x86_64-linux-gnu
   x86_64-linux-musl
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -576,4 +576,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.3
+   2.6.3


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

In commit de10f10 we added *-linux-musl platforms to the Bundler lockfile, because the Alpine docker images we use in production are based on musl and a Nokogiri update started differentiating between linux-gnu and linux-musl platforms.

However, in commit 8f725b3 a Depdenabot update removed those lines.

This PR re-adds them, hopefully we can also find a way to stop Dependabot from removing them. I also tried to clean up the list of platforms by running `bundle lock --normalize-platforms`, which required first updating the version of Bundler used.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?