### PR TITLE
Add reports to list forms with features

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -17,6 +17,24 @@ class ReportsController < ApplicationController
     render template: "reports/questions_with_answer_type", locals: { answer_type:, questions: }
   end
 
+  def forms_with_routes
+    forms = Reports::FeatureReportService.live_forms_with_routes
+
+    render template: "reports/forms_with_routes", locals: { forms: forms }
+  end
+
+  def forms_with_payments
+    forms = Reports::FeatureReportService.live_forms_with_payments
+
+    render template: "reports/forms_with_payments", locals: { forms: forms }
+  end
+
+  def forms_with_csv_submission_enabled
+    forms = Reports::FeatureReportService.live_forms_with_csv_submission_enabled
+
+    render template: "reports/forms_with_csv_submission_enabled", locals: { forms: forms }
+  end
+
   def users
     data = Reports::UsersReportService.new.user_data
 
@@ -61,6 +79,24 @@ class ReportsController < ApplicationController
     send_data Reports::CsvReportsService.new.live_forms_csv,
               type: "text/csv; charset=iso-8859-1",
               disposition: "attachment; filename=#{csv_filename('live_forms_report')}"
+  end
+
+  def live_forms_with_routes_csv
+    send_data Reports::CsvReportsService.new.live_forms_with_routes_csv,
+              type: "text/csv; charset=iso-8859-1",
+              disposition: "attachment; filename=#{csv_filename('live_forms_with_routes_report')}"
+  end
+
+  def live_forms_with_payments_csv
+    send_data Reports::CsvReportsService.new.live_forms_with_payments_csv,
+              type: "text/csv; charset=iso-8859-1",
+              disposition: "attachment; filename=#{csv_filename('live_forms_with_payments_report')}"
+  end
+
+  def live_forms_with_csv_submission_enabled_csv
+    send_data Reports::CsvReportsService.new.live_forms_with_csv_submission_enabled_csv,
+              type: "text/csv; charset=iso-8859-1",
+              disposition: "attachment; filename=#{csv_filename('live_forms_with_csv_submission_enabled_report')}"
   end
 
   def live_questions_csv

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -17,6 +17,12 @@ class ReportsController < ApplicationController
     render template: "reports/questions_with_answer_type", locals: { answer_type:, questions: }
   end
 
+  def questions_with_add_another_answer
+    questions = Reports::FeatureReportService.live_questions_with_add_another_answer
+
+    render template: "reports/questions_with_add_another_answer", locals: { questions: }
+  end
+
   def forms_with_routes
     forms = Reports::FeatureReportService.live_forms_with_routes
 
@@ -104,6 +110,12 @@ class ReportsController < ApplicationController
     send_data Reports::CsvReportsService.new.live_questions_csv(answer_type:),
               type: "text/csv; charset=iso-8859-1",
               disposition: "attachment; filename=#{questions_csv_filename(answer_type)}"
+  end
+
+  def live_questions_with_add_another_answer_csv
+    send_data Reports::CsvReportsService.new.live_questions_with_add_another_answer_csv,
+              type: "text/csv; charset=iso-8859-1",
+              disposition: "attachment; filename=#{csv_filename('live_questions_with_add_another_answer_report')}"
   end
 
 private

--- a/app/services/reports/csv_reports_service.rb
+++ b/app/services/reports/csv_reports_service.rb
@@ -24,37 +24,33 @@ class Reports::CsvReportsService
     "Submission type",
   ].freeze
 
-      Reports::FormDocumentsService.live_form_documents.each do |form_document|
-        csv << form_row(form_document)
-      end
-    end
-  end
+  IS_REPEATABLE = "Is repeatable?".freeze
+  QUESTIONS_CSV_HEADERS = [
+    "Form ID",
+    "Status",
+    "Form name",
+    "Organisation name",
+    "Organisation ID",
+    "Group name",
+    "Group ID",
+    "Question number in form",
+    "Question text",
+    "Answer type",
+    "Hint text",
+    "Page heading",
+    "Guidance markdown",
+    "Is optional?",
+    IS_REPEATABLE,
+    "Has routes?",
+    "Answer settings - Input type",
+    "Selection settings - Only one option?",
+    "Selection settings - Number of options",
+    "Name settings - Title needed?",
+    "Raw answer settings",
+  ].freeze
 
-  def live_questions_csv(answer_type: nil)
-    CSV.generate do |csv|
-      csv << [
-        "Form ID",
-        "Status",
-        "Form name",
-        "Organisation name",
-        "Organisation ID",
-        "Group name",
-        "Group ID",
-        "Question number in form",
-        "Question text",
-        "Answer type",
-        "Hint text",
-        "Page heading",
-        "Guidance markdown",
-        "Is optional?",
-        "Is repeatable?",
-        "Has routes?",
-        "Answer settings - Input type",
-        "Selection settings - Only one option?",
-        "Selection settings - Number of options",
-        "Name settings - Title needed?",
-        "Raw answer settings",
-      ]
+  IS_REPEATABLE_COLUMN_INDEX = QUESTIONS_CSV_HEADERS.find_index(IS_REPEATABLE)
+
   def live_forms_csv
     CSV.generate do |csv|
       csv << FORM_CSV_HEADERS
@@ -95,12 +91,29 @@ class Reports::CsvReportsService
     end
   end
 
