### PR TITLE
Add user research contact preference

### DIFF
--- a/app/controllers/account/contact_for_research_controller.rb
+++ b/app/controllers/account/contact_for_research_controller.rb
@@ -1,0 +1,40 @@
+module Account
+  class ContactForResearchController < ApplicationController
+    include AfterSignInPathHelper
+
+    # before_action :redirect_contact_for_research_set
+    skip_before_action :redirect_if_account_not_completed
+
+    def edit
+      @contact_for_research_input = ContactForResearchInput.new(research_contact_status:, user: current_user)
+    end
+
+    def update
+      @contact_for_research_input = ContactForResearchInput.new(account_contact_for_research_params(current_user))
+
+      if @contact_for_research_input.submit
+        redirect_to next_path
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def account_contact_for_research_params(user)
+      params.require(:account_contact_for_research_input).permit(:research_contact_status).merge(user:)
+    end
+
+  private
+
+    def redirect_contact_for_research_set
+      redirect_to root_path unless current_user.research_contact_to_be_asked?
+    end
+
+    def research_contact_status
+      current_user.research_contact_status.to_sym if current_user.research_contact_status.in?(ContactForResearchInput::RADIO_OPTIONS)
+    end
+
+    def next_path
+      after_sign_in_next_path
+    end
+  end
+end

--- a/app/controllers/account/contact_for_research_controller.rb
+++ b/app/controllers/account/contact_for_research_controller.rb
@@ -1,8 +1,7 @@
 module Account
-  class ContactForResearchController < ApplicationController
+  class ContactForResearchController < WebController
     include AfterSignInPathHelper
 
-    # before_action :redirect_contact_for_research_set
     skip_before_action :redirect_if_account_not_completed
 
     def edit

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -132,6 +132,12 @@ class ReportsController < WebController
               disposition: "attachment; filename=#{csv_filename('live_questions_report')}"
   end
 
+  def contact_for_research
+    data = Reports::ContactForResearchService.new.contact_for_research_data
+
+    render locals: { data: }
+  end
+
 private
 
   def questions_feature_report(tag, report, questions)

--- a/app/input_objects/account/contact_for_research_input.rb
+++ b/app/input_objects/account/contact_for_research_input.rb
@@ -9,6 +9,7 @@ class Account::ContactForResearchInput < BaseInput
     return false if invalid?
 
     user.research_contact_status = research_contact_status
+    user.user_research_opted_in_at = Time.zone.now
     user.save!
   end
 

--- a/app/input_objects/account/contact_for_research_input.rb
+++ b/app/input_objects/account/contact_for_research_input.rb
@@ -1,0 +1,18 @@
+class Account::ContactForResearchInput < BaseInput
+  attr_accessor :user, :research_contact_status
+
+  RADIO_OPTIONS = %w[consented declined].freeze
+
+  validates :research_contact_status, presence: true, inclusion: { in: RADIO_OPTIONS }
+
+  def submit
+    return false if invalid?
+
+    user.research_contact_status = research_contact_status
+    user.save!
+  end
+
+  def values
+    RADIO_OPTIONS
+  end
+end

--- a/app/lib/after_sign_in_path_helper.rb
+++ b/app/lib/after_sign_in_path_helper.rb
@@ -8,7 +8,9 @@ module AfterSignInPathHelper
 
     return edit_account_name_path if current_user.name.blank?
 
-    edit_account_terms_of_use_path if current_user.terms_agreed_at.blank?
+    return edit_account_terms_of_use_path if current_user.terms_agreed_at.blank?
+
+    edit_account_contact_for_research_path if current_user.research_contact_to_be_asked?
   end
 
   def store_location(path)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
   include GDS::SSO::User
-  has_paper_trail only: %i[role organisation_id has_access]
 
   class UserAuthenticationException < StandardError; end
 
@@ -20,6 +19,15 @@ class User < ApplicationRecord
   has_many :draft_questions
 
   serialize :permissions, coder: YAML, type: Array
