### PR TITLE
Add error messages to routes summary page

### DIFF
--- a/app/controllers/pages/routes_controller.rb
+++ b/app/controllers/pages/routes_controller.rb
@@ -1,13 +1,9 @@
 class Pages::RoutesController < PagesController
   def show
     back_link_url = form_pages_path(current_form.id)
-    pages = FormRepository.pages(current_form)
-    routes = PageRoutesService.new(form: current_form, pages:, page:).routes
-    errors = routes.flat_map { |route| route.validation_errors.map { |validation_error| error_construct(route: route, validation_error: validation_error) } }
-    # to be eligible for route question has to have one question after it, so should always have next_page
-    next_page = pages.find(proc { raise "Cannot find page with id #{page.next_page.inspect}" }) { _1.id == page.next_page }
+    route_summary_card_data_presenter = RouteSummaryCardDataPresenter.new(form: current_form, page:)
 
-    render locals: { current_form:, page:, pages:, next_page:, routes:, back_link_url:, errors: }
+    render locals: { current_form:, page:, back_link_url:, route_summary_card_data_presenter: }
   end
 
   def delete
@@ -33,28 +29,5 @@ private
 
   def delete_confirmation_input_params
     params.require(:pages_routes_delete_confirmation_input).permit(:confirm).merge(form: current_form, page: page)
-  end
-
-  def error_construct(route:, validation_error:)
-    case validation_error.name
-    when "answer_value_doesnt_exist"
-      OpenStruct.new(link: "#check-#{route.id}", message: I18n.t("page_route_card.errors.answer_value_doesnt_exist"))
-    when "cannot_route_to_next_page"
-      if route.secondary_skip?
-        OpenStruct.new(link: "#goto-#{route.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page_secondary_skip"))
-      else
-        OpenStruct.new(link: "#goto-#{route.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page"))
-      end
-    when "cannot_have_goto_page_before_routing_page"
-      if route.secondary_skip?
-        OpenStruct.new(link: "#goto-#{route.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page_secondary_skip"))
-      else
-        OpenStruct.new(link: "#goto-#{route.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page", question_number: question_number(route.check_page_id)))
-      end
-    end
-  end
-
-  def question_number(page_id)
-    current_form.pages.find { |page| page.id == page_id }.position
   end
 end

--- a/app/controllers/pages/routes_controller.rb
+++ b/app/controllers/pages/routes_controller.rb
@@ -3,11 +3,11 @@ class Pages::RoutesController < PagesController
     back_link_url = form_pages_path(current_form.id)
     pages = FormRepository.pages(current_form)
     routes = PageRoutesService.new(form: current_form, pages:, page:).routes
-
+    errors = routes.flat_map { |route| route.validation_errors.map { |validation_error| error_construct(route: route, validation_error: validation_error) } }
     # to be eligible for route question has to have one question after it, so should always have next_page
     next_page = pages.find(proc { raise "Cannot find page with id #{page.next_page.inspect}" }) { _1.id == page.next_page }
 
-    render locals: { current_form:, page:, pages:, next_page:, routes:, back_link_url: }
+    render locals: { current_form:, page:, pages:, next_page:, routes:, back_link_url:, errors: }
   end
 
   def delete
@@ -33,5 +33,28 @@ private
 
   def delete_confirmation_input_params
     params.require(:pages_routes_delete_confirmation_input).permit(:confirm).merge(form: current_form, page: page)
+  end
+
+  def error_construct(route:, validation_error:)
+    case validation_error.name
+    when "answer_value_doesnt_exist"
+      OpenStruct.new(link: "#check-#{route.id}", message: I18n.t("page_route_card.errors.answer_value_doesnt_exist"))
+    when "cannot_route_to_next_page"
+      if route.secondary_skip?
+        OpenStruct.new(link: "#goto-#{route.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page_secondary_skip"))
+      else
+        OpenStruct.new(link: "#goto-#{route.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page"))
+      end
+    when "cannot_have_goto_page_before_routing_page"
+      if route.secondary_skip?
+        OpenStruct.new(link: "#goto-#{route.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page_secondary_skip"))
+      else
+        OpenStruct.new(link: "#goto-#{route.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page", question_number: question_number(route.check_page_id)))
+      end
+    end
+  end
+
+  def question_number(page_id)
+    current_form.pages.find { |page| page.id == page_id }.position
   end
 end

