### PR TITLE
Log all validation errors on input objects

### DIFF
--- a/app/input_objects/base_input.rb
+++ b/app/input_objects/base_input.rb
@@ -1,4 +1,12 @@
 class BaseInput
   include ActiveModel::Model
   include ActiveModel::Validations
+  include ActiveModel::Validations::Callbacks
+  after_validation :set_validation_error_logging_attributes
+
+private
+
+  def set_validation_error_logging_attributes
+    CurrentLoggingAttributes.validation_errors = errors.map { |error| "#{error.attribute}: #{error.type}" } if errors.any?
+  end
 end

--- a/app/input_objects/pages/type_of_answer_input.rb
+++ b/app/input_objects/pages/type_of_answer_input.rb
@@ -22,7 +22,6 @@ private
   def not_more_than_4_file_upload_questions
     if answer_type.present? && answer_type.to_sym == :file && current_form.file_upload_question_count >= 4
       errors.add(:answer_type, :cannot_add_more_file_upload_questions)
-      Rails.logger.info("Attempt to add more than 4 file upload questions")
     end
   end
 

--- a/app/models/current_logging_attributes.rb
+++ b/app/models/current_logging_attributes.rb
@@ -2,5 +2,5 @@ class CurrentLoggingAttributes < ActiveSupport::CurrentAttributes
   attribute :request_host, :request_id, :session_id_hash, :trace_id, :user_ip,
             :user_id, :user_email, :user_organisation_slug, :acting_as_user_id,
             :acting_as_user_email, :acting_as_user_organisation_slug, :form_id,
-            :page_id, :auth0_session_id
+            :page_id, :auth0_session_id, :validation_errors
 end

--- a/spec/input_objects/pages/type_of_answer_input_spec.rb
+++ b/spec/input_objects/pages/type_of_answer_input_spec.rb
@@ -86,11 +86,6 @@ RSpec.describe Pages::TypeOfAnswerInput, type: :model do
             expect(type_of_answer_input).to be_invalid
             expect(type_of_answer_input.errors[:answer_type]).to include "You cannot have more than 4 file upload questions in a form"
           end
-
-          it "logs at info level" do
-            expect(Rails.logger).to receive(:info).with("Attempt to add more than 4 file upload questions")
-            type_of_answer_input.validate
-          end
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UcS768Hz/2175-log-validation-error-messages-in-admin-and-runner

Add an after_validation callback that will add a validation_errors logging attribute if there were any errors added by the validation.

Log the attribute name and the type of the attribute, rather than the actual error message. The reasoning for this is that we are probably less likely to rename the attributes and error

This doesn't log routing errors as these come from forms-api and are added in a different way.

Remove the explicit logging added for when someone tries to add more file upload questions than we allow, as the new logging will allow us to report on this.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