+
+  enum :research_contact_status, {
+    consented: "consented",
+    declined: "declined",
+    not_asked: "not_asked",
+    to_be_asked: "to_be_asked",
+  }, prefix: "research_contact"
+
+  has_paper_trail only: %i[role organisation_id has_access]
 
   enum :role, {
     super_admin: "super_admin",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,6 @@ class User < ApplicationRecord
   enum :research_contact_status, {
     consented: "consented",
     declined: "declined",
-    not_asked: "not_asked",
     to_be_asked: "to_be_asked",
   }, prefix: "research_contact"
 

--- a/app/services/reports/contact_for_research_service.rb
+++ b/app/services/reports/contact_for_research_service.rb
@@ -1,0 +1,29 @@
+class Reports::ContactForResearchService
+  def contact_for_research_data
+    {
+      caption: I18n.t("reports.contact_for_research.heading"),
+      head: [
+        { text: I18n.t("reports.contact_for_research.table_headings.name") },
+        { text: I18n.t("reports.contact_for_research.table_headings.email") },
+        { text: I18n.t("reports.contact_for_research.table_headings.date_added") },
+      ],
+      rows:,
+    }
+  end
+
+private
+
+  def rows
+    as_data_rows(user_contact_for_research)
+  end
+
+  def as_data_rows(raw_data)
+    raw_data.map do |name, email, created_at|
+      [{ text: name }, { text: email }, { text: created_at.to_date.to_formatted_s }]
+    end
+  end
+
+  def user_contact_for_research
+    User.research_contact_consented.order(created_at: :desc).pluck(:name, :email, :created_at)
+  end
+end

--- a/app/services/reports/contact_for_research_service.rb
+++ b/app/services/reports/contact_for_research_service.rb
@@ -18,12 +18,12 @@ private
   end
 
   def as_data_rows(raw_data)
-    raw_data.map do |name, email, created_at|
-      [{ text: name }, { text: email }, { text: created_at.to_date.to_formatted_s }]
+    raw_data.map do |name, email, user_research_opted_in_at|
+      [{ text: name }, { text: email }, { text: user_research_opted_in_at.to_formatted_s(:long) }]
     end
   end
 
   def user_contact_for_research
-    User.research_contact_consented.order(created_at: :desc).pluck(:name, :email, :created_at)
+    User.research_contact_consented.order(user_research_opted_in_at: :desc).pluck(:name, :email, :user_research_opted_in_at)
   end
 end

--- a/app/views/account/contact_for_research/edit.html.erb
+++ b/app/views/account/contact_for_research/edit.html.erb
@@ -1,0 +1,20 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.account_contact_for_research"), @contact_for_research_input.errors.any?)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @contact_for_research_input, url: account_contact_for_research_path, method: :patch) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%=t("page_titles.account_contact_for_research")%>
+      </h1>
+
+      <%= t(".content_html") %>
+
+      <%= f.govuk_collection_radio_buttons :research_contact_status, @contact_for_research_input.values, :itself, nil %>
+
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/account/contact_for_research/edit.html.erb
+++ b/app/views/account/contact_for_research/edit.html.erb
@@ -9,9 +9,7 @@
         <%=t("page_titles.account_contact_for_research")%>
       </h1>
 
-      <%= t(".content_html") %>
-
-      <%= f.govuk_collection_radio_buttons :research_contact_status, @contact_for_research_input.values, :itself, nil %>
+      <%= f.govuk_collection_radio_buttons :research_contact_status, @contact_for_research_input.values, :itself, legend: nil, hint:{ text: @hint } %>
 
       <%= f.govuk_submit t('continue') %>
     <% end %>

--- a/app/views/reports/contact_for_research.html.erb
+++ b/app/views/reports/contact_for_research.html.erb
@@ -1,0 +1,11 @@
+<% set_page_title(t(".title")) %>
+<% content_for :back_link, govuk_back_link_to(reports_path, t("reports.back_link")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+
+    <%= govuk_table(**data) %>
+
+  </div>
+</div>
+

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -10,6 +10,7 @@
       <li><%= govuk_link_to t("reports.users.title"), report_users_path %></li>
       <li><%= govuk_link_to t("reports.last_signed_in_at.title"), report_last_signed_in_at_path %></li>
       <li><%= govuk_link_to t("reports.csv_downloads.title"), report_csv_downloads_path %></li>
+      <li><%= govuk_link_to t("reports.contact_for_research.title"), report_contact_for_research_path %></li>
     </ul>
   </div>
 </div>

--- a/config/initializers/warden/strategies/user_research.rb
+++ b/config/initializers/warden/strategies/user_research.rb
@@ -17,6 +17,8 @@ private
       provider: Settings.auth_provider,
       uid: auth_hash[:uid],
       terms_agreed_at: Time.zone.now,
+      research_contact_status: "declined",
+      user_research_opted_in_at: Time.zone.now,
     )
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,21 +1,6 @@
 ---
 en:
   account:
-    contact_for_research:
-      edit:
-        content_html: |
-          <p>GOV.UK Forms needs your help to improve and to make sure our platform works well for the people who use it. You can help by agreeing to take part in user research.</p>
-          <p>If you select yes, you will get a confirmation email with a link to our sign up form. When you’ve completed the form, your name will be added to a list that we’ll use to recruit research participants. Your details will be stored in compliance with GDPR.</p>
-          <p>We’ll only contact you about upcoming research or to verify that your details are up to date.</p>
-          <p>We might invite you to:</p>
-
-          <ul class="govuk-list govuk-list--bullet">
-            <li>try out new things we are working on</li>
-            <li>answer questions by survey or email</li>
-            <li>talk to us about how you work with forms</li>
-          </ul>
-
-          <p>You can always say no to an invite and you can ask to be taken off our list at any time.</p>
     organisation_details_summary: If your organisation is not listed
     organisation_text_html: |
       <p>If you’re from a central government organisation that publishes content on the GOV.UK website but your organisation is not listed, please %{contact_link}.</p>
@@ -1169,7 +1154,7 @@ en:
       length: Length
   page_titles:
     access_denied: You do not have permission to access GOV.UK Forms
-    account_contact_for_research: Choose to take part in user research
+    account_contact_for_research: Can we send you an email with information about taking part in user research to improve GOV.UK Forms?
     account_name: Enter your name
     account_organisation: Select your organisation
     account_terms_of_use: Terms of use

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1415,6 +1415,13 @@ en:
       title: All forms with add another answer
     back_link: Back to reports
     back_to_feature_usage: Back to feature and answer type usage
+    contact_for_research:
+      heading: Users who have agreed to be contacted for user research
+      table_headings:
+        date_added: Sign up date
+        email: Email
+        name: Name
+      title: Users interested in research
     csv_downloads:
       live_forms: Download data about all live forms as a CSV file
       live_questions: Download all questions in live forms as a CSV file

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1417,9 +1417,9 @@ en:
     back_link: Back to reports
     back_to_feature_usage: Back to feature and answer type usage
     contact_for_research:
-      heading: Users who have agreed to be contacted for user research
+      heading: Users who’ve agreed to be contacted about user research
       table_headings:
-        date_added: Sign up date
+        date_added: Date agreed
         email: Email
         name: Name
       title: Users interested in research

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,21 @@
 ---
 en:
   account:
+    contact_for_research:
+      edit:
+        content_html: |
+          <p>GOV.UK Forms needs your help to improve and to make sure our platform works well for the people who use it. You can help by agreeing to take part in user research.</p>
+          <p>If you select yes, you will get a confirmation email with a link to our sign up form. When you’ve completed the form, your name will be added to a list that we’ll use to recruit research participants. Your details will be stored in compliance with GDPR.</p>
+          <p>We’ll only contact you about upcoming research or to verify that your details are up to date.</p>
+          <p>We might invite you to:</p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <li>try out new things we are working on</li>
+            <li>answer questions by survey or email</li>
+            <li>talk to us about how you work with forms</li>
+          </ul>
+
+          <p>You can always say no to an invite and you can ask to be taken off our list at any time.</p>
     organisation_details_summary: If your organisation is not listed
     organisation_text_html: |
       <p>If you’re from a central government organisation that publishes content on the GOV.UK website but your organisation is not listed, please %{contact_link}.</p>
@@ -1154,6 +1169,7 @@ en:
       length: Length
   page_titles:
     access_denied: You do not have permission to access GOV.UK Forms
+    account_contact_for_research: Choose to take part in user research
     account_name: Enter your name
     account_organisation: Select your organisation
     account_terms_of_use: Terms of use

--- a/config/locales/input_objects/contact_for_research.yml
+++ b/config/locales/input_objects/contact_for_research.yml
@@ -6,13 +6,13 @@ en:
         account/contact_for_research_input:
           attributes:
             research_contact_status:
-              blank: Choose if you want to sign up to take part in research
+              blank: Select ‘Yes’ if you’re happy for us to send you an email with information about taking part in user research
   helpers:
+    hint:
+      account_contact_for_research_input:
+        research_contact_status: This is not a commitment to take part. If you say ‘yes’ we’ll send you an email with more details about what’s involved and how to sign up.
     label:
       account_contact_for_research_input:
         research_contact_status_options:
           consented: 'Yes'
           declined: 'No'
-    legend:
-      account_contact_for_research_input:
-        research_contact_status: Do you want to sign up to take part in user research?

--- a/config/locales/input_objects/contact_for_research.yml
+++ b/config/locales/input_objects/contact_for_research.yml
@@ -1,0 +1,18 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        account/contact_for_research_input:
+          attributes:
+            research_contact_status:
+              blank: Choose if you want to sign up to take part in research
+  helpers:
+    label:
+      account_contact_for_research_input:
+        research_contact_status_options:
+          consented: 'Yes'
+          declined: 'No'
+    legend:
+      account_contact_for_research_input:
+        research_contact_status: Do you want to sign up to take part in user research?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,7 @@ Rails.application.routes.draw do
     resource :name, only: %i[edit update]
     resource :organisation, only: %i[edit update]
     resource :terms_of_use, controller: :terms_of_use, only: %i[edit update]
+    resource :contact_for_research, controller: :contact_for_research, only: %i[edit update]
   end
 
   resources :mou_signatures, only: %i[index], path: "mous"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,6 +226,7 @@ Rails.application.routes.draw do
     get "csv-downloads", to: "reports#csv_downloads", as: :report_csv_downloads
     get "live-forms-csv", to: "reports#live_forms_csv", as: :report_live_forms_csv
     get "live-questions-csv", to: "reports#live_questions_csv", as: :report_live_questions_csv
+    get "contact-for-research", to: "reports#contact_for_research", as: :report_contact_for_research
   end
 
   scope "api/v2", as: "api_v2" do

--- a/db/migrate/20250403131603_add_contact_for_research_to_users.rb
+++ b/db/migrate/20250403131603_add_contact_for_research_to_users.rb
@@ -1,0 +1,5 @@
+class AddContactForResearchToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :research_contact_status, :string, default: "not_asked"
+  end
+end

--- a/db/migrate/20250403131603_add_contact_for_research_to_users.rb
+++ b/db/migrate/20250403131603_add_contact_for_research_to_users.rb
@@ -1,5 +1,0 @@
-class AddContactForResearchToUsers < ActiveRecord::Migration[8.0]
-  def change
-    add_column :users, :research_contact_status, :string, default: "not_asked"
-  end
-end

--- a/db/migrate/20250908155727_add_contact_for_research_to_users.rb
+++ b/db/migrate/20250908155727_add_contact_for_research_to_users.rb
@@ -1,0 +1,8 @@
+class AddContactForResearchToUsers < ActiveRecord::Migration[8.0]
+  def change
+    change_table(:users, bulk: true) do |t|
+      t.column :research_contact_status, :string, default: "to_be_asked"
+      t.column :user_research_opted_in_at, :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -208,6 +208,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_140606) do
     t.string "provider"
     t.datetime "terms_agreed_at"
     t.datetime "last_signed_in_at"
