### PR TITLE
2245 add edit an exit page page

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -56,7 +56,11 @@ class Pages::ConditionsController < PagesController
     condition_input = Pages::ConditionsInput.new(form_params)
 
     if condition_input.update_condition
-      redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_updated", question_number: condition_input.page.position)
+      if condition_input.create_exit_page? && FeatureService.new(group: current_form.group).enabled?(:exit_pages)
+        redirect_to edit_exit_page_path(current_form.id, page.id, condition.id)
+      else
+        redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_updated", question_number: condition_input.page.position)
+      end
     else
       render template: "pages/conditions/edit", locals: { condition_input: }, status: :unprocessable_entity
     end

--- a/app/controllers/pages/exit_page_controller.rb
+++ b/app/controllers/pages/exit_page_controller.rb
@@ -20,6 +20,28 @@ class Pages::ExitPageController < PagesController
     end
   end
 
+  def edit
+    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+
+    update_exit_page_input = Pages::UpdateExitPageInput.new(form: current_form, page:, record: condition).assign_condition_values
+
+    render template: "pages/exit_page/edit", locals: { update_exit_page_input: }
+  end
+
+  def update
+    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+
+    form_params = update_exit_page_input_params.merge(record: condition)
+
+    update_exit_page_input = Pages::UpdateExitPageInput.new(form_params)
+
+    if update_exit_page_input.submit
+      redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.exit_page_updated")
+    else
+      render template: "pages/exit_page/edit", locals: { update_exit_page_input: }, status: :unprocessable_entity
+    end
+  end
+
 private
 
   def can_add_page_routing
@@ -32,6 +54,10 @@ private
 
   def exit_page_input_params
     params.require(:pages_exit_page_input).permit(:exit_page_heading, :exit_page_markdown, :answer_value).merge(form: current_form, page:)
+  end
+
+  def update_exit_page_input_params
+    params.require(:pages_update_exit_page_input).permit(:exit_page_heading, :exit_page_markdown).merge(form: current_form, page:)
   end
 
   def ensure_answer_value_present

--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -6,7 +6,7 @@ class Pages::ConditionsInput < BaseInput
   def submit
     return false if invalid?
 
-    if goto_page_id == "exit_page"
+    if create_exit_page?
       true
     else
       assign_skip_to_end
@@ -24,11 +24,16 @@ class Pages::ConditionsInput < BaseInput
   def update_condition
     return false if invalid?
 
-    assign_skip_to_end
-
     record.answer_value = answer_value
-    record.goto_page_id = goto_page_id
-    record.skip_to_end = skip_to_end
+
+    unless create_exit_page? || goto_page_id == "exit_page"
+      assign_skip_to_end
+
+      record.skip_to_end = skip_to_end
+      record.goto_page_id = goto_page_id
+      record.exit_page_heading = nil
+      record.exit_page_markdown = nil
+    end
 
     ConditionRepository.save!(record)
   end
@@ -57,6 +62,9 @@ class Pages::ConditionsInput < BaseInput
     if goto_page_id.nil? && skip_to_end
       self.goto_page_id = "check_your_answers"
     end
+    if record.exit_page?
+      self.goto_page_id = "exit_page"
+    end
     self
   end
 
@@ -77,7 +85,7 @@ class Pages::ConditionsInput < BaseInput
   end
 
   def create_exit_page?
-    goto_page_id == "exit_page"
+    goto_page_id == "create_exit_page"
   end
 
 private

--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -88,6 +88,10 @@ class Pages::ConditionsInput < BaseInput
     goto_page_id == "create_exit_page"
   end
 
+  def secondary_skip?
+    PageRoutesService.new(form:, pages: FormRepository.pages(form), page:).routes.find(&:secondary_skip?)
+  end
+
 private
 
   def pages_after_position(position)

