### PR TITLE
Add group scoped feature flag for branching

### DIFF
--- a/app/controllers/pages/routes_controller.rb
+++ b/app/controllers/pages/routes_controller.rb
@@ -1,7 +1,7 @@
 class Pages::RoutesController < PagesController
   def show
     back_link_url = form_pages_path(current_form.id)
-    render locals: { current_form:, page:, pages: FormRepository.pages(current_form), back_link_url: }
+    render locals: { current_form:, page:, pages: FormRepository.pages(current_form), back_link_url:, branching_enabled: }
   end
 
   def delete

--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -79,7 +79,9 @@ private
   end
 
   def ensure_branch_routing_feature_enabled
-    raise ActionController::RoutingError, "branch_routing feature not enabled" unless Settings.features.branch_routing
+    return if branching_enabled
+
+    raise ActionController::RoutingError, "branch_routing feature not enabled"
   end
 
   def ensure_page_has_skip_condition

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -88,6 +88,10 @@ class PagesController < ApplicationController
     redirect_to form_pages_path, success: t("banner.success.form.page_moved", question_text: page_to_move.question_text, direction: move_params[:direction], position:)
   end
 
+  def branching_enabled
+    @branching_enabled ||= Settings.features.branch_routing || current_form.group.branching_enabled?
+  end
+
 private
 
   def clear_draft_questions_data

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -3,7 +3,7 @@ class RouteSummaryCardDataPresenter
   include ActionView::Helpers::UrlHelper
   include GovukRailsCompatibleLinkHelper
 
-  attr_reader :form, :page, :pages
+  attr_reader :form, :page, :pages, :branching_enabled
 
   class << self
     def call(**args)
@@ -11,10 +11,11 @@ class RouteSummaryCardDataPresenter
     end
   end
 
-  def initialize(form:, page:, pages:)
+  def initialize(form:, page:, pages:, branching_enabled:)
     @page = page
     @pages = pages
     @form = form
+    @branching_enabled = branching_enabled
   end
 
   def summary_card_data
@@ -64,7 +65,7 @@ private
   def default_route_card(index)
     continue_to_name = page.has_next_page? ? page_name(page.next_page) : end_page_name
 
-    actions = if FeatureService.enabled?(:branch_routing) && all_routes.find(&:secondary_skip?).present?
+    actions = if branching_enabled && all_routes.find(&:secondary_skip?).present?
                 [
                   edit_secondary_skip_link,
                   delete_secondary_skip_link,
@@ -101,7 +102,7 @@ private
     secondary_skip = all_routes.find(&:secondary_skip?)
 
     if secondary_skip.blank?
-      if FeatureService.enabled?(:branch_routing)
+      if branching_enabled
         return [
           {
             key: { text: I18n.t("page_route_card.then") },

--- a/app/views/pages/conditions/_routing_options.html.erb
+++ b/app/views/pages/conditions/_routing_options.html.erb
@@ -11,7 +11,7 @@
     <%= t("routing_page.body_routing_text") %>
   </p>
 
-  <% if FeatureService.enabled?(:branch_routing) %>
+  <% if @branching_enabled %>
   <p>
     <%= t("routing_page.body_branching_text") %>
   </p>

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <% if policy(form).can_add_page_routing_conditions? %>
-      <%= render partial: "pages/conditions/routing_options", locals: {form:, routing_page_input:} %>
+      <%= render partial: "pages/conditions/routing_options", locals: {form:, routing_page_input:, branching_enabled: @branching_enabled } %>
     <% else %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= form.name %> </span>
@@ -15,7 +15,7 @@
         <%= t("routing_page.body_routing_text") %>
       </p>
 
-      <% if FeatureService.enabled?(:branch_routing) %>
+      <% if @branching_enabled %>
       <p>
         <%= t("routing_page.body_branching_text") %>
       </p>

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -16,7 +16,7 @@
           end;
       end %>
 
-      <% RouteSummaryCardDataPresenter.call(form: current_form, page:, pages:).summary_card_data.each do |card| %>
+      <% RouteSummaryCardDataPresenter.call(form: current_form, page:, pages:, branching_enabled: ).summary_card_data.each do |card| %>
           <%= govuk_summary_list(**card) %>
       <% end %>
 

--- a/db/migrate/20250124094215_add_branching_enabled_to_groups.rb
+++ b/db/migrate/20250124094215_add_branching_enabled_to_groups.rb
@@ -1,0 +1,5 @@
+class AddBranchingEnabledToGroups < ActiveRecord::Migration[8.0]
+  def change
+    add_column :groups, :branching_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_29_152103) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_24_094215) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "draft_questions", force: :cascade do |t|
     t.integer "form_id"
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_29_152103) do
     t.bigint "creator_id"
     t.bigint "upgrade_requester_id"
     t.boolean "file_upload_enabled", default: false
