### PR TITLE
Fix flaky test

### DIFF
--- a/spec/input_objects/pages/type_of_answer_input_spec.rb
+++ b/spec/input_objects/pages/type_of_answer_input_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Pages::TypeOfAnswerInput, type: :model do
   let(:current_form) { build :form, id: 1 }
 
   it "has a valid factory" do
-    type_of_answer_input = build(:type_of_answer_input, draft_question:)
     expect(type_of_answer_input).to be_valid
   end
 


### PR DESCRIPTION
This test wasn't setting the current_form on the input object, causing it to fail when the `answer_type` was `file`. The `answer_type` is selected randomly so this was only failing some of the time.
