### PR TITLE
Use new add another answer report endpoint

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -17,7 +17,7 @@ class ReportsController < ApplicationController
   end
 
   def add_another_answer
-    data = Report.find("features")
+    data = Report.find("add-another-answer-forms")
 
     render template: "reports/add_another_answer", locals: { data: }
   end

--- a/app/views/reports/add_another_answer.html.erb
+++ b/app/views/reports/add_another_answer.html.erb
@@ -15,7 +15,7 @@
         <%end%>
       <%end%>
       <%= table.with_body do |body| %>
-        <% data.all_forms_with_add_another_answer.sort_by(&:state).each do |form| %>
+        <% data.forms.sort_by(&:state).each do |form| %>
           <% form.repeatable_pages.each do |question| %>
             <%= body.with_row do |row| %>
               <%= row.with_cell(text: govuk_link_to(form.name, form_url(form.form_id))) %>

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 
 RSpec.describe ReportsController, type: :request do
   let(:question_text) { "Question text" }
-  let(:report_data) do
-    { total_live_forms: 3,
-      all_forms_with_add_another_answer: [{ form_id: 3, name: "form name", state: "Draft", repeatable_pages: [{ page_id: 5, question_text: }] }] }
-  end
 
   describe "#index" do
     context "when the user is an editor" do
@@ -186,9 +182,16 @@ RSpec.describe ReportsController, type: :request do
   end
 
   describe "#add_another_answer" do
+    let(:report_data) do
+      {
+        count: 3,
+        forms: [{ form_id: 3, name: "form name", state: "Draft", repeatable_pages: [{ page_id: 5, question_text: }] }],
+      }
+    end
+
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/reports/features", headers, report_data.to_json, 200
+        mock.get "/api/v1/reports/add-another-answer-forms", headers, report_data.to_json, 200
       end
     end
 

--- a/spec/views/reports/add_another_answer.html.erb_spec.rb
+++ b/spec/views/reports/add_another_answer.html.erb_spec.rb
@@ -6,7 +6,10 @@ describe "reports/add_another_answer.html.erb" do
   let(:question_text) { "Question text" }
   let(:state) { "live_with_draft" }
   let(:report) do
-    Report.new({ all_forms_with_add_another_answer: [{ form_id:, name:, state:, repeatable_pages: [{ page_id: 5, question_text: }] }] })
+    Report.new({
+      count: 1,
+      forms: [{ form_id:, name:, state:, repeatable_pages: [{ page_id: 5, question_text: }] }],
+    })
   end
 
   before do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SgDCKXcY/145-improve-our-feature-reports

Use the separate `/api/v1/reports/add-another-answer-forms` to render the forms with add another answer report. The old
`/api/v1/reports/features` endpoint that was returning this data is being removed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
