### PR TITLE
Add tables for forms models

### DIFF
--- a/db/migrate/20250130150000_add_forms.rb
+++ b/db/migrate/20250130150000_add_forms.rb
@@ -1,6 +1,6 @@
 class AddForms < ActiveRecord::Migration[7.2]
   def change
-    create_table "forms", force: :cascade do |t|
+    create_table "forms" do |t|
       t.text "name"
       t.text "submission_email"
       t.text "privacy_policy_url"
@@ -12,9 +12,8 @@ class AddForms < ActiveRecord::Migration[7.2]
       t.text "declaration_text"
       t.boolean "question_section_completed", default: false
       t.boolean "declaration_section_completed", default: false
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
-      t.bigint "creator_id"
+      t.timestamps
+      t.references :creator, index: false
       t.text "what_happens_next_markdown"
       t.string "state"
       t.string "payment_url"
@@ -24,39 +23,31 @@ class AddForms < ActiveRecord::Migration[7.2]
       t.string "s3_bucket_name"
       t.string "s3_bucket_aws_account_id"
       t.string "s3_bucket_region"
-      t.index ["external_id"], name: "index_forms_on_external_id", unique: true
+      t.index "external_id", unique: true
     end
 
-    create_table "pages", force: :cascade do |t|
+    create_table "pages" do |t|
       t.text "question_text"
       t.text "hint_text"
       t.text "answer_type"
       t.integer "next_page"
       t.boolean "is_optional", null: false
       t.jsonb "answer_settings"
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
-      t.bigint "form_id"
+      t.timestamps
+      t.references :form, foreign_key: true
       t.integer "position"
       t.text "page_heading"
       t.text "guidance_markdown"
       t.boolean "is_repeatable", default: false, null: false
-      t.index ["form_id"], name: "index_pages_on_form_id"
     end
 
-    create_table "conditions", force: :cascade do |t|
-      t.bigint "check_page_id", comment: "The question page this condition looks at to compare answers"
-      t.bigint "routing_page_id", comment: "The question page at which this conditional route takes place"
-      t.bigint "goto_page_id", comment: "The question page which this conditions will skip forwards to"
+    create_table "conditions" do |t|
+      t.references :check_page, comment: "The question page this condition looks at to compare answers"
+      t.references :routing_page, comment: "The question page at which this conditional route takes place"
+      t.references :goto_page, comment: "The question page which this conditions will skip forwards to"
       t.string "answer_value"
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
+      t.timestamps
       t.boolean "skip_to_end", default: false
-      t.index ["check_page_id"], name: "index_conditions_on_check_page_id"
-      t.index ["goto_page_id"], name: "index_conditions_on_goto_page_id"
-      t.index ["routing_page_id"], name: "index_conditions_on_routing_page_id"
     end
-
-    add_foreign_key "pages", "forms"
   end
 end

