### PR TITLE
Remove warning from delete route confirmation page

### DIFF
--- a/app/views/pages/conditions/delete.html.erb
+++ b/app/views/pages/conditions/delete.html.erb
@@ -33,10 +33,6 @@
 
       end %>
 
-      <%= govuk_inset_text do %>
-        <%= t(".delete_condition_inset_html") %>
-      <% end %>
-
       <%= f.govuk_collection_radio_buttons :confirm,
                                            delete_condition_input.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_action_input.options.' + "#{option}") },
                                            legend: { text: t(".delete_condition_legend")}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1149,13 +1149,6 @@ en:
       delete:
         answered_as_key: is answered as
         any_other_answer_warning: If you delete this route, the route for any other answer will also be deleted
-        delete_condition_inset_html: |
-          <p>
-            By deleting this route the person filling in the form will have to complete every question, even if you do not need them to.
-          </p>
-          <p>
-            Do you want this to happen? If you do, select yes.
-          </p>
         delete_condition_legend: Are you sure you want to delete this route?
         skip_to_key: skip the person to
       edit:


### PR DESCRIPTION
### What problem does this pull request solve?

This removes the inset warning from the confirmation page for deleting a route 1.

We don't need this warning and it may not be factually correct (depending on the form and its questions) so we have agreed to remove it.

Trello card: https://trello.com/c/BEDjOcLE/2201-cheeky-ticket-remove-warning-from-the-delete-route-1-confirmation-page

### Things to consider when reviewing

- I  have edited a ruby/html file! please check I did this right! 
- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