+    t.boolean "branching_enabled", default: false
     t.index ["creator_id"], name: "index_groups_on_creator_id"
     t.index ["external_id"], name: "index_groups_on_external_id", unique: true
     t.index ["name", "organisation_id"], name: "index_groups_on_name_and_organisation_id", unique: true

--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -71,6 +71,24 @@ namespace :groups do
     Group.find_by(external_id: args[:group_id]).update!(file_upload_enabled: false)
     Rails.logger.info("Updated file_upload_enabled to false for group #{args[:group_id]}")
   end
+
+  desc "Enable branching feature for group"
+  task :enable_branching, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:enable_branching[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+
+    Group.find_by(external_id: args[:group_id]).update!(branching_enabled: true)
+    Rails.logger.info("Updated branching_enabled to true for group #{args[:group_id]}")
+  end
+
+  desc "Disable branching feature for group"
+  task :disable_branching, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:disable_branching[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+
+    Group.find_by(external_id: args[:group_id]).update!(branching_enabled: false)
+    Rails.logger.info("Updated branching_enabled to false for group #{args[:group_id]}")
+  end
 end
 
 def run_task(task_name, args, rollback:)

--- a/spec/controller/pages_controller_spec.rb
+++ b/spec/controller/pages_controller_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe PagesController, type: :controller do
+  subject(:controller) { described_class.new }
+
+  let(:form) { build(:form) }
+  let(:group) { build(:group) }
+
+  before do
+    allow(FormRepository).to receive_messages(find: form)
+    allow(form).to receive_messages(group: group)
+    params = { form_id: 1 }
+    controller.params = ActionController::Parameters.new(params)
+  end
+
+  describe "#branching_enabled" do
+    context "when Settings.features.branch_routing is enabled" do
+      before do
+        allow(Settings.features).to receive(:branch_routing).and_return(true)
+      end
+
+      it "returns true regardless of group settings" do
+        # allow(form.group).to receive(:branching_enabled?).and_return(false)
+        group.branching_enabled = false
+        expect(controller.branching_enabled).to be true
+      end
+
+      it "assigns the branching_enabled variable" do
+        controller.branching_enabled
+        expect(controller.view_assigns["branching_enabled"]).to be true
+      end
+    end
+
+    context "when Settings.features.branch_routing is disabled" do
+      before do
+        allow(Settings.features).to receive(:branch_routing).and_return(false)
+      end
+
+      context "when group has branching enabled" do
+        before do
+          allow(form.group).to receive(:branching_enabled?).and_return(true)
+        end
+
+        it "returns true" do
+          expect(controller.branching_enabled).to be true
+        end
+      end
+
+      context "when group has branching disabled" do
+        before do
+          allow(form.group).to receive(:branching_enabled?).and_return(false)
+        end
+
+        it "returns false" do
+          expect(controller.branching_enabled).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe RouteSummaryCardDataPresenter do
   include Capybara::RSpecMatchers
 
-  subject(:service) { described_class.new(form:, page: current_page, pages:) }
+  subject(:service) { described_class.new(form:, page: current_page, pages:, branching_enabled:) }
 
   let(:form) { build :form, id: 99, pages: }
 
@@ -25,9 +25,11 @@ describe RouteSummaryCardDataPresenter do
 
   let(:next_page_routing_conditions) { [] }
 
+  let(:branching_enabled) { false }
+
   describe ".call" do
     it "instantiates and returns a new instance" do
-      service = described_class.call(form:, page: current_page, pages:)
+      service = described_class.call(form:, page: current_page, pages:, branching_enabled:)
       expect(service).to be_an_instance_of(described_class)
     end
   end
@@ -50,7 +52,9 @@ describe RouteSummaryCardDataPresenter do
         expect(result[1][:rows][0][:value][:text]).to eq("2. Next Question")
       end
 
-      context "with branch_routing enabled", :feature_branch_routing do
+      context "with branch_routing enabled" do
+        let(:branching_enabled) { true }
+
         it "has the link to create a secondary skip" do
           result = service.summary_card_data
           expect(result[1][:rows][1][:value][:text]).to have_link("Set one or more questions to skip later in the form (optional)", href: "/forms/99/pages/1/routes/any-other-answer/questions-to-skip/new")
@@ -106,6 +110,8 @@ describe RouteSummaryCardDataPresenter do
       end
 
       context "with branch_routing enabled", :feature_branch_routing do
+        let(:branching_enabled) { true }
+
         it "shows the edit secondary skip link" do
           result = service.summary_card_data
           expect(result[1][:card][:actions].first).to have_link("Edit", href: "/forms/99/pages/1/routes/any-other-answer/questions-to-skip")

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe "pages/conditions/routing_page.html.erb" do
   let(:routing_page_input) { Pages::RoutingPageInput.new }
   let(:allowed_to_create_routes) { true }
   let(:all_routes_created) { false }
+  let(:branching_enabled) { false }
 
   before do
     without_partial_double_verification do
@@ -14,6 +15,8 @@ describe "pages/conditions/routing_page.html.erb" do
 
     allow(view).to receive_messages(form_pages_path: "/forms/1/pages", routing_page_path: "/forms/1/new-condition", set_routing_page_path: "/forms/1/new-condition")
     allow(form).to receive_messages(qualifying_route_pages: pages, has_no_remaining_routes_available?: all_routes_created)
+
+    assign(:branching_enabled, branching_enabled)
 
     render template: "pages/conditions/routing_page", locals: { form:, routing_page_input: }
   end
@@ -28,12 +31,14 @@ describe "pages/conditions/routing_page.html.erb" do
   end
 
   context "when branch routing is enabled", :feature_branch_routing do
+    let(:branching_enabled) { true }
+
     it "contains content explaining branch routing" do
       expect(rendered).to have_text "you can make them skip one or more questions later in the form"
     end
   end
 
-  context "when branch routing is not enabled", feature_branch_routing: false do
+  context "when branch routing is not enabled" do
     it "does not contain content explaining branch routing" do
       expect(rendered).not_to have_text "you can make them skip one or more questions later in the form"
     end

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -19,7 +19,7 @@ describe "pages/routes/show.html.erb" do
 
   before do
     allow(RouteSummaryCardDataPresenter).to receive(:call).and_return(route_summary_card_data_service)
-    render template: "pages/routes/show", locals: { current_form: form, page:, pages: form.pages, back_link_url: "/back" }
+    render template: "pages/routes/show", locals: { current_form: form, page:, pages: form.pages, back_link_url: "/back", branching_enabled: true }
   end
 
   it "has the correct title" do


### PR DESCRIPTION
### Add new Group scoped feature flag for branching

Trello card: https://trello.com/c/GgbE96M1/2083-enable-branch-routing-feature-in-production-for-an-internal-test-group

To begin with, we want to release the advanced branching features to a small number of users.

To do this, we are enabling some Groups to have the feature flag enabled, instead of enabling it for the whole environment. We still want the flag to be enabled in dev for all users and groups.

This PR is heavily based off the changes @stephencdaly and feature team one did for [file upload](https://github.com/alphagov/forms-admin/pull/1645).

It's more complicated because the branching feature flag is used in more places, mainly views.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