+  def live_questions_csv(answer_type: nil)
+    CSV.generate do |csv|
+      csv << QUESTIONS_CSV_HEADERS
 
       Reports::FormDocumentsService.live_form_documents.each do |form_document|
         question_rows = question_rows(form_document, answer_type).compact
 
         question_rows.each do |question|
           csv << question
+        end
+      end
+    end
+  end
+
+  def live_questions_with_add_another_answer_csv
+    CSV.generate do |csv|
+      csv << QUESTIONS_CSV_HEADERS
+
+      Reports::FormDocumentsService.live_form_documents.each do |form_document|
+        question_rows = question_rows(form_document, nil).compact
+
+        question_rows.each do |question|
+          csv << question if question[IS_REPEATABLE_COLUMN_INDEX]
         end
       end
     end

--- a/app/services/reports/csv_reports_service.rb
+++ b/app/services/reports/csv_reports_service.rb
@@ -1,30 +1,28 @@
 require "csv"
 
 class Reports::CsvReportsService
-  def live_forms_csv
-    CSV.generate do |csv|
-      csv << [
-        "Form ID",
-        "Status",
-        "Form name",
-        "Slug",
-        "Organisation name",
-        "Organisation ID",
-        "Group name",
-        "Group ID",
-        "Created at",
-        "Updated at",
-        "Number of questions",
-        "Has routes",
-        "Payment URL",
-        "Support URL",
-        "Support URL text",
-        "Support email",
-        "Support phone",
-        "Privacy policy URL",
-        "What happens next markdown",
-        "Submission type",
-      ]
+  FORM_CSV_HEADERS = [
+    "Form ID",
+    "Status",
+    "Form name",
+    "Slug",
+    "Organisation name",
+    "Organisation ID",
+    "Group name",
+    "Group ID",
+    "Created at",
+    "Updated at",
+    "Number of questions",
+    "Has routes",
+    "Payment URL",
+    "Support URL",
+    "Support URL text",
+    "Support email",
+    "Support phone",
+    "Privacy policy URL",
+    "What happens next markdown",
+    "Submission type",
+  ].freeze
 
       Reports::FormDocumentsService.live_form_documents.each do |form_document|
         csv << form_row(form_document)
@@ -57,6 +55,46 @@ class Reports::CsvReportsService
         "Name settings - Title needed?",
         "Raw answer settings",
       ]
+  def live_forms_csv
+    CSV.generate do |csv|
+      csv << FORM_CSV_HEADERS
+
+      Reports::FormDocumentsService.live_form_documents.each do |form_document|
+        csv << form_row(form_document)
+      end
+    end
+  end
+
+  def live_forms_with_routes_csv
+    CSV.generate do |csv|
+      csv << FORM_CSV_HEADERS
+
+      Reports::FormDocumentsService.live_form_documents.each do |form_document|
+        csv << form_row(form_document) if Reports::FormDocumentsService.has_routes?(form_document)
+      end
+    end
+  end
+
+  def live_forms_with_payments_csv
+    CSV.generate do |csv|
+      csv << FORM_CSV_HEADERS
+
+      Reports::FormDocumentsService.live_form_documents.each do |form_document|
+        csv << form_row(form_document) if Reports::FormDocumentsService.has_payments?(form_document)
+      end
+    end
+  end
+
+  def live_forms_with_csv_submission_enabled_csv
+    CSV.generate do |csv|
+      csv << FORM_CSV_HEADERS
+
+      Reports::FormDocumentsService.live_form_documents.each do |form_document|
+        csv << form_row(form_document) if Reports::FormDocumentsService.has_csv_submission_enabled?(form_document)
+      end
+    end
+  end
+
 
       Reports::FormDocumentsService.live_form_documents.each do |form_document|
         question_rows = question_rows(form_document, answer_type).compact

--- a/app/services/reports/feature_report_service.rb
+++ b/app/services/reports/feature_report_service.rb
@@ -41,6 +41,13 @@ class Reports::FeatureReportService
       end
     end
 
+    def live_questions_with_add_another_answer
+      Reports::FormDocumentsService.live_form_documents.flat_map do |form|
+        form["content"]["steps"].select { |step| step["data"]["is_repeatable"] }
+                                .map { |step| questions_details(form, step) }
+      end
+    end
+
     def live_forms_with_routes
       Reports::FormDocumentsService.live_form_documents
                                    .select { |form| Reports::FormDocumentsService.has_routes?(form) }

--- a/app/services/reports/form_documents_service.rb
+++ b/app/services/reports/form_documents_service.rb
@@ -22,6 +22,18 @@ class Reports::FormDocumentsService
       end
     end
 
+    def has_routes?(form_document)
+      form_document["content"]["steps"].any? { |step| step["routing_conditions"].present? }
+    end
+
+    def has_payments?(form_document)
+      form_document["content"]["payment_url"].present?
+    end
+
+    def has_csv_submission_enabled?(form_document)
+      form_document["content"]["submission_type"] == "email_with_csv"
+    end
+
   private
 
     def live_form_documents_page(page)

--- a/app/views/reports/features.html.erb
+++ b/app/views/reports/features.html.erb
@@ -20,7 +20,7 @@
       <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_add_another_answer")) %>
-        <%= row.with_value(text: data[:live_forms_with_add_another_answer]) %>
+        <%= row.with_value(text: govuk_link_to(data[:live_forms_with_add_another_answer], report_questions_with_add_another_answer_path, no_visited_state: true)) %>
       <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_csv_submission_enabled")) %>

--- a/app/views/reports/features.html.erb
+++ b/app/views/reports/features.html.erb
@@ -12,11 +12,11 @@
       <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_routes")) %>
