### PR TITLE
Add page IDs to summary list rows for page summary component

### DIFF
--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -4,7 +4,7 @@
     <%= form_with url: move_page_url(@form_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <dl class="govuk-summary-list">
         <% @pages.each_with_index do |page, index| %>
-          <div class="govuk-summary-list__row">
+          <div id="<%= page_row_id(page) %>" class="govuk-summary-list__row">
 
             <dt class="govuk-summary-list__key app-page-list__key">
               <%= page.position %>

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -16,6 +16,10 @@ module PageListComponent
       index != @pages.length - 1
     end
 
+    def page_row_id(record)
+      "page_#{record.id}"
+    end
+
     def condition_description(condition)
       if condition.secondary_skip?
         I18n.t("page_conditions.secondary_skip_description", check_page_text: skip_condition_route_page_text(condition), goto_page_text: goto_page_text_for_condition(condition))

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe PageListComponent::View, type: :component do
         expect(page).not_to have_button("Move up")
         expect(page).not_to have_button("Move down")
       end
+
+      it "includes the page id in the id for the row" do
+        expect(page).to have_css "#page_1.govuk-summary-list__row"
+      end
     end
 
     context "when the form has multiple pages" do
@@ -51,6 +55,11 @@ RSpec.describe PageListComponent::View, type: :component do
 
       it "renders a move down link" do
         expect(page).to have_button("Move down")
+      end
+
+      it "includes the page id in the id for each row" do
+        expect(page).to have_css "#page_1.govuk-summary-list__row"
+        expect(page).to have_css "#page_2.govuk-summary-list__row"
       end
 
       context "when the form has conditions" do
@@ -172,6 +181,12 @@ RSpec.describe PageListComponent::View, type: :component do
 
       it "returns true for other pages" do
         expect(page_list_component.show_down_button(pages.length - 2)).to be true
+      end
+    end
+
+    describe "#page_row_id" do
+      it "returns the corrrect id text for a given page" do
+        expect(page_list_component.page_row_id(pages.second)).to eq "page_2"
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We already have IDs for each summary list row for a condition, this PR adds IDs for each summary list row for a page. This will be useful for automation tools such as our end to end tests.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?