### PR TITLE
Stop showing question straight after page to skip from in list of pages to skip to

### DIFF
--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -37,7 +37,7 @@ class Pages::ConditionsInput < BaseInput
   end
 
   def goto_page_options
-    page_options = pages_after_position(page.position).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
+    page_options = pages_after_position(page.position + 1).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
     page_options << OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))
 
     page_options

--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -37,7 +37,7 @@ class Pages::ConditionsInput < BaseInput
   end
 
   def goto_page_options
-    page_options = pages_after_current_page(FormRepository.pages(form), page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
+    page_options = pages_after_position(page.position).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
     page_options << OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))
 
     page_options
@@ -67,7 +67,8 @@ class Pages::ConditionsInput < BaseInput
 
 private
 
-  def pages_after_current_page(all_pages, current_page)
-    all_pages.filter { |page| page.position > current_page.position }
+  def pages_after_position(position)
+    all_pages = FormRepository.pages(form)
+    all_pages.filter { |page| page.position > position }
   end
 end

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -131,15 +131,15 @@ RSpec.describe Pages::ConditionsInput, type: :model do
         expect(goto_page_options).to all have_attributes(id: a_value, question_text: a_kind_of(String))
       end
 
-      it "excludes the first page" do
+      it "excludes the first page and the page straight after the first page" do
         expect(goto_page_options).not_to include(
-          *form.pages.take(1).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+          *form.pages.take(2).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
         )
       end
 
-      it "includes all pages after the first page" do
+      it "includes all pages after the page straight after the first page" do
         expect(goto_page_options).to start_with(
-          *form.pages.drop(1).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+          *form.pages.drop(2).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
         )
       end
 
@@ -159,15 +159,15 @@ RSpec.describe Pages::ConditionsInput, type: :model do
         expect(goto_page_options).to all have_attributes(id: a_value, question_text: a_kind_of(String))
       end
 
-      it "excludes any pages before the given page" do
+      it "excludes any pages before the given page and the page straight after the given page" do
         expect(goto_page_options).not_to include(
-          *form.pages.take(routing_from_page_count).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+          *form.pages.take(routing_from_page_count + 1).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
         )
       end
 
-      it "includes all pages after the given page" do
+      it "includes all pages after the page after the given page" do
         expect(goto_page_options).to start_with(
-          *form.pages.drop(routing_from_page_count).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+          *form.pages.drop(routing_from_page_count + 1).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
         )
       end
 

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -125,23 +125,56 @@ RSpec.describe Pages::ConditionsInput, type: :model do
 
   describe "#goto_page_options" do
     context "when routing from the first form page" do
-      it "returns a list of all pages after the first page and includes 'Check your answers before submitting'" do
-        result = described_class.new(form:, page: pages.first).goto_page_options
-        expect(result).to eq([
-          form.pages.drop(1).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+      subject(:goto_page_options) { described_class.new(form:, page: pages.first).goto_page_options }
+
+      it "returns a list of pages" do
+        expect(goto_page_options).to all have_attributes(id: a_value, question_text: a_kind_of(String))
+      end
+
+      it "excludes the first page" do
+        expect(goto_page_options).not_to include(
+          *form.pages.take(1).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+        )
+      end
+
+      it "includes all pages after the first page" do
+        expect(goto_page_options).to start_with(
+          *form.pages.drop(1).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+        )
+      end
+
+      it "includes 'Check your answers before submitting'" do
+        expect(goto_page_options).to include(
           OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
-        ].flatten)
+        )
       end
     end
 
     context "when routing from the third form page" do
-      it "returns a list of answers that excludes any pages before the given page and the given page" do
-        routing_from_page_position = 3
-        result = described_class.new(form:, page: pages[routing_from_page_position - 1]).goto_page_options
-        expect(result).to eq([
-          form.pages.drop(routing_from_page_position).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+      subject(:goto_page_options) { described_class.new(form:, page: pages[routing_from_page_count - 1]).goto_page_options }
+
+      let(:routing_from_page_count) { 2 }
+
+      it "returns a list of pages" do
+        expect(goto_page_options).to all have_attributes(id: a_value, question_text: a_kind_of(String))
+      end
+
+      it "excludes any pages before the given page" do
+        expect(goto_page_options).not_to include(
+          *form.pages.take(routing_from_page_count).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+        )
+      end
+
+      it "includes all pages after the given page" do
+        expect(goto_page_options).to start_with(
+          *form.pages.drop(routing_from_page_count).map { |p| OpenStruct.new(id: p.id, question_text: "#{p.position}. #{p.question_text}") },
+        )
+      end
+
+      it "includes 'Check your answers before submitting'" do
+        expect(goto_page_options).to include(
           OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
-        ].flatten)
+        )
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/tYdE1AMd/2108-p2-stop-users-from-setting-up-route-to-the-next-page <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We've seen users in user research expect that trying to set up a route to the page straight after the page to route from would show an error. So we think it makes sense to not include the question straight after in the select options.

### Screen recording

Recording of adding a question route and editing a question route when the goto page has been moved to be straight after the routing page:

https://github.com/user-attachments/assets/abc73040-1099-4b4f-b8e5-c933d7299298

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?