### PR TITLE
Allow super admin users to delete groups with no forms

### DIFF
--- a/app/input_objects/groups/delete_confirmation_input.rb
+++ b/app/input_objects/groups/delete_confirmation_input.rb
@@ -1,0 +1,2 @@
+class Groups::DeleteConfirmationInput < DeleteConfirmationInput
+end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -15,6 +15,12 @@ class GroupPolicy < ApplicationPolicy
   alias_method :update?, :edit?
   alias_method :add_editor?, :edit?
 
+  def delete?
+    user.super_admin?
+  end
+
+  alias_method :destroy?, :delete?
+
   def upgrade?
     organisation_admin_or_super_admin? && record.organisation.mou_signatures.present?
   end

--- a/app/views/groups/delete.html.erb
+++ b/app/views/groups/delete.html.erb
@@ -1,0 +1,14 @@
+<% set_page_title(title_with_error_prefix(t(".title"), @delete_confirmation_input.errors.any?)) %>
+
+<% content_for :back_link, govuk_back_link_to(group_path(@group), t("back_link.group", group_name: @group.name)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+      @delete_confirmation_input,
+      url: group_path(@group),
+      caption_text: @group.name,
+      legend_text: t(".title"),
+    ) %>
+  </div>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -67,4 +67,8 @@
 
 <% if @form_list_presenter %>
   <%= govuk_table(**@form_list_presenter.data) %>
+<% elsif policy(@group).delete? %>
+  <div>
+    <%= govuk_button_link_to t(".delete_group"), delete_group_path(@group), warning: true %>
+  </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,9 @@ en:
               user_in_other_org: This person has a different organisation set for their GOV.UK Forms account
             role:
               blank: Select the role this person should have
+        groups/delete_confirmation_input:
+          blank: Select ‘Yes’ to delete the group
+          group_has_forms: This group cannot be deleted because it has forms in it
         pages/delete_confirmation_input:
           blank: Select ‘Yes’ to delete the question
         pages/delete_secondary_skip_input:
@@ -466,6 +469,10 @@ en:
         <p>Your request will be sent to your organisation’s GOV.UK Forms admins.</p>
       inset_text: Some organisations are restricting who can make forms live in their organisation. Send a request to upgrade to find out if this will affect you.
       send_request_to_upgrade: Send request to upgrade
+    delete:
+      title: Are you sure you want to delete this group?
+    destroy:
+      success: Successfully deleted ‘%{group_name}’
     edit:
       title: Change the name of this group
     form_table_caption: Forms in ‘%{group_name}’
@@ -527,6 +534,7 @@ en:
         <p>We’ll send an email to the group admins to let them know your response to the upgrade request.</p>
       radios_legend: Do you want to upgrade this group?
     show:
+      delete_group: Delete this group
       edit_group_members: Edit members of this group
       edit_group_name: Change the name of this group
       review_group_members: View members of this group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,10 +170,12 @@ Rails.application.routes.draw do
     get "/signed", to: "mou_signatures#confirmation", as: :confirmation
   end
 
-  resources :groups, except: :destroy do
+  resources :groups do
     resources :forms, controller: :group_forms, only: %i[new create]
     resources :members, controller: :group_members, only: %i[index new create]
     member do
+      get "delete", to: "groups#delete"
+
       get "upgrade", to: "groups#confirm_upgrade"
       post "upgrade", to: "groups#upgrade"
 

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe GroupPolicy do
   context "when user is super_admin" do
     let(:user) { build :super_admin_user }
 
+    it { is_expected.to permit_actions(%i[delete destroy]) }
+
     it "forbids only request_upgrade and review_upgrade" do
       expect(policy).to forbid_only_actions(%i[request_upgrade review_upgrade])
     end
@@ -39,8 +41,8 @@ RSpec.describe GroupPolicy do
     let(:organisation) { group.organisation }
 
     context "and in the same organisation as the group" do
-      it "forbids only request_upgrade and review_upgrade" do
-        expect(policy).to forbid_only_actions(%i[request_upgrade review_upgrade])
+      it "forbids only request_upgrade, review_upgrade, delete and destroy" do
+        expect(policy).to forbid_only_actions(%i[request_upgrade review_upgrade delete destroy])
       end
     end
 
@@ -89,8 +91,8 @@ RSpec.describe GroupPolicy do
         create :membership, user:, group:, role: :group_admin
       end
 
-      it "forbids upgrade, add_group_admin and review_upgrade" do
-        expect(policy).to forbid_only_actions(%i[upgrade add_group_admin review_upgrade])
+      it "forbids upgrade, add_group_admin, review_upgrade, delete and destroy" do
+        expect(policy).to forbid_only_actions(%i[upgrade add_group_admin review_upgrade delete destroy])
       end
 
       context "when the group status is active" do