-        <%= row.with_value(text: data[:live_forms_with_routing]) %>
+        <%= row.with_value(text: govuk_link_to(data[:live_forms_with_routing], report_forms_with_routes_path, no_visited_state: true)) %>
       <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_payments")) %>
-        <%= row.with_value(text: data[:live_forms_with_payment]) %>
+        <%= row.with_value(text: govuk_link_to(data[:live_forms_with_payment], report_forms_with_payments_path, no_visited_state: true)) %>
       <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_add_another_answer")) %>
@@ -24,7 +24,7 @@
       <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".features.live_forms_with_csv_submission_enabled")) %>
-        <%= row.with_value(text: data[:live_forms_with_csv_submission_enabled]) %>
+        <%= row.with_value(text: govuk_link_to(data[:live_forms_with_csv_submission_enabled], report_forms_with_csv_submission_enabled_path, no_visited_state: true)) %>
       <% end %>
     <% end %>
 

--- a/app/views/reports/forms_with_csv_submission_enabled.html.erb
+++ b/app/views/reports/forms_with_csv_submission_enabled.html.erb
@@ -1,0 +1,29 @@
+<% set_page_title(t(".heading"))%>
+<% content_for :back_link, govuk_back_link_to(report_features_path, t("reports.back_to_feature_usage")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading")%></h1>
+
+    <p><%=govuk_link_to(t(".download_csv"), report_live_forms_with_csv_submission_enabled_csv_path)%></p>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <%= govuk_table do |table| %>
+
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.form_name")) %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.organisation")) %>
+        <% end %>
+      <% end %>
+      <%= table.with_body do |body| %>
+        <% forms.each do |form| %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell(text: govuk_link_to(form[:form_name], live_form_path(form_id: form[:form_id]))) %>
+            <%= row.with_cell(text: form[:organisation_name]) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reports/forms_with_payments.html.erb
+++ b/app/views/reports/forms_with_payments.html.erb
@@ -1,0 +1,29 @@
+<% set_page_title(t(".heading"))%>
+<% content_for :back_link, govuk_back_link_to(report_features_path, t("reports.back_to_feature_usage")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading")%></h1>
+
+    <p><%=govuk_link_to(t(".download_csv"), report_live_forms_with_payments_csv_path)%></p>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <%= govuk_table do |table| %>
+
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.form_name")) %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.organisation")) %>
+        <% end %>
+      <% end %>
+      <%= table.with_body do |body| %>
+        <% forms.each do |form| %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell(text: govuk_link_to(form[:form_name], live_form_path(form_id: form[:form_id]))) %>
+            <%= row.with_cell(text: form[:organisation_name]) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reports/forms_with_routes.html.erb
+++ b/app/views/reports/forms_with_routes.html.erb
@@ -1,0 +1,31 @@
+<% set_page_title(t(".heading"))%>
+<% content_for :back_link, govuk_back_link_to(report_features_path, t("reports.back_to_feature_usage")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading")%></h1>
+
+    <p><%=govuk_link_to(t(".download_csv"), report_live_forms_with_routes_csv_path)%></p>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <%= govuk_table do |table| %>
+
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.form_name")) %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.organisation")) %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.number_of_routes")) %>
+        <% end %>
+      <% end %>
+      <%= table.with_body do |body| %>
+        <% forms.each do |form| %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell(text: govuk_link_to(form[:form_name], live_form_pages_path(form_id: form[:form_id]))) %>
+            <%= row.with_cell(text: form[:organisation_name]) %>
+            <%= row.with_cell(text: form[:number_of_routes]) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reports/questions_with_add_another_answer.html.erb
+++ b/app/views/reports/questions_with_add_another_answer.html.erb
@@ -1,0 +1,31 @@
+<% set_page_title(t(".heading"))%>
+<% content_for :back_link, govuk_back_link_to(report_features_path, t("reports.back_to_feature_usage")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading")%></h1>
+
+    <p><%=govuk_link_to(t(".download_csv"), report_live_questions_with_add_another_answer_csv_path)%></p>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <%= govuk_table do |table| %>
+
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.form_name")) %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.organisation")) %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.question_text")) %>
+        <% end %>
+      <% end %>
+      <%= table.with_body do |body| %>
+        <% questions.each do |question| %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell(text: govuk_link_to(question[:form_name], live_form_pages_path(form_id: question[:form_id]))) %>
+            <%= row.with_cell(text: question[:organisation_name]) %>
+            <%= row.with_cell(text: question[:question_text]) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reports/questions_with_answer_type.html.erb
+++ b/app/views/reports/questions_with_answer_type.html.erb
@@ -1,5 +1,5 @@
 <% set_page_title(t(".heading", answer_type: t("helpers.label.page.answer_type_options.names.#{answer_type}").downcase)) %>
-<% content_for :back_link, govuk_back_link_to(report_features_path, t(".back_link")) %>
+<% content_for :back_link, govuk_back_link_to(report_features_path, t("reports.back_to_feature_usage")) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t(".heading", answer_type: t("helpers.label.page.answer_type_options.names.#{answer_type}").downcase) %></h1>
@@ -12,9 +12,9 @@
 
       <%= table.with_head do |head| %>
         <%= head.with_row do |row| %>
