### PR TITLE
Remove test forms from reports

### DIFF
--- a/app/services/reports/form_documents_service.rb
+++ b/app/services/reports/form_documents_service.rb
@@ -13,7 +13,7 @@ class Reports::FormDocumentsService
         page = 1
         loop do
           form_documents_response = live_form_documents_page(page)
-          form_documents_response.forms.each { |f| yielder << f }
+          form_documents_response.forms.each { |f| yielder << f unless is_in_internal_organisation?(f) }
 
           break unless form_documents_response.has_more_results?
 
@@ -46,6 +46,14 @@ class Reports::FormDocumentsService
       limit = response["pagination-limit"].to_i
 
       total > offset + limit
+    end
+
+    def is_in_internal_organisation?(form)
+      group_form = GroupForm.find_by_form_id(form["form_id"])
+
+      return false if group_form.blank?
+
+      group_form.group.organisation.internal?
     end
   end
 end

--- a/db/migrate/20250402115233_add_internal_to_organisations.rb
+++ b/db/migrate/20250402115233_add_internal_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddInternalToOrganisations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :organisations, :internal, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_07_150217) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_02_115233) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -144,6 +144,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_07_150217) do
     t.boolean "closed", default: false
     t.string "abbreviation"
     t.bigint "default_group_id"
+    t.boolean "internal", default: false
     t.index ["default_group_id"], name: "index_organisations_on_default_group_id"
     t.index ["govuk_content_id"], name: "index_organisations_on_govuk_content_id", unique: true
     t.index ["slug"], name: "index_organisations_on_slug", unique: true

--- a/spec/factories/models/organisations.rb
+++ b/spec/factories/models/organisations.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     slug { "test-org" }
     name { slug.titleize }
     abbreviation { name.split.collect(&:chr).join }
+    internal { false }
 
     initialize_with do
       Organisation.create_with(govuk_content_id:, name:).find_or_initialize_by(slug:)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/amETo48v/2120-live-forms-report-needs-amending

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to exclude our test forms from our reports. This PR adds:
- a new `internal` column in the organisations table
- rake tasks for setting and unsetting the new column
- logic to exclude this org's forms from the FormDocumentsService response. That's used in the CSV and feature reports as of #1872 and @stephencdaly is in the process of updating the other reports to use it.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
