### PR TITLE
Add breadcrumbs for super admins on show group page

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,5 +1,13 @@
 <% set_page_title(@group.name) %>
-<% content_for :back_link, govuk_back_link_to(groups_path, t("back_link.groups")) %>
+
+<% if @current_user.super_admin? %>
+  <% own_organisation = @current_user.organisation_id == @group.organisation_id %>
+  <% organisations_groups_text = own_organisation ? "Your groups" : "#{@group.organisation.name}’s groups" %>
+  <% search = own_organisation ? nil : { organisation_id: @group.organisation_id } %>
+  <% content_for :back_link, govuk_breadcrumbs(breadcrumbs: { organisations_groups_text => groups_path(search:) } ) %>
+<% else %>
+  <% content_for :back_link, govuk_back_link_to(groups_path, t("back_link.groups")) %>
+<% end %>
 
 <% unless @group.active? %>
   <div class="govuk-grid-row">


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

> As a super admin editing a group from another organisation
> I need to see which organisation the group is in,
> So that I can edit the group confidently.

This PR changes the back link on the page showing a group to be a breadcrumb to the page showing groups for the organisation the current group is in.

If the group is in the same organisation as the user the breadcrumb will take the user to the same page as the back link would; if the group is in a different organisation to the super admin user, the breadcrumb will take the user to the groups for that organisation as if they had searched for that organisation using the autocomplete.

This change should only affect super admins.

<img width="1147" alt="Screenshot 2025-04-01 at 11 07 33" src="https://github.com/user-attachments/assets/50b55ddc-352e-4817-9396-bda07106dd22" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?