### PR TITLE
Move ActiveResource models to resources/api/v1

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,7 +64,7 @@ class ApplicationController < ActionController::Base
   def set_request_id
     # Pass the request id to the API to enable tracing
     if Rails.env.production?
-      [Form, Page].each do |active_resource_model|
+      [Form, Api::V1::PageResource].each do |active_resource_model|
         active_resource_model.headers["X-Request-ID"] = request.request_id
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,7 +64,7 @@ class ApplicationController < ActionController::Base
   def set_request_id
     # Pass the request id to the API to enable tracing
     if Rails.env.production?
-      [Form, Api::V1::PageResource].each do |active_resource_model|
+      [Api::V1::FormResource, Api::V1::PageResource].each do |active_resource_model|
         active_resource_model.headers["X-Request-ID"] = request.request_id
       end
     end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -3,7 +3,7 @@ class Form < ActiveResource::Base
   self.include_format_in_path = false
   headers["X-API-Token"] = Settings.forms_api.auth_key
 
-  has_many :pages
+  has_many :pages, class_name: "Api::V1::PageResource"
 
   def self.find_live(id)
     find(:one, from: "#{prefix}forms/#{id}/live")
@@ -18,7 +18,7 @@ class Form < ActiveResource::Base
   end
 
   def qualifying_route_pages
-    Page.qualifying_route_pages(pages)
+    Api::V1::PageResource.qualifying_route_pages(pages)
   end
 
   def has_no_remaining_routes_available?

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,7 +14,7 @@ class Page < ActiveResource::Base
   ANSWER_TYPES_WITH_SETTINGS = %w[selection text date address name].freeze
 
   belongs_to :form
-  has_many :routing_conditions, class_name: :Condition
+  has_many :routing_conditions, class_name: "Api::V1::ConditionResource"
 
   validates :hint_text, length: { maximum: 500 }
 
@@ -52,7 +52,7 @@ class Page < ActiveResource::Base
 
   def conditions
     ActiveSupport::Deprecation.new.warn("Prefer Page#routing_conditions to Page#conditions")
-    routing_conditions.map { |routing_condition| Condition.new(routing_condition.attributes) }
+    routing_conditions.map { |routing_condition| Api::V1::ConditionResource.new(routing_condition.attributes) }
   end
 
   def question_with_number

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,72 +1,8 @@
-class Page < ActiveResource::Base
-  include QuestionTextValidation
-
-  self.site = Settings.forms_api.base_url
-  self.prefix = "/api/v1/forms/:form_id/"
-  self.include_format_in_path = false
-  headers["X-API-Token"] = Settings.forms_api.auth_key
-
+class Page
   ANSWER_TYPES_EXCLUDING_FILE = %w[name organisation_name email phone_number national_insurance_number address date selection number text].freeze
   ANSWER_TYPES_INCLUDING_FILE = (ANSWER_TYPES_EXCLUDING_FILE + %w[file]).freeze
 
   ANSWER_TYPES_WITHOUT_SETTINGS = %w[organisation_name email phone_number national_insurance_number number].freeze
 
   ANSWER_TYPES_WITH_SETTINGS = %w[selection text date address name].freeze
-
-  belongs_to :form
-  has_many :routing_conditions, class_name: "Api::V1::ConditionResource"
-
-  validates :hint_text, length: { maximum: 500 }
-
-  # we validate that users can't choose file if file upload isn't enabled for their group when creating the draft_question
-  validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES_INCLUDING_FILE }
-
-  before_validation :convert_boolean_fields
-
-  def has_next_page?
-    attributes.include?("next_page") && !attributes["next_page"].nil?
-  end
-
-  def convert_boolean_fields
-    self.is_optional = is_optional?
-    self.is_repeatable = is_repeatable?
-  end
-
-  def is_optional?
-    ActiveRecord::Type::Boolean.new.cast(@attributes["is_optional"]) || false
-  end
-
-  def is_repeatable?
-    ActiveRecord::Type::Boolean.new.cast(@attributes["is_repeatable"]) || false
-  end
-
-  def move_page(direction)
-    return false unless %i[up down].include? direction
-
-    put(direction)
-  end
-
-  def show_selection_options
-    answer_settings.selection_options.map { |option| option.attributes[:name] }.join(", ")
-  end
-
-  def conditions
-    ActiveSupport::Deprecation.new.warn("Prefer Page#routing_conditions to Page#conditions")
-    routing_conditions.map { |routing_condition| Api::V1::ConditionResource.new(routing_condition.attributes) }
-  end
-
-  def question_with_number
-    "#{position}. #{question_text}"
-  end
-
-  def show_optional_suffix?
-    is_optional? && answer_type != "selection"
-  end
-
-  def self.qualifying_route_pages(pages)
-    pages.filter do |page|
-      page.answer_type == "selection" && page.answer_settings.only_one_option == "true" &&
-        page.position != pages.length && page.routing_conditions.empty?
-    end
-  end
 end

