### PR TITLE
Add task to list groups which have a feature flag enabled

### DIFF
--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -54,6 +54,21 @@ namespace :groups do
     end
   end
 
+  desc "List enabled features for groups"
+  task features: :environment do
+    feature_flags = %i[branch_routing_enabled file_upload_enabled]
+    query = feature_flags.map { "#{it} IS TRUE" }.join(" OR ")
+
+    Group.where(query).find_each do |group|
+      puts({
+        id: group.external_id,
+        name: group.name,
+        organisation: group.organisation.name,
+        **group.slice(feature_flags),
+      })
+    end
+  end
+
   desc "Enable file upload feature"
   task :enable_file_upload, %i[group_id] => :environment do |_, args|
     usage_message = "usage: rake groups:enable_file_upload[<group_external_id>]".freeze


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

There isn't an easy way to see what feature flags are enabled for which groups currently; this PR adds a very simple Rake task to help with this.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?