### PR TITLE
Change live view for branches

### DIFF
--- a/app/resources/api/v1/condition_resource.rb
+++ b/app/resources/api/v1/condition_resource.rb
@@ -22,4 +22,8 @@ class Api::V1::ConditionResource < ActiveResource::Base
   def secondary_skip?
     answer_value.blank? && check_page_id != routing_page_id
   end
+
+  def exit_page?
+    attributes.include?("exit_page_markdown") && !attributes["exit_page_markdown"].nil?
+  end
 end

--- a/app/services/page_options_service.rb
+++ b/app/services/page_options_service.rb
@@ -156,6 +156,12 @@ private
 
     if condition.skip_to_end
       I18n.t("page_conditions.condition_compact_html_end_of_form", answer_value:).html_safe
+    elsif condition.secondary_skip?
+      goto_question = @pages.find { |page| page.id == condition.goto_page_id }
+      goto_page_question_text = ActionController::Base.helpers.sanitize(goto_question.question_text)
+      goto_page_question_number = @pages.find_index(goto_question) + 1
+
+      I18n.t("page_conditions.condition_compact_html_secondary_skip", goto_page_question_number:, goto_page_question_text:).html_safe
     elsif condition.exit_page?
       I18n.t("page_conditions.condition_compact_html_exit_page", answer_value:, exit_page_heading: condition.exit_page_heading).html_safe
     else

--- a/app/services/page_options_service.rb
+++ b/app/services/page_options_service.rb
@@ -156,6 +156,8 @@ private
 
     if condition.skip_to_end
       I18n.t("page_conditions.condition_compact_html_end_of_form", answer_value:).html_safe
+    elsif condition.exit_page?
+      I18n.t("page_conditions.condition_compact_html_exit_page", answer_value:, exit_page_heading: condition.exit_page_heading).html_safe
     else
       goto_question = @pages.find { |page| page.id == condition.goto_page_id }
       goto_page_question_text = ActionController::Base.helpers.sanitize(goto_question.question_text)

--- a/app/services/page_summary_card_data_service.rb
+++ b/app/services/page_summary_card_data_service.rb
@@ -24,8 +24,12 @@ class PageSummaryCardDataService
 private
 
   def build_title
-    return @page.question_text unless @page.is_optional? && @page.answer_type != "selection"
+    return "#{page_number(@page)}. #{@page.question_text}" unless @page.is_optional? && @page.answer_type != "selection"
 
-    "#{@page.question_text} (optional)"
+    "#{page_number(@page)}. #{@page.question_text} (optional)"
+  end
+
+  def page_number(page)
+    @pages.find_index(page) + 1
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1018,6 +1018,7 @@ en:
     condition_compact_html: If the answer is “%{answer_value}” go to %{goto_page_question_number}, “%{goto_page_question_text}”
     condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to “Check your answers before submitting”
     condition_compact_html_exit_page: If the answer is “%{answer_value}” go to the exit page, “%{exit_page_heading}”
+    condition_compact_html_secondary_skip: Go to %{goto_page_question_number}, “%{goto_page_question_text}”
     condition_description: If %{check_page_question_text} is answered as %{answer_value} go to %{goto_page_question_text}
     condition_goto_page_check_your_answers: "“Check your answers before submitting”."
     condition_goto_page_text: "%{goto_page_question_number}, “%{goto_page_question_text}”"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1017,6 +1017,7 @@ en:
     condition_check_page_text: "“%{check_page_question_text}”"
     condition_compact_html: If the answer is “%{answer_value}” go to %{goto_page_question_number}, “%{goto_page_question_text}”
     condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to “Check your answers before submitting”
+    condition_compact_html_exit_page: If the answer is “%{answer_value}” go to the exit page, “%{exit_page_heading}”
     condition_description: If %{check_page_question_text} is answered as %{answer_value} go to %{goto_page_question_text}
     condition_goto_page_check_your_answers: "“Check your answers before submitting”."
     condition_goto_page_text: "%{goto_page_question_number}, “%{goto_page_question_text}”"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1015,7 +1015,7 @@ en:
     condition_answer_value_text: "“%{answer_value}”"
     condition_answer_value_text_with_errors: "[Answer not selected]"
     condition_check_page_text: "“%{check_page_question_text}”"
-    condition_compact_html: 'If the answer is “%{answer_value}”<br> then skip to %{goto_page_question_number}: “%{goto_page_question_text}”'
+    condition_compact_html: If the answer is “%{answer_value}” go to %{goto_page_question_number}, “%{goto_page_question_text}”
     condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to “Check your answers before submitting”
     condition_description: If %{check_page_question_text} is answered as %{answer_value} go to %{goto_page_question_text}
     condition_goto_page_check_your_answers: "“Check your answers before submitting”."

--- a/spec/resources/api/v1/condition_resource_spec.rb
+++ b/spec/resources/api/v1/condition_resource_spec.rb
@@ -21,4 +21,21 @@ describe Api::V1::ConditionResource, type: :model do
       end
     end
   end
+
+  describe "#exit_page?" do
+    it "returns true if the exit_page_markdown attribute is present and not nil" do
+      exit_page_condition = build(:condition, exit_page_markdown: "Exit!")
+      expect(exit_page_condition.exit_page?).to be true
+    end
+
+    it "returns false if the exit_page_markdown attribute is not present" do
+      not_exit_page_condition = build(:condition)
+      expect(not_exit_page_condition.exit_page?).to be false
+    end
+
+    it "returns false if the exit_page_markdown attribute is nil" do
+      not_exit_page_condition = build(:condition, exit_page_markdown: nil)
+      expect(not_exit_page_condition.exit_page?).to be false
+    end
+  end
 end