--- a/app/policies/api/v1/form_resource_policy.rb
+++ b/app/policies/api/v1/form_resource_policy.rb
@@ -1,0 +1,1 @@
+Api::V1::FormResourcePolicy = FormPolicy

--- a/app/resources/api/v1/condition_resource.rb
+++ b/app/resources/api/v1/condition_resource.rb
@@ -1,4 +1,5 @@
-class Condition < ActiveResource::Base
+class Api::V1::ConditionResource < ActiveResource::Base
+  self.element_name = "condition"
   self.site = Settings.forms_api.base_url
   self.prefix = "/api/v1/forms/:form_id/pages/:page_id/"
   self.include_format_in_path = false

--- a/app/resources/api/v1/form_resource.rb
+++ b/app/resources/api/v1/form_resource.rb
@@ -1,4 +1,5 @@
-class Form < ActiveResource::Base
+class Api::V1::FormResource < ActiveResource::Base
+  self.element_name = "form"
   self.site = "#{Settings.forms_api.base_url}/api/v1"
   self.include_format_in_path = false
   headers["X-API-Token"] = Settings.forms_api.auth_key

--- a/app/resources/api/v1/page_resource.rb
+++ b/app/resources/api/v1/page_resource.rb
@@ -1,0 +1,66 @@
+class Api::V1::PageResource < ActiveResource::Base
+  include QuestionTextValidation
+
+  self.element_name = "page"
+  self.site = Settings.forms_api.base_url
+  self.prefix = "/api/v1/forms/:form_id/"
+  self.include_format_in_path = false
+  headers["X-API-Token"] = Settings.forms_api.auth_key
+
+  belongs_to :form
+  has_many :routing_conditions, class_name: "Api::V1::ConditionResource"
+
+  validates :hint_text, length: { maximum: 500 }
+
+  # we validate that users can't choose file if file upload isn't enabled for their group when creating the draft_question
+  validates :answer_type, presence: true, inclusion: { in: Page::ANSWER_TYPES_INCLUDING_FILE }
+
+  before_validation :convert_boolean_fields
+
+  def has_next_page?
+    attributes.include?("next_page") && !attributes["next_page"].nil?
+  end
+
+  def convert_boolean_fields
+    self.is_optional = is_optional?
+    self.is_repeatable = is_repeatable?
+  end
+
+  def is_optional?
+    ActiveRecord::Type::Boolean.new.cast(@attributes["is_optional"]) || false
+  end
+
+  def is_repeatable?
+    ActiveRecord::Type::Boolean.new.cast(@attributes["is_repeatable"]) || false
+  end
+
+  def move_page(direction)
+    return false unless %i[up down].include? direction
+
+    put(direction)
+  end
+
+  def show_selection_options
+    answer_settings.selection_options.map { |option| option.attributes[:name] }.join(", ")
+  end
+
+  def conditions
+    ActiveSupport::Deprecation.new.warn("Prefer #routing_conditions to #conditions")
+    routing_conditions.map { |routing_condition| Api::V1::ConditionResource.new(routing_condition.attributes) }
+  end
+
+  def question_with_number
+    "#{position}. #{question_text}"
+  end
+
+  def show_optional_suffix?
+    is_optional? && answer_type != "selection"
+  end
+
+  def self.qualifying_route_pages(pages)
+    pages.filter do |page|
+      page.answer_type == "selection" && page.answer_settings.only_one_option == "true" &&
+        page.position != pages.length && page.routing_conditions.empty?
+    end
+  end
+end

