### PR TITLE
Prevent multiple conditions created on single page

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -88,6 +88,12 @@ private
 
   def can_add_page_routing
     authorize current_form, :can_add_page_routing_conditions?
+
+    # currently we can only create one primary condition from a page
+    # if there is already a primary condition, redirect to the routes page
+    if page.routing_conditions.present?
+      redirect_to show_routes_path(form_id: current_form.id, page_id: page.id)
+    end
   end
 
   def condition_input_params

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -182,6 +182,18 @@ RSpec.describe Pages::ConditionsController, type: :request do
         expect(response.status).to eq(403)
       end
     end
+
+    context "when the page already has a condition associated with it" do
+      let(:selected_page) do
+        page.routing_conditions = [(build :condition, id: 1, routing_page_id: page.id, check_page_id: page.id, goto_page_id: 2)]
+        page
+      end
+
+      it "does not create the condition and redirects the user to the question routes page" do
+        expect(ConditionRepository).not_to have_received(:create!)
+        expect(response).to redirect_to show_routes_path(form.id, selected_page.id)
+      end
+    end
   end
 
   describe "#edit" do


### PR DESCRIPTION
Currently, form creators can create multiple conditions on a single page, by submitting the create form multiple times.

This commit prevents this by checking that the condition does not already exist before creating it.

Secondary skips can still be created because they are not stored in the page's routing conditions.

If a creator tries to add another condition, they are redirected to the route summary page.

### What problem does this pull request solve?

Trello card: https://trello.com/c/43v1wo67/2207-bug-you-can-create-2-routes-from-the-same-answer

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
