### PR TITLE
Get list of page routes in routes controller show action

### DIFF
--- a/app/controllers/pages/routes_controller.rb
+++ b/app/controllers/pages/routes_controller.rb
@@ -1,7 +1,9 @@
 class Pages::RoutesController < PagesController
   def show
     back_link_url = form_pages_path(current_form.id)
-    render locals: { current_form:, page:, pages: FormRepository.pages(current_form), back_link_url: }
+    pages = FormRepository.pages(current_form)
+    routes = PageRoutesService.new(form: current_form, pages:, page:).routes
+    render locals: { current_form:, page:, pages:, routes:, back_link_url: }
   end
 
   def delete

--- a/app/input_objects/pages/routes/delete_confirmation_input.rb
+++ b/app/input_objects/pages/routes/delete_confirmation_input.rb
@@ -18,8 +18,8 @@ class Pages::Routes::DeleteConfirmationInput < ConfirmActionInput
 private
 
   def delete_routes
-    all_form_routing_conditions = FormRepository.pages(form).flat_map(&:routing_conditions).compact_blank
-    page_routes = all_form_routing_conditions.select { |rc| rc.check_page_id == page.id }
+    pages = FormRepository.pages(form)
+    page_routes = PageRoutesService.new(form:, pages:, page:).routes
     page_routes.each do |rc|
       rc.prefix_options[:form_id] = form.id
       rc.prefix_options[:page_id] = rc.routing_page_id

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -23,8 +23,7 @@ class RouteSummaryCardDataPresenter
   end
 
   def all_routes
-    all_form_routing_conditions = pages.flat_map(&:routing_conditions).compact_blank
-    all_form_routing_conditions.select { |rc| rc.check_page_id == page.id }
+    PageRoutesService.new(form:, pages:, page:).routes
   end
 
   def conditional_routes

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -3,12 +3,13 @@ class RouteSummaryCardDataPresenter
   include ActionView::Helpers::UrlHelper
   include GovukRailsCompatibleLinkHelper
 
-  attr_reader :form, :pages, :page
+  attr_reader :form, :pages, :page, :routes
 
-  def initialize(form:, pages:, page:)
+  def initialize(form:, pages:, page:, routes:)
     @form = form
     @pages = pages
     @page = page
+    @routes = routes
   end
 
   def summary_card_data
@@ -17,10 +18,6 @@ class RouteSummaryCardDataPresenter
   end
 
 private
-
-  def routes
-    @routes ||= PageRoutesService.new(form:, pages:, page:).routes
-  end
 
   def secondary_skip
     @secondary_skip ||= routes.find(&:secondary_skip?)

--- a/app/services/page_conditions_service.rb
+++ b/app/services/page_conditions_service.rb
@@ -1,0 +1,21 @@
+class PageConditionsService
+  attr_reader :page
+
+  def initialize(form:, pages:, page:)
+    @form = form
+    @pages = pages
+    @page = page
+  end
+
+  def check_conditions
+    form_conditions.select { |condition| condition.check_page_id == page.id }
+  end
+
+  delegate :routing_conditions, to: :page
+
+private
+
+  def form_conditions
+    @form_conditions ||= @pages.flat_map(&:routing_conditions).compact_blank
+  end
+end

--- a/app/services/page_routes_service.rb
+++ b/app/services/page_routes_service.rb
@@ -1,0 +1,23 @@
+class PageRoutesService
+  attr_reader :page
+
+  def initialize(form:, pages:, page:)
+    @form = form
+    @pages = pages
+    @page = page
+  end
+
+  def routes
+    check_conditions
+  end
+
+private
+
+  def check_conditions
+    page_conditions_service.check_conditions
+  end
+
+  def page_conditions_service
+    @page_conditions_service ||= PageConditionsService.new(form: @form, pages: @pages, page: @page)
+  end
+end

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -16,7 +16,7 @@
           end;
       end %>
 
-      <% RouteSummaryCardDataPresenter.call(form: current_form, page:, pages:).summary_card_data.each do |card| %>
+      <% RouteSummaryCardDataPresenter.new(form: current_form, page:, pages:).summary_card_data.each do |card| %>
           <%= govuk_summary_list(**card) %>
       <% end %>
 

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -16,7 +16,7 @@
           end;
       end %>
 
-      <% RouteSummaryCardDataPresenter.new(form: current_form, page:, pages:).summary_card_data.each do |card| %>
+      <% RouteSummaryCardDataPresenter.new(form: current_form, page:, pages:, routes:).summary_card_data.each do |card| %>
           <%= govuk_summary_list(**card) %>
       <% end %>
 

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -3,12 +3,16 @@ require "rails_helper"
 describe RouteSummaryCardDataPresenter do
   include Capybara::RSpecMatchers
 
