### PR TITLE
Use chromedriver v128 in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,17 @@ jobs:
       RAILS_ENV: "test"
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/forms_admin_test"
     steps:
+      # TODO: remove these steps once we can use latest Chrome again (see https://github.com/teamcapybara/capybara/issues/2800)
+      - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: '128.0.6613.8600'
+          chromeapp: chrome
+      - run: |
+          sudo apt-get purge google-chrome-stable
+      - uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 128
+          install-chromedriver: 'false'
       - name: Checkout code
         uses: actions/checkout@v4
       # Add or replace dependency steps here


### PR DESCRIPTION
We are seeing intermittent failures when feature tests run in github actions. These failures are related to selenium and chromedriver. They are false positives and do not mean the code is broken.

This commit copies the solution gov.uk applied to their codebase.

https://github.com/alphagov/publisher/pull/2596/commits/68adc8858782949a1a38f4eb582a17462eb0e51c

This change should only be needed until the chromedriver/chrome version issue is fixed.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
