### PR TITLE
Mailchimp list sync refactor

### DIFF
--- a/app/services/mailchimp_list_sync_service.rb
+++ b/app/services/mailchimp_list_sync_service.rb
@@ -1,18 +1,10 @@
 class MailchimpListSyncService
   def synchronize_lists
     Rails.logger.debug "Synchronizing active users mailing list"
-
-    MailchimpListSynchronizer.synchronize(
-      list_id: Settings.mailchimp.active_users_list,
-      users_to_synchronize: active_users.pluck(:email),
-    )
+    MailchimpListSynchronizer.new(list_id: Settings.mailchimp.active_users_list).synchronize(users_to_synchronize: active_users.pluck(:email))
 
     Rails.logger.debug "Synchronizing MOU signers mailing list"
-
-    MailchimpListSynchronizer.synchronize(
-      list_id: Settings.mailchimp.mou_signers_list,
-      users_to_synchronize: mou_signers.pluck(:email),
-    )
+    MailchimpListSynchronizer.new(list_id: Settings.mailchimp.mou_signers_list).synchronize(users_to_synchronize: mou_signers.pluck(:email))
   end
 
   def active_users

--- a/app/services/mailchimp_list_sync_service.rb
+++ b/app/services/mailchimp_list_sync_service.rb
@@ -1,15 +1,25 @@
 class MailchimpListSyncService
   def synchronize_lists
     Rails.logger.debug "Synchronizing active users mailing list"
-    active_users_list = Settings.mailchimp.active_users_list
-    active_user_email_addresses = User.where(has_access: true).pluck(:email)
 
-    MailchimpListSynchronizer.synchronize(list_id: active_users_list, users_to_synchronize: active_user_email_addresses)
+    MailchimpListSynchronizer.synchronize(
+      list_id: Settings.mailchimp.active_users_list,
+      users_to_synchronize: active_users.pluck(:email),
+    )
 
     Rails.logger.debug "Synchronizing MOU signers mailing list"
-    mou_signers_list = Settings.mailchimp.mou_signers_list
-    mou_signer_email_addresses = MouSignature.all.map(&:user).filter { |user| user.has_access == true }.pluck(:email)
 
-    MailchimpListSynchronizer.synchronize(list_id: mou_signers_list, users_to_synchronize: mou_signer_email_addresses)
+    MailchimpListSynchronizer.synchronize(
+      list_id: Settings.mailchimp.mou_signers_list,
+      users_to_synchronize: mou_signers.pluck(:email),
+    )
+  end
+
+  def active_users
+    User.where(has_access: true)
+  end
+
+  def mou_signers
+    MouSignature.all.map(&:user).filter { |user| user.has_access == true }
   end
 end

--- a/app/services/mailchimp_list_sync_service.rb
+++ b/app/services/mailchimp_list_sync_service.rb
@@ -1,0 +1,15 @@
+class MailchimpListSyncService
+  def synchronize_lists
+    Rails.logger.debug "Synchronizing active users mailing list"
+    active_users_list = Settings.mailchimp.active_users_list
+    active_user_email_addresses = User.where(has_access: true).pluck(:email)
+
+    MailchimpListSynchronizer.synchronize(list_id: active_users_list, users_to_synchronize: active_user_email_addresses)
+
+    Rails.logger.debug "Synchronizing MOU signers mailing list"
+    mou_signers_list = Settings.mailchimp.mou_signers_list
+    mou_signer_email_addresses = MouSignature.all.map(&:user).filter { |user| user.has_access == true }.pluck(:email)
+
+    MailchimpListSynchronizer.synchronize(list_id: mou_signers_list, users_to_synchronize: mou_signer_email_addresses)
+  end
+end

--- a/app/services/mailchimp_list_sync_service.rb
+++ b/app/services/mailchimp_list_sync_service.rb
@@ -1,17 +1,25 @@
 class MailchimpListSyncService
   def synchronize_lists
     Rails.logger.debug "Synchronizing active users mailing list"
