### PR TITLE
Add markdown editor to edit an exit page

### DIFF
--- a/app/controllers/pages/exit_page_controller.rb
+++ b/app/controllers/pages/exit_page_controller.rb
@@ -70,6 +70,14 @@ class Pages::ExitPageController < PagesController
     redirect_to new_condition_path(@current_form.id, @page.id), success: t("banner.success.exit_page_deleted")
   end
 
+  def render_preview
+    authorize current_form, :can_view_form?
+    exit_page_input = Pages::ExitPageInput.new(exit_page_markdown: params[:markdown])
+    exit_page_input.validate if params[:check_preview_validation] == "true"
+
+    render json: { preview_html: preview_html(exit_page_input), errors: exit_page_input.errors[:exit_page_markdown] }.to_json
+  end
+
 private
 
   def can_add_page_routing
@@ -92,5 +100,11 @@ private
     return if params[:answer_value].present? || params.dig(:pages_exit_page_input, :answer_value).present?
 
     redirect_to new_condition_path(current_form.id, page.id)
+  end
+
+  def preview_html(exit_page_input_object)
+    return t("exit_page.no_content_added_html") if exit_page_input_object.exit_page_markdown.blank?
+
+    GovukFormsMarkdown.render(exit_page_input_object.exit_page_markdown)
   end
 end

--- a/app/controllers/pages/exit_page_controller.rb
+++ b/app/controllers/pages/exit_page_controller.rb
@@ -6,7 +6,7 @@ class Pages::ExitPageController < PagesController
   def new
     exit_page_input = Pages::ExitPageInput.new(form: current_form, page:, answer_value: params[:answer_value])
 
-    render template: "pages/exit_page/new", locals: { exit_page_input: }
+    render template: "pages/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: false }
   end
 
   def create
@@ -16,7 +16,7 @@ class Pages::ExitPageController < PagesController
       # TODO: Route number is hardcoded whilst we can only have one value for it
       redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.exit_page_created")
     else
-      render template: "pages/exit_page/new", locals: { exit_page_input: }, status: :unprocessable_entity
+      render template: "pages/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: true }, status: :unprocessable_entity
     end
   end
 
@@ -25,7 +25,7 @@ class Pages::ExitPageController < PagesController
 
     update_exit_page_input = Pages::UpdateExitPageInput.new(form: current_form, page:, record: condition).assign_condition_values
 
-    render template: "pages/exit_page/edit", locals: { update_exit_page_input: }
+    render template: "pages/exit_page/edit", locals: { update_exit_page_input:, preview_html: preview_html(update_exit_page_input) }
   end
 
   def update
@@ -38,7 +38,7 @@ class Pages::ExitPageController < PagesController
     if update_exit_page_input.submit
       redirect_to edit_condition_path(form_id: current_form.id, page_id: page.id, condition_id: update_exit_page_input.record.id), success: t("banner.success.exit_page_updated")
     else
-      render template: "pages/exit_page/edit", locals: { update_exit_page_input: }, status: :unprocessable_entity
+      render template: "pages/exit_page/edit", locals: { update_exit_page_input:, preview_html: preview_html(update_exit_page_input) }, status: :unprocessable_entity
     end
   end
 

--- a/app/input_objects/pages/exit_page_input.rb
+++ b/app/input_objects/pages/exit_page_input.rb
@@ -2,6 +2,7 @@ class Pages::ExitPageInput < BaseInput
   attr_accessor :form, :page, :record, :exit_page_markdown, :exit_page_heading, :answer_value
 
   validates :exit_page_heading, :exit_page_markdown, :answer_value, presence: true
+  validates :exit_page_heading, :exit_page_markdown, length: { maximum: 4999 }
 
   def submit
     return false if invalid?

--- a/app/input_objects/pages/update_exit_page_input.rb
+++ b/app/input_objects/pages/update_exit_page_input.rb
@@ -2,6 +2,7 @@ class Pages::UpdateExitPageInput < BaseInput
   attr_accessor :form, :page, :record, :exit_page_markdown, :exit_page_heading
 
   validates :exit_page_heading, :exit_page_markdown, presence: true
+  validates :exit_page_heading, :exit_page_markdown, length: { maximum: 4999 }
 
   def submit
     return false if invalid?

--- a/app/views/pages/exit_page/edit.html.erb
+++ b/app/views/pages/exit_page/edit.html.erb
@@ -15,8 +15,15 @@
       </h1>
 
       <%= f.govuk_text_field( :exit_page_heading, value: update_exit_page_input.exit_page_heading, label: { size: 'm' })  %>
-
-      <%= f.govuk_text_area( :exit_page_markdown, value: update_exit_page_input.exit_page_markdown, label: { size: 'm' })  %>
+      
+      <%= render MarkdownEditorComponent::View.new(:exit_page_markdown,
+        form_builder: f,
+        render_preview_path: exit_page_render_preview_path(form_id: update_exit_page_input.form.id, page_id: update_exit_page_input.page.id, check_preview_validation: true),
+        preview_html: preview_html,
+        form_model: update_exit_page_input,
+        label: t("helpers.label.pages_exit_page_input.exit_page_markdown"),
+        hint: t("helpers.hint.pages_exit_page_input.exit_page_markdown"),
+        allow_headings: true) %>
 
       <div class="govuk-button-group">
         <%= f.govuk_submit t("save_and_continue") %>