+    t.string "research_contact_status", default: "not_asked"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_20_140606) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_08_155727) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -208,7 +208,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_140606) do
     t.string "provider"
     t.datetime "terms_agreed_at"
     t.datetime "last_signed_in_at"
-    t.string "research_contact_status", default: "not_asked"
+    t.string "research_contact_status", default: "to_be_asked"
+    t.datetime "user_research_opted_in_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,7 +24,8 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
                                 role: :super_admin,
                                 uid: "123456",
                                 provider: :mock_gds_sso,
-                                terms_agreed_at: Time.zone.now })
+                                terms_agreed_at: Time.zone.now,
+                                research_contact_status: :consented })
 
   MouSignature.create! user: default_user, organisation: gds
 
@@ -55,6 +56,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     role: :standard,
     organisation: test_org,
     provider: :seed,
+    research_contact_status: :consented,
   )
 
   # create extra super admins
@@ -87,6 +89,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     last_signed_in_at: Time.utc(2024, 4, 22, 9, 30),
     terms_agreed_at: Time.utc(2024, 4, 22, 9, 30),
     provider: :seed,
+    research_contact_status: :consented,
   )
 
   # while we're using Signon it is possible to have users who aren't linked to

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,7 +25,8 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
                                 uid: "123456",
                                 provider: :mock_gds_sso,
                                 terms_agreed_at: Time.zone.now,
