### PR TITLE
Fix delete all routes journey

### DIFF
--- a/app/services/condition_repository.rb
+++ b/app/services/condition_repository.rb
@@ -30,6 +30,7 @@ class ConditionRepository
       condition = Api::V1::ConditionResource.new(record.attributes, true)
       condition.prefix_options = record.prefix_options
       condition.destroy # rubocop:disable Rails/SaveBang
+      record
     end
   end
 end

--- a/app/services/condition_repository.rb
+++ b/app/services/condition_repository.rb
@@ -29,7 +29,14 @@ class ConditionRepository
     def destroy(record)
       condition = Api::V1::ConditionResource.new(record.attributes, true)
       condition.prefix_options = record.prefix_options
-      condition.destroy # rubocop:disable Rails/SaveBang
+
+      begin
+        condition.destroy # rubocop:disable Rails/SaveBang
+      rescue ActiveResource::ResourceNotFound
+        # ActiveRecord::Persistence#destroy doesn't raise an error
+        # if record has already been destroyed, let's emulate that
+      end
+
       record
     end
   end

--- a/app/services/form_repository.rb
+++ b/app/services/form_repository.rb
@@ -40,7 +40,14 @@ class FormRepository
 
     def destroy(record)
       form = Api::V1::FormResource.new(record.attributes, true)
-      form.destroy # rubocop:disable Rails/SaveBang
+
+      begin
+        form.destroy # rubocop:disable Rails/SaveBang
+      rescue ActiveResource::ResourceNotFound
+        # ActiveRecord::Persistence#destroy doesn't raise an error
+        # if record has already been destroyed, let's emulate that
+      end
+
       record
     end
 

--- a/app/services/form_repository.rb
+++ b/app/services/form_repository.rb
@@ -41,6 +41,7 @@ class FormRepository
     def destroy(record)
       form = Api::V1::FormResource.new(record.attributes, true)
       form.destroy # rubocop:disable Rails/SaveBang
+      record
     end
 
     def pages(record)

--- a/app/services/page_repository.rb
+++ b/app/services/page_repository.rb
@@ -34,7 +34,14 @@ class PageRepository
     def destroy(record)
       page = Api::V1::PageResource.new(record.attributes, true)
       page.prefix_options = record.prefix_options
-      page.destroy # rubocop:disable Rails/SaveBang
+
+      begin
+        page.destroy # rubocop:disable Rails/SaveBang
+      rescue ActiveResource::ResourceNotFound
+        # ActiveRecord::Persistence#destroy doesn't raise an error
+        # if record has already been destroyed, let's emulate that
+      end
+
       record
     end
 

--- a/app/services/page_repository.rb
+++ b/app/services/page_repository.rb
@@ -35,6 +35,7 @@ class PageRepository
       page = Api::V1::PageResource.new(record.attributes, true)
       page.prefix_options = record.prefix_options
       page.destroy # rubocop:disable Rails/SaveBang
+      record
     end
 
     def move_page(record, direction)

--- a/spec/requests/pages/routes_controller_spec.rb
+++ b/spec/requests/pages/routes_controller_spec.rb
@@ -84,6 +84,22 @@ describe Pages::RoutesController, type: :request do
         expect(ConditionRepository).to receive(:destroy).with(have_attributes(id: secondary_skip.id))
         delete destroy_routes_path(form_id: form.id, page_id: selected_page.id, pages_routes_delete_confirmation_input: { confirm: "yes" })
       end
+
+      context "but one of the routes is already deleted" do
+        before do
+          # forms-api may choose to delete the secondary skip when the condition is deleted
+          allow(ConditionRepository).to receive(:destroy).and_call_original
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.delete "/api/v1/forms/#{form.id}/pages/#{selected_page.id}/conditions/#{condition.id}", delete_headers, nil, 204
+            mock.delete "/api/v1/forms/#{form.id}/pages/#{secondary_skip_page.id}/conditions/#{secondary_skip.id}", delete_headers, nil, 404
+          end
+        end
+
+        it "does not render an error page" do
+          delete destroy_routes_path(form_id: form.id, page_id: selected_page.id, pages_routes_delete_confirmation_input: { confirm: "yes" })
+          expect(response).not_to be_client_error
+        end
+      end
     end
 
     context "when given invalid params" do

--- a/spec/requests/pages/routes_controller_spec.rb
+++ b/spec/requests/pages/routes_controller_spec.rb
@@ -60,9 +60,9 @@ describe Pages::RoutesController, type: :request do
   end
 
   describe "#destroy" do
-    let(:condition) { build :condition, routing_page_id: selected_page.id, check_page_id: selected_page.id, goto_page_id: pages.last.id, answer_value: "Option 1" }
+    let(:condition) { build :condition, id: 1, routing_page_id: selected_page.id, check_page_id: selected_page.id, goto_page_id: pages.last.id, answer_value: "Option 1" }
     let(:secondary_skip_page) { form.pages[2] }
-    let(:secondary_skip) { build :condition, routing_page_id: secondary_skip_page.id, check_page_id: selected_page.id, goto_page_id: pages[3].id }
+    let(:secondary_skip) { build :condition, id: 2, routing_page_id: secondary_skip_page.id, check_page_id: selected_page.id, goto_page_id: pages[3].id }
 
     before do
       allow(PageRepository).to receive(:find).with(page_id: "101", form_id: 1).and_return(selected_page)

