### PR TITLE
Use new CloudWatch metrics

### DIFF
--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -1,18 +1,17 @@
 class CloudWatchService
   REGION = "eu-west-2".freeze
   A_WEEK = 604_800
+  METRICS_NAMESPACE = "Forms".freeze
 
   def self.week_submissions(form_id:)
     cloudwatch_client = Aws::CloudWatch::Client.new(region: REGION)
 
     response = cloudwatch_client.get_metric_statistics({
-      metric_name: "submitted",
-      namespace: metric_namespace.to_s,
+      metric_name: "Submitted",
+      namespace: METRICS_NAMESPACE,
       dimensions: [
-        {
-          name: "form_id",
-          value: form_id.to_s,
-        },
+        environment_dimension,
+        form_id_dimension(form_id),
       ],
       start_time: start_of_today - 7.days,
       end_time: start_of_today,
@@ -28,13 +27,11 @@ class CloudWatchService
     cloudwatch_client = Aws::CloudWatch::Client.new(region: REGION)
 
     response = cloudwatch_client.get_metric_statistics({
-      metric_name: "started",
-      namespace: metric_namespace.to_s,
+      metric_name: "Started",
+      namespace: METRICS_NAMESPACE,
       dimensions: [
-        {
-          name: "form_id",
-          value: form_id.to_s,
-        },
+        environment_dimension,
+        form_id_dimension(form_id),
       ],
       start_time: start_of_today - 7.days,
       end_time: start_of_today,
@@ -46,8 +43,18 @@ class CloudWatchService
     response.datapoints[0]&.sum.to_i || 0
   end
 
-  def self.metric_namespace
-    "forms/#{Settings.forms_env}".downcase
+  def self.environment_dimension
+    {
+      name: "Environment",
+      value: Settings.forms_env.downcase,
+    }
+  end
+
+  def self.form_id_dimension(form_id)
+    {
+      name: "FormId",
+      value: form_id.to_s,
+    }
   end
 
   def self.start_of_today

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -25,11 +25,15 @@ describe CloudWatchService do
       allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
 
       allow(cloudwatch_client).to receive(:get_metric_statistics).with({
-        metric_name: "submitted",
-        namespace: "forms/#{forms_env}",
+        metric_name: "Submitted",
+        namespace: "Forms",
         dimensions: [
           {
-            name: "form_id",
+            name: "Environment",
+            value: forms_env,
+          },
+          {
+            name: "FormId",
             value: form_id.to_s,
           },
         ],
@@ -41,11 +45,15 @@ describe CloudWatchService do
       }).and_return(metric_response)
 
       expect(cloudwatch_client).to receive(:get_metric_statistics).with({
-        metric_name: "submitted",
-        namespace: "forms/#{forms_env}",
+        metric_name: "Submitted",
+        namespace: "Forms",
         dimensions: [
           {
-            name: "form_id",
+            name: "Environment",
+            value: forms_env,
+          },
+          {
+            name: "FormId",
             value: form_id.to_s,
           },
         ],
@@ -95,11 +103,15 @@ describe CloudWatchService do
       allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
 
       allow(cloudwatch_client).to receive(:get_metric_statistics).with({
-        metric_name: "started",
-        namespace: "forms/#{forms_env}",
+        metric_name: "Started",
+        namespace: "Forms",
         dimensions: [
           {
-            name: "form_id",
+            name: "Environment",
+            value: forms_env,
+          },
+          {
+            name: "FormId",
             value: form_id.to_s,
           },
         ],
@@ -111,11 +123,15 @@ describe CloudWatchService do
       }).and_return(metric_response)
 
       expect(cloudwatch_client).to receive(:get_metric_statistics).with({
-        metric_name: "started",
-        namespace: "forms/#{forms_env}",
+        metric_name: "Started",
+        namespace: "Forms",
         dimensions: [
           {
-            name: "form_id",
+            name: "Environment",
+            value: forms_env,
+          },
+          {
+            name: "FormId",
             value: form_id.to_s,
           },
         ],


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/yxarCr91/2241-use-new-cloudwatch-metrics-in-forms-admin

We've now been sending modified metrics to Cloudwatch for the form started and submitted event for over a month. We can now use these new metrics that have a different name, namespace and dimensions for displaying the form metrics to form creators. After this, we can stop sending the old metrics from forms-runner.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