--- a/app/services/condition_repository.rb
+++ b/app/services/condition_repository.rb
@@ -7,27 +7,27 @@ class ConditionRepository
                 answer_value:,
                 goto_page_id:,
                 skip_to_end:)
-      Condition.create!(form_id:,
-                        page_id:,
-                        check_page_id:,
-                        routing_page_id:,
-                        answer_value:,
-                        goto_page_id:,
-                        skip_to_end:)
+      Api::V1::ConditionResource.create!(form_id:,
+                                         page_id:,
+                                         check_page_id:,
+                                         routing_page_id:,
+                                         answer_value:,
+                                         goto_page_id:,
+                                         skip_to_end:)
     end
 
     def find(condition_id:, form_id:, page_id:)
-      Condition.find(condition_id, params: { form_id:, page_id: })
+      Api::V1::ConditionResource.find(condition_id, params: { form_id:, page_id: })
     end
 
     def save!(record)
-      condition = Condition.new(record.attributes, true)
+      condition = Api::V1::ConditionResource.new(record.attributes, true)
       condition.prefix_options = record.prefix_options
       condition.save!
     end
 
     def destroy(record)
-      condition = Condition.new(record.attributes, true)
+      condition = Api::V1::ConditionResource.new(record.attributes, true)
       condition.prefix_options = record.prefix_options
       condition.destroy # rubocop:disable Rails/SaveBang
     end

--- a/app/services/form_repository.rb
+++ b/app/services/form_repository.rb
@@ -1,50 +1,50 @@
 class FormRepository
   class << self
     def create!(creator_id:, name:)
-      Form.create!(creator_id:, name:)
+      Api::V1::FormResource.create!(creator_id:, name:)
     end
 
     def find(form_id:)
-      Form.find(form_id)
+      Api::V1::FormResource.find(form_id)
     end
 
     def find_live(form_id:)
-      Form.find_live(form_id)
+      Api::V1::FormResource.find_live(form_id)
     end
 
     def find_archived(form_id:)
-      Form.find_archived(form_id)
+      Api::V1::FormResource.find_archived(form_id)
     end
 
     def where(creator_id:)
-      Form.where(creator_id:)
+      Api::V1::FormResource.where(creator_id:)
     end
 
     def save!(record)
-      form = Form.new(record.attributes, true)
+      form = Api::V1::FormResource.new(record.attributes, true)
       form.save!
       form
     end
 
     def make_live!(record)
-      form = Form.new(record.attributes, true)
+      form = Api::V1::FormResource.new(record.attributes, true)
       form.make_live!
       form
     end
 
     def archive!(record)
-      form = Form.new(record.attributes, true)
+      form = Api::V1::FormResource.new(record.attributes, true)
       form.archive!
       form
     end
 
     def destroy(record)
-      form = Form.new(record.attributes, true)
+      form = Api::V1::FormResource.new(record.attributes, true)
       form.destroy # rubocop:disable Rails/SaveBang
     end
 
     def pages(record)
-      form = Form.new(record.attributes, true)
+      form = Api::V1::FormResource.new(record.attributes, true)
       form.pages
     end
   end

--- a/app/services/page_repository.rb
+++ b/app/services/page_repository.rb
@@ -1,7 +1,7 @@
 class PageRepository
   class << self
     def find(page_id:, form_id:)
-      Page.find(page_id, params: { form_id: })
+      Api::V1::PageResource.find(page_id, params: { form_id: })
     end
 
     def create!(form_id:,
@@ -13,32 +13,32 @@ class PageRepository
                 page_heading:,
                 guidance_markdown:,
                 answer_type:)
-      Page.create!(form_id:,
-                   question_text:,
-                   hint_text:,
-                   is_optional:,
-                   is_repeatable:,
-                   answer_settings:,
-                   page_heading:,
-                   guidance_markdown:,
-                   answer_type:)
+      Api::V1::PageResource.create!(form_id:,
+                                    question_text:,
+                                    hint_text:,
+                                    is_optional:,
+                                    is_repeatable:,
+                                    answer_settings:,
+                                    page_heading:,
+                                    guidance_markdown:,
+                                    answer_type:)
     end
 
     def save!(record)