--- a/app/views/pages/exit_page/new.html.erb
+++ b/app/views/pages/exit_page/new.html.erb
@@ -14,7 +14,14 @@
 
       <%= f.govuk_text_field( :exit_page_heading, label: { size: 'm' })  %>
 
-      <%= f.govuk_text_area( :exit_page_markdown, label: { size: 'm' })  %>
+      <%= render MarkdownEditorComponent::View.new(:exit_page_markdown,
+        form_builder: f,
+        render_preview_path: exit_page_render_preview_path(form_id: exit_page_input.form.id, page_id: exit_page_input.page.id, check_preview_validation:),
+        preview_html: preview_html,
+        form_model: exit_page_input,
+        label: t("helpers.label.pages_exit_page_input.exit_page_markdown"),
+        hint: t("helpers.hint.pages_exit_page_input.exit_page_markdown"),
+        allow_headings: true) %>
 
       <%= f.hidden_field :answer_value, value: exit_page_input.answer_value %>
       

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,6 +305,8 @@ en:
       goto_page_doesnt_exist: The question you’re taking the person to no longer exists - edit question %{question_number}’s route
       route_number_for_any_other_answer: for any other answer
     prefix: 'Error:'
+  exit_page:
+    no_content_added_html: "<p>No content added</p>"
   footer:
     accessibility_statement: Accessibility statement
     cookies: Cookies

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -23,8 +23,10 @@ en:
               blank: Select the answer to base this route on
             exit_page_heading:
               blank: Enter a page heading
+              too_long: The page heading must be shorter than 5,000 characters
             exit_page_markdown:
               blank: Enter page content
+              too_long: The page content must be shorter than 5,000 characters
         pages/routing_page_input:
           attributes:
             routing_page_id:
@@ -34,8 +36,10 @@ en:
           attributes:
             exit_page_heading:
               blank: Enter a page heading
+              too_long: The page heading must be shorter than 5,000 characters
             exit_page_markdown:
               blank: Enter page content
+              too_long: The page content must be shorter than 5,000 characters
   helpers:
     hint:
       pages_exit_page_input:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,12 +108,13 @@ Rails.application.routes.draw do
           put "/:condition_id" => "pages/conditions#update", as: :update_condition
           get "/:condition_id/delete" => "pages/conditions#delete", as: :delete_condition
           delete "/:condition_id/delete" => "pages/conditions#destroy", as: :destroy_condition
-          get "/exit_page/new" => "pages/exit_page#new", as: :new_exit_page
-          post "/exit_page/new" => "pages/exit_page#create", as: :create_exit_page
-          get "/exit_page/:condition_id" => "pages/exit_page#edit", as: :edit_exit_page
-          put "/exit_page/:condition_id" => "pages/exit_page#update", as: :update_exit_page
-          get "/exit_page/:condition_id/delete" => "pages/exit_page#delete", as: :delete_exit_page
-          delete "/exit_page/:condition_id" => "pages/exit_page#destroy", as: :destroy_exit_page
+          get "/exit-page/new" => "pages/exit_page#new", as: :new_exit_page
+          post "/exit-page/new" => "pages/exit_page#create", as: :create_exit_page
+          post "/exit-page-preview" => "pages/exit_page#render_preview", as: :exit_page_render_preview
+          get "/exit-page/:condition_id" => "pages/exit_page#edit", as: :edit_exit_page
+          put "/exit-page/:condition_id" => "pages/exit_page#update", as: :update_exit_page
+          get "/exit-page/:condition_id/delete" => "pages/exit_page#delete", as: :delete_exit_page
+          delete "/exit-page/:condition_id" => "pages/exit_page#destroy", as: :destroy_exit_page
         end
 
         scope "/routes" do

--- a/spec/input_objects/pages/exit_page_input_spec.rb
+++ b/spec/input_objects/pages/exit_page_input_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe Pages::ExitPageInput, type: :model do
       expect(exit_page_input).to be_invalid
       expect(exit_page_input.errors.full_messages_for(:exit_page_markdown)).to include("Exit page markdown #{error_message}")
     end
+
+    it "is invalid if exit_page_heading is too long" do
+      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_heading.too_long")
+      exit_page_input.exit_page_heading = "a" * 5000
+      expect(exit_page_input).to be_invalid
+      expect(exit_page_input.errors.full_messages_for(:exit_page_heading)).to include("Exit page heading #{error_message}")
+    end
+
+    it "in invalid if exit_page_markdown is too long" do
+      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_markdown.too_long")
+      exit_page_input.exit_page_markdown = "a" * 5000
+      expect(exit_page_input).to be_invalid
+      expect(exit_page_input.errors.full_messages_for(:exit_page_markdown)).to include("Exit page markdown #{error_message}")
+    end
   end
 
   describe "#submit" do

