### PR TITLE
2259 add page for deleting exit pages

### DIFF
--- a/app/input_objects/pages/delete_exit_page_input.rb
+++ b/app/input_objects/pages/delete_exit_page_input.rb
@@ -1,0 +1,2 @@
+class Pages::DeleteExitPageInput < DeleteConfirmationInput
+end

--- a/app/views/input_objects/_delete_confirmation_input.html.erb
+++ b/app/views/input_objects/_delete_confirmation_input.html.erb
@@ -8,5 +8,5 @@
                                        legend: { text: legend_text, size: 'l', tag: 'h1' }
                                        %>
 
-  <%= f.govuk_submit %>
+  <%= f.govuk_submit local_assigns.fetch(:submit_text, t(:continue)) %>
 <% end %>

--- a/app/views/pages/exit_page/delete.html.erb
+++ b/app/views/pages/exit_page/delete.html.erb
@@ -1,0 +1,21 @@
+<% set_page_title(title_with_error_prefix(t(".title"), @delete_exit_page_input.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(edit_exit_page_path(@current_form.id, @page.id, @exit_page.id), t(".back_link")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <%= govuk_notification_banner(title_text: t("banner.default.title")) do %>
+    <%= t(".banner") %>
+  <% end %>
+
+  <%= render(
+    @delete_exit_page_input,
+    url: destroy_exit_page_path(condition_id: @exit_page.id, form_id: @current_form.id, page_id: @page.id),
+    caption_text: @exit_page.exit_page_heading,
+    legend_text: t(".title"),
+    hint_text: nil,
+    submit_text: t(:save_and_continue),
+  ) %>
+
+  </div>
+</div>

--- a/app/views/pages/exit_page/edit.html.erb
+++ b/app/views/pages/exit_page/edit.html.erb
@@ -17,11 +17,12 @@
       <%= f.govuk_text_field( :exit_page_heading, value: update_exit_page_input.exit_page_heading, label: { size: 'm' })  %>
 
       <%= f.govuk_text_area( :exit_page_markdown, value: update_exit_page_input.exit_page_markdown, label: { size: 'm' })  %>
-      
+
       <div class="govuk-button-group">
         <%= f.govuk_submit t("save_and_continue") %>
         <%= govuk_link_to t('cancel'), edit_condition_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id) %>
       </div>
+      <%= govuk_button_link_to t('.delete_exit_page'), delete_exit_page_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id), warning: true %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1237,6 +1237,7 @@ en:
         title: Are you sure you want to delete this exit page?
       edit:
         back_link: Back to edit route 1
+        delete_exit_page: Delete exit page
     go_to_your_questions: Back to your questions
     heading: Edit question
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,6 +192,7 @@ en:
       title: Important
     success:
       exit_page_created: Your exit page has been added
+      exit_page_deleted: Your exit page has been deleted
       exit_page_updated: Your exit page has been saved
       form:
         change_name: Your form name has been saved

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,8 @@ en:
           group_has_forms: This group cannot be deleted because it has forms in it
         pages/delete_confirmation_input:
           blank: Select ‘Yes’ to delete the question
+        pages/delete_exit_page_input:
+          blank: Select ‘Yes’ to delete this exit page
         pages/delete_secondary_skip_input:
           attributes:
             confirm:
@@ -1228,6 +1230,10 @@ en:
     destroy:
       success: Successfully deleted ‘%{question_text}’
     exit_page:
+      delete:
+        back_link: Back to edit exit page
+        banner: If you delete this exit page, the route to it will also be deleted
+        title: Are you sure you want to delete this exit page?
       edit:
         back_link: Back to edit route 1
     go_to_your_questions: Back to your questions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,8 @@ Rails.application.routes.draw do
           post "/exit_page/new" => "pages/exit_page#create", as: :create_exit_page
           get "/exit_page/:condition_id" => "pages/exit_page#edit", as: :edit_exit_page
           put "/exit_page/:condition_id" => "pages/exit_page#update", as: :update_exit_page
+          get "/exit_page/:condition_id/delete" => "pages/exit_page#delete", as: :delete_exit_page
+          delete "/exit_page/:condition_id" => "pages/exit_page#destroy", as: :destroy_exit_page
         end
 
         scope "/routes" do

--- a/spec/requests/pages/exit_page_controller_spec.rb
+++ b/spec/requests/pages/exit_page_controller_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
   let(:group) { create(:group, organisation: standard_user.organisation, exit_pages_enabled:) }
   let(:user) { standard_user }
+  let(:condition) { build(:condition, id: 1, form_id: form.id, page_id: page.id, exit_page_heading: "Exit Page Heading") }
 
   before do
     allow(FormRepository).to receive_messages(find: form, pages: pages)
@@ -164,7 +165,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
     end
 
     it "redirects to the edit condition page" do
-      expect(response).to redirect_to show_routes_path(form:, page:)
+      expect(response).to redirect_to edit_condition_path(form:, page:, condition:)
     end
 
     it "displays success message" do
@@ -189,6 +190,125 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
       it "renders edit page" do
         expect(response).to render_template("pages/exit_page/edit")
+      end
+    end
+  end
+
+  describe "#delete" do
+    before do
+      allow(ConditionRepository).to receive(:find).and_return(condition)
+      allow(condition).to receive(:exit_page?).and_return(true)
+
+      get delete_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id)
+    end
+
+    it "renders the delete exit page template" do
+      expect(response).to render_template("pages/exit_page/delete")
+    end
+
+    it "assigns the exit page" do
+      expect(assigns(:exit_page)).to eq(condition)
+    end
+
+    it "assigns a new delete exit page input" do
+      expect(assigns(:delete_exit_page_input)).to be_a(Pages::DeleteExitPageInput)
+    end
+
+    context "when user should not be allowed to add/delete routes to pages" do
+      let(:form) { build :form, id: 1 }
+      let(:pages) { [build(:page)] }
+
+      it "renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when group the form is in should not be allowed to add/delete exit pages" do
+      let(:exit_pages_enabled) { false }
+
+      it "returns a 404 status" do
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let(:params) { { pages_delete_exit_page_input: { confirm: "yes" } } }
+
+    before do
+      allow(condition).to receive(:exit_page?).and_return(true)
+      allow(ConditionRepository).to receive_messages(find: condition, destroy: true)
+
+      delete destroy_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
+    end
+
+    it "redirects to form pages path" do
+      expect(response).to redirect_to(new_condition_path(form.id, selected_page.id))
+    end
+
+    it "displays success message" do
+      follow_redirect!
+
+      expect(response.body).to include(I18n.t("banner.success.exit_page_deleted"))
+    end
+
+    it "deletes the exit page" do
+      expect(ConditionRepository).to have_received(:destroy).with(condition)
+    end
+
+    context "when confirmation is not provided" do
+      let(:params) { { pages_delete_exit_page_input: { confirm: nil } } }
+
+      it "renders the delete template again" do
+        expect(response).to render_template("pages/exit_page/delete")
+      end
+    end
+
+    context "when confirmation is no" do
+      let(:params) { { pages_delete_exit_page_input: { confirm: "no" } } }
+
+      it "redirects to form pages path" do
+        expect(response).to redirect_to(edit_exit_page_path(form.id, page.id, condition.id))
+      end
+
+      it "doesn't delete the exit page" do
+        expect(ConditionRepository).not_to have_received(:destroy)
+      end
+    end
+
+    context "when the condition is not an exit page" do
+      before do
+        allow(condition).to receive(:exit_page?).and_return(false)
+        delete destroy_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
+      end
+
+      it "redirects to the form pages page" do
+        expect(response).to redirect_to(form_pages_path(form.id))
+      end
+    end
+
+    context "when user should not be allowed to add/delete routes to pages" do
+      let(:form) { build :form, id: 1 }
+      let(:pages) { [build(:page)] }
+
+      it "renders the forbidden page" do
+        expect(response).to render_template("errors/forbidden")
+      end
+
+      it "returns a 403 status" do
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when group the form is in should not be allowed to add/delete exit pages" do
+      let(:exit_pages_enabled) { false }
+
+      it "returns a 404 status" do
+        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/views/pages/exit_page/delete.html.erb_spec.rb
+++ b/spec/views/pages/exit_page/delete.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe "pages/exit_page/delete.html.erb" do
+  let(:form) { build :form, id: 1 }
+  let(:pages) do
+    build_list(:page, 3) do |page, i|
+      page.id = i + 1
+    end
+  end
+  let(:exit_page_input) { Pages::DeleteExitPageInput.new }
+  let(:exit_page) { build :condition, :with_exit_page, id: 1 }
+
+  before do
+    assign(:current_form, form)
+    assign(:page, pages.first)
+    assign(:exit_page, exit_page)
+    assign(:delete_exit_page_input, exit_page_input)
+
+    render template: "pages/exit_page/delete"
+  end
+
+  it "sets the correct title" do
+    expect(view.content_for(:title)).to eq "Are you sure you want to delete this exit page?"
+  end
+
+  it "contains page heading and sub-heading" do
+    expect(rendered).to have_css(".govuk-caption-l", text: exit_page.exit_page_heading)
+    expect(rendered).to have_css("h1", text: "Are you sure you want to delete this exit page?")
+  end
+
+  it "has a submit button" do
+    expect(rendered).to have_css("button[type='submit'].govuk-button", text: I18n.t("save_and_continue"))
+  end
+end


### PR DESCRIPTION
### Add a way for form creators to delete exit pages

Trello card: https://trello.com/c/PioTk5zP/2259-add-page-for-deleting-exit-pages

Add a button to the edit exit page to delete an exit page.

![image](https://github.com/user-attachments/assets/a0313bba-b7e5-438e-8aee-e0ff10064095)

The delete button is outside the button group to make sure it's on it's own line. This isn't ideal but it follows the design. 

![image](https://github.com/user-attachments/assets/7a6f8b0b-a8c9-4ed3-9008-5ba6cf2d3db4)
![image](https://github.com/user-attachments/assets/4881952c-7d2f-4fa0-a0f7-af208d94c1b0)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