-    MailchimpListSynchronizer.new(list_id: Settings.mailchimp.active_users_list).synchronize(users_to_synchronize: active_users.pluck(:email))
+    MailchimpListSynchronizer.new(list_id: Settings.mailchimp.active_users_list).synchronize(desired_members: active_users)
 
     Rails.logger.debug "Synchronizing MOU signers mailing list"
-    MailchimpListSynchronizer.new(list_id: Settings.mailchimp.mou_signers_list).synchronize(users_to_synchronize: mou_signers.pluck(:email))
+    MailchimpListSynchronizer.new(list_id: Settings.mailchimp.mou_signers_list).synchronize(desired_members: mou_signers)
   end
 
   def active_users
-    User.where(has_access: true)
+    User
+      .where(has_access: true)
+      .pluck(:email)
+      .map { |email| MailchimpMember.new(email: email, status: "subscribed") }
   end
 
   def mou_signers
-    MouSignature.all.map(&:user).filter { |user| user.has_access == true }
+    MouSignature
+      .all
+      .map(&:user)
+      .filter { |user| user.has_access == true }
+      .pluck(:email)
+      .map { |email| MailchimpMember.new(email: email, status: "subscribed") }
   end
 end

--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -1,93 +1,138 @@
 require "digest"
 require "MailchimpMarketing"
 
+MailchimpMember = Data.define(:email, :status) do
+  def unsubscribed?
+    status == "unsubscribed"
+  end
+
+  def archivable?
+    %w[subscribed cleaned pending transactional].include?(status)
+  end
+
+  def subscriber_hash
+    Digest::MD5.hexdigest email.downcase
+  end
+end
+
 class MailchimpListSynchronizer
-  attr_reader :list_id
+  attr_reader :client, :list_id
+
+  PAGE_SIZE = 1000
 
   def initialize(list_id:)
     @list_id = list_id
+    @client = setup_client(Settings.mailchimp.api_key, Settings.mailchimp.api_prefix)
+  end
+
+  def setup_client(api_key, server)
+    MailchimpMarketing::Client.new.tap do |client|
+      client.set_config(
+        api_key: api_key,
+        server: server,
+      )
+    end
   end
 
   def synchronize(users_to_synchronize:)
-    mailchimp_api_key = Settings.mailchimp.api_key
-    mailchimp_server_prefix = Settings.mailchimp.api_prefix
-    puts "Mailchimp server prefix: #{mailchimp_server_prefix}"
-    mailchimp = MailchimpMarketing::Client.new
-    mailchimp.set_config({
-      api_key: mailchimp_api_key,
-      server: mailchimp_server_prefix,
-    })
-    puts "List id: #{list_id}"
+    desired_members = users_to_synchronize.map { |email| MailchimpMember.new(email: email, status: "subscribed") }
 
-    target_list = mailchimp.lists.get_list(list_id, include_total_contacts: true)
-    target_list or raise
+    Rails.logger.debug "Mailchimp server prefix: #{Settings.mailchimp.api_prefix}"
+    Rails.logger.debug "List id: #{list_id}"
 
-    puts "Found Mailchimp list: #{target_list['name']}"
-    puts "Mailchimp list has #{target_list['stats']['member_count']} active members"
-    puts "Mailchimp list has #{target_list['stats']['total_contacts']} total members"
+    desired_members_hash = desired_members.index_by(&:subscriber_hash)
+    existing_members_hash = fetch_all_members.index_by(&:subscriber_hash)
 
-    currently_subscribed_members = []
-    members_who_can_be_archived = []
-    unsubscribed_members = []
+    add_and_update_members(existing_members_hash, desired_members_hash)
+    archive_removed_members(existing_members_hash, desired_members_hash)
+  end
 
