### PR TITLE
Refactor retrieval of answer types

### DIFF
--- a/app/controllers/pages/type_of_answer_controller.rb
+++ b/app/controllers/pages/type_of_answer_controller.rb
@@ -1,8 +1,6 @@
 class Pages::TypeOfAnswerController < PagesController
-  before_action :set_answer_types
-
   def new
-    @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type, answer_types:)
+    @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type)
     @type_of_answer_path = type_of_answer_create_path(current_form.id)
     render :type_of_answer, locals: { current_form: }
   end
@@ -19,7 +17,7 @@ class Pages::TypeOfAnswerController < PagesController
   end
 
   def edit
-    @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type, answer_types:)
+    @type_of_answer_input = Pages::TypeOfAnswerInput.new(answer_type: draft_question.answer_type)
     @type_of_answer_path = type_of_answer_update_path(current_form.id)
     render :type_of_answer, locals: { current_form: }
   end
@@ -81,18 +79,10 @@ private
   end
 
   def answer_type_form_params
-    params.require(:pages_type_of_answer_input).permit(:answer_type).merge(draft_question:, answer_types:, current_form:)
+    params.require(:pages_type_of_answer_input).permit(:answer_type).merge(draft_question:, current_form:)
   end
 
   def answer_type_changed?
     @type_of_answer_input.answer_type != @type_of_answer_input.draft_question.answer_type
-  end
-
-  def set_answer_types
-    @answer_types = answer_types
-  end
-
-  def answer_types
-    Page::ANSWER_TYPES
   end
 end

--- a/app/input_objects/pages/type_of_answer_input.rb
+++ b/app/input_objects/pages/type_of_answer_input.rb
@@ -1,10 +1,10 @@
 class Pages::TypeOfAnswerInput < BaseInput
-  attr_accessor :answer_type, :draft_question, :answer_types, :current_form
+  attr_accessor :answer_type, :draft_question, :current_form
 
   SELECTION_DEFAULT_OPTIONS = { selection_options: [{ name: "" }, { name: "" }] }.freeze
 
   validates :draft_question, presence: true
-  validates :answer_type, presence: true, inclusion: { in: :answer_types }
+  validates :answer_type, presence: true, inclusion: { in: Page::ANSWER_TYPES }
   validate :not_more_than_4_file_upload_questions
 
   def submit

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -15,7 +15,7 @@
 
       <%= f.govuk_collection_radio_buttons(
             :answer_type,
-            @answer_types,
+            Page::ANSWER_TYPES,
             ->(option) { option },
             ->(option) { t('helpers.label.page.answer_type_options.names.' + option) },
             ->(option) { t('helpers.label.page.answer_type_options.descriptions.' + option) },

--- a/spec/factories/input_objects/pages/type_of_answer_input.rb
+++ b/spec/factories/input_objects/pages/type_of_answer_input.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :type_of_answer_input, class: "Pages::TypeOfAnswerInput" do
     answer_type { Page::ANSWER_TYPES.sample }
     draft_question { build :draft_question, answer_type: }
-    answer_types { Page::ANSWER_TYPES }
 
     trait :with_simple_answer_type do
       answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }

--- a/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_a_question_for_each_type_of_answer_spec.rb
@@ -17,17 +17,19 @@ feature "Add/editing a single question", type: :feature do
 
   context "when a form has no existing pages" do
     let(:pages) { [] }
-    let(:answer_types) { %w[organisation_name email phone_number national_insurance_number address date selection number text] }
 
     scenario "add a question for each type of answer" do
-      answer_types.each do |answer_type|
+      Page::ANSWER_TYPES.each do |answer_type|
         when_i_am_viewing_an_existing_form
         and_i_want_to_create_or_edit_a_page
         and_i_select_a_type_of_answer_option(answer_type)
-        and_i_provide_a_question_text
+        and_i_provide_a_question_text(answer_type)
 
         unless answer_type == "selection"
           and_i_make_the_question_mandatory
+        end
+
+        unless %w[selection file].include?(answer_type)
           and_i_make_the_question_not_repeatable
         end
 
@@ -50,7 +52,7 @@ feature "Add/editing a single question", type: :feature do
       and_i_can_see_a_list_of_existing_pages
       and_i_start_adding_a_new_question
       and_i_select_a_type_of_answer_option("national_insurance_number")
-      and_i_provide_a_question_text
+      and_i_provide_a_question_text("national_insurance_number")
       and_i_make_the_question_mandatory
       and_i_make_the_question_not_repeatable
       and_i_click_save
@@ -85,8 +87,12 @@ private
     expect_page_to_have_no_axe_errors(page)
   end
 
-  def and_i_provide_a_question_text
-    fill_in "Question text", with: "What is your name?"
+  def and_i_provide_a_question_text(answer_type)
+    if answer_type == "file"
+      fill_in "Ask for a file", with: "Upload a file"
+    else
+      fill_in "Question text", with: "What is your name?"
+    end
   end
 
   def and_i_make_the_question_mandatory

--- a/spec/input_objects/pages/type_of_answer_input_spec.rb
+++ b/spec/input_objects/pages/type_of_answer_input_spec.rb
@@ -1,13 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Pages::TypeOfAnswerInput, type: :model do
-  let(:type_of_answer_input) { build :type_of_answer_input, draft_question:, answer_types:, current_form: }
+  let(:type_of_answer_input) { build :type_of_answer_input, draft_question:, current_form: }
   let(:draft_question) { build :draft_question, form_id: 1 }
-  let(:answer_types) { Page::ANSWER_TYPES }
   let(:current_form) { build :form, id: 1 }
 
   it "has a valid factory" do
-    type_of_answer_input = build(:type_of_answer_input, draft_question:, answer_types:)
+    type_of_answer_input = build(:type_of_answer_input, draft_question:)
     expect(type_of_answer_input).to be_valid
   end
 

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 describe "pages/type_of_answer.html.erb", type: :view do
   let(:form) { build :form, id: 1 }
   let(:type_of_answer_input) { build :type_of_answer_input }
-  let(:answer_types) { Page::ANSWER_TYPES }
   let(:page) { OpenStruct.new(routing_conditions: [], answer_type: "number") }
   let(:question_number) { 1 }
   let(:is_new_page) { true }
@@ -22,7 +21,6 @@ describe "pages/type_of_answer.html.erb", type: :view do
     # setup instance variables
     assign(:page, page)
     assign(:type_of_answer_input, type_of_answer_input)
-    assign(:answer_types, answer_types)
     assign(:type_of_answer_path, "/type-of-answer")
 
     render(template: "pages/type_of_answer")
@@ -50,7 +48,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
   end
 
   it "has radio buttons for each answer_type" do
-    answer_types.each do |type|
+    Page::ANSWER_TYPES.each do |type|
       expect(rendered).to have_field("pages_type_of_answer_input[answer_type]", with: type)
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

This PR restores the use of the constant Page::ANSWER_TYPES over use of a controller attribute to get the list of current answer types. This is because we no longer need to feature flag the file answer type.

Trello card: https://trello.com/c/CLmKzjAX

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
