### PR TITLE
Fix server error when question with route is at the end of a form

### DIFF
--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -24,7 +24,11 @@
       <% if route_summary_card_data_presenter.routes.map(&:secondary_skip?).none? %>
         <h2 class="govuk-heading-m"><%= t(".any_other_answer.heading") %></h2>
 
-        <p class="govuk-body"><%= t(".any_other_answer.will_continue_to", next_question_number: route_summary_card_data_presenter.next_page&.position) %></p>
+        <% if page.has_next_page? %>
+          <p class="govuk-body"><%= t(".any_other_answer.will_continue_to", next_question_number: route_summary_card_data_presenter.next_page&.position) %></p>
+        <% else %>
+          <p class="govuk-body"><%= t(".any_other_answer.will_continue_to_check_your_answers") %></p>
+        <% end %>
 
         <% if FeatureService.new(group: current_form.group).enabled? :branch_routing %>
           <p class="govuk-body"><%= t(".any_other_answer.skip_later") %></p>

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -26,14 +26,14 @@
 
         <% if page.has_next_page? %>
           <p class="govuk-body"><%= t(".any_other_answer.will_continue_to", next_question_number: route_summary_card_data_presenter.next_page&.position) %></p>
+
+          <% if FeatureService.new(group: current_form.group).enabled? :branch_routing %>
+            <p class="govuk-body"><%= t(".any_other_answer.skip_later") %></p>
+
+            <%= govuk_button_link_to t(".any_other_answer.set_questions_to_skip"), new_secondary_skip_path(current_form.id, page.id), secondary: true %>
+          <% end %>
         <% else %>
           <p class="govuk-body"><%= t(".any_other_answer.will_continue_to_check_your_answers") %></p>
-        <% end %>
-
-        <% if FeatureService.new(group: current_form.group).enabled? :branch_routing %>
-          <p class="govuk-body"><%= t(".any_other_answer.skip_later") %></p>
-
-          <%= govuk_button_link_to t(".any_other_answer.set_questions_to_skip"), new_secondary_skip_path(current_form.id, page.id), secondary: true %>
         <% end %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1226,6 +1226,7 @@ en:
           set_questions_to_skip: Set questions to skip
           skip_later: If you need to, you can make them skip one or more questions that only people on route 1 need to answer.
           will_continue_to: People who select any other answer will continue to question %{next_question_number} and through the rest of the form.
+          will_continue_to_check_your_answers: People who select any other answer will continue to “Check your answers before submitting”.
     submit_save: Save question
   payment_link_input:
     body_html: |

--- a/spec/requests/pages/routes_controller_spec.rb
+++ b/spec/requests/pages/routes_controller_spec.rb
@@ -44,6 +44,25 @@ describe Pages::RoutesController, type: :request do
     it "renders the routing page template" do
       expect(response).to render_template("pages/routes/show")
     end
+
+    context "when the page is at the end of the form" do
+      let(:page) do
+        pages.last.tap do |last_page|
+          last_page.id = 101
+          last_page.is_optional = false
+          last_page.answer_type = "selection"
+          last_page.answer_settings = DataStruct.new(
+            only_one_option: true,
+            selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                                OpenStruct.new(attributes: { name: "Option 2" })],
+          )
+        end
+      end
+
+      it "renders the routing page template" do
+        expect(response).to render_template("pages/routes/show")
+      end
+    end
   end
 
   describe "#delete" do

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -88,6 +88,16 @@ describe "pages/routes/show.html.erb" do
         it "shows the check your answers page as the next question in the form" do
           expect(rendered).to have_text "People who select any other answer will continue to “Check your answers before submitting”."
         end
+
+        context "when branch routing is enabled", :feature_branch_routing do
+          it "does not have a link to set questions to skip" do
+            expect(rendered).not_to have_link(
+              "Set questions to skip",
+              class: "govuk-button--secondary",
+              href: new_secondary_skip_path(form.id, page.id),
+            )
+          end
+        end
       end
 
       context "when branch routing is enabled", :feature_branch_routing do

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -80,8 +80,13 @@ describe "pages/routes/show.html.erb" do
       end
 
       context "when the page is the last question" do
+        let(:page) do
+          page_with_skip_route.next_page = nil
+          page_with_skip_route
+        end
+
         it "shows the check your answers page as the next question in the form" do
-          expect(rendered).to have_text "People who select any other answer will continue to question 11 and through the rest of the form"
+          expect(rendered).to have_text "People who select any other answer will continue to “Check your answers before submitting”."
         end
       end
 

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "pages/routes/show.html.erb" do
-  let(:form) { build :form, id: 1, pages: [page] }
+  let(:form) { build :form, id: 1, pages: }
   let(:pages) { [page, next_page] }
   let(:page) { build :page, id: 1, position: 1, next_page: 2, routing_conditions: [build(:condition)] }
   let(:next_page) { build :page, id: 2 }
@@ -56,6 +56,7 @@ describe "pages/routes/show.html.erb" do
   context "when the page has a single skip route" do
     include_context "with pages with routing"
 
+    let(:route_summary_card_data_service) { RouteSummaryCardDataPresenter.new form:, page: }
     let(:page) { page_with_skip_route }
 
     it "does not have a link to delete all routes" do
@@ -66,8 +67,8 @@ describe "pages/routes/show.html.erb" do
   context "when the page does not have a secondary skip route" do
     include_context "with pages with routing"
 
+    let(:route_summary_card_data_service) { RouteSummaryCardDataPresenter.new form:, page: }
     let(:page) { page_with_skip_route }
-    let(:next_page) { pages.find { _1.id == page_with_skip_route.next_page } }
 
     it "has an any other answer section" do
       expect(rendered).to have_css "h2.govuk-heading-m", text: "If people select any other answer"
@@ -99,6 +100,7 @@ describe "pages/routes/show.html.erb" do
   context "when the page has a skip and a secondary skip" do
     include_context "with pages with routing"
 
+    let(:route_summary_card_data_service) { RouteSummaryCardDataPresenter.new form:, page: }
     let(:page) { page_with_skip_and_secondary_skip }
 
     it "has a link to delete all routes" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/T8ww3HhL/2208-bug-if-you-move-a-question-at-the-start-of-a-route-1-to <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We’re seeing errors in production because on the routes page we want to tell the user about the any other answer route, but in the case where the question with the route has been moved to the end of the form we can't find the question object for the next question number.

This commit fixes the error by not trying to find the next question if the route question is at the end of the form, and instead showing content telling the user the form filler will see the check your answers page next.

Curiously it looks like something like this was originally the plan, because there was already a spec for the show routes view for a question at the end of the form; I just fluffed the test when writing it 😅

### Screenshots

![Screenshot of question's routes page when question is at the end of a form](https://github.com/user-attachments/assets/495895cd-6f39-4553-b207-636b3eb38c01)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?