### PR TITLE
Add server side double click prevention for creating a form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  gem "cuprite"
   gem "selenium-webdriver"
 
   gem "pundit-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,9 @@ GEM
       rexml
     crass (1.0.6)
     csv (3.3.3)
+    cuprite (0.15.1)
+      capybara (~> 3.0)
+      ferrum (~> 0.15.0)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -194,6 +197,11 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    ferrum (0.15)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     gds-sso (20.0.0)
       oauth2 (~> 2.0)
       omniauth (~> 2.1)
@@ -529,6 +537,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.9.1)
     websocket (1.2.11)
     websocket-driver (0.7.7)
       base64
@@ -560,6 +569,7 @@ DEPENDENCIES
   capybara
   config
   csv
+  cuprite
   debug
   dfe-autocomplete!
   factory_bot_rails

--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -18,9 +18,7 @@ class GroupFormsController < ApplicationController
     @name_input = Forms::NameInput.new(name_input_params)
 
     if @name_input.valid?
-      @form = FormRepository.create!(creator_id: @current_user.id, name: @name_input.name)
-      @group_form.form_id = @form.id
-      @group_form.save!
+      @form = CreateFormService.new.create!(creator: @current_user, group: @group, name: @name_input.name)
 
       redirect_to form_path(@form.id)
     else

--- a/app/services/create_form_service.rb
+++ b/app/services/create_form_service.rb
@@ -1,7 +1,37 @@
 class CreateFormService
+  class CreateFormEvent < ApplicationRecord
+    belongs_to :user
+    belongs_to :group
+  end
+
   def create!(creator:, group:, name:)
-    form = FormRepository.create!(creator_id: creator.id, name:)
-    GroupForm.create!(group:, form_id: form.id)
+    event = begin
+      CreateFormEvent.create!(group:, form_name: name, user: creator, dedup_version: 1)
+    rescue ActiveRecord::RecordNotUnique
+      # If a form with the same name in the same group was created by the same
+      # user less than a second ago, assume that this was a duplicate request
+      # and return the form ID of the previously created form
+      previous_event = CreateFormEvent.order(created_at: :desc).find_by(group:, form_name: name)
+
+      if previous_event.user == creator && previous_event.created_at > 1.second.ago
+        while previous_event.form_id.blank?
+          sleep(0.01)
+          previous_event.reload
+        end
+
+        previous_event
+      else
+        CreateFormEvent.create!(group:, form_name: name, user: creator, dedup_version: previous_event.dedup_version + 1)
+      end
+    end
+
+    if event.form_id.present?
+      form = FormRepository.find(form_id: event.form_id)
+    else
+      form = FormRepository.create!(creator_id: creator.id, name:)
+      GroupForm.create!(group:, form_id: form.id)
+      event.update!(form_id: form.id)
+    end
 
     form
   end

--- a/app/services/create_form_service.rb
+++ b/app/services/create_form_service.rb
@@ -1,0 +1,8 @@
+class CreateFormService
+  def create!(creator:, group:, name:)
+    form = FormRepository.create!(creator_id: creator.id, name:)
+    GroupForm.create!(group:, form_id: form.id)
+
+    form
+  end
+end

--- a/db/migrate/20250410160700_create_create_form_events.rb
+++ b/db/migrate/20250410160700_create_create_form_events.rb
@@ -1,0 +1,15 @@
+class CreateCreateFormEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :create_form_events do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :group, null: false, foreign_key: true
+      t.string :form_name, null: false
+      t.references :form, index: false
+      t.integer :dedup_version
+
+      t.timestamps
+    end
+
+    add_index :create_form_events, %i[group_id form_name dedup_version], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_02_115233) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_10_160700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -27,6 +27,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_02_115233) do
     t.index ["check_page_id"], name: "index_conditions_on_check_page_id"
     t.index ["goto_page_id"], name: "index_conditions_on_goto_page_id"
     t.index ["routing_page_id"], name: "index_conditions_on_routing_page_id"
+  end
+
+  create_table "create_form_events", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
+    t.string "form_name", null: false
+    t.bigint "form_id"
+    t.integer "dedup_version"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id", "form_name", "dedup_version"], name: "idx_on_group_id_form_name_dedup_version_9b12b4ae60", unique: true
+    t.index ["group_id"], name: "index_create_form_events_on_group_id"
+    t.index ["user_id"], name: "index_create_form_events_on_user_id"
   end
 
   create_table "draft_questions", force: :cascade do |t|
@@ -205,6 +218,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_02_115233) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "create_form_events", "groups"
+  add_foreign_key "create_form_events", "users"
   add_foreign_key "draft_questions", "users"
   add_foreign_key "groups", "users", column: "creator_id"
   add_foreign_key "groups", "users", column: "upgrade_requester_id"