-    # Set up API pagination
-    total_list_size = target_list["stats"]["total_contacts"]
+  def add_and_update_members(existing_members, desired_members)
+    Rails.logger.debug "Subscribing any new users..."
+    members_to_update = []
+
+    desired_members.each do |subscriber_hash, desired_member|
+      existing_member = existing_members[subscriber_hash]
+
+      next if existing_member&.unsubscribed?
+      next if existing_member == desired_member
+
+      members_to_update << desired_member
+    end
+
+    Rails.logger.debug "There are #{members_to_update} to subscribe"
+
+    members_to_update.each do |member|
+      update_member(member)
+    end
+  end
+
+  def archive_removed_members(existing_members, desired_members)
+    Rails.logger.debug "Archiving any removed users..."
+    members_to_remove = []
+
+    existing_members.each do |subscriber_hash, existing_member|
+      if !desired_members[subscriber_hash] && existing_member.archivable?
+        members_to_remove << existing_member
+      end
+    end
+
+    Rails.logger.debug "There are #{members_to_remove.size} to archive"
+
+    members_to_remove.each do |member|
+      remove_member(member)
+    end
+  end
+
+  def fetch_all_members
+    return enum_for(:fetch_all_members) unless block_given?
+
     offset = 0
-    page_size = 1000 # maximum page size is 1000 results, default is 10
+    mailchimp_list = client.lists.get_list(list_id, include_total_contacts: true)
+    total_size = mailchimp_list["stats"]["total_contacts"]
 
-    while offset < total_list_size
-      api_response = mailchimp.lists.get_list_members_info(list_id, count: page_size, offset:)
+    Rails.logger.debug "Found Mailchimp list: #{mailchimp_list['name']}"
+    Rails.logger.debug "Mailchimp list has #{mailchimp_list['stats']['member_count']} active members"
+    Rails.logger.debug "Mailchimp list has #{mailchimp_list['stats']['total_contacts']} total members"
 
-      api_response["members"].each do |member|
-        currently_subscribed_members.push(member["email_address"]) if member["status"] == "subscribed"
-        members_who_can_be_archived.push(member["email_address"]) if %w[subscribed cleaned pending transactional].include?(member["status"])
-        unsubscribed_members.push(member["email_address"]) if member["status"] == "unsubscribed"
+    while offset < total_size
+      response = client.lists.get_list_members_info(list_id, count: PAGE_SIZE, offset: offset)
+
+      response["members"].each do |member_data|
+        yield MailchimpMember.new(
+          email: member_data["email_address"],
+          status: member_data["status"],
+        )
       end
 
-      offset += page_size
+      offset += PAGE_SIZE
     end
+  end
 
-    users_to_synchronize_set = users_to_synchronize
-                             .to_set
+  def update_member(member)
+    member_data = {
+      "email_address" => member.email,
+      "status" => member.status,
+    }
 
-    currently_subscribed_members_set = currently_subscribed_members
-                             .to_set
+    client.lists.set_list_member(
+      list_id,
+      member.subscriber_hash,
+      member_data,
+    )
+  rescue MailchimpMarketing::ApiError => e
+    log_mailchimp_error("subscribe", member.subscriber_hash, e)
+  end
 
-    unsubscribed_members_set = unsubscribed_members.to_set
+  def remove_member(member)
+    client.lists.delete_list_member(list_id, member.subscriber_hash)
+  rescue MailchimpMarketing::ApiError => e
+    log_mailchimp_error("archive", member.subscriber_hash, e)
+  end
 