--- a/app/input_objects/pages/update_exit_page_input.rb
+++ b/app/input_objects/pages/update_exit_page_input.rb
@@ -1,0 +1,22 @@
+class Pages::UpdateExitPageInput < BaseInput
+  attr_accessor :form, :page, :record, :exit_page_markdown, :exit_page_heading
+
+  validates :exit_page_heading, :exit_page_markdown, presence: true
+
+  def submit
+    return false if invalid?
+
+    record.exit_page_heading = exit_page_heading
+    record.exit_page_markdown = exit_page_markdown
+    record.goto_page_id = nil
+    record.skip_to_end = false
+
+    ConditionRepository.save!(record)
+  end
+
+  def assign_condition_values
+    self.exit_page_heading = record.exit_page_heading
+    self.exit_page_markdown = record.exit_page_markdown
+    self
+  end
+end

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -34,7 +34,7 @@
               <%= option.question_text %>
             </option>
           <% end %>
-          <% unless PageRoutesService.new(form: condition_input.form, pages: FormRepository.pages(condition_input.form), page: condition_input.page).routes.find(&:secondary_skip?) %>
+          <% unless condition_input.secondary_skip? %>
             <optgroup label="<%= I18n.t("page_conditions.exit_page_label") %>">
               <% if condition_input.record.exit_page? %>
                 <option value="exit_page" <% if condition_input.record.exit_page? %>selected<% end %>>

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -24,7 +24,38 @@
       end %>
 
       <%= f.govuk_collection_select :answer_value, condition_input.routing_answer_options, :value, :label, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_answer_value") } %>
-      <%= f.govuk_collection_select :goto_page_id, condition_input.goto_page_options, :id, :question_text, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") } %>
+      
+      <% unless FeatureService.new(group: condition_input.form.group).enabled?(:exit_pages) %>
+        <%= f.govuk_collection_select :goto_page_id, condition_input.goto_page_options, :id, :question_text, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") } %>
+      <% else %>
+        <%= f.govuk_select(:goto_page_id, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") }) do %>
+          <% condition_input.goto_page_options.each do |option| %>
+            <option value=<%= option.id %> <% if condition_input.record.goto_page_id == option.id || (condition_input.record.skip_to_end? && option.id == "check_your_answers") %>selected<% end %>>
+              <%= option.question_text %>
+            </option>
+          <% end %>
+          <% unless PageRoutesService.new(form: condition_input.form, pages: FormRepository.pages(condition_input.form), page: condition_input.page).routes.find(&:secondary_skip?) %>
+            <optgroup label="<%= I18n.t("page_conditions.exit_page_label") %>">
+              <% if condition_input.record.exit_page? %>
+                <option value="exit_page" <% if condition_input.record.exit_page? %>selected<% end %>>
+                  <%= condition_input.record.exit_page_heading %>
+                </option>
+              <% else %>
+                <option value="create_exit_page">
+                  <%= I18n.t("page_conditions.exit_page") %>
+                </option>
+              <% end %>
+            </optgroup>
+          <% end %>
+        <% end %>
+
+        <% if condition_input.record.exit_page? %>
+          <p class="govuk-body">
+            <%= govuk_link_to t("page_conditions.edit_exit_page", exit_page_heading: condition_input.record.exit_page_heading), edit_exit_page_path(condition_input.form.id, condition_input.page.id, condition_input.record.id) %>
+          </p>
+        <% end %>
+      <% end %>
+      
       <%= f.govuk_submit t("save_and_continue") do
         govuk_button_link_to "Delete route", delete_condition_path(condition_input.form.id, condition_input.page.id, condition_input.record.id), warning: true
       end %>

--- a/app/views/pages/conditions/new.html.erb
+++ b/app/views/pages/conditions/new.html.erb
@@ -35,7 +35,7 @@
             </option>
           <% end %>
           <optgroup label="<%= I18n.t("page_conditions.exit_page_label") %>">
-            <option value="exit_page">
+            <option value="create_exit_page">
               <%= I18n.t("page_conditions.exit_page") %>
             </option>
           </optgroup>

--- a/app/views/pages/exit_page/edit.html.erb
+++ b/app/views/pages/exit_page/edit.html.erb
@@ -1,0 +1,27 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.edit_exit_page"), update_exit_page_input.errors&.any?)) %>
+<% content_for :back_link, govuk_back_link_to(edit_condition_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id), t(".back_link")) %>
+
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <%= form_with model: update_exit_page_input, url: update_exit_page_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id), method: 'PUT' do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("page_titles.routing_page_caption", question_number: update_exit_page_input.page.position) %></span>
+        <span class="govuk-visually-hidden"> - </span>
+        <%= t("page_titles.edit_exit_page") %>
+      </h1>
+
+      <%= f.govuk_text_field( :exit_page_heading, value: update_exit_page_input.exit_page_heading, label: { size: 'm' })  %>
+
+      <%= f.govuk_text_area( :exit_page_markdown, value: update_exit_page_input.exit_page_markdown, label: { size: 'm' })  %>
+      
+      <div class="govuk-button-group">
+        <%= f.govuk_submit t("save_and_continue") %>
+        <%= govuk_link_to t('cancel'), edit_condition_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1055,6 +1055,7 @@ en:
     condition_goto_page_text: "%{goto_page_question_number}, “%{goto_page_question_text}”"
     condition_goto_page_text_with_errors: "[Question not selected]"
     condition_name: Question %{question_number}’s routes
