### PR TITLE
Improve error logging in MailchimpListSynchronizer

### DIFF
--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -126,8 +126,6 @@ class MailchimpListSynchronizer
   end
 
   def log_mailchimp_error(action, subscriber_hash, error)
-    Rails.logger.warn "Could not #{action} user with subscriber hash #{subscriber_hash} from list #{list_id}"
-    Rails.logger.warn "#{error.title}: #{error.detail}"
-    Rails.logger.warn "Continuing"
+    Rails.logger.warn "Could not #{action} user with subscriber hash #{subscriber_hash} from list #{list_id}. HTTP status: #{error.status}, response body: #{error.response_body}"
   end
 end


### PR DESCRIPTION
# Fix the logging in the Mailchimp sync to find out why it has been failing so much

[Looking at the splunk logs](https://gds.splunkcloud.com/en-GB/app/gds-543-forms/search?sid=1741079955.215116), the Mailchimp sync task often has a lot of failures.

The logging in the Mailchimp task logs attributes which don't exist so it's hard to diagnose the issues.

This PR changes what's being logged so that we can see what's going on.

When Mailchimp cannot complete a request, an exception is thrown and the error is logged. The .title .detail attributes are logged after the subscriber_hash and list_id.

These attributes aren't set on the exception returned.

Looking at the Mailchimp docs and API source, it looks like they are contained in the response_body attribute, which should be a JSON object.

This commit changes the logging to directly log status and response_body and combines these with the original error message to make them easier to find in logs.

In the future, it may be better to extract the original attributes from the response_body. For now the whole object is logged so we can see whats in it.

See the following:
https://mailchimp.com/developer/marketing/docs/errors/#the-basics https://github.com/mailchimp/mailchimp-marketing-ruby/blob/dd4fd7adeb10cae5afbb0a4e8c332ae23345bb8b/lib/MailchimpMarketing/api_client.rb#L83

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
