### PR TITLE
Remove references to 'question route'

### DIFF
--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -24,7 +24,7 @@
       <%= f.govuk_collection_select :answer_value, condition_input.routing_answer_options, :value, :label, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_answer_value") } %>
       <%= f.govuk_collection_select :goto_page_id, condition_input.goto_page_options, :id, :question_text, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") } %>
       <%= f.govuk_submit t("save_and_continue") do
-        govuk_button_link_to "Delete question route", delete_condition_path(condition_input.form.id, condition_input.page.id, condition_input.record.id), warning: true
+        govuk_button_link_to "Delete route", delete_condition_path(condition_input.form.id, condition_input.page.id, condition_input.record.id), warning: true
       end %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1151,12 +1151,12 @@ en:
         any_other_answer_warning: If you delete this route, the route for any other answer will also be deleted
         delete_condition_inset_html: |
           <p>
-            By deleting this question route the person filling in the form will have to complete every question, even if you do not need them to.
+            By deleting this route the person filling in the form will have to complete every question, even if you do not need them to.
           </p>
           <p>
             Do you want this to happen? If you do, select yes.
           </p>
-        delete_condition_legend: Are you sure you want to delete this question route?
+        delete_condition_legend: Are you sure you want to delete this route?
         skip_to_key: skip the person to
       edit:
         back_link: Back to question %{question_number}’s routes
@@ -1523,13 +1523,13 @@ en:
     not_started: Not started
     optional: Optional
   type_of_answer:
-    routing_warning_about_change_answer_type_heading: Your existing question route may be deleted
+    routing_warning_about_change_answer_type_heading: Your existing route may be deleted
     routing_warning_about_change_answer_type_html: |
       <p>
         Changing the answer type from “Selection from a list of options” to a different answer type means your route will no longer work and will be deleted.
       </p>
       <p>
-        If you do not want to lose your question route you can cancel this change by using the back button or <a href="%{pages_link_url}">go to your questions</a>.
+        If you do not want to lose your route you can cancel this change by using the back button or <a href="%{pages_link_url}">go to your questions</a>.
       </p>
   unarchive:
     new:

--- a/spec/views/pages/conditions/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/edit.html.erb_spec.rb
@@ -42,7 +42,7 @@ describe "pages/conditions/edit.html.erb" do
   end
 
   it "has a delete route link" do
-    expect(rendered).to have_link(text: "Delete question route", href: "/forms/1/pages/1/conditions/2/delete")
+    expect(rendered).to have_link(text: "Delete route", href: "/forms/1/pages/1/conditions/2/delete")
   end
 
   context "with a validation error" do


### PR DESCRIPTION
### What problem does this pull request solve?

This changes 'Delete question route' to 'Delete route' in a few places.

Why: We’ve switched to using just ‘route’ to describe a route - rather than ‘question route’. We want to make this consistent so we're changing the last few references to ‘question route’.

(Note: we're leaving the main button as 'Add a question route' for now because it doesn't have any context in that location)

Trello card: https://trello.com/c/XuSPLcGh/2200-change-most-references-to-question-route-to-just-route

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