+    edit_exit_page: Edit “%{exit_page_heading}”
     exit_page: Add an exit page
     exit_page_label: An ‘exit page’ to leave the form
     none_of_the_above: None of the above

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,6 +190,7 @@ en:
       title: Important
     success:
       exit_page_created: Your exit page has been added
+      exit_page_updated: Your exit page has been saved
       form:
         change_name: Your form name has been saved
         declaration_saved: Your declaration has been saved
@@ -1136,6 +1137,7 @@ en:
     date_settings: Are you asking for someone’s date of birth?
     declaration: Add a declaration for people to agree to
     delete_secondary_skip: Are you sure you want to delete the route for any other answer?
+    edit_exit_page: Edit exit page
     email_code_sent: Confirmation code sent
     error_prefix: 'Error: '
     exit_page_new: Add exit page
@@ -1224,6 +1226,9 @@ en:
     delete_question: Delete question
     destroy:
       success: Successfully deleted ‘%{question_text}’
+    exit_page:
+      edit:
+        back_link: Back to edit route 1
     go_to_your_questions: Back to your questions
     heading: Edit question
     index:

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -30,9 +30,18 @@ en:
             routing_page_id:
               blank: Select the question you want to add a route from
               branch_routing_disabled_blank: Select the question you want your route to start from
+        pages/update_exit_page_input:
+          attributes:
+            exit_page_heading:
+              blank: Enter a page heading
+            exit_page_markdown:
+              blank: Enter page content
   helpers:
     hint:
       pages_exit_page_input:
+        exit_page_heading: Use a heading that summarises why someone cannot continue with the form. For example, ‘You’re not eligible for this service’.
+        exit_page_markdown: Explain why they cannot continue to use the form and, if possible, tell them what they should do instead.
+      pages_update_exit_page_input:
         exit_page_heading: Use a heading that summarises why someone cannot continue with the form. For example, ‘You’re not eligible for this service’.
         exit_page_markdown: Explain why they cannot continue to use the form and, if possible, tell them what they should do instead.
     label:
@@ -40,5 +49,8 @@ en:
         answer_value: If the answer selected is
         goto_page_id: skip the person to
       pages_exit_page_input:
+        exit_page_heading: Page heading
+        exit_page_markdown: Page content
+      pages_update_exit_page_input:
         exit_page_heading: Page heading
         exit_page_markdown: Page content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,8 @@ Rails.application.routes.draw do
           delete "/:condition_id/delete" => "pages/conditions#destroy", as: :destroy_condition
           get "/exit_page/new" => "pages/exit_page#new", as: :new_exit_page
           post "/exit_page/new" => "pages/exit_page#create", as: :create_exit_page
+          get "/exit_page/:condition_id" => "pages/exit_page#edit", as: :edit_exit_page
+          put "/exit_page/:condition_id" => "pages/exit_page#update", as: :update_exit_page
         end
 
         scope "/routes" do

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -275,4 +275,18 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       end
     end
   end
+
+  describe "#secondary_skip?" do
+    let(:page_routes_service) { instance_double(PageRoutesService) }
+
+    before do
+      allow(PageRoutesService).to receive(:new).and_return(page_routes_service)
+      allow(page_routes_service).to receive(:routes).and_return([instance_double(Api::V1::ConditionResource, secondary_skip?: true)])
+    end
+
+    it "calls the PageRoutesService" do
+      expect(PageRoutesService).to receive(:new).with(form:, pages: FormRepository.pages(form), page:)
+      conditions_input.secondary_skip?
+    end
+  end
 end

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe Pages::ConditionsInput, type: :model do
         expect(ConditionRepository).to have_received(:create!)
       end
 
-      context "when goto_page_id is 'exit_page'" do
+      context "when goto_page_id is 'create_exit_page'" do
         it "returns true" do
-          conditions_input.goto_page_id = "exit_page"
+          conditions_input.goto_page_id = "create_exit_page"
           expect(conditions_input.submit).to be true
         end
       end
@@ -95,6 +95,17 @@ RSpec.describe Pages::ConditionsInput, type: :model do
         conditions_input.update_condition
 
         expect(ConditionRepository).to have_received(:save!)
+      end
+    end
+
+    context "when going to an exit page" do
+      it "does not call assign_skip_to_end" do
+        allow(conditions_input).to receive(:assign_skip_to_end)
+
+        conditions_input.goto_page_id = "exit_page"
+        conditions_input.update_condition
+
+        expect(conditions_input).not_to have_received(:assign_skip_to_end)
       end
     end
 
@@ -225,6 +236,15 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       it "sets goto_page_id to 'check_your_answers'" do
         conditions_input.assign_condition_values
         expect(conditions_input.goto_page_id).to eq 3
+      end
+    end
+
+    context "when exit_page? is true" do
+      let(:condition) { build :condition, :with_exit_page }
+
+      it "sets goto_page_id to 'exit_page'" do
+        conditions_input.assign_condition_values
+        expect(conditions_input.goto_page_id).to eq "exit_page"
       end
     end
   end

--- a/spec/input_objects/pages/update_exit_page_input_spec.rb
+++ b/spec/input_objects/pages/update_exit_page_input_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Pages::UpdateExitPageInput, type: :model do
+  let(:update_exit_page_input) { described_class.new(form:, page:, record: condition) }
+  let(:condition) { build :condition, :with_exit_page, form:, page: }
+  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:page) { form.pages.first }
+
+  describe "validations" do
+    it "is invalid if exit_page_heading is nil" do
+      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_heading.blank")
+      update_exit_page_input.exit_page_heading = nil
+      expect(update_exit_page_input).to be_invalid
+      expect(update_exit_page_input.errors.full_messages_for(:exit_page_heading)).to include("Exit page heading #{error_message}")
+    end
+
+    it "is invalid if exit_page_markdown is nil" do
+      error_message = I18n.t("activemodel.errors.models.pages/update_exit_page_input.attributes.exit_page_markdown.blank")
+      update_exit_page_input.exit_page_markdown = nil
+      expect(update_exit_page_input).to be_invalid
+      expect(update_exit_page_input.errors.full_messages_for(:exit_page_markdown)).to include("Exit page markdown #{error_message}")
+    end
+  end
+
+  describe "#submit" do
+    context "when validation pass" do
+      before do
+        allow(ConditionRepository).to receive(:save!).and_return(true)
+
+        update_exit_page_input.exit_page_heading = "Exit page heading"
+        update_exit_page_input.exit_page_markdown = "Exit page markdown"
+      end
+
+      it "saves the condition" do
+        update_exit_page_input.submit
+
+        expect(ConditionRepository).to have_received(:save!)
+      end
+    end
+
+    context "when validations fail" do
+      it "returns false" do
+        invalid_conditions_input = described_class.new
+        expect(invalid_conditions_input.submit).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when the goto page is an exit page" do
-      let(:params) { { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: "exit_page", answer_value: "Wales" } } }
+      let(:params) { { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: "create_exit_page", answer_value: "Wales" } } }
       let(:group) { create(:group, organisation: standard_user.organisation, exit_pages_enabled: true) }
 
       it "redirects to the new exit page" do

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -300,6 +300,15 @@ RSpec.describe Pages::ConditionsController, type: :request do
       end
     end
 