--- a/app/frontend/styles/_app_summary_card.scss
+++ b/app/frontend/styles/_app_summary_card.scss
@@ -21,4 +21,28 @@
   .govuk-summary-list__row:last-child > * {
     border-bottom: 0;
   }
+
+  .govuk-summary-list__row--error {
+    border-left: 5px solid $govuk-error-colour;
+
+    padding-left: govuk-spacing(2);
+
+    @include govuk-media-query($from: tablet) {
+      padding-left: 0;
+    }
+
+  }
+
+  .govuk-summary-list__row--error .govuk-summary-list__key {
+    @include govuk-media-query($from: tablet) {
+      padding-left: govuk-spacing(2);
+    }
+  }
+
+  .govuk-summary-list__value--error {
+    @include govuk-responsive-margin(1, "bottom");
+    color: $govuk-error-colour;
+    font-weight: 700;
+  }
+
 }

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -34,6 +34,9 @@ private
 
   def conditional_route_card(routing_condition, route_number)
     goto_page_name = routing_condition.skip_to_end ? end_page_name : goto_question_name(routing_condition.goto_page_id)
+    check_value_error = format_error(I18n.t("page_route_card.errors.answer_value_doesnt_exist")) if routing_condition.validation_errors.any? { |error| error.name == "answer_value_doesnt_exist" }
+    goto_page_next_error = format_error(I18n.t("page_route_card.errors.cannot_route_to_next_page")) if routing_condition.validation_errors.any? { |error| error.name == "cannot_route_to_next_page" }
+    goto_page_before_error = format_error(I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page", question_number: question_number(routing_condition.check_page_id))) if routing_condition.validation_errors.any? { |error| error.name == "cannot_have_goto_page_before_routing_page" }
 
     {
       card: {
@@ -46,11 +49,13 @@ private
       rows: [
         {
           key: { text: I18n.t("page_route_card.if_answer_is") },
-          value: { text: I18n.t("page_route_card.conditional_answer_value", answer_value: routing_condition.answer_value) },
+          html_attributes: { id: "check-#{routing_condition.id}", class: check_value_error ? "govuk-summary-list__row--error" : "" },
+          value: { text: safe_join([check_value_error, I18n.t("page_route_card.conditional_answer_value", answer_value: routing_condition.answer_value)]) },
         },
         {
           key: { text: I18n.t("page_route_card.take_the_person_to") },
-          value: { text: goto_page_name },
+          html_attributes: { id: "goto-#{routing_condition.id}", class: goto_page_next_error || goto_page_before_error ? "govuk-summary-list__row--error" : "" },
+          value: { text: safe_join([goto_page_next_error, goto_page_before_error, goto_page_name]) },
         },
       ],
     }
@@ -108,6 +113,8 @@ private
 
     goto_page_name = secondary_skip.skip_to_end ? end_page_name : goto_question_name(secondary_skip.goto_page_id)
     routing_page_name = question_name(secondary_skip.routing_page_id)
+    goto_page_next_error = format_error(I18n.t("page_route_card.errors.cannot_route_to_next_page_secondary_skip")) if secondary_skip.validation_errors.any? { |error| error.name == "cannot_route_to_next_page" }
+    goto_page_before_error = format_error(I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page_secondary_skip")) if secondary_skip.validation_errors.any? { |error| error.name == "cannot_have_goto_page_before_routing_page" }
 
     [
       {
@@ -116,7 +123,8 @@ private
       },
       {
         key: { text: I18n.t("page_route_card.secondary_skip_then") },
-        value: { text: goto_page_name },
+        html_attributes: { id: "goto-#{secondary_skip.id}", class: goto_page_next_error || goto_page_before_error ? "govuk-summary-list__row--error" : "" },
+        value: { text: safe_join([goto_page_next_error, goto_page_before_error, goto_page_name]) },
       },
     ]
   end
@@ -138,5 +146,13 @@ private
 
   def end_page_name
     I18n.t("page_route_card.check_your_answers")
+  end
+
+  def question_number(page_id)
+    pages.find { |page| page.id == page_id }.position
+  end
+
+  def format_error(message)
+    "<div class=\"govuk-summary-list__value--error\">#{message}</div>".html_safe
   end
 end

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -1,9 +1,9 @@
-<% set_page_title(title_with_error_prefix(t('page_titles.routes_show', question_number: page.position), false)) %>
+<% set_page_title(title_with_error_prefix(t('page_titles.routes_show', question_number: route_summary_card_data_presenter.page.position), false)) %>
 <% content_for :back_link, govuk_back_link_to(back_link_url, t('pages.go_to_your_questions')) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-      <%= render ErrorSummaryComponent::View.new(errors:) %>
+      <%= render ErrorSummaryComponent::View.new(errors: route_summary_card_data_presenter.errors) %>
 
       <h1 class="govuk-heading-l">
           <span class="govuk-caption-l"><%= current_form.name %></span>
@@ -17,14 +17,14 @@
           end;
       end %>
 
-      <% RouteSummaryCardDataPresenter.new(form: current_form, page:, pages:, routes:).summary_card_data.each do |card| %>
+      <% route_summary_card_data_presenter.summary_card_data.each do |card| %>
           <%= govuk_summary_list(**card) %>
       <% end %>
 
-      <% if routes.map(&:secondary_skip?).none? %>
+      <% if route_summary_card_data_presenter.routes.map(&:secondary_skip?).none? %>
         <h2 class="govuk-heading-m"><%= t(".any_other_answer.heading") %></h2>
 
-        <p class="govuk-body"><%= t(".any_other_answer.will_continue_to", next_question_number: next_page.position) %></p>
+        <p class="govuk-body"><%= t(".any_other_answer.will_continue_to", next_question_number: route_summary_card_data_presenter.next_page&.position) %></p>
 
         <% if FeatureService.new(group: current_form.group).enabled? :branch_routing %>
           <p class="govuk-body"><%= t(".any_other_answer.skip_later") %></p>
@@ -33,7 +33,7 @@
         <% end %>
       <% end %>
 
-      <% if routes.many? %>
+      <% if route_summary_card_data_presenter.routes.many? %>
         <%= govuk_button_link_to t("page_route_card.delete_route"), delete_routes_path(current_form.id, page.id), warning: true %>
       <% end %>
 

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -3,6 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+      <%= render ErrorSummaryComponent::View.new(errors:) %>
 
       <h1 class="govuk-heading-l">
           <span class="govuk-caption-l"><%= current_form.name %></span>

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(title_with_error_prefix(t('page_titles.routes_show', question_number: route_summary_card_data_presenter.page.position), false)) %>
+<% set_page_title(title_with_error_prefix(t('page_titles.routes_show', question_number: page.position), false)) %>
 <% content_for :back_link, govuk_back_link_to(back_link_url, t('pages.go_to_your_questions')) %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1056,6 +1056,12 @@ en:
     delete: Delete
     delete_route: Delete routes
     edit: Edit
+    errors:
+      answer_value_doesnt_exist: The answer that route 1 is based on no longer exists - edit or delete this route
+      cannot_have_goto_page_before_routing_page: The question route 1 skips to cannot be before question %{question_number} - edit or delete this route
+      cannot_have_goto_page_before_routing_page_secondary_skip: The question the route for any other answer skips to cannot be before the question it skips from - edit or delete this route
+      cannot_route_to_next_page: Route 1 is not skipping any questions - edit or delete this route
+      cannot_route_to_next_page_secondary_skip: The route for any other answer is not skipping any questions - edit or delete this route
     goto_page_invalid: Edit this route to select the question or page you want to take the person to, or delete the route
     if_answer_is: If the answer is
     question_name_long: "%{question_number}. %{question_text}"

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -87,6 +87,56 @@ describe RouteSummaryCardDataPresenter do
           expect(result[1][:card][:actions].second).to have_link("Delete", href: "/forms/99/pages/2/routes/any-other-answer/questions-to-skip/delete")
         end
       end
+
+      context "when the route's check answer does not exist" do
+        it "shows an error message" do
+          branch_route_1.validation_errors << OpenStruct.new(name: "answer_value_doesnt_exist")
+
+          result = service.summary_card_data
+          expect(result[0][:rows][0][:value][:text]).to include("The answer that route 1 is based on no longer exists - edit or delete this route")
+          expect(result[0][:rows][0][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
+        end
+      end
+
+      context "when route 1 does not skip any questions" do
+        it "shows an error message" do
+          branch_route_1.validation_errors << OpenStruct.new(name: "cannot_route_to_next_page")
+
+          result = service.summary_card_data
+          expect(result[0][:rows][1][:value][:text]).to include("Route 1 is not skipping any questions - edit or delete this route")
+          expect(result[0][:rows][1][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
+        end
+      end
+
+      context "when route 1 routes to a previous question" do
+        it "shows an error message" do
+          branch_route_1.validation_errors << OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")
+
+          result = service.summary_card_data
+          expect(result[0][:rows][1][:value][:text]).to include("The question route 1 skips to cannot be before question 2 - edit or delete this route")
+          expect(result[0][:rows][1][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
+        end
+      end
+
+      context "when the any other answer route does not skip a question" do
+        it "shows an error message" do
+          branch_any_other_answer_route.validation_errors << OpenStruct.new(name: "cannot_route_to_next_page")
+
+          result = service.summary_card_data
+          expect(result[1][:rows][2][:value][:text]).to include("The route for any other answer is not skipping any questions - edit or delete this route")
+          expect(result[1][:rows][2][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
+        end
+      end
+
+      context "when the any other answer route skips to a previous question" do
+        it "shows an error message" do
+          branch_any_other_answer_route.validation_errors << OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")
+
+          result = service.summary_card_data
+          expect(result[1][:rows][2][:value][:text]).to include("The question the route for any other answer skips to cannot be before the question it skips from - edit or delete this route")
+          expect(result[1][:rows][2][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
+        end
+      end
     end
 
     context "with no conditional routes" do
@@ -95,6 +145,72 @@ describe RouteSummaryCardDataPresenter do
       it "returns an empty array" do
         result = service.summary_card_data
         expect(result).to eq []
+      end
+    end
+  end
+
+  describe "#routes" do
+    it "calls the PageRoutesService" do
+      double = instance_double(PageRoutesService, routes: [])
+      allow(PageRoutesService).to receive(:new).with(form: form, pages: pages, page: page).and_return(double)
+      service.routes
+      expect(double).to have_received(:routes)
+    end
+  end
+
+  describe "#pages" do
+    it "calls the FormRepository" do
+      expect(FormRepository).to receive(:pages).with(form)
+      service.pages
+    end
+  end
+
+  describe "#next_page" do
+    it "returns the next page" do
+      allow(FormRepository).to receive(:pages).and_return(pages)
+      expect(service.next_page).to eq(pages[10])
+    end
+  end
+
+  describe "#errors" do
+    let(:page) { page_with_skip_and_secondary_skip }
+
+    it "returns an array of errors" do
+      expect(service.errors).to be_empty
+    end
+
+    context "when there is a check error" do
+      it "contains the check error link and message" do
+        branch_route_1.validation_errors << OpenStruct.new(name: "answer_value_doesnt_exist")
+        expect(service.errors).to eq([OpenStruct.new(link: "#check-#{branch_route_1.id}", message: I18n.t("page_route_card.errors.answer_value_doesnt_exist"))])
+      end
+    end
+
+    context "when there is a next page error" do
+      it "contains the next page error link and message" do
+        branch_route_1.validation_errors << OpenStruct.new(name: "cannot_route_to_next_page")
+        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{branch_route_1.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page"))])
+      end
+    end
+
+    context "when there is a next page error for the secondary skip" do
+      it "contains the secondary skip next page error link and message" do
+        branch_any_other_answer_route.validation_errors << OpenStruct.new(name: "cannot_route_to_next_page")
+        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{branch_any_other_answer_route.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page_secondary_skip"))])
+      end
+    end
+
+    context "when there is a goto page before routing page error" do
+      it "contains the goto page before routing page error link and message" do
+        branch_route_1.validation_errors << OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")
+        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{branch_route_1.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page", question_number: 2))])
+      end
+    end
+
+    context "when there is a goto page before routing page error for the secondary skip" do
+      it "contains the secondary skip goto page before routing page error link and message" do
+        branch_any_other_answer_route.validation_errors << OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")
+        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{branch_any_other_answer_route.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page_secondary_skip"))])
       end
     end
   end

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe RouteSummaryCardDataPresenter do
   include Capybara::RSpecMatchers
 
-  subject(:service) { described_class.new(form:, pages:, page:, routes:) }
+  subject(:service) { described_class.new(form:, page:) }
 
   include_context "with pages with routing"
 

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe "pages/routes/show.html.erb" do
   before do
     allow(RouteSummaryCardDataPresenter).to receive(:new).and_return(route_summary_card_data_service)
     allow(form).to receive(:group).and_return(build(:group))
-    render template: "pages/routes/show", locals: { current_form: form, page:, pages:, next_page:, routes:, back_link_url: "/back" }
+    render template: "pages/routes/show", locals: { current_form: form, page:, pages:, next_page:, routes:, back_link_url: "/back", errors: [] }
   end
 
   it "has the correct title" do

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe "pages/routes/show.html.erb" do
   let(:page) { build :page, id: 1, position: 1, next_page: 2, routing_conditions: [build(:condition)] }
   let(:next_page) { build :page, id: 2 }
   let(:routes) { PageRoutesService.new(form:, pages:, page:).routes }
+  let(:errors) { [] }
 
   let(:route_cards) do
     [
@@ -18,12 +19,11 @@ describe "pages/routes/show.html.erb" do
     ]
   end
 
-  let(:route_summary_card_data_service) { instance_double(RouteSummaryCardDataPresenter, summary_card_data: route_cards) }
+  let(:route_summary_card_data_service) { instance_double(RouteSummaryCardDataPresenter, summary_card_data: route_cards, errors:, routes:, next_page:, pages:, page:, form:) }
 
   before do
-    allow(RouteSummaryCardDataPresenter).to receive(:new).and_return(route_summary_card_data_service)
     allow(form).to receive(:group).and_return(build(:group))
-    render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: OpenStruct.new(page:, pages:, next_page:, routes:, errors: [], summary_card_data: route_cards) }
+    render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: route_summary_card_data_service }
   end
 
   it "has the correct title" do
@@ -108,6 +108,14 @@ describe "pages/routes/show.html.erb" do
     it "does not have an any other answer section" do
       expect(rendered).not_to have_css "h2", text: "Any other answer"
       expect(rendered).not_to have_link "Set questions to skip"
+    end
+  end
+
+  context "when there is an error" do
+    let(:errors) { [OpenStruct.new(link: "goto-1", message: "Error text")] }
+
+    it "shows the error message" do
+      expect(rendered).to have_text("Error text")
     end
   end
 end

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe "pages/routes/show.html.erb" do
   before do
     allow(RouteSummaryCardDataPresenter).to receive(:new).and_return(route_summary_card_data_service)
     allow(form).to receive(:group).and_return(build(:group))
-    render template: "pages/routes/show", locals: { current_form: form, page:, pages:, next_page:, routes:, back_link_url: "/back", errors: [] }
+    render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: OpenStruct.new(page:, pages:, next_page:, routes:, errors: [], summary_card_data: route_cards) }
   end
 
   it "has the correct title" do


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/HWFQ632W/2149-add-error-messages-to-routes-summary-page

Adds routing errors to the routes page. There are 5 different error messages being added

**Route is based on an answer that no longer exists**
![image](https://github.com/user-attachments/assets/d4f67b78-6aa2-409e-9970-064508474fad)

**Route does not skip any questions**
![image](https://github.com/user-attachments/assets/3f96caac-4d12-45c2-8cda-425d90abe058)

**Route skips to a question before itself**
![image](https://github.com/user-attachments/assets/7adfc6f2-79da-4330-967f-55ba4861c086)

**Secondary skip route does not skip any questions**
![image](https://github.com/user-attachments/assets/2330c63b-4fff-456d-81d5-d2d592f833f0)

**Secondary skip goes to a question that is before itself**
![image](https://github.com/user-attachments/assets/04ef8959-d05b-4c3a-be85-6a345e3c0124)

Try and get them all to trigger!


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
