### PR TITLE
Add sleep after updating user organisation in tests

### DIFF
--- a/spec/features/mou/upgrade_user_changes_mou_spec.rb
+++ b/spec/features/mou/upgrade_user_changes_mou_spec.rb
@@ -44,6 +44,7 @@ private
   def then_i_update_the_user_organisation
     fill_in "Organisation", with: "#{organisation.name}\n"
     click_button "Save"
+    sleep 1
   end
 
   def then_i_see_the_mou_with_organisation


### PR DESCRIPTION
### What problem does this pull request solve?

Through experimentation I found that tests in
spec/features/mou/upgrade_user_changes_mou_spec.rb would often fail because we were attempting to visit the MOU page too soon after updating a user's organisation. I assume this is a race condition between the tests and the redirect to the users page after successfully updating a user's organisation.

For now I've just added a 1s sleep before visiting the MOU index in the tests. This could be more graceful (wait to make sure we hit the users page first?) but this is probably ok for now.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
