### PR TITLE
Update content for routing when exit_pages on

### DIFF
--- a/app/views/pages/conditions/_routing_options.html.erb
+++ b/app/views/pages/conditions/_routing_options.html.erb
@@ -1,6 +1,16 @@
 <% branch_routing_enabled = FeatureService.new(group: form.group).enabled?(:branch_routing) %>
-<% body_text = branch_routing_enabled ? t("routing_page.branch_routing.body_html") : t("routing_page.body_html") %>
-<% hint_text = branch_routing_enabled ? t("routing_page.branch_routing.legend_hint_text") : t("routing_page.legend_hint_text") %>
+<% exit_pages_enabled = FeatureService.new(group: form.group).enabled?(:exit_pages) %>
+
+<% if exit_pages_enabled %>
+  <% body_text = t("routing_page.exit_pages.body_html") %>
+  <% hint_text = t("routing_page.exit_pages.legend_hint_text") %>
+<% elsif branch_routing_enabled %>
+  <% body_text = t("routing_page.branch_routing.body_html") %>
+  <% hint_text = t("routing_page.branch_routing.legend_hint_text") %>
+<% else %>
+  <% body_text = t("routing_page.body_html") %>
+  <% hint_text = t("routing_page.legend_hint_text") %>
+<% end %>
 
 <%= form_with(model: routing_page_input, url: set_routing_page_path(form.id), method: 'POST') do |f| %>
   <% if routing_page_input&.errors.any? %>

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -3,7 +3,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% branch_routing_enabled = FeatureService.new(group: form.group).enabled?(:branch_routing) %>
-    <% prefix = branch_routing_enabled ? 'branch_routing.' : '' %>
+    <% exit_pages_enabled = FeatureService.new(group: form.group).enabled?(:exit_pages) %>
+
+    <% if exit_pages_enabled %>
+      <% prefix = 'exit_pages.' %>
+    <% elsif branch_routing_enabled %>
+      <% prefix = 'branch_routing.' %>
+    <% else %>
+      <% prefix = '' %>
+    <% end %>
 
     <% if policy(form).can_add_page_routing_conditions? %>
       <%= render partial: "pages/conditions/routing_options", locals: {form:, routing_page_input:} %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -132,7 +132,7 @@ ignore_unused:
 - 'errors.*'
 - 'date.formats.*'
 - 'helpers.*'
-- 'routing_page.branch_routing.*'
+- 'routing_page.{branch_routing,exit_pages}.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1482,6 +1482,32 @@ en:
 
         <p>It’s usually easiest to create all your form’s questions first, then add the routes you need.</p>
     dropdown_default_text: Select a question to start your route from
+    exit_pages:
+      body_html: |
+        <p> You can add a route to a question so if someone selects one specific answer, they’ll be skipped to: </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li> a later question </li>
+          <li> the end of the form </li>
+          <li> an ‘exit page’ to remove them from the form - for example, because they’re not eligible </li>
+        </ul>
+
+        <p> People who select any other answer will continue to the next question and through the rest of the form. </p>
+      legend_hint_text: A route can only start from a question where people select one option from a list. Go back to your questions if you need to edit an existing route.
+      no_remaining_routes_html: |
+        <h2 class="govuk-heading-m">You have no more questions to add a route from</h2>
+        <p>A route can only start from a question where people select one option from a list. If you need to edit an existing route, go back to your questions.</p>
+      routing_requirements_not_met_html: |
+        <h2 class="govuk-heading-m">You cannot add a route yet</h2>
+
+        <p>A route can only start from a question that:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>asks people to select only one option from a list</li>
+          <li>has at least one question after it</li>
+        </ul>
+
+        <p>It’s usually easiest to create all your form’s questions first, then add the routes you need.</p>
     legend_hint_text: A route can only start from a question where people select one item from a list. You can only add one route from each question.
     legend_text: Which question do you want to add a route from?
     no_remaining_routes_html: |

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -34,6 +34,12 @@ describe "pages/conditions/routing_page.html.erb" do
     end
   end
 
+  context "when exit pages are enabled", :feature_exit_pages do
+    it "contains content for exit pages" do
+      expect(rendered).to have_text "an ‘exit page’ to remove them from the form - for example, because they’re not eligible ", normalize_ws: true
+    end
+  end
+
   context "when branch routing is not enabled", feature_branch_routing: false do
     it "does not contain content explaining branch routing" do
       expect(rendered).not_to have_text "You can add a route from a question where people can select only one answer from a list."
@@ -105,6 +111,22 @@ describe "pages/conditions/routing_page.html.erb" do
       it "explains to the user that they have created all available routes" do
         guidance = Capybara.string(I18n.t("routing_page.no_remaining_routes_html").to_s).text(normalize_ws: true)
         expect(rendered).to have_text(guidance, normalize_ws: true)
+      end
+    end
+
+    context "when exit_pages is enabled", :feature_exit_pages do
+      it "explains to the user what is required for them to be able to add a new routes" do
+        guidance = Capybara.string(I18n.t("routing_page.exit_pages.routing_requirements_not_met_html")).text(normalize_ws: true)
+        expect(rendered).to have_text(guidance, normalize_ws: true)
+      end
+
+      context "when all qualifying questions have a route" do
+        let(:all_routes_created) { true }
+
+        it "explains to the user that they have created all available routes" do
+          guidance = Capybara.string(I18n.t("routing_page.exit_pages.no_remaining_routes_html")).text(normalize_ws: true)
+          expect(rendered).to have_text(guidance, normalize_ws: true)
+        end
       end
     end
   end


### PR DESCRIPTION
# Update content for creating routes when the exit pages feature is enabled

This commit changes the content for routing when exit_pages is enabled.

The changed content is all on the "Add route" page, `forms/1/pages/new-condition`.

Trello card: https://trello.com/c/ti9612rd/2258-update-content-on-add-a-route-from-a-question-page-to-add-exit-pages?filter=member:tomiles3

## When a route can be added

Without exit pages enabled:
![image](https://github.com/user-attachments/assets/ce766f37-54a0-4d2a-b408-275c6f4f2662)

With exit pages enabled:
![image](https://github.com/user-attachments/assets/697429db-c269-4e3e-a139-84ebe376d968)

## When there are no questions eligible for routes:

Without exit pages enabled:
![image](https://github.com/user-attachments/assets/4b14323b-7698-4a50-a8a0-516ffdb6ad08)

With exit pages enabled:
![image](https://github.com/user-attachments/assets/0b4d3051-9839-4054-bbdf-c824ba08d237)

## When there are no questions left to add routes to:

Without exit pages enabled:
![image](https://github.com/user-attachments/assets/94106524-9958-4d2a-882d-4e46b9bb6764)

With exit pages enabled:
![image](https://github.com/user-attachments/assets/d5bb979f-ca19-4b0a-95a7-e5b80ee6804c)

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