-  subject(:service) { described_class.new(form:, pages:, page: current_page) }
+  subject(:service) { described_class.new(form:, pages:, page: current_page, routes:) }
 
   let(:form) { build :form, id: 99, pages: }
 
   let(:current_page) do
     build(:page, id: 1, position: 1, question_text: "Current Question", next_page: next_page.id, routing_conditions:)
+  end
+
+  let(:routes) do
+    PageRoutesService.new(form:, pages:, page: current_page).routes
   end
 
   let(:next_page) do

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe RouteSummaryCardDataPresenter do
   include Capybara::RSpecMatchers
 
-  subject(:service) { described_class.new(form:, page: current_page, pages:) }
+  subject(:service) { described_class.new(form:, pages:, page: current_page) }
 
   let(:form) { build :form, id: 99, pages: }
 
@@ -27,13 +27,6 @@ describe RouteSummaryCardDataPresenter do
 
   before do
     allow(form).to receive(:group).and_return(build(:group))
-  end
-
-  describe ".call" do
-    it "instantiates and returns a new instance" do
-      service = described_class.call(form:, page: current_page, pages:)
-      expect(service).to be_an_instance_of(described_class)
-    end
   end
 
   describe "#summary_card_data" do
@@ -140,37 +133,6 @@ describe RouteSummaryCardDataPresenter do
       it 'shows "Check your answers" as default destination' do
         result = service.summary_card_data
         expect(result[0][:rows][0][:value][:text]).to eq("Check your answers before submitting")
