### PR TITLE
Prevent ActiveRecord errors when adding columns

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -62,5 +62,8 @@ module FormsAdmin
     # logging use ActiveSupport::Logger.new($stdout).
     config.logger = ApplicationLogger.new($stdout)
     config.logger.formatter = JsonLogFormatter.new
+
+    # Prevent ActiveRecord::PreparedStatementCacheExpired errors when adding columns
+    config.active_record.enumerate_columns_in_select_statements = true
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->N/A

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Rails uses [prepared
statements](https://www.postgresql.org/docs/current/sql-prepare.html) to query the database. By default these use wildcard select statements.

This commonly causes issues when adding new columns - the new column will cause postgres to throw an error `cached plan must not change result type`.

In Rails 7, a new config setting,
`enumerate_columns_in_select_statements`, was added. This replaces the wildcard select statements with explicit calls to each column. See [the Rails PR](https://github.com/rails/rails/pull/41718) for details

This means that the prepared statements will be regenerated every time a column is added, so postgres won't throw the error.

This PR turns that config setting on for our ActiveRecord models.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