+    context "when the form is submitted creates an exit page" do
+      let(:group) { create(:group, organisation: standard_user.organisation, exit_pages_enabled: true) }
+      let(:params) { { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: "create_exit_page", answer_value: "Wales" } } }
+
+      it "redirects to the edit exit page" do
+        expect(response).to redirect_to edit_exit_page_path(form:, page:, condition:)
+      end
+    end
+
     context "when user should not be allowed to add routes to pages" do
       let(:user) { build :user }
 

--- a/spec/requests/pages/exit_page_controller_spec.rb
+++ b/spec/requests/pages/exit_page_controller_spec.rb
@@ -130,4 +130,66 @@ RSpec.describe Pages::ExitPageController, type: :request do
       end
     end
   end
+
+  describe "#edit" do
+    let(:condition) { build :condition, :with_exit_page, id: 3, form:, page: selected_page }
+
+    before do
+      allow(ConditionRepository).to receive(:find).and_return(condition)
+
+      get edit_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id)
+    end
+
+    it "renders the edit exit page template" do
+      expect(response).to render_template("pages/exit_page/edit")
+    end
+
+    context "when the group the form is in should not be allowed to manipulate exit pages" do
+      let(:exit_pages_enabled) { false }
+
+      it "Returns a 404 status" do
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:condition) { build :condition, :with_exit_page, id: 3, form:, page: selected_page }
+    let(:params) { { pages_update_exit_page_input: { exit_page_heading: "Exit Page Heading", exit_page_markdown: "Exit Page Markdown" } } }
+
+    before do
+      allow(ConditionRepository).to receive_messages(save!: true, find: condition)
+
+      put update_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
+    end
+
+    it "redirects to the edit condition page" do
+      expect(response).to redirect_to show_routes_path(form:, page:)
+    end
+
+    it "displays success message" do
+      follow_redirect!
+      expect(response.body).to include(I18n.t("banner.success.exit_page_updated"))
+    end
+
+    context "when the group the form is in should not be allowed to manipulate exit pages" do
+      let(:exit_pages_enabled) { false }
+
+      it "Returns a 404 status" do
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when form submit fails" do
+      let(:params) { { pages_update_exit_page_input: { exit_page_heading: nil, exit_page_markdown: nil } } }
+
+      it "return 422 error code" do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders edit page" do
+        expect(response).to render_template("pages/exit_page/edit")
+      end
+    end
+  end
 end