--- a/spec/services/page_options_service_spec.rb
+++ b/spec/services/page_options_service_spec.rb
@@ -248,6 +248,21 @@ describe PageOptionsService do
           )
         end
       end
+
+      context "with an exit page" do
+        let(:page) { build :page, routing_conditions: }
+        let(:exit_page_condition) { build :condition, routing_page_id: page.id, answer_value: "yes", goto_page_id: nil, check_page_id: page.id, exit_page_markdown: "Exit!", exit_page_heading: "You are not eligible" }
+
+        it "returns the correct options" do
+          page.routing_conditions = [exit_page_condition]
+          expect(page_options_service.all_options_for_answer_type).to include(
+            {
+              key: { text: I18n.t("page_conditions.route") },
+              value: { text: I18n.t("page_conditions.condition_compact_html_exit_page", answer_value: "yes", exit_page_heading: "You are not eligible") },
+            },
+          )
+        end
+      end
     end
 
     context "with guidance" do

--- a/spec/services/page_options_service_spec.rb
+++ b/spec/services/page_options_service_spec.rb
@@ -249,6 +249,21 @@ describe PageOptionsService do
         end
       end
 
+      context "with a secondary skip" do
+        let(:page) { build :page, routing_conditions: }
+        let(:skip_condition) { build :condition, routing_page_id: pages.third.id, goto_page_id: pages.fourth.id, check_page_id: page.id, skip_to_end: false }
+
+        it "returns the correct options" do
+          page.routing_conditions = [skip_condition]
+          expect(page_options_service.all_options_for_answer_type).to include(
+            {
+              key: { text: I18n.t("page_conditions.route") },
+              value: { text: I18n.t("page_conditions.condition_compact_html_secondary_skip", goto_page_question_number: 4, goto_page_question_text: pages.fourth.question_text) },
+            },
+          )
+        end
+      end
+
       context "with an exit page" do
         let(:page) { build :page, routing_conditions: }
         let(:exit_page_condition) { build :condition, routing_page_id: page.id, answer_value: "yes", goto_page_id: nil, check_page_id: page.id, exit_page_markdown: "Exit!", exit_page_heading: "You are not eligible" }

--- a/spec/services/page_summary_card_data_service_spec.rb
+++ b/spec/services/page_summary_card_data_service_spec.rb
@@ -4,8 +4,7 @@ describe PageSummaryCardDataService do
   let(:page) { build :page, is_optional: }
   let(:is_optional) { false }
   let(:pages) do
-    form = build :form, :with_pages
-    form.pages
+    [page, *build_list(:page, 5)]
   end
   let(:service) { described_class.call(page:, pages:) }
 
@@ -15,7 +14,7 @@ describe PageSummaryCardDataService do
     end
 
     it "includes a title" do
-      expect(service.build_data[:card][:title]).to eq page.question_text
+      expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
     end
 
     it "includes an array of rows" do
@@ -26,7 +25,7 @@ describe PageSummaryCardDataService do
       let(:page) { build :page, :with_selection_settings, is_optional: }
 
       it "includes a title without (optional) added to it" do
-        expect(service.build_data[:card][:title]).to eq page.question_text.to_s
+        expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
       end
     end
 
@@ -34,14 +33,14 @@ describe PageSummaryCardDataService do
       let(:is_optional) { "true" }
 
       it "includes a title with (optional) added to it" do
-        expect(service.build_data[:card][:title]).to eq "#{page.question_text} (optional)"
+        expect(service.build_data[:card][:title]).to eq "1. #{page.question_text} (optional)"
       end
 
       context "when the page is a selection question" do
         let(:page) { build :page, :with_selection_settings, is_optional: }
 
         it "includes a title without (optional) added to it" do
-          expect(service.build_data[:card][:title]).to eq page.question_text.to_s
+          expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
         end
       end
     end
@@ -50,14 +49,14 @@ describe PageSummaryCardDataService do
       let(:is_optional) { nil }
 
       it "includes a title" do
-        expect(service.build_data[:card][:title]).to eq page.question_text
+        expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
       end
 
       context "when the page is a selection question" do
         let(:page) { build :page, :with_selection_settings, is_optional: }
 
         it "includes a title without (optional) added to it" do
-          expect(service.build_data[:card][:title]).to eq page.question_text.to_s
+          expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

This PR covers two trello cards because they are closely related and the issue with exit pages stops either being reviewed in the review apps.

They could be split into two very small PR's if preferred.

Fix the question view for live forms with exit pages and update the content to correctly show secondary skips.

Trello cards:
https://trello.com/c/Do0lsSF2/2789-change-the-page-that-shows-questions-in-a-live-form-to-work-with-exit-pages
https://trello.com/c/9Ff0wFPH/2204-change-the-page-that-shows-questions-in-a-live-form-to-work-with-branching-routes

![image](https://github.com/user-attachments/assets/61208023-ab8c-4b76-b787-befa2a809b9f)

## The design

[The design is in mural](https://app.mural.co/t/gaap0347/m/gaap0347/1728478914347/6a7e0b709f50f00f81cab37414fdf44ec8601a70) and linked from the trello cards.

![image](https://github.com/user-attachments/assets/25636606-57e8-4c1a-837a-720e7de3476d)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
