### PR TITLE
Fix deleting group when forms have been created in it

### DIFF
--- a/db/migrate/20250513062011_change_foreign_keys_create_form_events.rb
+++ b/db/migrate/20250513062011_change_foreign_keys_create_form_events.rb
@@ -1,0 +1,9 @@
+class ChangeForeignKeysCreateFormEvents < ActiveRecord::Migration[8.0]
+  def change
+    remove_foreign_key :create_form_events, :groups
+    add_foreign_key :create_form_events, :groups, on_delete: :cascade, validate: false
+
+    remove_foreign_key :create_form_events, :users
+    add_foreign_key :create_form_events, :users, on_delete: :cascade, validate: false
+  end
+end

--- a/db/migrate/20250513065144_validate_foreign_keys_create_form_events.rb
+++ b/db/migrate/20250513065144_validate_foreign_keys_create_form_events.rb
@@ -1,0 +1,6 @@
+class ValidateForeignKeysCreateFormEvents < ActiveRecord::Migration[8.0]
+  def change
+    validate_foreign_key :create_form_events, :groups
+    validate_foreign_key :create_form_events, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_10_160700) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_13_065144) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -218,8 +218,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_10_160700) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  add_foreign_key "create_form_events", "groups"
-  add_foreign_key "create_form_events", "users"
+  add_foreign_key "create_form_events", "groups", on_delete: :cascade
+  add_foreign_key "create_form_events", "users", on_delete: :cascade
   add_foreign_key "draft_questions", "users"
   add_foreign_key "groups", "users", column: "creator_id"
   add_foreign_key "groups", "users", column: "upgrade_requester_id"

--- a/spec/integration/create_a_form_prevent_double_click_spec.rb
+++ b/spec/integration/create_a_form_prevent_double_click_spec.rb
@@ -60,6 +60,38 @@ RSpec.describe "Create a form", type: :feature do
     end
   end
 
+  describe "deleting a group" do
+    context "when a form has been created and then deleted in that group" do
+      before do
+        login_as_super_admin_user
+
+        visit group_path(group)
+        click_on "Create a form"
+
+        fill_in "What’s the name of your form?", with: form.name
+
+        click_on "Save and continue"
+
+        allow(FormRepository).to receive(:destroy).and_invoke(lambda do |record|
+          GroupForm.find_by_form_id(record.id).destroy!
+          record
+        end)
+
+        click_on "Delete draft form"
+        choose "Yes"
+        click_on "Continue"
+      end
+
+      it "deletes the group" do
+        click_on "Delete this group"
+        choose "Yes"
+        click_on "Continue"
+
+        expect(page).to have_selector ".govuk-notification-banner--success", text: "Successfully deleted"
+      end
+    end
+  end
+
   # Element#double_click isn't working as expected in Ferrum
   # (see https://github.com/rubycdp/ferrum/issues/529),
   # so we need to reimplement it


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We were getting foreign key constraint errors (see https://govuk-forms.sentry.io/issues/6562756176/) when trying to delete groups because the create_form_event table has associations with groups.

We currently only use the events for checking whether a form has already been created with the same name (to catch double clicks), so we can just delete the events.

This commit fixes the errors by adding a before_destroy callback to remove create form events before deleting the groups.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?