-      end
-    end
-
-    describe "#all_routes" do
-      context "when no pages have conditions" do
-        let(:routing_conditions) { [] }
-
-        it "is an empty array when there are no matching conditions" do
-          expect(service.all_routes).to be_empty
-        end
-      end
-
-      context "when pages have conditions with matching check_page_ids" do
-        let(:pages) do
-          [
-            build(:page, id: 1, position: 1, question_text: "Current Question", next_page: next_page.id, routing_conditions: [
-              build(:condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Yes", goto_page_id: 2, skip_to_end: false),
-            ]),
-            build(:page, id: 2, position: 2, question_text: "Next Question", routing_conditions: [
-              build(:condition, id: 1, routing_page_id: 2, check_page_id: 1, answer_value: nil, goto_page_id: nil, skip_to_end: true),
-            ]),
-            build(:page, id: 3, position: 3, question_text: "unrelated question", routing_conditions: [
-              build(:condition, id: 1, routing_page_id: 3, check_page_id: 3, answer_value: "Unrelated", goto_page_id: 5, skip_to_end: false),
-            ]),
-          ]
-        end
-
-        it "returns all condtions which match the check_page_id" do
-          expected_condtions = pages.first.routing_conditions + pages.second.routing_conditions
-          expect(service.all_routes).to match_array(expected_condtions)
-        end
       end
     end
   end

--- a/spec/services/page_conditions_service_spec.rb
+++ b/spec/services/page_conditions_service_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe PageConditionsService do
+  subject(:page_conditions_service) do
+    described_class.new(form:, pages:, page:)
+  end
+
+  let(:form) do
+    build(:form)
+  end
+
+  include_context "with pages with routing"
+
+  describe "#check_conditions" do
+    subject(:check_conditions) { page_conditions_service.check_conditions }
+
+    context "when page has no routes" do
+      let(:page) { page_with_no_routes }
+
+      it { is_expected.to eq [] }
+    end
+
+    context "when page has no check conditions" do
+      let(:page) { end_of_a_secondary_skip }
+
+      it { is_expected.to eq [] }
+    end
+
+    context "when page has check conditions" do
+      let(:page) { page_with_skip_and_secondary_skip }
+
+      it { is_expected.to eq(page_with_skip_and_secondary_skip.routing_conditions + start_of_a_secondary_skip.routing_conditions) }
+    end
+  end
+
+  describe "#routing_conditions" do
+    subject(:routing_conditions) { page_conditions_service.routing_conditions }
+
+    context "when page has no routes" do
+      let(:page) { page_with_no_routes }
+
+      it { is_expected.to eq [] }
+    end
+
+    context "when page has no routing conditions" do
+      let(:page) { end_of_a_secondary_skip }
+
+      it { is_expected.to eq [] }
+    end
+
+    context "when page has routing conditions" do
+      let(:page) { page_with_skip_and_secondary_skip }
+
+      it { is_expected.to eq page.routing_conditions }
+    end
+  end
+end

--- a/spec/services/page_routes_service_spec.rb
+++ b/spec/services/page_routes_service_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe PageRoutesService do
+  subject(:page_routes_service) do
+    described_class.new(form:, pages:, page:)
+  end
+
+  let(:form) do
+    build(:form)
+  end
+
+  include_context "with pages with routing"
+
+  describe "#routes" do
+    subject(:routes) { page_routes_service.routes }
+
+    context "when page has no routes" do
+      let(:page) { page_with_no_routes }
+
+      it { is_expected.to eq [] }
+    end
+
+    context "when page is at the end of a route" do
+      let(:page) { end_of_a_secondary_skip }
+
+      it { is_expected.to eq [] }
+    end
+
+    context "when page has a skip route" do
+      let(:page) { page_with_skip_route }
+
+      it { is_expected.to eq page.routing_conditions }
+    end
+
+    context "when page has a skip and secondary skip" do
+      let(:page) { page_with_skip_and_secondary_skip }
+
+      it { is_expected.to eq(page.routing_conditions + start_of_a_secondary_skip.routing_conditions) }
+    end
+  end
+end

--- a/spec/support/shared_context/pages_with_routing.rb
+++ b/spec/support/shared_context/pages_with_routing.rb
@@ -1,0 +1,117 @@
+RSpec.shared_context "with pages with routing" do
+  let(:pages) do
+    [
+      build(
+        :page,
+        id: 1,
+        question_text: "Question",
+      ),
+      build(
+        :page,
+        :with_selection_settings,
+        id: 2,
+        question_text: "Branch question (start of a route)",
+        selection_options: [{ name: "First branch" }, { name: "Second branch" }],
+        routing_conditions: [
+          build(
+            :condition,
+            answer_value: "Second branch",
+            check_page_id: 2,
+            goto_page_id: 5,
+            routing_page_id: 2,
+          ),
+        ],
+      ),
+      build(
+        :page,
+        id: 3,
+        question_text: "Question in branch 1",
+      ),
+      build(
+        :page,
+        id: 4,
+        question_text: "Question at the end of branch 1 (start of a secondary skip)",
+        routing_conditions: [
+          build(
+            :condition,
+            answer_value: nil,
+            check_page_id: 2,
+            goto_page_id: 8,
+            routing_page_id: 4,
+          ),
+        ],
+      ),
+      build(
+        :page,
+        id: 5,
+        question_text: "Question at the start of branch 2 (end of a route)",
+      ),
+      build(
+        :page,
+        id: 6,
+        question_text: "Question in branch 2",
+      ),
+      build(
+        :page,
+        id: 7,
+        question_text: "Question at the end of branch 2",
+      ),
+      build(
+        :page,
+        id: 8,
+        question_text: "Question after a branch route (end of a secondary skip)",
+      ),
+      build(
+        :page,
+        id: 9,
+        question_text: "Question",
+      ),
+      build(
+        :page,
+        :with_selection_settings,
+        id: 10,
+        question_text: "Skip question",
+        selection_options: [{ name: "Skip" }, { name: "Don't skip" }],
+        routing_conditions: [
+          build(
+            :condition,
+            answer_value: "Skip",
+            check_page_id: 10,
+            goto_page_id: 12,
+            routing_page_id: 10,
+          ),
+        ],
+      ),
+      build(
+        :page,
+        id: 11,
+        question_text: "Question to be skipped",
+      ),
+      build(
+        :page,
+        id: 12,
+        question_text: "Question",
+      ),
+    ]
+  end
+
+  let(:page_with_no_routes) do
+    pages[0]
+  end
+
+  let(:page_with_skip_and_secondary_skip) do
+    pages[1]
+  end
+
+  let(:start_of_a_secondary_skip) do
+    pages[3]
+  end
+
+  let(:end_of_a_secondary_skip) do
+    pages[7]
+  end
+
+  let(:page_with_skip_route) do
+    pages[9]
+  end
+end

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "pages/routes/show.html.erb" do
   let(:form) { build :form, id: 1, pages: [page] }
   let(:page) { build :page, id: 1, position: 1 }
+  let(:routes) { [build(:condition)] }
 
   let(:route_cards) do
     [
@@ -19,7 +20,7 @@ describe "pages/routes/show.html.erb" do
 
   before do
     allow(RouteSummaryCardDataPresenter).to receive(:new).and_return(route_summary_card_data_service)
-    render template: "pages/routes/show", locals: { current_form: form, page:, pages: form.pages, back_link_url: "/back" }
+    render template: "pages/routes/show", locals: { current_form: form, page:, pages: form.pages, routes:, back_link_url: "/back" }
   end
 
   it "has the correct title" do

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -18,7 +18,7 @@ describe "pages/routes/show.html.erb" do
   let(:route_summary_card_data_service) { instance_double(RouteSummaryCardDataPresenter, summary_card_data: route_cards) }
 
   before do
-    allow(RouteSummaryCardDataPresenter).to receive(:call).and_return(route_summary_card_data_service)
+    allow(RouteSummaryCardDataPresenter).to receive(:new).and_return(route_summary_card_data_service)
     render template: "pages/routes/show", locals: { current_form: form, page:, pages: form.pages, back_link_url: "/back" }
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/6qRDmaOg/2095-changes-to-question-xs-routes-page-to-make-it-clearer <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Change the routes/show action, view and RouteSummaryCardDataPresenter to get page routes up front and pass down the chain to other objects. This lets us use the list of routes in places other than the presenter.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?