--- a/db/migrate/20250130150000_add_forms.rb
+++ b/db/migrate/20250130150000_add_forms.rb
@@ -1,0 +1,62 @@
+class AddForms < ActiveRecord::Migration[7.2]
+  def change
+    create_table "forms", force: :cascade do |t|
+      t.text "name"
+      t.text "submission_email"
+      t.text "privacy_policy_url"
+      t.text "form_slug"
+      t.text "support_email"
+      t.text "support_phone"
+      t.text "support_url"
+      t.text "support_url_text"
+      t.text "declaration_text"
+      t.boolean "question_section_completed", default: false
+      t.boolean "declaration_section_completed", default: false
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.bigint "creator_id"
+      t.text "what_happens_next_markdown"
+      t.string "state"
+      t.string "payment_url"
+      t.string "external_id"
+      t.string "submission_type", default: "email", null: false
+      t.boolean "share_preview_completed", default: false, null: false
+      t.string "s3_bucket_name"
+      t.string "s3_bucket_aws_account_id"
+      t.string "s3_bucket_region"
+      t.index ["external_id"], name: "index_forms_on_external_id", unique: true
+    end
+
+    create_table "pages", force: :cascade do |t|
+      t.text "question_text"
+      t.text "hint_text"
+      t.text "answer_type"
+      t.integer "next_page"
+      t.boolean "is_optional", null: false
+      t.jsonb "answer_settings"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.bigint "form_id"
+      t.integer "position"
+      t.text "page_heading"
+      t.text "guidance_markdown"
+      t.boolean "is_repeatable", default: false, null: false
+      t.index ["form_id"], name: "index_pages_on_form_id"
+    end
+
+    create_table "conditions", force: :cascade do |t|
+      t.bigint "check_page_id", comment: "The question page this condition looks at to compare answers"
+      t.bigint "routing_page_id", comment: "The question page at which this conditional route takes place"
+      t.bigint "goto_page_id", comment: "The question page which this conditions will skip forwards to"
+      t.string "answer_value"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.boolean "skip_to_end", default: false
+      t.index ["check_page_id"], name: "index_conditions_on_check_page_id"
+      t.index ["goto_page_id"], name: "index_conditions_on_goto_page_id"
+      t.index ["routing_page_id"], name: "index_conditions_on_routing_page_id"
+    end
+
+    add_foreign_key "pages", "forms"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_24_094215) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_30_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "conditions", force: :cascade do |t|
+    t.bigint "check_page_id", comment: "The question page this condition looks at to compare answers"
+    t.bigint "routing_page_id", comment: "The question page at which this conditional route takes place"
+    t.bigint "goto_page_id", comment: "The question page which this conditions will skip forwards to"
+    t.string "answer_value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "skip_to_end", default: false
+    t.index ["check_page_id"], name: "index_conditions_on_check_page_id"
+    t.index ["goto_page_id"], name: "index_conditions_on_goto_page_id"
+    t.index ["routing_page_id"], name: "index_conditions_on_routing_page_id"
+  end
 
   create_table "draft_questions", force: :cascade do |t|
     t.integer "form_id"
@@ -43,6 +56,33 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_24_094215) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["form_id"], name: "index_form_submission_emails_on_form_id"
+  end
+
+  create_table "forms", force: :cascade do |t|
+    t.text "name"
+    t.text "submission_email"
+    t.text "privacy_policy_url"
+    t.text "form_slug"
+    t.text "support_email"
+    t.text "support_phone"
+    t.text "support_url"
+    t.text "support_url_text"
+    t.text "declaration_text"
+    t.boolean "question_section_completed", default: false
+    t.boolean "declaration_section_completed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "creator_id"
+    t.text "what_happens_next_markdown"
+    t.string "state"
+    t.string "payment_url"
+    t.string "external_id"
+    t.string "submission_type", default: "email", null: false
+    t.boolean "share_preview_completed", default: false, null: false
+    t.string "s3_bucket_name"
+    t.string "s3_bucket_aws_account_id"
+    t.string "s3_bucket_region"
+    t.index ["external_id"], name: "index_forms_on_external_id", unique: true
   end
 
   create_table "groups", force: :cascade do |t|
@@ -106,6 +146,23 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_24_094215) do
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
+  create_table "pages", force: :cascade do |t|
+    t.text "question_text"
+    t.text "hint_text"
+    t.text "answer_type"
+    t.integer "next_page"
+    t.boolean "is_optional", null: false
+    t.jsonb "answer_settings"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "form_id"
+    t.integer "position"
+    t.text "page_heading"
+    t.text "guidance_markdown"
+    t.boolean "is_repeatable", default: false, null: false
+    t.index ["form_id"], name: "index_pages_on_form_id"
+  end
+
   create_table "schema_info", id: false, force: :cascade do |t|
     t.integer "version", default: 0, null: false
   end
@@ -153,5 +210,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_24_094215) do
   add_foreign_key "mou_signatures", "organisations"
   add_foreign_key "mou_signatures", "users"
   add_foreign_key "organisations", "groups", column: "default_group_id"
+  add_foreign_key "pages", "forms"
   add_foreign_key "users", "organisations"
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/xotu6KNy/1995-add-tables-for-form-models-to-forms-admin <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to migrate the records for forms conditions and pages to this app from forms-api.

This PR adds the tables we'll need in the database.

I've purposely not added models to use those tables, as for now we want the tables to be empty and unused.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?