### PR TITLE
Add mailchimp role for MOU signers mailchimp list

### DIFF
--- a/lib/mailchimp_list_synchronizer.rb
+++ b/lib/mailchimp_list_synchronizer.rb
@@ -1,7 +1,9 @@
 require "digest"
 require "MailchimpMarketing"
 
-MailchimpMember = Data.define(:email, :status) do
+MailchimpMember = Data.define(:email, :status, :role) do
+  def initialize(email:, status:, role: nil) = super
+
   def unsubscribed?
     status == "unsubscribed"
   end
@@ -97,6 +99,7 @@ class MailchimpListSynchronizer
         yield MailchimpMember.new(
           email: member_data["email_address"],
           status: member_data["status"],
+          role: member_data.dig("merge_fields", "ROLE"),
         )
       end
 
@@ -109,6 +112,8 @@ class MailchimpListSynchronizer
       "email_address" => member.email,
       "status" => member.status,
     }
+
+    member_data["merge_fields"] = { "ROLE" => member.role } if member.role
 
     client.lists.set_list_member(
       list_id,

--- a/spec/services/mailchimp_list_sync_service_spec.rb
+++ b/spec/services/mailchimp_list_sync_service_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe MailchimpListSyncService do
 
     let(:mou_signer_without_access) { users_without_access.first }
 
+    let(:organisation_admin_with_access) { users_with_access.second }
+    let(:mou_signer_and_organisation_admin_with_access) { users_with_access.third }
+
     before do
       users_with_access.each do |email|
         create :user, email:, has_access: true
@@ -32,6 +35,13 @@ RSpec.describe MailchimpListSyncService do
 
       # Create MOU signer with an inactive user
       create :mou_signature, user: User.where(email: mou_signer_without_access).first
+
+      # Create MOU signer for org admin user
+      create :mou_signature, user: User.where(email: mou_signer_and_organisation_admin_with_access).first
+
+      # set organisation admins
+      User.find_by(email: organisation_admin_with_access).organisation_admin!
+      User.find_by(email: mou_signer_and_organisation_admin_with_access).organisation_admin!
     end
 
     it "runs the mailchimp synchronization on each list" do
@@ -40,12 +50,42 @@ RSpec.describe MailchimpListSyncService do
       allow(MailchimpListSynchronizer).to receive(:new).with(list_id: Settings.mailchimp.mou_signers_list).and_return(list_synchronizer)
 
       expect(list_synchronizer).to receive(:synchronize).with(desired_members: match_array(users_with_access.map { |email| MailchimpMember.new(email: email, status: "subscribed") })).once
-      expect(list_synchronizer).to receive(:synchronize).with(desired_members: [MailchimpMember.new(email: mou_signer_with_access, status: "subscribed")]).once
+      expect(list_synchronizer).to receive(:synchronize).with(desired_members: contain_exactly(MailchimpMember.new(email: mou_signer_with_access, status: "subscribed", role: "Agreed MOU"), MailchimpMember.new(email: organisation_admin_with_access, status: "subscribed", role: "Organisation admin"), MailchimpMember.new(email: mou_signer_and_organisation_admin_with_access, status: "subscribed", role: "Organisation admin agreed MOU"))).once
 
       expect(Rails.logger).to receive(:debug).with("Synchronizing active users mailing list").once
       expect(Rails.logger).to receive(:debug).with("Synchronizing MOU signers mailing list").once
 
       mailchimp_list_sync_service.synchronize_lists
+    end
+  end
+
+  describe "#mou_signers" do
+    let(:user_with_access_and_mou) { create(:user, email: "mou_user@example.com") }
+    let(:user_with_access_admin) { create(:user, email: "admin_user@example.com") }
+    let(:user_without_access) { create(:user, email: "inactive_user@example.com", has_access: false) }
+    let(:user_access_and_admin_with_mou) { create(:user, email: "admin_mou_user@example.com") }
+
+    before do
+      create(:mou_signature, user: user_with_access_and_mou)
+      create(:mou_signature, user: user_access_and_admin_with_mou)
+      user_with_access_admin.reload.organisation_admin!
+      user_access_and_admin_with_mou.reload.organisation_admin!
+    end
+
+    it "returns MOU signers with access and correct roles" do
+      expected_members = [
+        MailchimpMember.new(email: "mou_user@example.com", status: "subscribed", role: "Agreed MOU"),
+        MailchimpMember.new(email: "admin_user@example.com", status: "subscribed", role: "Organisation admin"),
+        MailchimpMember.new(email: "admin_mou_user@example.com", status: "subscribed", role: "Organisation admin agreed MOU"),
+      ]
+
+      expect(mailchimp_list_sync_service.mou_signers).to match_array(expected_members)
+    end
+
+    it "does not include users without access" do
+      expect(mailchimp_list_sync_service.mou_signers).not_to include(
+        MailchimpMember.new(email: "inactive_user@example.com", status: "subscribed"),
+      )
     end
   end
 end


### PR DESCRIPTION
### Record role for the MOOU signers mailchimp list

Trello card: https://trello.com/c/jEXoX309/2125-change-mailchimp-audience-for-mou-updates-to-include-org-admins-as-well-as-mou-agreers

The updates in this commit will overwrite any existing merge_field values. We don't have any merge fields set but mailchimp adds some default values which are empty for almost all our users.

The role hasn't been added to the mailchimp list yet, I'll add it after this commit is approved.

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
