### PR TITLE
Review apps: make apps' root filesystems readonly

### DIFF
--- a/.review_apps/ecs_task_definition.tf
+++ b/.review_apps/ecs_task_definition.tf
@@ -176,7 +176,7 @@ resource "aws_ecs_task_definition" "task" {
     {
       name                   = "forms-admin-seeding"
       image                  = var.forms_admin_container_image
-      command                = ["rake", "db:setup"]
+      command                = ["rake", "db:create", "db:migrate", "db:seed"]
       essential              = false
       environment            = local.forms_admin_env_vars
       readonlyRootFilesystem = true
@@ -202,7 +202,7 @@ resource "aws_ecs_task_definition" "task" {
     {
       name                   = "forms-api-seeding"
       image                  = "711966560482.dkr.ecr.eu-west-2.amazonaws.com/forms-api-deploy:latest"
-      command                = ["rake", "db:setup"]
+      command                = ["rake", "db:create", "db:migrate", "db:seed"]
       essential              = false
       environment            = local.forms_api_env_vars
       readonlyRootFilesystem = true


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/KoHvaEUA/681-aws-m112-ecs-read-only-root-filesystem-configuration

In production they will have readonly root filesystems. Making them readonly in review will allow us to catch places where that causes a problem earlier on.

Also takes the opportunity to make database seeding happen in three separate Rake tasks instead of one, because `db:migrate` is what we run in production and it has some file writing behaviour we don't see from `db:setup` alone.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
