### PR TITLE
Fix discrepancy between character count and validation

### DIFF
--- a/app/helpers/text_input_helper.rb
+++ b/app/helpers/text_input_helper.rb
@@ -1,0 +1,5 @@
+module TextInputHelper
+  def strip_carriage_returns!(input)
+    input.gsub!(/\r\n?/, "\n") if input.present?
+  end
+end

--- a/app/input_objects/forms/declaration_input.rb
+++ b/app/input_objects/forms/declaration_input.rb
@@ -1,7 +1,11 @@
 class Forms::DeclarationInput < Forms::MarkCompleteInput
+  include TextInputHelper
+
   attr_accessor :declaration_text
 
   validates :declaration_text, length: { maximum: 2000 }
+
+  before_validation :strip_carriage_returns_from_input
 
   def submit
     return false if invalid?
@@ -15,5 +19,11 @@ class Forms::DeclarationInput < Forms::MarkCompleteInput
     self.declaration_text = form.declaration_text
     self.mark_complete = form.try(:declaration_section_completed)
     self
+  end
+
+private
+
+  def strip_carriage_returns_from_input
+    strip_carriage_returns!(declaration_text)
   end
 end

--- a/spec/helpers/text_input_helper_spec.rb
+++ b/spec/helpers/text_input_helper_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe TextInputHelper, type: :helper do
+  describe "#strip_carriage_returns" do
+    it "removes carriage returns" do
+      input = "some\r\ntext\r\with\nnew lines\r\n"
+      helper.strip_carriage_returns!(input)
+
+      expect(input).to eq("some\ntext\nwith\nnew lines\n")
+    end
+
+    it "does not error if input is nil" do
+      expect {
+        helper.strip_carriage_returns!(nil)
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/input_objects/forms/declaration_input_spec.rb
+++ b/spec/input_objects/forms/declaration_input_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe Forms::DeclarationInput, type: :model do
         expect(declaration_input).to be_valid
       end
 
+      it "is strips carriage returns before calculating the length" do
+        declaration_text = "#{'a' * 1000}\r\n#{'a' * 999}"
+        declaration_input = described_class.new(declaration_text:, mark_complete: true)
+
+        expect(declaration_input).to be_valid
+      end
+
       it "is invalid if more than 2000 characters" do
         declaration_input = described_class.new(declaration_text: "a" * 2001, mark_complete: true)
         error_message = I18n.t("activemodel.errors.models.forms/declaration_input.attributes.declaration_text.too_long")


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/XHXO9rQv/2441-bug-discrepancy-in-character-count-for-declaration

There was a discrepancy between the character count reported in the textarea input on the webpage and our backend validation due to carriage returns (CR) as well as line feed characters (LF) being sent in the HTTP request when the form is submitted for line breaks, which causes a line break to be counted by our backend validation as 2 characters.

Stripping out carriage returns makes the length match the length reported by the character count frontend component.

This is discussed in https://github.com/alphagov/govuk-design-system-backlog/issues/67#issuecomment-1377488771

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