-                                research_contact_status: :consented })
+                                research_contact_status: :consented,
+                                user_research_opted_in_at: Time.zone.now })
 
   MouSignature.create! user: default_user, organisation: gds
 
@@ -57,6 +58,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     organisation: test_org,
     provider: :seed,
     research_contact_status: :consented,
+    user_research_opted_in_at: Time.zone.now,
   )
 
   # create extra super admins
@@ -90,6 +92,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     terms_agreed_at: Time.utc(2024, 4, 22, 9, 30),
     provider: :seed,
     research_contact_status: :consented,
+    user_research_opted_in_at: Time.utc(2024, 4, 22, 9, 30),
   )
 
   # while we're using Signon it is possible to have users who aren't linked to

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
     updated_at { created_at }
     last_signed_in_at { created_at }
     terms_agreed_at { Time.zone.now }
+    research_contact_status { "declined" }
+    user_research_opted_in_at { Time.zone.now }
 
     factory :basic_auth_user do
       provider { "basic_auth" }

--- a/spec/features/research/add_user_research_contact_preference_spec.rb
+++ b/spec/features/research/add_user_research_contact_preference_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+feature "Add user research contact preference", type: :feature do
+  let(:user) { create(:user, name: "Test name", research_contact_status: "to_be_asked") }
+
+  before do
+    login_as user
+  end
+
+  describe "user adds their user research content preference" do
+    scenario "user can update their preference" do
+      when_i_visit_the_edit_page
+      when_i_choose_yes
+      then_i_should_be_redirecteed_to_the_groups_page
+    end
+  end
+
+  def when_i_visit_the_edit_page
+    visit edit_account_contact_for_research_path
+  end
+
+  def when_i_choose_yes
+    choose "Yes"
+    click_button "Continue"
+  end
+
+  def then_i_should_be_redirecteed_to_the_groups_page
+    expect(page.find("h1")).to have_text "Your groups"
+  end
+end