-          <%= row.with_cell(text: t(".table_headings.form_name")) %>
-          <%= row.with_cell(text: t(".table_headings.organisation")) %>
-          <%= row.with_cell(text: t(".table_headings.question_text")) %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.form_name")) %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.organisation")) %>
+          <%= row.with_cell(text: t("reports.form_or_questions_list_table.headings.question_text")) %>
         <% end %>
       <% end %>
       <%= table.with_body do |body| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1368,6 +1368,9 @@ en:
       not_since_auth0_enabled: People who last signed in before 3 November 2023
       not_since_last_signed_in_at_added: People who last signed in sometime between 3 November 2023 and 4 November 2024
       title: When users last signed in
+    questions_with_add_another_answer:
+      download_csv: Download all questions with add another answer in live forms as a CSV file
+      heading: Questions with add another answer in live forms
     questions_with_answer_type:
       download_csv: Download all questions in live forms with this answer type as a CSV file
       heading: Live questions with %{answer_type} answer type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1323,6 +1323,7 @@ en:
       heading: All forms with add another answer
       title: All forms with add another answer
     back_link: Back to reports
+    back_to_feature_usage: Back to feature and answer type usage
     csv_downloads:
       live_forms: Download data about all live forms as a CSV file
       live_questions: Download all questions in live forms as a CSV file
@@ -1344,6 +1345,21 @@ en:
       long_list_usage:
         title: Selection from a list of options feature usage in live forms
       title: Feature and answer type usage in live forms
+    form_or_questions_list_table:
+      headings:
+        form_name: Form name
+        number_of_routes: Number of routes
+        organisation: Organisation
+        question_text: Question text
+    forms_with_csv_submission_enabled:
+      download_csv: Download data about all live forms with CSV submission enabled as a CSV file
+      heading: Live forms with CSV submission enabled
+    forms_with_payments:
+      download_csv: Download data about all live forms with payments as a CSV file
+      heading: Live forms with payments
+    forms_with_routes:
+      download_csv: Download data about all live forms with routes as a CSV file
+      heading: Live forms with routes
     index:
       title: Reports
     last_signed_in_at:
@@ -1353,13 +1369,8 @@ en:
       not_since_last_signed_in_at_added: People who last signed in sometime between 3 November 2023 and 4 November 2024
       title: When users last signed in
     questions_with_answer_type:
-      back_link: Back to feature and answer type usage
       download_csv: Download all questions in live forms with this answer type as a CSV file
       heading: Live questions with %{answer_type} answer type
-      table_headings:
-        form_name: Form name
-        organisation: Organisation
-        question_text: Question
     selection_questions:
       autocomplete:
         title: Questions where you can select one from over 30 options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,7 @@ Rails.application.routes.draw do
     get "/", to: "reports#index", as: :reports
     get "features", to: "reports#features", as: :report_features
     get "questions-with-answer-type/:answer_type", to: "reports#questions_with_answer_type", as: :report_questions_with_answer_type
+    get "questions-with-add-another-answer", to: "reports#questions_with_add_another_answer", as: :report_questions_with_add_another_answer
     get "forms-with-routes", to: "reports#forms_with_routes", as: :report_forms_with_routes
     get "forms-with-payments", to: "reports#forms_with_payments", as: :report_forms_with_payments
     get "forms-with-csv-submission-enabled", to: "reports#forms_with_csv_submission_enabled", as: :report_forms_with_csv_submission_enabled
@@ -206,6 +207,7 @@ Rails.application.routes.draw do
     get "live-forms-with-payments-csv", to: "reports#live_forms_with_payments_csv", as: :report_live_forms_with_payments_csv
     get "live-forms-with-csv-submission-enabled-csv", to: "reports#live_forms_with_csv_submission_enabled_csv", as: :report_live_forms_with_csv_submission_enabled_csv
     get "live-questions-csv", to: "reports#live_questions_csv", as: :report_live_questions_csv
+    get "live-questions-with-add-another-answer-csv", to: "reports#live_questions_with_add_another_answer_csv", as: :report_live_questions_with_add_another_answer_csv
   end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,9 @@ Rails.application.routes.draw do
     get "/", to: "reports#index", as: :reports
     get "features", to: "reports#features", as: :report_features
     get "questions-with-answer-type/:answer_type", to: "reports#questions_with_answer_type", as: :report_questions_with_answer_type
+    get "forms-with-routes", to: "reports#forms_with_routes", as: :report_forms_with_routes
+    get "forms-with-payments", to: "reports#forms_with_payments", as: :report_forms_with_payments
+    get "forms-with-csv-submission-enabled", to: "reports#forms_with_csv_submission_enabled", as: :report_forms_with_csv_submission_enabled
     get "users", to: "reports#users", as: :report_users
     get "add_another_answer", to: "reports#add_another_answer", as: :report_add_another_answer
     get "last-signed-in-at", to: "reports#last_signed_in_at", as: :report_last_signed_in_at
@@ -199,6 +202,9 @@ Rails.application.routes.draw do
     get "selection-questions-with-checkboxes", to: "reports#selection_questions_with_checkboxes", as: :report_selection_questions_with_checkboxes
     get "csv-downloads", to: "reports#csv_downloads", as: :report_csv_downloads
     get "live-forms-csv", to: "reports#live_forms_csv", as: :report_live_forms_csv
+    get "live-forms-with-routes-csv", to: "reports#live_forms_with_routes_csv", as: :report_live_forms_with_routes_csv
+    get "live-forms-with-payments-csv", to: "reports#live_forms_with_payments_csv", as: :report_live_forms_with_payments_csv
+    get "live-forms-with-csv-submission-enabled-csv", to: "reports#live_forms_with_csv_submission_enabled_csv", as: :report_live_forms_with_csv_submission_enabled_csv
     get "live-questions-csv", to: "reports#live_questions_csv", as: :report_live_questions_csv
   end
 

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ReportsController, type: :request do
   end
 
   describe "#index" do
