### PR TITLE
Rename host logging field

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_logging_attributes
-    CurrentLoggingAttributes.host = request.host
+    CurrentLoggingAttributes.request_host = request.host
     CurrentLoggingAttributes.request_id = request.request_id
     CurrentLoggingAttributes.session_id_hash = Digest::SHA256.hexdigest session.id.to_s if session.exists? && session.id.present?
     CurrentLoggingAttributes.trace_id = request.env["HTTP_X_AMZN_TRACE_ID"].presence

--- a/app/models/current_logging_attributes.rb
+++ b/app/models/current_logging_attributes.rb
@@ -1,5 +1,5 @@
 class CurrentLoggingAttributes < ActiveSupport::CurrentAttributes
-  attribute :host, :request_id, :session_id_hash, :trace_id, :user_ip,
+  attribute :request_host, :request_id, :session_id_hash, :trace_id, :user_ip,
             :user_id, :user_email, :user_organisation_slug, :acting_as_user_id,
             :acting_as_user_email, :acting_as_user_organisation_slug, :form_id,
             :page_id

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe ApplicationController, type: :request do
       expect(log_lines[0]["request_id"]).to eq(request_id)
     end
 
-    it "includes the host on log lines" do
-      expect(log_lines[0]["host"]).to eq("www.example.com")
+    it "includes the request_host on log lines" do
+      expect(log_lines[0]["request_host"]).to eq("www.example.com")
     end
 
     it "includes the user_id on log lines" do


### PR DESCRIPTION
### What problem does this pull request solve?

Rename the "host" logging field to "hostname". An additional "host" field is added to the logs that go to Splunk for Kenesis. This means we end up with 2 values for "host" making it difficult to filter searches by it.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