--- a/spec/input_objects/account/contact_for_research_input_spec.rb
+++ b/spec/input_objects/account/contact_for_research_input_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe Account::ContactForResearchInput do
+  include ActiveSupport::Testing::TimeHelpers
+
+  subject(:contact_for_research_input) { described_class.new(user:) }
+
+  let(:user) { create(:user) }
+
+  describe "#submit" do
+    context "with valid attributes" do
+      before do
+        contact_for_research_input.research_contact_status = "consented"
+      end
+
+      it "updates the user research opted in at timestamp" do
+        current_time = Time.zone.now.midnight
+        travel_to current_time
+
+        expect { contact_for_research_input.submit }.to change { user.reload.user_research_opted_in_at }.to(current_time)
+      end
+
+      it "returns true" do
+        expect(contact_for_research_input.submit).to be true
+      end
+    end
+  end
+end

--- a/spec/requests/account/contact_for_research_controller_spec.rb
+++ b/spec/requests/account/contact_for_research_controller_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe Account::ContactForResearchController do
+  let(:user) { create(:user, name: nil, research_contact_status: "to_be_asked") }
+
+  before do
+    login_as user
+  end
+
+  describe "GET #edit" do
+    context "when user adds a research contact status" do
+      it "assigns a new ContactForResearchInput to @contact_for_research_input" do
+        get edit_account_contact_for_research_path
+        expect(assigns(:contact_for_research_input)).to be_a(Account::ContactForResearchInput)
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    context "with valid params" do
+      let(:valid_params) { { account_contact_for_research_input: { research_contact_status: "consented" } } }
+
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(AfterSignInPathHelper).to receive(:after_sign_in_next_path).and_return("/next-path")
+        # rubocop:enable RSpec/AnyInstance
+      end
+
+      it "updates the user's research contact status" do
+        put account_contact_for_research_path, params: valid_params
+        expect(user.reload.research_contact_status).to eq("consented")
+      end
+
+      it "redirects to the root path" do
+        put account_contact_for_research_path, params: valid_params
+        expect(response).to redirect_to("/next-path")
+      end
+    end
+
+    context "with invalid params" do
+      let(:invalid_params) { { account_contact_for_research_input: { research_contact_status: "" } } }
+
+      it "does not update the user's research contact status" do
+        put account_contact_for_research_path, params: invalid_params
+        expect(user.reload.research_contact_status).to eq("to_be_asked")
+      end
+
+      it "renders the edit template" do
+        put account_contact_for_research_path, params: invalid_params
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -721,4 +721,54 @@ RSpec.describe ReportsController, type: :request do
       end
     end
   end