-    context "when the user is an editor" do
+    context "when the user is a standard user" do
       before do
         login_as_standard_user
 
@@ -73,7 +73,7 @@ RSpec.describe ReportsController, type: :request do
   end
 
   describe "#features" do
-    context "when the user is an editor" do
+    context "when the user is a standard user" do
       before do
         login_as_standard_user
 
@@ -131,7 +131,7 @@ RSpec.describe ReportsController, type: :request do
   end
 
   describe "#questions_with_answer_type" do
-    context "when the user is an editor" do
+    context "when the user is a standard user" do
       before do
         login_as_standard_user
 
@@ -189,7 +189,7 @@ RSpec.describe ReportsController, type: :request do
   end
 
   describe "#questions_with_add_another_answer" do
-    context "when the user is an editor" do
+    context "when the user is a standard user" do
       before do
         login_as_standard_user
 
@@ -247,7 +247,7 @@ RSpec.describe ReportsController, type: :request do
   end
 
   describe "#forms_with_routes" do
-    context "when the user is an editor" do
+    context "when the user is a standard user" do
       before do
         login_as_standard_user
 
@@ -305,7 +305,7 @@ RSpec.describe ReportsController, type: :request do
   end
 
   describe "#forms_with_payments" do
-    context "when the user is an editor" do
+    context "when the user is a standard user" do
       before do
         login_as_standard_user
 
@@ -363,7 +363,7 @@ RSpec.describe ReportsController, type: :request do
   end
 
   describe "#forms_with_csv_submission_enabled" do
-    context "when the user is an editor" do
+    context "when the user is a standard user" do
       before do
         login_as_standard_user
 
@@ -421,7 +421,7 @@ RSpec.describe ReportsController, type: :request do
   end
 
   describe "#users" do
-    context "when the user is an editor" do
+    context "when the user is a standard user" do
       before do
         login_as_standard_user
 
@@ -484,7 +484,7 @@ RSpec.describe ReportsController, type: :request do
       end
     end
 
-    context "when the user is an editor" do
+    context "when the user is a standard user" do
       before do
         login_as_standard_user
 

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -188,6 +188,64 @@ RSpec.describe ReportsController, type: :request do
     end
   end
 
+  describe "#questions_with_add_another_answer" do
+    context "when the user is an editor" do
+      before do
+        login_as_standard_user
+
+        get report_questions_with_add_another_answer_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is an organisation admin" do
+      before do
+        login_as_organisation_admin_user
+
+        get report_questions_with_add_another_answer_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get report_questions_with_add_another_answer_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the features report view" do
+        expect(response).to render_template("reports/questions_with_add_another_answer")
+      end
+
+      it "includes the report data" do
+        page = Capybara.string(response.body)
+        within(page.find_all(".govuk-summary-list").first) do
+          expect(page.find_all(".govuk-summary-list__key")[2]).to have_text "Question text"
+          expect(page.find_all(".govuk-summary-list__value")[0]).to have_text "Single line of text"
+        end
+      end
+    end
+  end
+
   describe "#forms_with_routes" do
     context "when the user is an editor" do
       before do

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe ReportsController, type: :request do
       before do
         login_as_standard_user
 
-        get report_features_path
+        get report_questions_with_answer_type_path(answer_type: "email")
       end
 
       it "returns http code 403" do
@@ -151,7 +151,7 @@ RSpec.describe ReportsController, type: :request do
       before do
         login_as_organisation_admin_user
 
-        get report_features_path
+        get report_questions_with_answer_type_path(answer_type: "email")
       end
 
       it "returns http code 403" do
@@ -183,6 +183,180 @@ RSpec.describe ReportsController, type: :request do
         within(page.find_all(".govuk-summary-list").first) do
           expect(page.find_all(".govuk-summary-list__key")[2]).to have_text "Question text"
           expect(page.find_all(".govuk-summary-list__value")[0]).to have_text "Email address"
+        end
+      end
+    end
+  end
+
+  describe "#forms_with_routes" do
+    context "when the user is an editor" do
+      before do
+        login_as_standard_user
+
+        get report_forms_with_routes_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is an organisation admin" do
+      before do
+        login_as_organisation_admin_user
+
+        get report_forms_with_routes_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get report_forms_with_routes_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the features report view" do
+        expect(response).to render_template("reports/forms_with_routes")
+      end
+
+      it "includes the report data" do
+        page = Capybara.string(response.body)
+        within(page.find_all(".govuk-summary-list").first) do
+          expect(page.find_all(".govuk-summary-list__key")[2]).to have_text "Number of routes"
+          expect(page.find_all(".govuk-summary-list__value")[0]).to have_text "2"
+        end
+      end
+    end
+  end
+
+  describe "#forms_with_payments" do
+    context "when the user is an editor" do
+      before do
+        login_as_standard_user
+
+        get report_forms_with_payments_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is an organisation admin" do
+      before do
+        login_as_organisation_admin_user
+
+        get report_forms_with_payments_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get report_forms_with_payments_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the features report view" do
+        expect(response).to render_template("reports/forms_with_payments")
+      end
+
+      it "includes the report data" do
+        page = Capybara.string(response.body)
+        within(page.find_all(".govuk-summary-list").first) do
+          expect(page.find_all(".govuk-summary-list__key")[2]).to have_text "Form name"
+          expect(page.find_all(".govuk-summary-list__value")[0]).to have_text "All question types form"
+        end
+      end
+    end
+  end
+
+  describe "#forms_with_csv_submission_enabled" do
+    context "when the user is an editor" do
+      before do
+        login_as_standard_user
+
+        get report_forms_with_csv_submission_enabled_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is an organisation admin" do
+      before do
+        login_as_organisation_admin_user
+
+        get report_forms_with_csv_submission_enabled_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get report_forms_with_csv_submission_enabled_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the features report view" do
+        expect(response).to render_template("reports/forms_with_csv_submission_enabled")
+      end
+
+      it "includes the report data" do
+        page = Capybara.string(response.body)
+        within(page.find_all(".govuk-summary-list").first) do
+          expect(page.find_all(".govuk-summary-list__key")[2]).to have_text "Form name"
+          expect(page.find_all(".govuk-summary-list__value")[0]).to have_text "All question types form"
         end
       end
     end

