### PR TITLE
Remove groups feature flag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -113,10 +113,6 @@ class ApplicationController < ActionController::Base
     @current_form ||= FormRepository.find(form_id: params[:form_id])
   end
 
-  def groups_enabled
-    @groups_enabled ||= current_user.present? && FeatureService.new(user: current_user).enabled?(:groups)
-  end
-
 private
 
   def authenticate_and_check_access

--- a/app/controllers/forms/delete_confirmation_controller.rb
+++ b/app/controllers/forms/delete_confirmation_controller.rb
@@ -44,7 +44,7 @@ module Forms
     end
 
     def delete_form(form)
-      success_url = groups_enabled && form.group.present? ? group_path(form.group) : root_path
+      success_url = form.group.present? ? group_path(form.group) : root_path
 
       if FormRepository.destroy(form)
         redirect_to success_url, status: :see_other, success: "Successfully deleted ‘#{form.name}’"

--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -1,5 +1,4 @@
 class GroupFormsController < ApplicationController
-  before_action :feature_enabled
   before_action :set_group
   after_action :verify_authorized
 
@@ -30,10 +29,6 @@ class GroupFormsController < ApplicationController
   end
 
 private
-
-  def feature_enabled
-    raise ActionController::RoutingError, "Groups feature is not enabled" unless groups_enabled
-  end
 
   def set_group
     @group = Group.find_by!(external_id: params[:group_id])

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -1,5 +1,4 @@
 class GroupMembersController < ApplicationController
-  before_action :feature_enabled
   before_action :set_group
   after_action :verify_authorized
 
@@ -27,10 +26,6 @@ class GroupMembersController < ApplicationController
   end
 
 private
-
-  def feature_enabled
-    raise ActionController::RoutingError, "Groups feature not enabled" unless groups_enabled
-  end
 
   def set_group
     @group = Group.find_by!(external_id: params[:group_id])

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -1,6 +1,6 @@
 <% set_page_title(form.name) %>
 
-<% if FeatureService.new(user: @current_user).enabled?(:groups) && form.group.present? %>
+<% if form.group.present? %>
   <% content_for :back_link, govuk_back_link_to(group_path(form.group), t("back_link.group", group_name: form.group.name)) %>
 <% else %>
   <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -4,7 +4,7 @@
   <% content_for :back_link, govuk_back_link_to(live_form_path(current_form.id), t("back_link.form_view")) %>
 <% elsif current_form.is_archived? %>
   <% content_for :back_link, govuk_back_link_to(archived_form_path(current_form.id), t("back_link.form_view")) %>
-<% elsif FeatureService.new(user: @current_user).enabled?(:groups) && current_form.group.present? %>
+<% elsif current_form.group.present? %>
   <% content_for :back_link, govuk_back_link_to(group_path(current_form.group), t("back_link.group", group_name: current_form.group.name)) %>
 <% else %>
   <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,5 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
-  groups: true # Do not switch off!
   branch_routing:
     enabled_by_group: true
   exit_pages:

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,18 +1,4 @@
 namespace :users do
-  desc "Update all trial and editor users to be standard users - dry run"
-  task update_user_roles_to_standard_dry_run: :environment do
-    ActiveRecord::Base.transaction do
-      update_user_roles
-      Rails.logger.info "users:update_user_roles_to_standard_dry_run rollback"
-      raise ActiveRecord::Rollback
-    end
-  end
-
-  desc "Update all trial and editor users to be standard users"
-  task update_user_roles_to_standard: :environment do
-    update_user_roles
-  end
-
   desc "Delete user (dry run)"
   task :delete_user_dry_run, %i[user_id] => :environment do |_, args|
     run_deletion_task("delete_user_dry_run", args, rollback: true)

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,7 +22,6 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    include_examples expected_value_test, :groups, features, true
     include_examples expected_value_test, :branch_routing, features, { "enabled_by_group" => true }
     include_examples expected_value_test, :exit_pages, features, { "enabled_by_group" => true }
   end