-    members_who_can_be_archived_set = members_who_can_be_archived.to_set
-
-    users_to_subscribe = (users_to_synchronize_set - currently_subscribed_members_set) - unsubscribed_members_set
-    users_to_archive = members_who_can_be_archived_set - users_to_synchronize_set
-
-    puts "There are #{users_to_subscribe.size} to subscribe"
-    puts "There are #{users_to_archive.size} to archive"
-
-    puts "Subscribing any new users..."
-    users_to_subscribe.each do |email|
-      subscriber_hash = Digest::MD5.hexdigest email.downcase
-      mailchimp.lists.set_list_member(
-        list_id,
-        subscriber_hash,
-        {
-          "email_address" => email,
-          "status" => "subscribed",
-        },
-      )
-    rescue MailchimpMarketing::ApiError => e
-      warn "Could not subscribe user with subscriber hash #{subscriber_hash} to list #{list_id}."
-      warn "#{e.title}: #{e.detail}"
-      warn "Continuing"
-    end
-
-    puts "Archiving any removed users..."
-    users_to_archive.each do |email|
-      subscriber_hash = Digest::MD5.hexdigest email.downcase
-      mailchimp.lists.delete_list_member(list_id, subscriber_hash)
-    rescue MailchimpMarketing::ApiError => e
-      warn "Could not archive user with subscriber hash #{subscriber_hash} from list #{list_id}"
-      warn "#{e.title}: #{e.detail}"
-      warn "Continuing"
-    end
+  def log_mailchimp_error(action, subscriber_hash, error)
+    warn "Could not #{action} user with subscriber hash #{subscriber_hash} from list #{list_id}"
+    warn "#{error.title}: #{error.detail}"
+    warn "Continuing"
   end
 end

--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -2,7 +2,13 @@ require "digest"
 require "MailchimpMarketing"
 
 class MailchimpListSynchronizer
-  def self.synchronize(list_id:, users_to_synchronize:)
+  attr_reader :list_id
+
+  def initialize(list_id:)
+    @list_id = list_id
+  end
+
+  def synchronize(users_to_synchronize:)
     mailchimp_api_key = Settings.mailchimp.api_key
     mailchimp_server_prefix = Settings.mailchimp.api_prefix
     puts "Mailchimp server prefix: #{mailchimp_server_prefix}"

--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -55,7 +55,7 @@ class MailchimpListSynchronizer
       members_to_update << desired_member
     end
 
-    Rails.logger.debug "There are #{members_to_update} to subscribe"
+    Rails.logger.debug "There are #{members_to_update.count} to subscribe"
 
     members_to_update.each do |member|
       update_member(member)
@@ -126,8 +126,8 @@ class MailchimpListSynchronizer
   end
 
   def log_mailchimp_error(action, subscriber_hash, error)
-    warn "Could not #{action} user with subscriber hash #{subscriber_hash} from list #{list_id}"
-    warn "#{error.title}: #{error.detail}"
-    warn "Continuing"
+    Rails.logger.warn "Could not #{action} user with subscriber hash #{subscriber_hash} from list #{list_id}"
+    Rails.logger.warn "#{error.title}: #{error.detail}"
+    Rails.logger.warn "Continuing"
   end
 end

--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -34,12 +34,7 @@ class MailchimpListSynchronizer
     end
   end
 
-  def synchronize(users_to_synchronize:)
-    desired_members = users_to_synchronize.map { |email| MailchimpMember.new(email: email, status: "subscribed") }
-
-    Rails.logger.debug "Mailchimp server prefix: #{Settings.mailchimp.api_prefix}"
-    Rails.logger.debug "List id: #{list_id}"
-
+  def synchronize(desired_members:)
     desired_members_hash = desired_members.index_by(&:subscriber_hash)
     existing_members_hash = fetch_all_members.index_by(&:subscriber_hash)
 

--- a/lib/tasks/mailchimp.rake
+++ b/lib/tasks/mailchimp.rake
@@ -1,16 +1,6 @@
 namespace :mailchimp do
   desc "Synchronise Mailchimp audiences with the users in the database"
   task synchronize_audiences: :environment do
