### PR TITLE
Allow database seeds to be run in a review environment

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -15,6 +15,10 @@ module HostingEnvironment
     environment_name == "dev"
   end
 
+  def self.review?
+    environment_name == "review"
+  end
+
   def self.test_environment?
     dev? || local_development?
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 
 require "factory_bot"
 
-if HostingEnvironment.local_development? && User.none?
+if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User.none?
 
   gds = Organisation.find_or_create_by!(
     govuk_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/u0AOLJYF/579-terraform-for-deploying-forms-admin-to-integration-ecs-cluster

We need to be able to apply database seed data in review environments, but review environments use `RAILS_ENV=production` which prevented this from happening. Instead, we enable it for review environments also.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