+
+  describe "#contact_for_research" do
+    context "when the user is an editor" do
+      before do
+        login_as_standard_user
+
+        get report_contact_for_research_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is an organisation admin" do
+      before do
+        login_as_organisation_admin_user
+
+        get report_contact_for_research_path
+      end
+
+      it "returns http code 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders the forbidden view" do
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get report_contact_for_research_path
+      end
+
+      it "returns http code 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the users report view" do
+        expect(response).to render_template("reports/contact_for_research")
+      end
+    end
+  end
 end

--- a/spec/services/reports/contact_for_research_service_spec.rb
+++ b/spec/services/reports/contact_for_research_service_spec.rb
@@ -20,17 +20,16 @@ describe Reports::ContactForResearchService do
 
     context "with users" do
       it "returns the correct rows" do
-        create :user, research_contact_status: :consented, created_at: Time.zone.local(2024, 6, 1), name: "Middle", email: "test@example.gov.uk"
-        create :user, research_contact_status: :consented, created_at: Time.zone.local(2025, 2, 1), name: "Top", email: "ur@another.gov.uk"
-        create :user, research_contact_status: :consented, created_at: Time.zone.local(2023, 4, 1), name: "Bottom", email: "last@example.gov.uk"
-        create :user, research_contact_status: :not_asked
+        create :user, research_contact_status: :consented, user_research_opted_in_at: Time.zone.local(2024, 6, 1, 15, 30), name: "Middle", email: "test@example.gov.uk"
+        create :user, research_contact_status: :consented, user_research_opted_in_at: Time.zone.local(2025, 2, 1, 11, 15), name: "Top", email: "ur@another.gov.uk"
+        create :user, research_contact_status: :consented, user_research_opted_in_at: Time.zone.local(2023, 4, 1, 9, 45), name: "Bottom", email: "last@example.gov.uk"
         create :user, research_contact_status: :to_be_asked
         create :user, research_contact_status: :declined
 
         expect(contact_for_research_service.contact_for_research_data[:rows]).to eq([
-          [{ text: "Top" }, { text: "ur@another.gov.uk" }, { text: "1 February 2025" }],
-          [{ text: "Middle" }, { text: "test@example.gov.uk" }, { text: "1 June 2024" }],
-          [{ text: "Bottom" }, { text: "last@example.gov.uk" }, { text: "1 April 2023" }],
+          [{ text: "Top" }, { text: "ur@another.gov.uk" }, { text: "February 01, 2025 11:15" }],
+          [{ text: "Middle" }, { text: "test@example.gov.uk" }, { text: "June 01, 2024 15:30" }],
+          [{ text: "Bottom" }, { text: "last@example.gov.uk" }, { text: "April 01, 2023 09:45" }],
         ])
       end
     end