--- a/spec/integration/create_a_form_prevent_double_click_spec.rb
+++ b/spec/integration/create_a_form_prevent_double_click_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe "Create a form", type: :feature do
+  let(:form) { build :form, id: 1, name: "Test form", created_at: Faker::Time.backward }
+  let(:unwanted_form) { build :form, id: 2, name: "Test form", created_at: form.created_at + 0.1 }
+
+  let(:group) do
+    group = create :group, name: "Test group", creator: user
+    create :membership, group:, user:, added_by: user
+    group
+  end
+
+  let(:user) { standard_user }
+
+  let(:javascript_enabled) { true }
+
+  before do
+    Capybara.current_driver = Settings.show_browser_during_tests ? :cuprite : :cuprite_headless
+
+    page.driver.browser.disable_javascript unless javascript_enabled
+
+    login_as user
+
+    allow(FormRepository).to receive(:create!).and_return form, unwanted_form
+    allow(FormRepository).to receive(:find).with(form_id: 1).and_return form
+    allow(FormRepository).to receive(:find).with(form_id: "1").and_return form
+    allow(FormRepository).to receive(:find).with(form_id: 2).and_return unwanted_form
+    allow(FormRepository).to receive(:find).with(form_id: "2").and_return unwanted_form
+    allow(FormRepository).to receive(:pages).and_return([])
+  end
+
+  after do
+    Capybara.use_default_driver
+  end
+
+  context "when a user double clicks on the button to create a new form" do
+    before do
+      visit group_path(group)
+      click_on "Create a form"
+
+      fill_in "What’s the name of your form?", with: form.name
+
+      double_click find_button("Save and continue")
+    end
+
+    it "creates only one form" do
+      expect(page).to have_title form.name
+      expect(FormRepository).to have_received(:create!).once
+      expect(GroupForm.count).to eq 1
+    end
+
+    context "when javascript is disabled" do
+      let(:javascript_enabled) { false }
+
+      it "creates only one form" do
+        expect(page).to have_title form.name
+        expect(FormRepository).to have_received(:create!).once
+        expect(GroupForm.count).to eq 1
+      end
+    end
+  end
+
+  # Element#double_click isn't working as expected in Ferrum
+  # (see https://github.com/rubycdp/ferrum/issues/529),
+  # so we need to reimplement it
+  def double_click(element)
+    node = element.base.node
+    mouse = node.page.mouse
+
+    x, y = node.find_position
+    mouse.move(x:, y:)
+    mouse.down
+    mouse.up
+    sleep(0.05)
+    mouse.down
+    mouse.up
+
+    element
+  end
+end

--- a/spec/services/create_form_service_spec.rb
+++ b/spec/services/create_form_service_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe CreateFormService do
+  subject(:create_form_service) do
+    described_class.new
+  end
+
+  let(:creator) { build :user, id: 100 }
+  let(:group) { build :group, id: 1000, organisation: creator.organisation }
+  let(:name) { "Test form" }
+
+  describe "#create!" do
+    before do
+      allow(FormRepository).to receive(:create!).and_invoke(->(**attributes) { build(:form, id: 1, **attributes) })
+    end
+
+    it "creates a form" do
+      create_form_service.create!(creator:, group:, name:)
+
+      expect(FormRepository).to have_received(:create!).with(creator_id: 100, name: "Test form")
+    end
+
+    it "creates a group_form record" do
+      create_form_service.create!(creator:, group:, name:)
+
+      expect(GroupForm.last).to have_attributes(form_id: 1, group_id: 1000)
+    end
+  end
+end

--- a/spec/support/capybara_headless_chrome.rb
+++ b/spec/support/capybara_headless_chrome.rb
@@ -1,3 +1,4 @@
+require "capybara/cuprite"
 require "selenium/webdriver"
 
 options = Selenium::WebDriver::Chrome::Options.new
@@ -37,6 +38,14 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 Capybara.default_driver = Settings.show_browser_during_tests ? :chrome : :headless_chrome
+
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(app, headless: false, browser_options: { "no-sandbox": nil })
+end
+
+Capybara.register_driver(:cuprite_headless) do |app|
+  Capybara::Cuprite::Driver.new(app, headless: true, browser_options: { "no-sandbox": nil })
+end
 
 Capybara.configure do |config|
   config.automatic_label_click = true


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/VUQH4gJS/2153-bug-sometimes-creating-a-form-creates-two-or-more-new-forms-with-the-same-name <!-- link -->

In production we've been seeing 1% to 2% of create a form journeys result in multiple forms with the same name being created. After spending time looking at logs and experimenting I've concluded that is likely because the browser is sometimes sending multiple requests if the button to submit the form is repeatedly activated.

We want to make sure that on the create a form page clicking the submit button more than once (or using the enter key more than once) doesn't result in multiple forms being created. Normally we have the `prevent-double-click` JavaScript from GOV.UK Frontend to do this. I haven't been able to find any bug in this, or recreate the issue of multiple requests being sent except by having JavaScript disabled.

So this PR I've adds a test which has JavaScript disabled and clicks the button to create a new form twice. This test fails when it is initially committed, we then commit a fix to turn it green.

The typical way to make a create request idempotent is to have a uniqueness constraint in the database. I experimented with locks of various kinds, but in the end I couldn't find something as reliable.

Because we don't keep the form records in the forms-admin database yet, this PR adds a new `create_form_events` table that we can enforce our constraint on. This can be thought of as a sort of event coalescing.

However, we don't actually want to restrict what forms can be named, so instead we add `dedup_version` column, which we can increment if there is a name collision that doesn't look to be due to a double click. This is partly inspired by the optimistic locking in ActiveRecord.

Note that to be able to have a browser test which does not use JavaScript, this PR adds Cuprite and Ferrum, drop-in replacements for Selenium and ChromeDriver that are pure Ruby.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
