### PR TITLE
Fix question numbers in error messages for any other answer routes

### DIFF
--- a/app/components/page_list_component/error_summary/view.rb
+++ b/app/components/page_list_component/error_summary/view.rb
@@ -14,19 +14,23 @@ module PageListComponent
         OpenStruct.new(message: I18n.t("page_conditions.errors.#{error_name}", question_number: page.position), link: "##{self.class.error_id(condition.id)}")
       end
 
-      def conditions_with_routing_pages
-        @pages.map { |page| page.routing_conditions.map { |condition| OpenStruct.new(condition:, routing_page: page) } }
-          .flatten
+      def conditions_with_check_pages
+        @pages.map { |page|
+          page.routing_conditions.map do |condition|
+            check_page = @pages.find { it.id == condition.check_page_id }
+            OpenStruct.new(condition:, check_page:)
+          end
+        }.flatten
       end
 
       def errors_for_summary
-        conditions_with_routing_pages
-          .map { |condition_with_routing_page|
-            condition_with_routing_page.condition.validation_errors.map do |error|
+        conditions_with_check_pages
+          .map { |condition_with_check_page|
+            condition_with_check_page.condition.validation_errors.map do |error|
               error_object(
                 error_name: error.name,
-                page: condition_with_routing_page.routing_page,
-                condition: condition_with_routing_page.condition,
+                page: condition_with_check_page.check_page,
+                condition: condition_with_check_page.condition,
               )
             end
           }

--- a/app/components/page_list_component/error_summary/view.rb
+++ b/app/components/page_list_component/error_summary/view.rb
@@ -15,22 +15,22 @@ module PageListComponent
       end
 
       def conditions_with_check_pages
-        @pages.map { |page|
+        @pages.flat_map do |page|
           page.routing_conditions.map do |condition|
-            check_page = @pages.find { it.id == condition.check_page_id }
-            OpenStruct.new(condition:, check_page:)
+            condition.attributes[:check_page] ||= @pages.find { it.id == condition.check_page_id }
+            condition
           end
-        }.flatten
+        end
       end
 
       def errors_for_summary
         conditions_with_check_pages
           .map { |condition_with_check_page|
-            condition_with_check_page.condition.validation_errors.map do |error|
+            condition_with_check_page.validation_errors.map do |error|
               error_object(
                 error_name: error.name,
                 page: condition_with_check_page.check_page,
-                condition: condition_with_check_page.condition,
+                condition: condition_with_check_page,
               )
             end
           }

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -33,16 +33,17 @@
           </div>
 
           <%  page.routing_conditions.each do |condition| %>
+            <% condition_page_position = self.condition_page_position(condition) %>
             <div id="<%= PageListComponent::ErrorSummary::View.error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "govuk-form-group--error": condition.has_routing_errors?) %>">
               <dt class="govuk-summary-list__key govuk-summary-list__key app-page-list__key">
-                <%= t("page_conditions.condition_name", question_number: condition_page_position(condition)) %>
+                <%= t("page_conditions.condition_name", question_number: condition_page_position) %>
               </dt>
 
               <dd class="govuk-summary-list__value">
                 <ul class="govuk-list govuk-!-margin-0">
                   <% condition.validation_errors.each do |error| %>
                     <li class="app-page_list__route-text--error">
-                      <%= t("page_conditions.errors.#{error.name}", question_number: page.position) %>
+                      <%= t("page_conditions.errors.#{error.name}", question_number: condition_page_position) %>
                     </li>
                   <% end %>
                 </ul>
@@ -53,7 +54,7 @@
 
               <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
                 <%= govuk_link_to show_routes_path(form_id: @form.id, page_id: condition.check_page_id) do %>
-                  <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", question_number: page.position)) %>
+                  <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", question_number: condition_page_position)) %>
                 <% end %>
               </dd>
             </div>

--- a/spec/components/page_list_component/error_summary/view_spec.rb
+++ b/spec/components/page_list_component/error_summary/view_spec.rb
@@ -127,9 +127,9 @@ RSpec.describe PageListComponent::ErrorSummary::View, type: :component do
 
     describe "#conditions_with_check_pages" do
       it "returns all of the conditions for a form with their respective conditions and check pages" do
-        expect(error_summary_component.conditions_with_check_pages).to eq [
-          OpenStruct.new(condition: routing_conditions_page_with_answer_value_missing[0], check_page: pages.first),
-          OpenStruct.new(condition: routing_conditions_page_with_goto_page_missing[0], check_page: pages.second),
+        expect(error_summary_component.conditions_with_check_pages).to match [
+          an_object_having_attributes(id: routing_conditions_page_with_answer_value_missing[0].id, check_page: pages.first),
+          an_object_having_attributes(id: routing_conditions_page_with_goto_page_missing[0].id, check_page: pages.second),
         ]
       end
 
@@ -137,10 +137,10 @@ RSpec.describe PageListComponent::ErrorSummary::View, type: :component do
         include_context "with pages with routing"
 
         it "returns all of the conditions for a form with their respective conditions and check pages" do
-          expect(error_summary_component.conditions_with_check_pages).to eq [
-            OpenStruct.new(condition: branch_route_1, check_page: page_with_skip_and_secondary_skip),
-            OpenStruct.new(condition: branch_any_other_answer_route, check_page: page_with_skip_and_secondary_skip),
-            OpenStruct.new(condition: skip_route, check_page: page_with_skip_route),
+          expect(error_summary_component.conditions_with_check_pages).to match [
+            an_object_having_attributes(id: branch_route_1.id, check_page: page_with_skip_and_secondary_skip),
+            an_object_having_attributes(id: branch_any_other_answer_route.id, check_page: page_with_skip_and_secondary_skip),
+            an_object_having_attributes(id: skip_route.id, check_page: page_with_skip_route),
           ]
         end
       end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -155,6 +155,32 @@ RSpec.describe PageListComponent::View, type: :component do
           end
         end
       end
+
+      context "when the form has a branch route" do
+        include_examples "with pages with routing"
+
+        it "renders a summary list row for the any other answer route" do
+          expect(page).to have_css("#condition_2.govuk-summary-list__row", text: "Question 2’s routes") do |summary_list_row|
+            expect(summary_list_row).to have_link(href: show_routes_path(form_id: 1, page_id: 2)) do |link|
+              expect(link).to have_content("Edit Question 2’s routes")
+            end
+          end
+        end
+
+        context "and there is an error with the any other answer route" do
+          before do
+            branch_any_other_answer_route.has_routing_errors = true
+            branch_any_other_answer_route.validation_errors = [OpenStruct.new(name: "cannot_route_to_next_page")]
+
+            render_inline(page_list_component)
+          end
+
+          it "renders an error message" do
+            error_message = I18n.t("page_conditions.errors.cannot_route_to_next_page", question_number: 2)
+            expect(page).to have_css ".app-page_list__route-text--error", text: error_message
+          end
+        end
+      end
     end
   end
 

--- a/spec/support/shared_context/pages_with_routing.rb
+++ b/spec/support/shared_context/pages_with_routing.rb
@@ -121,6 +121,18 @@ RSpec.shared_context "with pages with routing" do
     ]
   end
 
+  let(:branch_route_1) do
+    page_with_skip_and_secondary_skip.routing_conditions.first
+  end
+
+  let(:branch_any_other_answer_route) do
+    start_of_a_secondary_skip.routing_conditions.first
+  end
+
+  let(:skip_route) do
+    page_with_skip_route.routing_conditions.first
+  end
+
   let(:page_with_no_routes) do
     pages[0]
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/xei3DTuv/2147-fix-question-numbers-in-error-messages-for-any-other-answer-routes <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

For "normal" skip routes, the check page and the routing page for the condition are the same, but for the "any other answer" route in a branch the secondary skip condition has the check page as the page that starts the branch, which in the current model for branch routing is the page that is of interest when editing the routes for the branch.

This PR adds tests describing the behaviour we expect in terms of what the content should say, and changes the page list component to use the condition check page in all places to make those tests pass. It also does some small refactors.

It's probably a smell that we have to do this bookkeeping to model routes, and maybe we should have a record or class that models a route properly.

<details><summary><h3>Screenshots</h3></summary>

#### Before

![Screenshot of the add and edit your questions page with errors in the any other answer route, before these changes](https://github.com/user-attachments/assets/f979cd6e-8027-49d7-bf96-0670eab7a462)

#### After

![Screenshot of the add and edit your questions page with errors in the any other answer route, after these changes](https://github.com/user-attachments/assets/f00f3790-ebe0-4bfa-918b-cac60d183900)

</details>

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?