### PR TITLE
Update en.yml - added 's' to the word 'questions' in details component link text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1434,7 +1434,7 @@ en:
       details_html: |
         <p>People who select an answer that does not have a route assigned to it will continue to the next question.</p>
         <p>If you need to, you can make these people skip one or more questions later in the form. For example, you might want them to skip route 1’s questions. This allows you to create 2 different ‘branches’ of questions.</p>
-      details_summary: Why set question to skip?
+      details_summary: Why set questions to skip?
       primary_route_answer_key: is not
       primary_route_continue_key: continue to
       primary_route_question_key: If the answer to


### PR DESCRIPTION
Corrected a tiny typo: added a missing 's' to the word 'questions' in the details component link text, 'Why set questions to skip?'

This appears on the 'Set questions to skip' page when a form creator adds a secondary skip to the 'for any other answer' route

### What problem does this pull request solve?

Trello card: https://trello.com/c/faPNxjxY/2133-update-routing-pages-to-match-designs-snags-ticket?search_id=6ea6f47b-3770-42b3-823f-dd25a51b9eb3

This is bullet point #3 on this snags ticket. (One less thing for the devs to have to change when they address the other two.)

### Things to consider when reviewing

- Make sure I've changed the right thing in the right place :)