-      page = Page.new(record.attributes, true)
+      page = Api::V1::PageResource.new(record.attributes, true)
       page.prefix_options = record.prefix_options
       page.save!
       page
     end
 
     def destroy(record)
-      page = Page.new(record.attributes, true)
+      page = Api::V1::PageResource.new(record.attributes, true)
       page.prefix_options = record.prefix_options
       page.destroy # rubocop:disable Rails/SaveBang
     end
 
     def move_page(record, direction)
-      page = Page.new(record.attributes, true)
+      page = Api::V1::PageResource.new(record.attributes, true)
       page.prefix_options = record.prefix_options
       page.move_page(direction)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,13 @@ en:
           attributes:
             agreed:
               accepted: You must agree to the terms of use to continue
+        api/v1/page_resource:
+          attributes:
+            hint_text:
+              too_long: Hint text must be %{count} characters or less
+            question_text:
+              blank: Enter a question
+              too_long: Question text must be %{count} characters or less
         forms/receive_csv_input:
           attributes:
             submission_type:
@@ -86,13 +93,6 @@ en:
               user_in_other_org: This person has a different organisation set for their GOV.UK Forms account
             role:
               blank: Select the role this person should have
-        page:
-          attributes:
-            hint_text:
-              too_long: Hint text must be %{count} characters or less
-            question_text:
-              blank: Enter a question
-              too_long: Question text must be %{count} characters or less
         pages/delete_secondary_skip_input:
           attributes:
             confirm:

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -90,7 +90,7 @@ def delete_users_with_no_name_or_org(dry_run: false)
       next
     end
 
-    forms = Form.where(creator_id: user.id).find_all
+    forms = Api::V1::FormResource.where(creator_id: user.id).find_all
 
     if forms.any?(&:is_live?)
       Rails.logger.info "#{task_name}: Found live forms #{forms.select(&:is_live?).map(&:id)} created by user, skipping deleting user #{user.id} (#{user.email})"

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -84,7 +84,7 @@ describe ApplicationController, type: :controller do
   describe "#current_form" do
     it "returns the current form" do
       params = ActionController::Parameters.new(form_id: id)
-      allow(Form).to receive(:find).with(id).and_return(form)
+      allow(Api::V1::FormResource).to receive(:find).with(id).and_return(form)
       allow(controller).to receive(:params).and_return(params)
 
       expect(controller.current_form).to eq form
@@ -92,12 +92,12 @@ describe ApplicationController, type: :controller do
 
     it "memorizes the find form request so it doesn't have to repeat the calls" do
       params = ActionController::Parameters.new(form_id: id)
-      allow(Form).to receive(:find).with(id).and_return(form)
+      allow(Api::V1::FormResource).to receive(:find).with(id).and_return(form)
       allow(controller).to receive(:params).and_return(params)
       controller.current_form
       controller.current_form
 
-      expect(Form).to have_received(:find).exactly(1).times
+      expect(Api::V1::FormResource).to have_received(:find).exactly(1).times
     end
   end
 end

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :condition, class: "Condition" do
+  factory :condition, class: "Api::V1::ConditionResource" do
     routing_page_id { nil }
     check_page_id { nil }
     answer_value { nil }

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :form, class: :Form do
+  factory :form, class: "Api::V1::FormResource" do
     sequence(:name) { |n| "Form #{n}" }
     sequence(:form_slug) { |n| "form-#{n}" }
     has_draft_version { true }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -9,7 +9,7 @@ class DataStruct < OpenStruct
 end
 
 FactoryBot.define do
-  factory :page, class: "Page" do
+  factory :page, class: "Api::V1::PageResource" do
     sequence(:id) { |n| n }
     question_text { Faker::Lorem.question.truncate(250) }
     answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
 
   describe "#update_condition" do
     context "when validation pass" do
