### PR TITLE
Change name of default route/secondary skip route to "any other answer"

### DIFF
--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -14,7 +14,7 @@ class RouteSummaryCardDataPresenter
 
   def summary_card_data
     conditional_cards = conditional_route_cards
-    conditional_cards + [default_route_card(conditional_cards.length + 1)]
+    conditional_cards + [default_route_card]
   end
 
 private
@@ -55,7 +55,7 @@ private
     }
   end
 
-  def default_route_card(index)
+  def default_route_card
     continue_to_name = page.has_next_page? ? page_name(page.next_page) : end_page_name
 
     actions = if FeatureService.new(group: form.group).enabled?(:branch_routing) && secondary_skip
@@ -69,7 +69,7 @@ private
 
     {
       card: {
-        title: I18n.t("page_route_card.route_title", index:),
+        title: I18n.t("page_route_card.any_other_answer"),
         classes: "app-summary-card",
         actions:,
       },

--- a/app/views/pages/secondary_skip/edit.html.erb
+++ b/app/views/pages/secondary_skip/edit.html.erb
@@ -4,8 +4,7 @@
 <% content_for :heading do %>
   <h1 class="govuk-heading-l">
     <span class="govuk-caption-l"><%= t("secondary_skip.new.caption", page_position: secondary_skip_input.page.position) %></span>
-    <%= t("page_titles.new_secondary_skip", route_index: 2) %>
-    <%# TODO: route_index is hardcoded as 2 here because we know there are only two conditions. It will need to change in the future %>
+    <%= t("page_titles.new_secondary_skip") %>
   </h1>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,7 +96,7 @@ en:
         pages/delete_secondary_skip_input:
           attributes:
             confirm:
-              blank: Select ‘Yes’ to delete route 2
+              blank: Select ‘Yes’ to delete the route
         pages/question_input:
           attributes:
             hint_text:
@@ -1052,6 +1052,7 @@ en:
       none_of_the_above: None of the above
       only_one_option: Selection from a list, one option only
   page_route_card:
+    any_other_answer: Route for any other answer
     check_your_answers: Check your answers before submitting
     conditional_answer_value: "%{answer_value}"
     continue_to: For any other answer, continue to
@@ -1104,7 +1105,7 @@ en:
     contact_details: Provide contact details for support
     date_settings: Are you asking for someone’s date of birth?
     declaration: Add a declaration for people to agree to
-    delete_secondary_skip: Are you sure you want to delete route 2?
+    delete_secondary_skip: Are you sure you want to delete the route for any other answer?
     email_code_sent: Confirmation code sent
     error_prefix: 'Error: '
     forbidden: You cannot view this page
@@ -1123,7 +1124,7 @@ en:
     mou_signatures: Memorandum of Understanding agreements
     name_settings: Ask for a person’s name
     new_page: Edit question
-    new_secondary_skip: 'Route %{route_index}: set questions to skip'
+    new_secondary_skip: Set questions to skip
     not_found: Page not found
     payment_link: Add a link to a payment page on GOV.UK Pay
     privacy_policy: Provide a link to privacy information for this form

--- a/spec/input_objects/pages/delete_secondary_skip_input_spec.rb
+++ b/spec/input_objects/pages/delete_secondary_skip_input_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pages::DeleteSecondarySkipInput, type: :model do
     it "is invalid if confirm is nil" do
       delete_secondary_skip_input.confirm = nil
       expect(delete_secondary_skip_input).to be_invalid
-      expect(delete_secondary_skip_input.errors.full_messages_for(:confirm)).to include("Confirm Select ‘Yes’ to delete route 2")
+      expect(delete_secondary_skip_input.errors.full_messages_for(:confirm)).to include("Confirm Select ‘Yes’ to delete the route")
     end
   end
 

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -46,7 +46,7 @@ describe RouteSummaryCardDataPresenter do
         expect(result[0][:rows][1][:value][:text]).to eq("2. Next Question")
 
         # default route
-        expect(result[1][:card][:title]).to eq("Route 2")
+        expect(result[1][:card][:title]).to eq("Route for any other answer")
         expect(result[1][:card][:actions][0]).to be_nil
         expect(result[1][:rows][0][:value][:text]).to eq("2. Next Question")
       end
@@ -125,7 +125,7 @@ describe RouteSummaryCardDataPresenter do
       it "returns only the default route card" do
         result = service.summary_card_data
         expect(result.length).to eq(1)
-        expect(result[0][:card][:title]).to eq("Route 1")
+        expect(result[0][:card][:title]).to eq("Route for any other answer")
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/yW68wpBI/2121-change-route-2-name-to-route-for-any-other-answer-in-several-places <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We think it will make it clearer what the secondary skip route is to call it the "any other answer" route.

### Screenshots

![Screenshot of the "Question x's routes" page with a summary card for a secondary skip route](https://github.com/user-attachments/assets/03b9d135-0ab2-4f2c-a7a9-80b5c21df23b)

![Screenshot of the page to set questions to skip for secondary skip route](https://github.com/user-attachments/assets/19daa181-0a74-426f-b041-97a27004212e)

![Screenshot of the page to confirm deletion of a secondary skip route](https://github.com/user-attachments/assets/02e19158-6a80-4a5b-bf74-c356746c55ee)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?