--- a/spec/routing/groups_routing_spec.rb
+++ b/spec/routing/groups_routing_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe GroupsController, type: :routing do
     it "routes to #update via PATCH" do
       expect(patch: "/groups/1").to route_to("groups#update", id: "1")
     end
+
+    it "routes to #delete" do
+      expect(get: "/groups/1/delete").to route_to("groups#delete", id: "1")
+    end
+
+    it "routes to #destroy via DELETE" do
+      expect(delete: "/groups/1").to route_to("groups#destroy", id: "1")
+    end
   end
 
   describe "path helpers" do

--- a/spec/views/groups/delete.html.erb_spec.rb
+++ b/spec/views/groups/delete.html.erb_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+describe "groups/delete", type: :view do
+  let(:delete_confirmation_input) { Groups::DeleteConfirmationInput.new }
+  let(:group) { create :group, name: "Test Group" }
+
+  before do
+    assign(:delete_confirmation_input, delete_confirmation_input)
+    assign(:group, group)
+
+    render
+  end
+
+  it "has a page title" do
+    expect(view.content_for(:title)).to include "Are you sure you want to delete this group?"
+  end
+
+  it "has a back link" do
+    expect(view.content_for(:back_link)).to have_link "Back to Test Group", href: group_path(group)
+  end
+
+  it "has a heading" do
+    expect(rendered).to have_css "h1", text: "Are you sure you want to delete this group?"
+  end
+
+  it "has a heading caption with the group name" do
+    expect(rendered).to have_css ".govuk-caption-l", text: "Test Group"
+  end
+
+  it "has a delete confirmation input" do
+    expect(rendered).to render_template "input_objects/_delete_confirmation_input"
+  end
+
+  describe "delete confirmation input" do
+    it "posts the confirm value to the destroy action" do
+      expect(rendered).to have_element "form", action: "/groups/#{group.external_id}" do |form|
+        expect(form).to have_field "_method", type: "hidden", with: "delete"
+      end
+    end
+  end
+
+  context "when there is an error" do
+    context "when the user has not confirmed whether or not they want to delete the group" do
+      let(:delete_confirmation_input) do
+        delete_confirmation_input = Groups::DeleteConfirmationInput.new confirm: nil
+        delete_confirmation_input.validate
+        delete_confirmation_input
+      end
+
+      it "has error in the page title" do
+        expect(view.content_for(:title)).to start_with "Error: "
+      end
+
+      it "has an error message" do
+        expect(rendered).to have_css ".govuk-error-message", text: "Select ‘Yes’ to delete the group"
+      end
+    end
+  end
+end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "groups/show", type: :view do
   let(:membership_role) { :editor }
   let(:upgrade?) { false }
   let(:edit?) { true }
+  let(:delete?) { false }
   let(:request_upgrade?) { false }
   let(:review_upgrade?) { false }
 
@@ -25,6 +26,7 @@ RSpec.describe "groups/show", type: :view do
       policy_double = instance_double(GroupPolicy,
                                       upgrade?: upgrade?,
                                       edit?: edit?,
+                                      delete?: delete?,
                                       request_upgrade?: request_upgrade?,
                                       review_upgrade?: review_upgrade?)
 
@@ -300,6 +302,50 @@ RSpec.describe "groups/show", type: :view do
     render
     expect(rendered).to have_css ".govuk-button--start", text: "Create a form" do |start_button|
       expect(start_button).to match_selector :link, href: new_group_form_path(group)
+    end
+  end
+
+  describe "delete button" do
+    shared_examples "deletable" do
+      it "has a button to delete the group" do
+        expect(rendered).to have_link "Delete this group", class: "govuk-button--warning", href: delete_group_path(group)
+      end
+    end
+
+    shared_examples "not deletable" do
+      it "does not have a button to delete the group" do
+        expect(rendered).not_to have_link href: delete_group_path(group)
+      end
+    end
+
+    context "when the group has no forms" do
+      let(:form_list_presenter) { nil }
+
+      context "and the user has permission to delete the group" do
+        let(:delete?) { true }
+
+        it_behaves_like "deletable"
+      end
+
+      context "and the user does not have permission to delete the group" do
+        let(:delete?) { false }
+
+        it_behaves_like "not deletable"
+      end
+    end
+
+    context "and the group has some forms" do
+      context "and the user has permission to delete the group" do
+        let(:delete?) { true }
+
+        it_behaves_like "not deletable"
+      end
+
+      context "and the user does not have permission to delete the group" do
+        let(:delete?) { false }
+
+        it_behaves_like "not deletable"
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR adds a journey for deleting a group, including a confirmation page.

The link to delete a group only shows if the group does not have forms in it. If the group somehow does have forms in it when the delete is confirmed an error is shown to the user on the confirmation page (and the group is not deleted). This whole bit probably needs polish.

For now only super admins are permitted to delete groups.

https://github.com/user-attachments/assets/0c3e1673-2fb6-4ead-86c0-9bf67df00614

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?