-      let(:condition) { Condition.new id: 3, form_id: 1, page_id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
+      let(:condition) { build :condition, id: 3, form_id: 1, page_id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
 
       before do
         allow(ConditionRepository).to receive(:save!)

--- a/spec/input_objects/pages/delete_condition_input_spec.rb
+++ b/spec/input_objects/pages/delete_condition_input_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Pages::DeleteConditionInput, type: :model do
   let(:answer_value) { "Wales" }
   let(:goto_page_id) { goto_page.id }
   let(:skip_to_end) { false }
-  let(:condition) { Condition.new id: 2, form_id: form.id, page_id: page.id, routing_page_id: page.id, check_page_id: page.id, answer_value:, goto_page_id:, skip_to_end: }
+  let(:condition) { build :condition, id: 2, form_id: form.id, page_id: page.id, routing_page_id: page.id, check_page_id: page.id, answer_value:, goto_page_id:, skip_to_end: }
 
   describe "validations" do
     it "is invalid if confirm is nil" do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -11,7 +11,7 @@ describe Page, type: :model do
 
         it "has many routing conditions" do
           expect(page.routing_conditions.length).to eq 3
-          expect(page.routing_conditions).to all be_a Condition
+          expect(page.routing_conditions).to all be_a Api::V1::ConditionResource
           expect(page.routing_conditions).to all have_attributes(routing_page_id: 10)
         end
 
@@ -26,7 +26,7 @@ describe Page, type: :model do
 
           it "has many routing conditions" do
             expect(page_resource.routing_conditions.length).to eq 3
-            expect(page_resource.routing_conditions).to all be_a Condition
+            expect(page_resource.routing_conditions).to all be_a Api::V1::ConditionResource
             expect(page_resource.routing_conditions).to all have_attributes(routing_page_id: 10)
           end
         end

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
   end
 
   let(:form) do
-    Form.new(
+    build(
+      :form,
       name: "Form name",
       submission_email: "submission@email.com",
       id: 2,
@@ -23,13 +24,9 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
   end
 
   let(:updated_form) do
-    Form.new({
-      name: "Form name",
-      submission_email: "submission@email.com",
-      id: 2,
-      what_happens_next_markdown: "Wait until you get a reply",
-      live_at: nil,
-    })
+    updated_form = form.dup
+    updated_form.what_happens_next_markdown = "Wait until you get a reply"
+    updated_form
   end
 
   let(:user) { standard_user }

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -284,14 +284,15 @@ RSpec.describe PagesController, type: :request do
   describe "#destroy" do
     describe "given a valid page" do
       let(:page) do
-        Page.new({
+        build(
+          :page,
           id: 1,
           form_id: 2,
           question_text: "What is your work address?",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
           next_page: nil,
-        })
+        )
       end
 
       let(:form_pages_response) do

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PagesController, type: :request do
-  let(:form_response) { Form.new(attributes_for(:form, id: 2), true) }
+  let(:form_response) { Api::V1::FormResource.new(attributes_for(:form, id: 2), true) }
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
   let(:membership) { create :membership, group:, user: standard_user }

--- a/spec/resources/api/v1/condition_resource_spec.rb
+++ b/spec/resources/api/v1/condition_resource_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Condition, type: :model do
+describe Api::V1::ConditionResource, type: :model do
   let(:validation_errors) { [] }
   let(:condition) { described_class.new(id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3, validation_errors:) }
 

--- a/spec/resources/api/v1/form_resource_spec.rb
+++ b/spec/resources/api/v1/form_resource_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Form, type: :model do
+describe Api::V1::FormResource, type: :model do
   let(:id) { 1 }
   let(:organisation) { build :organisation, id: 1 }
   let(:form) { described_class.new(id:, name: "Form 1", organisation:, submission_email: "") }

--- a/spec/resources/api/v1/page_resource_spec.rb
+++ b/spec/resources/api/v1/page_resource_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Page, type: :model do
+describe Api::V1::PageResource, type: :model do
   describe "validations" do
     let(:page) { build :page, question_text: }
     let(:question_text) { "What is your address?" }
@@ -36,7 +36,7 @@ describe Page, type: :model do
     describe "#question_text" do
       [nil, ""].each do |question_text|
         it "is invalid given {question_text} question text" do
-          error_message = I18n.t("activemodel.errors.models.page.attributes.question_text.blank")
+          error_message = I18n.t("activemodel.errors.models.api/v1/page_resource.attributes.question_text.blank")
           page.question_text = question_text
           expect(page).not_to be_valid
           expect(page.errors[:question_text]).to include(error_message)
@@ -64,7 +64,7 @@ describe Page, type: :model do
 
         it "has an error message" do
           page.valid?
-          expect(page.errors[:question_text]).to include(I18n.t("activemodel.errors.models.page.attributes.question_text.too_long", count: 250))
+          expect(page.errors[:question_text]).to include(I18n.t("activemodel.errors.models.api/v1/page_resource.attributes.question_text.too_long", count: 250))
         end
       end
     end
@@ -99,7 +99,7 @@ describe Page, type: :model do
 
         it "has an error message" do
           page.valid?
-          expect(page.errors[:hint_text]).to include(I18n.t("activemodel.errors.models.page.attributes.hint_text.too_long", count: 500))
+          expect(page.errors[:hint_text]).to include(I18n.t("activemodel.errors.models.api/v1/page_resource.attributes.hint_text.too_long", count: 500))
         end
       end
     end

--- a/spec/services/condition_repository_spec.rb
+++ b/spec/services/condition_repository_spec.rb
@@ -20,7 +20,7 @@ describe ConditionRepository do
 
     it "creates a condition through ActiveResource" do
       described_class.create!(**condition_params)
-      expect(Condition.new(**condition_params)).to have_been_created
+      expect(Api::V1::ConditionResource.new(**condition_params)).to have_been_created
     end
   end
 
@@ -35,7 +35,7 @@ describe ConditionRepository do
 
     it "finds the condition through ActiveResource" do
       described_class.find(condition_id: condition.id, form_id: 1, page_id: 2)
-      expect(Condition.new(id: 4, form_id: 1, page_id: 2)).to have_been_read
+      expect(Api::V1::ConditionResource.new(id: 4, form_id: 1, page_id: 2)).to have_been_read
     end
   end
 
@@ -53,7 +53,7 @@ describe ConditionRepository do
       condition = described_class.find(condition_id: 4, form_id: 1, page_id: 2)
       condition.skip_to_end = true
       described_class.save!(condition)
-      expect(Condition.new(id: 4, skip_to_end: true, form_id: 1, page_id: 2)).to have_been_updated
+      expect(Api::V1::ConditionResource.new(id: 4, skip_to_end: true, form_id: 1, page_id: 2)).to have_been_updated
     end
   end
 
@@ -70,7 +70,7 @@ describe ConditionRepository do
     it "destroys the condition through ActiveResource" do
       condition = described_class.find(condition_id: 4, form_id: 1, page_id: 2)
       described_class.destroy(condition)
-      expect(Condition.new(id: 4, form_id: 1, page_id: 2)).to have_been_deleted
+      expect(Api::V1::ConditionResource.new(id: 4, form_id: 1, page_id: 2)).to have_been_deleted
     end
   end
 end

--- a/spec/services/form_repository_spec.rb
+++ b/spec/services/form_repository_spec.rb
@@ -6,13 +6,13 @@ describe FormRepository do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.post "/api/v1/forms", post_headers, Form.new(form_params).to_json, 200
+        mock.post "/api/v1/forms", post_headers, Api::V1::FormResource.new(form_params).to_json, 200
       end
     end
 
     it "creates a form through ActiveResource" do
       described_class.create!(**form_params)
-      expect(Form.new(form_params)).to have_been_created
+      expect(Api::V1::FormResource.new(form_params)).to have_been_created
     end
   end
 
@@ -27,7 +27,7 @@ describe FormRepository do
 
     it "finds the form through ActiveResource" do
       described_class.find(form_id: 2)
-      expect(Form.new(id: 2)).to have_been_read
+      expect(Api::V1::FormResource.new(id: 2)).to have_been_read
     end
   end
 
@@ -93,7 +93,7 @@ describe FormRepository do
       form = described_class.find(form_id: 2)
       form.name = "new name"
       described_class.save!(form)
-      expect(Form.new(id: 2, name: "new name")).to have_been_updated
+      expect(Api::V1::FormResource.new(id: 2, name: "new name")).to have_been_updated
     end
   end
 
@@ -142,7 +142,7 @@ describe FormRepository do
     it "destroys the form through ActiveResource" do
       form = described_class.find(form_id: 2)
       described_class.destroy(form)
-      expect(Form.new(id: 2)).to have_been_deleted
+      expect(Api::V1::FormResource.new(id: 2)).to have_been_deleted
     end
   end
 

--- a/spec/services/page_repository_spec.rb
+++ b/spec/services/page_repository_spec.rb
@@ -12,7 +12,7 @@ describe PageRepository do
 
     it "finds the page through ActiveResource" do
       described_class.find(page_id: page.id, form_id: 1)
-      expect(Page.new(id: 2, form_id: 1)).to have_been_read
+      expect(Api::V1::PageResource.new(id: 2, form_id: 1)).to have_been_read
     end
   end
 
@@ -31,13 +31,13 @@ describe PageRepository do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.post "/api/v1/forms/1/pages", post_headers, Page.new(page_params).to_json, 200
+        mock.post "/api/v1/forms/1/pages", post_headers, Api::V1::PageResource.new(page_params).to_json, 200
       end
     end
 
     it "creates a page through ActiveResource" do
       described_class.create!(**page_params)
-      expect(Page.new(page_params)).to have_been_created
+      expect(Api::V1::PageResource.new(page_params)).to have_been_created
     end
   end
 
@@ -55,7 +55,7 @@ describe PageRepository do
       page = described_class.find(page_id: 2, form_id: 1)
       page.is_optional = true
       described_class.save!(page)
-      expect(Page.new(id: 2, form_id: 1, is_optional: true)).to have_been_updated
+      expect(Api::V1::PageResource.new(id: 2, form_id: 1, is_optional: true)).to have_been_updated
     end
   end
 
@@ -72,7 +72,7 @@ describe PageRepository do
     it "destroys the page through ActiveResource" do
       page = described_class.find(page_id: 2, form_id: 1)
       described_class.destroy(page)
-      expect(Page.new(id: 2, form_id: 1)).to have_been_deleted
+      expect(Api::V1::PageResource.new(id: 2, form_id: 1)).to have_been_deleted
     end
   end
 

--- a/spec/support/matchers/active_resource/have_been_updated_to.rb
+++ b/spec/support/matchers/active_resource/have_been_updated_to.rb
@@ -13,8 +13,8 @@ RSpec::Matchers.define :have_been_updated_to do |updated_resource|
 
   failure_message do |resource|
     expected_request_path = resource.class.element_path(resource.id, resource.prefix_options)
-    expected_request = ActiveResource::Request.new(:put, expected_request_path, resource.to_json)
+    expected_request = ActiveResource::Request.new(:put, expected_request_path, updated_resource.to_json)
 
-    HelperMethods.format_failure_message(resource, expected_request, ActiveResource::HttpMock.requests)
+    HelperMethods.format_failure_message(updated_resource, expected_request, ActiveResource::HttpMock.requests)
   end
 end

--- a/spec/support/matchers/active_resource/helper_methods.rb
+++ b/spec/support/matchers/active_resource/helper_methods.rb
@@ -2,9 +2,10 @@ class HelperMethods
   def self.format_failure_message(resource, expected_request, _requests)
     msg = []
     msg << "Expected #{resource.class} to have been updated."
-    msg << "Expected #{expected_request} to have been made."
+    msg << "Expected request:"
+    msg << expected_request
     msg << "The following requests have been made:"
-    msg << ActiveResource::HttpMock.requests.to_s
+    msg << ActiveResource::HttpMock.requests.map(&:to_s)
     msg.join("\r\n")
   end
 end

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -15,15 +15,15 @@ describe "pages/type_of_answer.html.erb", type: :view do
     # mock the form.page_number method
     allow(form).to receive_messages(persisted?: true, page_number: question_number)
 
-    # mock the path helper
     without_partial_double_verification do
-      allow(view).to receive_messages(form_pages_type_of_answer_input_path: "/type-of-answer", current_form: form)
+      allow(view).to receive_messages(current_form: form)
     end
 
     # setup instance variables
     assign(:page, page)
     assign(:type_of_answer_input, type_of_answer_input)
     assign(:answer_types, answer_types)
+    assign(:type_of_answer_path, "/type-of-answer")
 
     render(template: "pages/type_of_answer")
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/xotu6KNy/1995-add-tables-for-form-models-to-forms-admin <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to move tables with form, page, and condition records from the forms-api app to the forms-admin app. When we do this we will want the models in this app to use ActiveModel instead of ActiveResource. To make that future change easier, this PR moves the ActiveResource models classes to a different namespace.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?