--- a/spec/services/reports/csv_reports_service_spec.rb
+++ b/spec/services/reports/csv_reports_service_spec.rb
@@ -52,6 +52,51 @@ RSpec.describe Reports::CsvReportsService do
     end
   end
 
+  describe "#live_forms_with_routes_csv" do
+    it "returns a CSV with 2 rows, including the header row" do
+      csv = csv_reports_service.live_forms_with_routes_csv
+      rows = CSV.parse(csv)
+      expect(rows.length).to eq 2
+    end
+
+    it "includes form with routes" do
+      csv = csv_reports_service.live_forms_with_routes_csv
+      rows = CSV.parse(csv)
+      has_routes_column_index = rows[0].find_index("Has routes")
+      expect(rows[1][has_routes_column_index]).to eq "true"
+    end
+  end
+
+  describe "#live_forms_with_payments_csv" do
+    it "returns a CSV with 2 rows, including the header row" do
+      csv = csv_reports_service.live_forms_with_payments_csv
+      rows = CSV.parse(csv)
+      expect(rows.length).to eq 2
+    end
+
+    it "includes form with payments" do
+      csv = csv_reports_service.live_forms_with_payments_csv
+      rows = CSV.parse(csv)
+      payment_url_column_index = rows[0].find_index("Payment URL")
+      expect(rows[1][payment_url_column_index]).to eq "https://www.gov.uk/payments/your-payment-link"
+    end
+  end
+
+  describe "#live_forms_with_csv_submission_enabled_csv" do
+    it "returns a CSV with 2 rows, including the header row" do
+      csv = csv_reports_service.live_forms_with_csv_submission_enabled_csv
+      rows = CSV.parse(csv)
+      expect(rows.length).to eq 2
+    end
+
+    it "includes form with submission type email_with_csv" do
+      csv = csv_reports_service.live_forms_with_csv_submission_enabled_csv
+      rows = CSV.parse(csv)
+      submission_type_column_index = rows[0].find_index("Submission type")
+      expect(rows[1][submission_type_column_index]).to eq "email_with_csv"
+    end
+  end
+
   describe "#live_forms_questions" do
     context "when answer_type is nil" do
       it "returns a CSV with 16 rows, including the header row" do

--- a/spec/services/reports/csv_reports_service_spec.rb
+++ b/spec/services/reports/csv_reports_service_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Reports::CsvReportsService do
     end
   end
 
-  describe "#live_forms_questions" do
+  describe "#live_questions_csv" do
     context "when answer_type is nil" do
       it "returns a CSV with 16 rows, including the header row" do
         csv = csv_reports_service.live_questions_csv
@@ -236,6 +236,22 @@ RSpec.describe Reports::CsvReportsService do
         expect(rows[1][answer_type_column_index]).to eq "email"
         expect(rows[2][answer_type_column_index]).to eq "email"
       end
+    end
+  end
+
+  describe "#live_questions_with_add_another_answer_csv" do
+    it "returns 3 rows, including the header row" do
+      csv = csv_reports_service.live_questions_with_add_another_answer_csv
+      rows = CSV.parse(csv)
+      expect(rows.length).to eq 3
+    end
+
+    it "only includes questions with add another answer" do
+      csv = csv_reports_service.live_questions_with_add_another_answer_csv
+      rows = CSV.parse(csv)
+      answer_type_column_index = rows[0].find_index("Is repeatable?")
+      expect(rows[1][answer_type_column_index]).to eq "true"
+      expect(rows[2][answer_type_column_index]).to eq "true"
     end
   end
 end

--- a/spec/services/reports/feature_report_service_spec.rb
+++ b/spec/services/reports/feature_report_service_spec.rb
@@ -67,4 +67,41 @@ RSpec.describe Reports::FeatureReportService do
       })
     end
   end
+
+  describe "#live_forms_with_routes" do
+    it "returns forms with routes" do
+      forms = described_class.live_forms_with_routes
+      expect(forms.length).to eq 1
+      expect(forms).to include(
+        form_name: "Branch route form",
+        form_id: 3,
+        organisation_name: group.organisation.name,
+        number_of_routes: 2,
+      )
+    end
+  end
+
+  describe "#live_forms_with_payments" do
+    it "returns live forms with payments" do
+      forms = described_class.live_forms_with_payments
+      expect(forms.length).to eq 1
+      expect(forms).to include(
+        form_name: "All question types form",
+        form_id: 1,
+        organisation_name: group.organisation.name,
+      )
+    end
+  end
+
+  describe "#live_forms_with_csv_submission_enabled" do
+    it "returns live forms with csv enabled" do
+      forms = described_class.live_forms_with_csv_submission_enabled
+      expect(forms.length).to eq 1
+      expect(forms).to include(
+        form_name: "All question types form",
+        form_id: 1,
+        organisation_name: group.organisation.name,
+      )
+    end
+  end
 end

