### PR TITLE
2152 add feature flag for exit pages

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,8 @@ features:
   groups: true # Do not switch off!
   branch_routing:
     enabled_by_group: true
+  exit_pages:
+    enabled_by_group: true
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,5 +1,6 @@
 features:
   branch_routing: true
+  exit_pages: true
 
 forms_api:
   # URL to form-api endpoints

--- a/db/migrate/20250307150217_add_exit_pages_enabled_to_groups.rb
+++ b/db/migrate/20250307150217_add_exit_pages_enabled_to_groups.rb
@@ -1,0 +1,5 @@
+class AddExitPagesEnabledToGroups < ActiveRecord::Migration[8.0]
+  def change
+    add_column :groups, :exit_pages_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_30_150000) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_07_150217) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -96,6 +96,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_30_150000) do
     t.bigint "upgrade_requester_id"
     t.boolean "file_upload_enabled", default: false
     t.boolean "branch_routing_enabled", default: false
+    t.boolean "exit_pages_enabled", default: false
     t.index ["creator_id"], name: "index_groups_on_creator_id"
     t.index ["external_id"], name: "index_groups_on_external_id", unique: true
     t.index ["name", "organisation_id"], name: "index_groups_on_name_and_organisation_id", unique: true

--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -56,7 +56,7 @@ namespace :groups do
 
   desc "List enabled features for groups"
   task features: :environment do
-    feature_flags = %i[branch_routing_enabled file_upload_enabled]
+    feature_flags = %i[branch_routing_enabled file_upload_enabled exit_pages_enabled]
     query = feature_flags.map { "#{it} IS TRUE" }.join(" OR ")
 
     Group.where(query).find_each do |group|
@@ -103,6 +103,24 @@ namespace :groups do
 
     Group.find_by(external_id: args[:group_id]).update!(branch_routing_enabled: false)
     Rails.logger.info("Updated branch_routing_enabled to false for group #{args[:group_id]}")
+  end
+
+  desc "Enable exit_pages feature for group"
+  task :enable_exit_pages, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:enable_exit_pages[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+
+    Group.find_by(external_id: args[:group_id]).update!(exit_pages_enabled: true)
+    Rails.logger.info("Updated exit_pages_enabled to true for group #{args[:group_id]}")
+  end
+
+  desc "Disable exit_pages feature for group"
+  task :disable_exit_pages, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:disable_exit_pages[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+
+    Group.find_by(external_id: args[:group_id]).update!(exit_pages_enabled: false)
+    Rails.logger.info("Updated exit_pages_enabled to false for group #{args[:group_id]}")
   end
 end
 

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -24,6 +24,7 @@ describe "Settings" do
 
     include_examples expected_value_test, :groups, features, true
     include_examples expected_value_test, :branch_routing, features, { "enabled_by_group" => true }
+    include_examples expected_value_test, :exit_pages, features, { "enabled_by_group" => true }
   end
 
   describe "forms_api" do


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/cp1oXNvH/2152-add-feature-flag-for-exit-pages

Adds a feature flag that will allow us to control the exit pages feature group-by-group. I've followed the instructions in this commit 16fb756a05fcfc7aebdeb4b38ad4c1139394d6d4

Also added a rake task which is run using `rake "groups:enable_exit_pages[<group_external_id>]"` or `disable_exit_pages` as needed. 

I've currently set it to be enabled by default for all groups in the dev environment, the same as our `branch_routing` feature flag

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
