### PR TITLE
Change where add a question route goes if selected question already has a route

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -12,7 +12,7 @@ class Pages::ConditionsController < PagesController
 
     if routing_page_input.valid?
       routing_page = PageRepository.find(page_id: routing_page_id, form_id: current_form.id)
-      redirect_to new_condtion_or_skip_path(routing_page)
+      redirect_to new_condition_or_show_routes_path(routing_page)
     else
       render template: "pages/conditions/routing_page", locals: { form: current_form, routing_page_input: }, status: :unprocessable_entity
     end
@@ -97,9 +97,9 @@ private
     params.require(:pages_delete_condition_input).permit(:answer_value, :goto_page_id, :confirm).merge(form: current_form, page:)
   end
 
-  def new_condtion_or_skip_path(page)
+  def new_condition_or_show_routes_path(page)
     if FeatureService.new(group: current_form.group).enabled?(:branch_routing) && page.routing_conditions.present?
-      return new_secondary_skip_path(form_id: current_form.id, page_id: page.id)
+      return show_routes_path(form_id: current_form.id, page_id: page.id)
     end
 
     new_condition_path(current_form.id, page.id)

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Pages::ConditionsController, type: :request do
         page
       end
 
-      it "when branch_routing enabled, redirects the user to the new skip condition page", :feature_branch_routing do
-        expect(response).to redirect_to new_secondary_skip_path(form.id, selected_page.id)
+      it "when branch_routing enabled, redirects the user to the question routes page", :feature_branch_routing do
+        expect(response).to redirect_to show_routes_path(form.id, selected_page.id)
       end
 
       it "when branch_routing disabled, redirects the user to the new conditions page" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/uqN7WiGA/2082-changes-to-add-a-route-from-a-question-page-to-make-it-easier-to-find-where-and-how-to-add-second-route <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We've decided that if a question already has a route we should take the user to the 'Question x's routes' page instead of straight to the settings for the secondary skip, to better summarise the current situation of routes for the page - before the new one is added - and to future proof the journey when you can add multiple routes.

<h3>Screen recording</h3>

Screen recording of the new behaviour:

https://github.com/user-attachments/assets/3aa9c882-9736-4399-a332-af9beba60f4c

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?