### PR TITLE
Log when user attempts to add more than 4 file upload questions

### DIFF
--- a/app/input_objects/pages/type_of_answer_input.rb
+++ b/app/input_objects/pages/type_of_answer_input.rb
@@ -22,6 +22,7 @@ private
   def not_more_than_4_file_upload_questions
     if answer_type.present? && answer_type.to_sym == :file && current_form.file_upload_question_count >= 4
       errors.add(:answer_type, :cannot_add_more_file_upload_questions)
+      Rails.logger.info("Attempt to add more than 4 file upload questions")
     end
   end
 

--- a/spec/input_objects/pages/type_of_answer_input_spec.rb
+++ b/spec/input_objects/pages/type_of_answer_input_spec.rb
@@ -86,6 +86,11 @@ RSpec.describe Pages::TypeOfAnswerInput, type: :model do
             expect(type_of_answer_input).to be_invalid
             expect(type_of_answer_input.errors[:answer_type]).to include "You cannot have more than 4 file upload questions in a form"
           end
+
+          it "logs at info level" do
+            expect(Rails.logger).to receive(:info).with("Attempt to add more than 4 file upload questions")
+            type_of_answer_input.validate
+          end
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UcS768Hz/2175-log-validation-error-messages-in-admin-and-runner

We want to track how often form creators are attempting to add more than 4 file upload questions so that we can assess the need of allowing users to add more than 4, or support multiple answers for file upload.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