--- a/spec/services/reports/feature_report_service_spec.rb
+++ b/spec/services/reports/feature_report_service_spec.rb
@@ -68,6 +68,27 @@ RSpec.describe Reports::FeatureReportService do
     end
   end
 
+  describe "#live_questions_with_add_another_answer" do
+    it "returns questions with add another answer" do
+      questions = described_class.live_questions_with_add_another_answer
+      expect(questions.length).to eq 2
+      expect(questions).to include(
+        {
+          form_name: "All question types form",
+          form_id: 1,
+          organisation_name: group.organisation.name,
+          question_text: "Single line of text",
+        },
+      )
+      expect(questions).to include({
+        form_name: "All question types form",
+        form_id: 1,
+        organisation_name: group.organisation.name,
+        question_text: "Number",
+      })
+    end
+  end
+
   describe "#live_forms_with_routes" do
     it "returns forms with routes" do
       forms = described_class.live_forms_with_routes

--- a/spec/views/reports/forms_with_csv_submission_enabled.html.erb_spec.rb
+++ b/spec/views/reports/forms_with_csv_submission_enabled.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe "reports/forms_with_csv_submission_enabled.html.erb" do
+  let(:forms) do
+    [
+      {
+        form_name: "All question types form",
+        form_id: 1,
+        organisation_name: "Government Digital Service",
+      },
+      {
+        form_name: "Branch route form",
+        form_id: 3,
+        organisation_name: "Government Digital Service",
+      },
+    ]
+  end
+
+  before do
+    render template: "reports/forms_with_csv_submission_enabled", locals: { forms: }
+  end
+
+  describe "page title" do
+    it "matches the heading" do
+      expect(view.content_for(:title)).to eq "Live forms with CSV submission enabled"
+    end
+  end
+
+  it "has a back link to feature usage report" do
+    expect(view.content_for(:back_link)).to have_link("Back to feature and answer type usage", href: report_features_path)
+  end
+
+  it "has a link to download the CSV" do
+    expect(rendered).to have_link("Download data about all live forms with CSV submission enabled as a CSV file", href: report_live_forms_with_csv_submission_enabled_csv_path)
+  end
+
+  describe "questions table" do
+    it "has the correct headers" do
+      page = Capybara.string(rendered.html)
+      within(page.find(".govuk-table__head")) do
+        expect(page.find_all(".govuk-table__header"[0])).to have_text "Form name"
+        expect(page.find_all(".govuk-table__header"[1])).to have_text "Organisation"
+      end
+    end
+
+    it "has rows for each question" do
+      page = Capybara.string(rendered.html)
+      within(page.find_all(".govuk-table__row")[1]) do
+        expect(page.find_all(".govuk-table__cell"[0])).to have_text "All question types form"
+        expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
+      end
+      within(page.find_all(".govuk-table__row")[2]) do
+        expect(page.find_all(".govuk-table__cell"[0])).to have_text "Branch route form"
+        expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
+      end
+    end
+  end
+end

--- a/spec/views/reports/forms_with_payments.html.erb_spec.rb
+++ b/spec/views/reports/forms_with_payments.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe "reports/forms_with_payments.html.erb" do
+  let(:forms) do
+    [
+      {
+        form_name: "All question types form",
+        form_id: 1,
+        organisation_name: "Government Digital Service",
+      },
+      {
+        form_name: "Branch route form",
+        form_id: 3,
+        organisation_name: "Government Digital Service",
+      },
+    ]
+  end
+
+  before do
+    render template: "reports/forms_with_payments", locals: { forms: }
+  end
+
+  describe "page title" do
+    it "matches the heading" do
+      expect(view.content_for(:title)).to eq "Live forms with payments"
+    end
+  end
+
+  it "has a back link to feature usage report" do
+    expect(view.content_for(:back_link)).to have_link("Back to feature and answer type usage", href: report_features_path)
+  end
+
+  it "has a link to download the CSV" do
+    expect(rendered).to have_link("Download data about all live forms with payments as a CSV file", href: report_live_forms_with_payments_csv_path)
+  end
+
+  describe "questions table" do
+    it "has the correct headers" do
+      page = Capybara.string(rendered.html)
+      within(page.find(".govuk-table__head")) do
+        expect(page.find_all(".govuk-table__header"[0])).to have_text "Form name"
+        expect(page.find_all(".govuk-table__header"[1])).to have_text "Organisation"
+      end
+    end
+
+    it "has rows for each question" do
+      page = Capybara.string(rendered.html)
+      within(page.find_all(".govuk-table__row")[1]) do
+        expect(page.find_all(".govuk-table__cell"[0])).to have_text "All question types form"
+        expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
+      end
+      within(page.find_all(".govuk-table__row")[2]) do
+        expect(page.find_all(".govuk-table__cell"[0])).to have_text "Branch route form"
+        expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
+      end
+    end
+  end
+end