--- a/spec/services/condition_repository_spec.rb
+++ b/spec/services/condition_repository_spec.rb
@@ -72,5 +72,10 @@ describe ConditionRepository do
       described_class.destroy(condition)
       expect(Api::V1::ConditionResource.new(id: 4, form_id: 1, page_id: 2)).to have_been_deleted
     end
+
+    it "returns the deleted condition" do
+      condition = described_class.find(condition_id: 4, form_id: 1, page_id: 2)
+      expect(described_class.destroy(condition)).to eq condition
+    end
   end
 end

--- a/spec/services/condition_repository_spec.rb
+++ b/spec/services/condition_repository_spec.rb
@@ -77,5 +77,31 @@ describe ConditionRepository do
       condition = described_class.find(condition_id: 4, form_id: 1, page_id: 2)
       expect(described_class.destroy(condition)).to eq condition
     end
+
+    context "when the condition has already been deleted" do
+      it "does not raise an error" do
+        condition = described_class.find(condition_id: 4, form_id: 1, page_id: 2)
+        described_class.destroy(condition)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.delete "/api/v1/forms/1/pages/2/conditions/4", delete_headers, nil, 404
+        end
+
+        expect {
+          described_class.destroy(condition)
+        }.not_to raise_error
+      end
+
+      it "returns the deleted condition" do
+        condition = described_class.find(condition_id: 4, form_id: 1, page_id: 2)
+        described_class.destroy(condition)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.delete "/api/v1/forms/1/pages/2/conditions/4", delete_headers, nil, 404
+        end
+
+        expect(described_class.destroy(condition)).to eq condition
+      end
+    end
   end
 end

--- a/spec/services/form_repository_spec.rb
+++ b/spec/services/form_repository_spec.rb
@@ -149,6 +149,32 @@ describe FormRepository do
       form = described_class.find(form_id: 2)
       expect(described_class.destroy(form)).to eq form
     end
+
+    context "when the form has already been deleted" do
+      it "does not raise an error" do
+        form = described_class.find(form_id: 2)
+        described_class.destroy(form)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.delete "/api/v1/forms/2", delete_headers, nil, 404
+        end
+
+        expect {
+          described_class.destroy(form)
+        }.not_to raise_error
+      end
+
+      it "returns the deleted form" do
+        form = described_class.find(form_id: 2)
+        described_class.destroy(form)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.delete "/api/v1/forms/2", delete_headers, nil, 404
+        end
+
+        expect(described_class.destroy(form)).to eq form
+      end
+    end
   end
 
   describe "#pages" do

--- a/spec/services/form_repository_spec.rb
+++ b/spec/services/form_repository_spec.rb
@@ -144,6 +144,11 @@ describe FormRepository do
       described_class.destroy(form)
       expect(Api::V1::FormResource.new(id: 2)).to have_been_deleted
     end
+
+    it "returns the deleted form" do
+      form = described_class.find(form_id: 2)
+      expect(described_class.destroy(form)).to eq form
+    end
   end
 
   describe "#pages" do

--- a/spec/services/page_repository_spec.rb
+++ b/spec/services/page_repository_spec.rb
@@ -79,6 +79,32 @@ describe PageRepository do
       page = described_class.find(page_id: 2, form_id: 1)
       expect(described_class.destroy(page)).to eq page
     end
+
+    context "when the page has already been deleted" do
+      it "does not raise an error" do
+        page = described_class.find(page_id: 2, form_id: 1)
+        described_class.destroy(page)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.delete "/api/v1/forms/1/pages/2", delete_headers, nil, 404
+        end
+
+        expect {
+          described_class.destroy(page)
+        }.not_to raise_error
+      end
+
+      it "returns the deleted page" do
+        page = described_class.find(page_id: 2, form_id: 1)
+        described_class.destroy(page)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.delete "/api/v1/forms/1/pages/2", delete_headers, nil, 404
+        end
+
+        expect(described_class.destroy(page)).to eq page
+      end
+    end
   end
 
   describe "#move_page" do

--- a/spec/services/page_repository_spec.rb
+++ b/spec/services/page_repository_spec.rb
@@ -74,6 +74,11 @@ describe PageRepository do
       described_class.destroy(page)
       expect(Api::V1::PageResource.new(id: 2, form_id: 1)).to have_been_deleted
     end
+
+    it "returns the deleted page" do
+      page = described_class.find(page_id: 2, form_id: 1)
+      expect(described_class.destroy(page)).to eq page
+    end
   end
 
   describe "#move_page" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/cFZnCzve/2127-bug-delete-all-routes-redirects-to-a-page-not-found-error <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Currently when a user tries to delete all routes for a question they are shown a page not found error rather being redirected to the "Add and edit questions" page as expected.

I think this is happening because of a change in forms-api that means deleting a condition can also delete secondary skip conditions in the same request (alphagov/forms-api#686).

This PR adds a test that simulates the behaviour of forms-api currently, and changes the `destroy` methods for each repository so that trying to delete a condition that has already been deleted doesn't result in an exception. This behaviour is closer to how ActiveRecord behaves, and fixes the problem so that users won't see the error page any more.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?