### PR TITLE
.review_apps: use app autoscaling to turn review apps off at night, weekends

### DIFF
--- a/.review_apps/app_autoscaling.tf
+++ b/.review_apps/app_autoscaling.tf
@@ -1,0 +1,38 @@
+resource "aws_appautoscaling_target" "review_app" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${data.terraform_remote_state.review.outputs.ecs_cluster_id}/${aws_ecs_service.app.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  max_capacity = 1
+  min_capacity = 1
+}
+
+resource "aws_appautoscaling_scheduled_action" "shutdown_at_night" {
+  name = "pr-${var.pull_request_number}-shutdown-at-night"
+
+  service_namespace  = aws_appautoscaling_target.review_app.service_namespace
+  resource_id        = aws_appautoscaling_target.review_app.resource_id
+  scalable_dimension = aws_appautoscaling_target.review_app.scalable_dimension
+
+  schedule = "cron(0 18 * * ? *)" # daily at 1800
+
+  scalable_target_action {
+    min_capacity = 0
+    max_capacity = 0
+  }
+}
+
+resource "aws_appautoscaling_scheduled_action" "startup_weekday_mornings" {
+  name = "pr-${var.pull_request_number}-startup-weekday-mornings"
+
+  service_namespace  = aws_appautoscaling_target.review_app.service_namespace
+  resource_id        = aws_appautoscaling_target.review_app.resource_id
+  scalable_dimension = aws_appautoscaling_target.review_app.scalable_dimension
+
+  schedule = "cron(0 8 ? * MON-FRI *)" # Monday-Friday at 0800
+
+  scalable_target_action {
+    min_capacity = 1
+    max_capacity = 1
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This PR has been raised so that we can check the review app in the morning and see if it went down to zero.
>
> A matching PR has been raised to give the role permission to do this: https://github.com/alphagov/forms-deploy/pull/1391

### What problem does this pull request solve?

Trello card: https://github.com/alphagov/forms-admin/pull/1806

AWS App Autoscaling allows us to scale AWS ECS services up and down on a schedule. To save money, we want to turn them off at 6pm each day, and then back on at 8am Monday to Friday.

The result should be them being turned off from 6pm to 8am Monday to Friday, and all day on weekends.


### Things to consider when reviewing

I let the scaling rules take effect overnight to demonstrate them working against the review app for this PR

![image](https://github.com/user-attachments/assets/ce87c65f-f9cc-4869-b90c-5689ecd4c457)

![image](https://github.com/user-attachments/assets/4947aa9a-254b-4f31-ac82-674b221d77e1)