--- a/spec/views/reports/forms_with_routes.html.erb_spec.rb
+++ b/spec/views/reports/forms_with_routes.html.erb_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+describe "reports/forms_with_routes.html.erb" do
+  let(:forms) do
+    [
+      {
+        form_name: "All question types form",
+        form_id: 1,
+        organisation_name: "Government Digital Service",
+        number_of_routes: 1,
+      },
+      {
+        form_name: "Branch route form",
+        form_id: 3,
+        organisation_name: "Government Digital Service",
+        number_of_routes: 2,
+      },
+    ]
+  end
+
+  before do
+    render template: "reports/forms_with_routes", locals: { forms: }
+  end
+
+  describe "page title" do
+    it "matches the heading" do
+      expect(view.content_for(:title)).to eq "Live forms with routes"
+    end
+  end
+
+  it "has a back link to feature usage report" do
+    expect(view.content_for(:back_link)).to have_link("Back to feature and answer type usage", href: report_features_path)
+  end
+
+  it "has a link to download the CSV" do
+    expect(rendered).to have_link("Download data about all live forms with routes as a CSV file", href: report_live_forms_with_routes_csv_path)
+  end
+
+  describe "questions table" do
+    it "has the correct headers" do
+      page = Capybara.string(rendered.html)
+      within(page.find(".govuk-table__head")) do
+        expect(page.find_all(".govuk-table__header"[0])).to have_text "Form name"
+        expect(page.find_all(".govuk-table__header"[1])).to have_text "Organisation"
+        expect(page.find_all(".govuk-table__header"[2])).to have_text "Number of routes"
+      end
+    end
+
+    it "has rows for each question" do
+      page = Capybara.string(rendered.html)
+      within(page.find_all(".govuk-table__row")[1]) do
+        expect(page.find_all(".govuk-table__cell"[0])).to have_text "All question types form"
+        expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
+        expect(page.find_all(".govuk-table__cell"[2])).to have_text "1"
+      end
+      within(page.find_all(".govuk-table__row")[2]) do
+        expect(page.find_all(".govuk-table__cell"[0])).to have_text "Branch route form"
+        expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
+        expect(page.find_all(".govuk-table__cell"[2])).to have_text "2"
+      end
+    end
+  end
+end

--- a/spec/views/reports/questions_with_add_another_answer.html.erb_spec.rb
+++ b/spec/views/reports/questions_with_add_another_answer.html.erb_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+describe "reports/questions_with_add_another_answer.html.erb" do
+  let(:questions) do
+    [
+      {
+        form_name: "All question types form",
+        form_id: 1,
+        organisation_name: "Government Digital Service",
+        question_text: "Email address",
+      },
+      {
+        form_name: "Branch route form",
+        form_id: 3,
+        organisation_name: "Government Digital Service",
+        question_text: "What’s your email address?",
+      },
+    ]
+  end
+
+  before do
+    render template: "reports/questions_with_add_another_answer", locals: { answer_type: "email", questions: }
+  end
+
+  describe "page title" do
+    it "matches the heading" do
+      expect(view.content_for(:title)).to eq "Questions with add another answer in live forms"
+    end
+  end
+
+  it "has a back link to feature usage report" do
+    expect(view.content_for(:back_link)).to have_link("Back to feature and answer type usage", href: report_features_path)
+  end
+
+  it "has a link to download the CSV" do
+    expect(rendered).to have_link("Download all questions with add another answer in live forms as a CSV file", href: report_live_questions_with_add_another_answer_csv_path)
+  end
+
+  describe "questions table" do
+    it "has the correct headers" do
+      page = Capybara.string(rendered.html)
+      within(page.find(".govuk-table__head")) do
+        expect(page.find_all(".govuk-table__header"[0])).to have_text "Form name"
+        expect(page.find_all(".govuk-table__header"[1])).to have_text "Organisation"
+        expect(page.find_all(".govuk-table__header"[2])).to have_text "Question text"
+      end
+    end
+
+    it "has rows for each question" do
+      page = Capybara.string(rendered.html)
+      within(page.find_all(".govuk-table__row")[1]) do
+        expect(page.find_all(".govuk-table__cell"[0])).to have_text "All question types form"
+        expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
+        expect(page.find_all(".govuk-table__cell"[2])).to have_text "Email address"
+      end
+      within(page.find_all(".govuk-table__row")[2]) do
+        expect(page.find_all(".govuk-table__cell"[0])).to have_text "Branch route form"
+        expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
+        expect(page.find_all(".govuk-table__cell"[2])).to have_text "What's your email address?"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SgDCKXcY/145-improve-our-feature-reports

Add new report pages that list the forms that have a given features for "List forms with routes", "Live forms with payments", "Live forms with CSV submission enabled".

For "Live forms with add another answer" add a report that lists the questions in live forms that have add another answer instead as that seems more useful.

The pages all have a link to download a CSV that just contains forms with those particular features enabled.

The new report pages are linked from the "Feature usage" table on the "Feature and answer type usage in live forms" report.

<img width="880" alt="Screenshot 2025-04-07 at 18 01 11" src="https://github.com/user-attachments/assets/a1077a09-86c6-447f-94a9-29842eb126c6" />


<img width="880" alt="Screenshot 2025-04-07 at 18 01 22" src="https://github.com/user-attachments/assets/68df7ae5-699f-48a5-b2c7-2b0309594be2" />


<img width="880" alt="Screenshot 2025-04-07 at 18 01 38" src="https://github.com/user-attachments/assets/ba040ae7-f861-4a82-b8af-7b160817e105" />



### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
