### PR TITLE
Add volume hints to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,11 @@ RUN npm ci --ignore-scripts --only=production
 
 FROM base AS app
 
+# Each directory that Rails or our application needs to
+# write to under /app/tmp/ must be added individually
+VOLUME "/tmp/"
+VOLUME "/app/tmp/sockets/"
+
 ENV RAILS_ENV="${RAILS_ENV:-production}" \
     PATH="${PATH}:/home/ruby/.local/bin" \
     USER="ruby"


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/KoHvaEUA/681-aws-m112-ecs-read-only-root-filesystem-configuration

We can use VOLUME instructions in our Dockerfile to instruct the runtime to create a mount point for an external volume.

When AWS ECS sees the instruction (from the built container), it automatically attaches ephemeral storage at that location [1]. This is useful for us because we want to enable read only root filesystems, but the applications still need to be able to write to a small portion of it. We can achieve that by mounting ephemeral storage atop the paths it needs to write to.

[1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html#bind-mount-considerations

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