--- a/spec/lib/tasks/users.rake_spec.rb
+++ b/spec/lib/tasks/users.rake_spec.rb
@@ -8,28 +8,6 @@ RSpec.describe "users.rake" do
     Rake::Task.define_task(:environment)
   end
 
-  describe "users:update_user_roles_to_standard" do
-    subject(:task) do
-      Rake::Task["users:update_user_roles_to_standard"]
-        .tap(&:reenable) # make sure task is invoked every time
-    end
-
-    let!(:super_admin_user) { create(:user, :super_admin) }
-    let!(:org_admin_user) { create(:organisation_admin_user) }
-
-    before do
-      task.invoke
-    end
-
-    it "does not update the role for a super_admin user" do
-      expect(super_admin_user.reload.role).to eq("super_admin")
-    end
-
-    it "does not update the role for a organisation_admin user" do
-      expect(org_admin_user.reload.role).to eq("organisation_admin")
-    end
-  end
-
   describe "users:delete_user_dry_run" do
     subject(:task) do
       Rake::Task["users:delete_user_dry_run"]

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -53,12 +53,6 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
         expect(response).to have_http_status :not_found
       end
     end
-
-    context "when the groups feature is disabled", feature_groups: false do
-      it "returns a 404 response" do
-        expect(response).to have_http_status(:not_found)
-      end
-    end
   end
 
   describe "POST /" do
@@ -126,13 +120,6 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
         post group_forms_url(nonexistent_group), params: { forms_name_input: valid_attributes }
 
         expect(response).to have_http_status :not_found
-      end
-    end
-
-    context "when the groups feature is disabled", feature_groups: false do
-      it "returns a 404 response" do
-        post group_forms_url(group), params: { forms_name_input: valid_attributes }
-        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/group_members_controller_spec.rb
+++ b/spec/requests/group_members_controller_spec.rb
@@ -34,13 +34,6 @@ RSpec.describe "/groups/:group_id/members", type: :request do
         expect(response).to have_http_status :not_found
       end
     end
-
-    context "when the groups feature flag is disabled", feature_groups: false do
-      it "returns a 404 response" do
-        get group_members_url(group)
-        expect(response).to have_http_status(:not_found)
-      end
-    end
   end
 
   describe "GET /groups/:group_id/members/new" do
@@ -62,13 +55,6 @@ RSpec.describe "/groups/:group_id/members", type: :request do
       it "renders a 404 not found response" do
         get new_group_member_url(nonexistent_group)
         expect(response).to have_http_status :not_found
-      end
-    end
-
-    context "when the groups feature flag is disabled", feature_groups: false do
-      it "returns a 404 response" do
-        get new_group_member_url(group)
-        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -140,13 +126,6 @@ RSpec.describe "/groups/:group_id/members", type: :request do
       it "renders a 404 not found response" do
         post group_members_url(nonexistent_group), params: { group_member_input: { member_email_address: user.email } }
         expect(response).to have_http_status :not_found
-      end
-    end
-
-    context "when the groups feature flag is disabled", feature_groups: false do
-      it "returns a 404 response" do
-        post group_members_url(group), params: { group_member_input: { member_email_address: user.email } }
-        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -231,10 +231,4 @@ describe "forms/_made_live_form.html.erb" do
       expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
     end
   end
-
-  context "when the groups feature is not enabled", feature_groups: false do
-    it "back link is set to root" do
-      expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
-    end
-  end
 end

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -44,12 +44,6 @@ describe "forms/show.html.erb" do
     expect(view.content_for(:back_link)).to have_link("Back to Group 1", href: group_path(group))
   end
 
-  context "when the groups feature is not enabled", feature_groups: false do
-    it "has a back link to the forms page" do
-      expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
-    end
-  end
-
   context "when a form is not in a group" do
     let(:group) { nil }
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We are now fully on groups for user management, so we don't need the feature flag any more.

This PR removes the groups feature flag from the app and any code that depends on the flag being off.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?