--- a/spec/services/reports/contact_for_research_service_spec.rb
+++ b/spec/services/reports/contact_for_research_service_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe Reports::ContactForResearchService do
+  subject(:contact_for_research_service) do
+    described_class.new
+  end
+
+  describe "#contact_for_research_data" do
+    it "returns the correct format" do
+      expect(contact_for_research_service.contact_for_research_data).to match({
+        caption: I18n.t("reports.contact_for_research.heading"),
+        head: [
+          { text: I18n.t("reports.contact_for_research.table_headings.name") },
+          { text: I18n.t("reports.contact_for_research.table_headings.email") },
+          { text: I18n.t("reports.contact_for_research.table_headings.date_added") },
+        ],
+        rows: [],
+      })
+    end
+
+    context "with users" do
+      it "returns the correct rows" do
+        create :user, research_contact_status: :consented, created_at: Time.zone.local(2024, 6, 1), name: "Middle", email: "test@example.gov.uk"
+        create :user, research_contact_status: :consented, created_at: Time.zone.local(2025, 2, 1), name: "Top", email: "ur@another.gov.uk"
+        create :user, research_contact_status: :consented, created_at: Time.zone.local(2023, 4, 1), name: "Bottom", email: "last@example.gov.uk"
+        create :user, research_contact_status: :not_asked
+        create :user, research_contact_status: :to_be_asked
+        create :user, research_contact_status: :declined
+
+        expect(contact_for_research_service.contact_for_research_data[:rows]).to eq([
+          [{ text: "Top" }, { text: "ur@another.gov.uk" }, { text: "1 February 2025" }],
+          [{ text: "Middle" }, { text: "test@example.gov.uk" }, { text: "1 June 2024" }],
+          [{ text: "Bottom" }, { text: "last@example.gov.uk" }, { text: "1 April 2023" }],
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Ask new users for consent to be contacted about user research

Trello cards: 
https://trello.com/c/8R5O8PTf/162-add-sign-up-screen-to-collect-user-research-interest
https://trello.com/c/ZBHqh34G/161-add-report-for-users-who-have-agreed-to-be-contacted-for-user-research
https://trello.com/c/6Vsps6ev/2380-design-and-build-the-new-opt-in-to-be-invited-to-take-part-in-ur-page-for-the-govuk-forms-signup-journey

This work was done during firebreak to add a report for users who have agreed to be contacted and a new form at the end of the signup journey which asks them.

Further work needed:
- ~update content for consent (it's still being worked on) (done)~
 - ~add tests for the new controller and a feature test (done)~
 - ~think about deployment - we don't want to ask all users for their consent, only new ones~ (we've decided to ask all users for consent, not just new users)

 
See [this ticket for the final parts of implementation](https://trello.com/c/3J84Fl0T/2807-update-content-and-add-tests-for-user-research-contact-page-and-report).


![image](https://github.com/user-attachments/assets/ce3d5d41-caad-4483-a4cf-16e6dda013e8)
![image](https://github.com/user-attachments/assets/8ac8a5eb-6f06-422c-a84a-c36f305ad09e)


 
### Things to consider when reviewing
<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
