### PR TITLE
Change review apps PR workflow to leave only one comment

### DIFF
--- a/.github/workflows/review_apps_on_pr_change.yml
+++ b/.github/workflows/review_apps_on_pr_change.yml
@@ -76,9 +76,9 @@ jobs:
 
       - name: Comment on PR
         env:
+          COMMENT_MARKER: <!-- review apps on pr change -->
           GH_TOKEN: ${{ github.token }}
         run: |
-
           cat <<EOF > "${{runner.temp}}/pr-comment.md"
           :tada: A review copy of this PR has been deployed! You can reach it at ${{steps.deploy.outputs.REVIEW_APP_URL}}.
 
@@ -87,6 +87,13 @@ jobs:
           to debug, or otherwise ask an infrastructure person.
 
           For more details please see the [review app wiki page](https://github.com/alphagov/forms-team/wiki/Review-apps)
+
+          $COMMENT_MARKER
           EOF
+
+          old_comment_ids=$(gh api "repos/{owner}/{repo}/issues/${{github.event.pull_request.number}}/comments" --jq 'map(select((.user.login == "github-actions[bot]") and (.body | endswith($ENV.COMMENT_MARKER + "\n")))) | .[].id')
+          for comment_id in $old_comment_ids; do
+            gh api -X DELETE "repos/{owner}/{repo}/issues/comments/${comment_id}"
+          done
 
           gh pr comment "${{github.event.pull_request.html_url}}" --body-file "${{runner.temp}}/pr-comment.md"


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The way we work with GitHub in this repo means we need to rebase our PRs often; this on top of the usual back and forth when reviewing means that review apps might get deployed several times before a PR is merged. This is fine, except that every time the review apps are deployed there is a new comment left by the workflow, which is a bit noisy.

This PR changes the workflow to first delete any existing comments about review apps (similar to what our other sonarqube cloud bot does), so that there should only be one comment about review apps on a PR at a time, but it keeps its useful place in the timeline.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?