### PR TITLE
Update URI gem to 1.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,7 +484,7 @@ GEM
     tzinfo-data (1.2025.1)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.6.0)
-    uri (1.0.2)
+    uri (1.0.3)
     useragent (0.16.11)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)


### PR DESCRIPTION
A CVE in the URI gem is causing our CI pipeline to fail for new commits and dependabot is having trouble raising a PR.

This commit updates the URI gem to a version which isn't affected by the issue.

Before this change, running bundle-audit:
```sh
bundle exec bundle-audit check --update
```

Outputs:

```
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up to date.
Updated ruby-advisory-db
ruby-advisory-db:
  advisories:   963 advisories
  last updated: 2025-03-03 08:44:49 -0800
  commit:       4b6766fe26a9f2590732bca3b563bf37d3aeacc9
Name: uri
Version: 1.0.2
CVE: CVE-2025-27221
Criticality: Unknown
URL: https://www.cve.org/CVERecord?id=CVE-2025-27221
Title: CVE-2025-27221 - userinfo leakage in URI#join, URI#merge and URI#+.
Solution: update to '~> 0.11.3', '~> 0.12.4', '~> 0.13.2', '>= 1.0.3'

Vulnerabilities found!
```
