### PR TITLE
Enable the "developer" auth strategy in review environments

### DIFF
--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -20,7 +20,7 @@ Rails.application.config.before_initialize do
   )
 
   # add developer provider
-  if Rails.env.development? || Rails.env.test?
+  if Rails.env.development? || Rails.env.test? || (Settings.forms_env == "review")
     Rails.application.config.app_middleware.use(
       OmniAuth::Strategies::Developer,
       fields: [:email],


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/u0AOLJYF/579-terraform-for-deploying-forms-admin-to-integration-ecs-cluster

The review app deployments of forms-admin want to use the developer authentication strategy, but also needs to use RAILS_ENV=production. Previously it was only possible to use it when the RAILS_ENV value was development or test.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
