### PR TITLE
Change 'take' to 'skip' on route input labels

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -771,7 +771,7 @@ en:
       pages_secondary_skip_input:
         default_goto_page_id: Select a question or page
         default_routing_page_id: Select a question
-        goto_page_id: take them to
+        goto_page_id: skip them to
         routing_page_id: Then after the person answers
       pages_selection_bulk_options_input:
         include_none_of_the_above_options:

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -26,4 +26,4 @@ en:
     label:
       pages_conditions_input:
         answer_value: is answered as
-        goto_page_id: take the person to
+        goto_page_id: skip the person to


### PR DESCRIPTION
### What problem does this pull request solve?

We're changing 'take' to 'skip' on the input labels on the pages where you add and edit routes. 'Skip' has been a helpful term in usability sessions and makes it clearer that the purpose of the route is to miss something out.

No Trello card but this has been agreed with the team. 

We'll be changing other places where we say 'take them to' to 'skip' separately - we wanted to change it on the labels as a priority ahead of testing next week.

### Screenshots

<img width="1231" alt="Screenshot of Edit question x's route page with these changes" src="https://github.com/user-attachments/assets/1bfcf759-0aaa-45a7-a270-74e1cb3f36c0" />

<img width="1231" alt="Screenshot of Set questions to skip page with these changes" src="https://github.com/user-attachments/assets/d0c05baf-3a19-4e38-bebe-b49b3444015e" />



### Things to consider when reviewing

Please double check that I have changed this in the right places.

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
