### PR TITLE
Add global feature flag for file upload

### DIFF
--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -89,7 +89,7 @@ private
   end
 
   def file_upload_enabled
-    current_form.group&.file_upload_enabled
+    Settings.features.file_upload || current_form.group&.file_upload_enabled
   end
 
   def set_answer_types

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,7 @@ features:
     enabled_by_group: true
   exit_pages:
     enabled_by_group: true
+  file_upload: false
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/spec/requests/pages/type_of_answer_controller_spec.rb
+++ b/spec/requests/pages/type_of_answer_controller_spec.rb
@@ -37,16 +37,32 @@ RSpec.describe Pages::TypeOfAnswerController, type: :request do
     end
 
     context "when file upload is disabled for the group" do
-      it "does not show the file answer type option" do
-        expect(response.body).not_to include("File")
+      context "when the file upload feature is not enabled globally", feature_file_upload: false do
+        it "does not show the file answer type option" do
+          expect(response.body).not_to include("File")
+        end
+      end
+
+      context "when the file upload feature is enabled globally", :feature_file_upload do
+        it "shows the file answer type option" do
+          expect(response.body).to include("File")
+        end
       end
     end
 
     context "when file upload is enabled for the group" do
       let(:file_upload_enabled) { true }
 
-      it "shows the file answer type option" do
-        expect(response.body).to include("File")
+      context "when the file upload feature is not enabled globally", feature_file_upload: false do
+        it "shows the file answer type option" do
+          expect(response.body).to include("File")
+        end
+      end
+
+      context "when the file upload feature is enabled globally", :feature_file_upload do
+        it "shows the file answer type option" do
+          expect(response.body).to include("File")
+        end
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/0EA6BrNQ/2169-new-feature-launch-file-upload

Adds a feature flag so we can turn file upload on/off easily.

forms-deploy PR here: https://github.com/alphagov/forms-deploy/pull/1477

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