--- a/spec/input_objects/pages/update_exit_page_input_spec.rb
+++ b/spec/input_objects/pages/update_exit_page_input_spec.rb
@@ -20,6 +20,20 @@ RSpec.describe Pages::UpdateExitPageInput, type: :model do
       expect(update_exit_page_input).to be_invalid
       expect(update_exit_page_input.errors.full_messages_for(:exit_page_markdown)).to include("Exit page markdown #{error_message}")
     end
+
+    it "is invalid if exit_page_heading is too long" do
+      error_message = I18n.t("activemodel.errors.models.pages/update_exit_page_input.attributes.exit_page_heading.too_long")
+      update_exit_page_input.exit_page_heading = "a" * 5000
+      expect(update_exit_page_input).to be_invalid
+      expect(update_exit_page_input.errors.full_messages_for(:exit_page_heading)).to include("Exit page heading #{error_message}")
+    end
+
+    it "is invalid if exit_page_markdown is too long" do
+      error_message = I18n.t("activemodel.errors.models.pages/update_exit_page_input.attributes.exit_page_markdown.too_long")
+      update_exit_page_input.exit_page_markdown = "a" * 5000
+      expect(update_exit_page_input).to be_invalid
+      expect(update_exit_page_input.errors.full_messages_for(:exit_page_markdown)).to include("Exit page markdown #{error_message}")
+    end
   end
 
   describe "#submit" do

--- a/spec/requests/pages/exit_page_controller_spec.rb
+++ b/spec/requests/pages/exit_page_controller_spec.rb
@@ -312,4 +312,45 @@ RSpec.describe Pages::ExitPageController, type: :request do
       end
     end
   end
+
+  describe "#render_preview" do
+    let(:markdown) { "### Markdown" }
+    let(:check_preview_validation) { "true" }
+
+    before do
+      post exit_page_render_preview_path(form_id: form.id, page_id: page.id), params: { markdown:, check_preview_validation: }
+    end
+
+    it "returns a JSON object containing the converted HTML" do
+      expect(response.body).to eq({ preview_html: "<h3 class=\"govuk-heading-s\">Markdown</h3>", errors: [] }.to_json)
+    end
+
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "when markdown is blank" do
+      let(:markdown) { "" }
+
+      it "returns a JSON object containing the converted HTML with an error" do
+        expect(response.body).to eq({ preview_html: I18n.t("exit_page.no_content_added_html"), errors: [I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_markdown.blank")] }.to_json)
+      end
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      context "when validation is disabled" do
+        let(:check_preview_validation) { "false" }
+
+        it "returns a JSON object containing the converted HTML" do
+          expect(response.body).to eq({ preview_html: I18n.t("exit_page.no_content_added_html"), errors: [] }.to_json)
+        end
+
+        it "returns 200" do
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
 end

--- a/spec/views/pages/exit_page/edit.html.erb_spec.rb
+++ b/spec/views/pages/exit_page/edit.html.erb_spec.rb
@@ -10,7 +10,7 @@ describe "pages/exit_page/edit.html.erb" do
   let(:update_exit_page_input) { Pages::UpdateExitPageInput.new(form:, page: pages.first, record: condition).assign_condition_values }
 
   before do
-    render template: "pages/exit_page/edit", locals: { update_exit_page_input: }
+    render template: "pages/exit_page/edit", locals: { update_exit_page_input:, preview_html: "Preview HTML" }
   end
 
   it "sets the correct title" do

--- a/spec/views/pages/exit_page/new.html.erb_spec.rb
+++ b/spec/views/pages/exit_page/new.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe "pages/exit_page/new.html.erb" do
   let(:exit_page_input) { Pages::ExitPageInput.new(form:, page: pages.first, answer_value: "Option 1") }
 
   before do
-    render template: "pages/exit_page/new", locals: { exit_page_input: }
+    render template: "pages/exit_page/new", locals: { exit_page_input:, preview_html: "Preview HTML", check_preview_validation: "true" }
   end
 
   it "sets the correct title" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/nImD1lje/2246-add-markdown-editor-to-edit-an-exit-page

Introduces the markdown editor component to the exit page add and edit bits. Exit page content will be input using the markdown editor. This involved adding a preview endpoint for exit page stuff.

This also adds a character length limit validation to exit page heading and content fields of 5000 chars, as this was missed in the initial input object's creation. 

Try adding a new exit page, or editing an existing one. The markdown editor should be present, and will validate your content accordingly. 

![image](https://github.com/user-attachments/assets/356ff795-7f03-4a74-816b-afca6e8268c0)

![image](https://github.com/user-attachments/assets/cbc5dffa-c685-4b35-b3a5-b92d9266f191)

![image](https://github.com/user-attachments/assets/8d280511-abbf-4e55-ba91-f187761f9f1b)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