--- a/spec/views/pages/conditions/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/edit.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe "pages/conditions/edit.html.erb" do
   let(:group) { build :group }
   let(:condition) { build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
   let(:pages) { form.pages << page }
+  let(:secondary_skip) { false }
   let(:page) do
     build :page,
           form_id: form.id,
@@ -20,6 +21,7 @@ describe "pages/conditions/edit.html.erb" do
     page.position = 1
     allow(view).to receive_messages(form_pages_path: "/forms/1/pages", create_condition_path: "/forms/1/pages/1/conditions/new", delete_condition_path: "/forms/1/pages/1/conditions/2/delete")
     allow(form).to receive_messages(group: group, qualifying_route_pages: pages)
+    allow(condition_input).to receive(:secondary_skip?).and_return(secondary_skip)
     condition_input.check_errors_from_api
 
     render template: "pages/conditions/edit", locals: { condition_input: }
@@ -74,6 +76,14 @@ describe "pages/conditions/edit.html.erb" do
 
       it "has the exit page heading" do
         expect(rendered).to have_content(condition.exit_page_heading)
+      end
+    end
+
+    context "when the page already has a secondary skip route" do
+      let(:secondary_skip) { true }
+
+      it "does not have an 'add exit page' option" do
+        expect(rendered).not_to have_content("Add an exit page")
       end
     end
   end

--- a/spec/views/pages/conditions/new.html.erb_spec.rb
+++ b/spec/views/pages/conditions/new.html.erb_spec.rb
@@ -40,7 +40,7 @@ describe "pages/conditions/new.html.erb" do
     let(:group) { build :group, exit_pages_enabled: true }
 
     it "has an exit page option" do
-      expect(rendered).to have_css("option[value='exit_page']", text: I18n.t("page_conditions.exit_page"))
+      expect(rendered).to have_css("option[value='create_exit_page']", text: I18n.t("page_conditions.exit_page"))
     end
   end
 end

--- a/spec/views/pages/exit_page/edit.html.erb_spec.rb
+++ b/spec/views/pages/exit_page/edit.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe "pages/exit_page/edit.html.erb" do
+  let(:form) { build :form, id: 1 }
+  let(:group) { build :group }
+  let(:pages) do
+    build_list(:page, 3)
+  end
+  let(:condition) { build :condition, :with_exit_page, id: 3, form:, page: pages.first }
+  let(:update_exit_page_input) { Pages::UpdateExitPageInput.new(form:, page: pages.first, record: condition).assign_condition_values }
+
+  before do
+    render template: "pages/exit_page/edit", locals: { update_exit_page_input: }
+  end
+
+  it "sets the correct title" do
+    expect(view.content_for(:title)).to eq "Edit exit page"
+  end
+
+  it "contains page heading and sub-heading" do
+    expect(rendered).to have_css("h1 .govuk-caption-l", text: "Question #{pages.first.position}’s routes")
+    expect(rendered).to have_css("h1.govuk-heading-l", text: "Edit exit page")
+  end
+
+  it "has a submit button" do
+    expect(rendered).to have_css("button[type='submit'].govuk-button", text: I18n.t("save_and_continue"))
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/TpkOCn5o/2245-add-edit-an-exit-page-page

Adds the ability to add and edit an exit page when modifying an existing route. 

To test, create a route-qualifying form, and add a route. You can opt to also add an exit page as part of this. Once you've done this, edit the route. You'll see the exit page options available in the goto dropdown. 

![image](https://github.com/user-attachments/assets/a88b98d3-367f-46cc-91c9-0c888b1553f6)

When adding an exit page here, you'll be taken to the `Edit exit page` page. 

![image](https://github.com/user-attachments/assets/da60fc2d-0941-459e-85f5-8bc1f39a2b27)

Once you save your heading and content, you'll go back to the edit route page, with the new exit page as the goto option - and a link to edit the exit page. 

![image](https://github.com/user-attachments/assets/5518087c-fac5-4105-bb3d-067329690bf9)

If your page has a secondary skip route already, then you won't see the exit page option. 

I've added a very rudimentary deletion bit, so that if you choose to route to a question instead of an existing exit page, it'll delete the exit page. This is to prevent it breaking and makes it easier to test with. There's a followup card to properly implement deleting. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