-    puts "Synchronizing active users mailing list"
-    active_users_list = Settings.mailchimp.active_users_list
-    active_user_email_addresses = User.where(has_access: true).pluck(:email)
-
-    MailchimpListSynchronizer.synchronize(list_id: active_users_list, users_to_synchronize: active_user_email_addresses)
-
-    puts "Synchronizing MOU signers mailing list"
-    mou_signers_list = Settings.mailchimp.mou_signers_list
-    mou_signer_email_addresses = MouSignature.all.map(&:user).filter { |user| user.has_access == true }.pluck(:email)
-
-    MailchimpListSynchronizer.synchronize(list_id: mou_signers_list, users_to_synchronize: mou_signer_email_addresses)
+    MailchimpListSyncService.new.synchronize_lists
   end
 end

--- a/spec/lib/mailchimp_list_synchronizer_spec.rb
+++ b/spec/lib/mailchimp_list_synchronizer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe MailchimpListSynchronizer do
           },
         )
 
-        described_class.synchronize(list_id: "list-1", users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe MailchimpListSynchronizer do
 
         expect(mailchimp_client_lists).to receive(:delete_list_member).with("list-1", archived_email_hash)
 
-        described_class.synchronize(list_id: "list-1", users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe MailchimpListSynchronizer do
         expect(mailchimp_client_lists).not_to receive(:set_list_member)
         expect(mailchimp_client_lists).not_to receive(:delete_list_member)
 
-        described_class.synchronize(list_id: "list-1", users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
       end
     end
 
@@ -97,13 +97,13 @@ RSpec.describe MailchimpListSynchronizer do
           expect(body["email_address"]).to eq("some_other_user@domain.org")
         end
 
-        described_class.synchronize(list_id: "list-1", users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
       end
 
       it "does not archive the user" do
         expect(mailchimp_client_lists).not_to receive(:delete_list_member)
 
-        described_class.synchronize(list_id: "list-1", users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
       end
     end
 
@@ -304,7 +304,7 @@ RSpec.describe MailchimpListSynchronizer do
       it "handles all of the results" do
         expect(mailchimp_client_lists).to receive(:delete_list_member).with("list-1", anything).exactly(1001).times
 
-        described_class.synchronize(list_id: "list-1", users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
       end
     end
   end

--- a/spec/lib/mailchimp_list_synchronizer_spec.rb
+++ b/spec/lib/mailchimp_list_synchronizer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe MailchimpListSynchronizer do
           },
         )
 
-        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(desired_members:)
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe MailchimpListSynchronizer do
 
         expect(mailchimp_client_lists).to receive(:delete_list_member).with("list-1", archived_email_hash)
 
-        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(desired_members:)
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe MailchimpListSynchronizer do
         expect(mailchimp_client_lists).not_to receive(:set_list_member)
         expect(mailchimp_client_lists).not_to receive(:delete_list_member)
 
-        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(desired_members:)
       end
     end
 
@@ -97,18 +97,18 @@ RSpec.describe MailchimpListSynchronizer do
           expect(body["email_address"]).to eq("some_other_user@domain.org")
         end
 
-        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(desired_members:)
       end
 
       it "does not archive the user" do
         expect(mailchimp_client_lists).not_to receive(:delete_list_member)
 
-        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(desired_members:)
       end
     end
 
     context "when the user is in the list of users to synchronize" do
-      let(:users_to_synchronize) { ["user@domain.org"] }
+      let(:desired_members) { [MailchimpMember.new(email: "user@domain.org", status: "subscribed")] }
 
       context "when the user is not present in the MailChimp list" do
         let(:list_1_members_info) do
@@ -194,7 +194,7 @@ RSpec.describe MailchimpListSynchronizer do
     end
 
     context "when the user is not in the list of users to synchronize" do
-      let(:users_to_synchronize) { ["some_other_user@domain.org"] }
+      let(:desired_members) { [MailchimpMember.new(email: "some_other_user@domain.org", status: "subscribed")] }
 
       context "when the user is not present in the MailChimp list" do
         let(:list_1_members_info) do
@@ -280,9 +280,7 @@ RSpec.describe MailchimpListSynchronizer do
     end
 
     context "when the mailing list has more than 1000 members" do
-      let(:users_to_synchronize) do
-        ["some_email_address@domain.org"]
-      end
+      let(:desired_members) { [MailchimpMember.new(email: "some_email_address@domain.org", status: "subscribed")] }
 
       let(:list_1) do
         {
@@ -304,7 +302,7 @@ RSpec.describe MailchimpListSynchronizer do
       it "handles all of the results" do
         expect(mailchimp_client_lists).to receive(:delete_list_member).with("list-1", anything).exactly(1001).times
 
-        described_class.new(list_id: "list-1").synchronize(users_to_synchronize:)
+        described_class.new(list_id: "list-1").synchronize(desired_members:)
       end
     end
   end

--- a/spec/lib/tasks/mailchimp.rake_spec.rb
+++ b/spec/lib/tasks/mailchimp.rake_spec.rb
@@ -9,44 +9,16 @@ RSpec.describe "mailchimp.rake" do
         .tap(&:reenable)
     end
 
-    let(:users_with_access) do
-      10.times.map { Faker::Internet.unique.email }
-    end
-
-    let(:users_without_access) do
-      10.times.map { Faker::Internet.unique.email }
-    end
-
-    let(:mou_signer_with_access) { users_with_access.first }
-
-    let(:mou_signer_without_access) { users_without_access.first }
-
     before do
-      # Rake.application.options.trace = true
-
       Rake.application.rake_require "tasks/mailchimp"
       Rake::Task.define_task(:environment)
-
-      users_with_access.each do |email|
-        create :user, email:, has_access: true
-      end
-
-      users_without_access.each do |email|
-        create :user, email:, has_access: false
-      end
-
-      # Create MOU signer with an active user
-      create :mou_signature, user: User.where(email: mou_signer_with_access).first
-
-      # Create MOU signer with an inactive user
-      create :mou_signature, user: User.where(email: mou_signer_without_access).first
     end
 
-    it "runs the mailchimp synchronization on each list" do
-      expect(MailchimpListSynchronizer).to receive(:synchronize).with(list_id: Settings.mailchimp.active_users_list, users_to_synchronize: match_array(users_with_access)).once
-      expect(MailchimpListSynchronizer).to receive(:synchronize).with(list_id: Settings.mailchimp.mou_signers_list, users_to_synchronize: [mou_signer_with_access]).once
-
-      expect { task.invoke }.to output.to_stdout
+    it "creates MailchimpListSyncService and calls synchronize_lists" do
+      mail_chimp_list_sync_service = instance_double(MailchimpListSyncService)
+      allow(MailchimpListSyncService).to receive(:new).and_return(mail_chimp_list_sync_service)
+      expect(mail_chimp_list_sync_service).to receive(:synchronize_lists)
+      task.invoke
     end
   end
 end

--- a/spec/services/mailchimp_list_sync_service_spec.rb
+++ b/spec/services/mailchimp_list_sync_service_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe MailchimpListSyncService do
       allow(MailchimpListSynchronizer).to receive(:new).with(list_id: Settings.mailchimp.active_users_list).and_return(list_synchronizer)
       allow(MailchimpListSynchronizer).to receive(:new).with(list_id: Settings.mailchimp.mou_signers_list).and_return(list_synchronizer)
 
-      expect(list_synchronizer).to receive(:synchronize).with(users_to_synchronize: match_array(users_with_access)).once
-      expect(list_synchronizer).to receive(:synchronize).with(users_to_synchronize: [mou_signer_with_access]).once
+      expect(list_synchronizer).to receive(:synchronize).with(desired_members: match_array(users_with_access.map { |email| MailchimpMember.new(email: email, status: "subscribed") })).once
+      expect(list_synchronizer).to receive(:synchronize).with(desired_members: [MailchimpMember.new(email: mou_signer_with_access, status: "subscribed")]).once
 
       expect(Rails.logger).to receive(:debug).with("Synchronizing active users mailing list").once
       expect(Rails.logger).to receive(:debug).with("Synchronizing MOU signers mailing list").once

--- a/spec/services/mailchimp_list_sync_service_spec.rb
+++ b/spec/services/mailchimp_list_sync_service_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe MailchimpListSyncService do
+  subject(:mailchimp_list_sync_service) do
+    described_class.new
+  end
+
+  describe "#synchronize_lists" do
+    let(:users_with_access) do
+      10.times.map { Faker::Internet.unique.email }
+    end
+
+    let(:users_without_access) do
+      10.times.map { Faker::Internet.unique.email }
+    end
+
+    let(:mou_signer_with_access) { users_with_access.first }
+
+    let(:mou_signer_without_access) { users_without_access.first }
+
+    before do
+      users_with_access.each do |email|
+        create :user, email:, has_access: true
+      end
+
+      users_without_access.each do |email|
+        create :user, email:, has_access: false
+      end
+
+      # Create MOU signer with an active user
+      create :mou_signature, user: User.where(email: mou_signer_with_access).first
+
+      # Create MOU signer with an inactive user
+      create :mou_signature, user: User.where(email: mou_signer_without_access).first
+    end
+
+    it "runs the mailchimp synchronization on each list" do
+      expect(MailchimpListSynchronizer).to receive(:synchronize).with(list_id: Settings.mailchimp.active_users_list, users_to_synchronize: match_array(users_with_access)).once
+      expect(MailchimpListSynchronizer).to receive(:synchronize).with(list_id: Settings.mailchimp.mou_signers_list, users_to_synchronize: [mou_signer_with_access]).once
+
+      expect(Rails.logger).to receive(:debug).with("Synchronizing active users mailing list").once
+      expect(Rails.logger).to receive(:debug).with("Synchronizing MOU signers mailing list").once
+
+      mailchimp_list_sync_service.synchronize_lists
+    end
+  end
+end

--- a/spec/services/mailchimp_list_sync_service_spec.rb
+++ b/spec/services/mailchimp_list_sync_service_spec.rb
@@ -35,8 +35,12 @@ RSpec.describe MailchimpListSyncService do
     end
 
     it "runs the mailchimp synchronization on each list" do
-      expect(MailchimpListSynchronizer).to receive(:synchronize).with(list_id: Settings.mailchimp.active_users_list, users_to_synchronize: match_array(users_with_access)).once
-      expect(MailchimpListSynchronizer).to receive(:synchronize).with(list_id: Settings.mailchimp.mou_signers_list, users_to_synchronize: [mou_signer_with_access]).once
+      list_synchronizer = instance_double(MailchimpListSynchronizer)
+      allow(MailchimpListSynchronizer).to receive(:new).with(list_id: Settings.mailchimp.active_users_list).and_return(list_synchronizer)
+      allow(MailchimpListSynchronizer).to receive(:new).with(list_id: Settings.mailchimp.mou_signers_list).and_return(list_synchronizer)
+
+      expect(list_synchronizer).to receive(:synchronize).with(users_to_synchronize: match_array(users_with_access)).once
+      expect(list_synchronizer).to receive(:synchronize).with(users_to_synchronize: [mou_signer_with_access]).once
 
       expect(Rails.logger).to receive(:debug).with("Synchronizing active users mailing list").once
       expect(Rails.logger).to receive(:debug).with("Synchronizing MOU signers mailing list").once


### PR DESCRIPTION
### Refactor the mailchimp sync code in anticipation of adding role to the MOU signers

Trello card: https://trello.com/c/jEXoX309/2125-change-mailchimp-audience-for-mou-updates-to-include-org-admins-as-well-as-mou-agreers?filter=member:tomiles3

This PR makes some changes to the mailchimp sync code to make adding role easier.

It changes the code from using email address only to decide which users need to be added or removed and makes it possible to add other attributes. It also allows makes it easier to update existing records if they have changed.

Other changes are just to make it clearer and more like our other services.


- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
