### PR TITLE
2260 changing a route that goes to an exit page to go to a question should delete the exit page

### DIFF
--- a/app/views/pages/conditions/confirm_delete_exit_page.html.erb
+++ b/app/views/pages/conditions/confirm_delete_exit_page.html.erb
@@ -1,0 +1,26 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.confirm_delete_exit_page"), delete_exit_page_input.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(edit_condition_path(@current_form.id, @page.id, exit_page.id), t(".back_link")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: delete_exit_page_input, url: update_change_exit_page_path(condition_id: exit_page.id, form_id: @current_form.id, page_id: @page.id, params: { answer_value:, goto_page_id:})) do |f| %>
+      <% if delete_exit_page_input&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("page_titles.routing_page_caption", question_number: @page.position) %></span>
+        <%= t('page_titles.confirm_delete_exit_page') %>
+      </h1>
+
+      <%= t(".body_html", exit_page_heading: link_to(exit_page.exit_page_heading, edit_exit_page_path(@current_form.id, @page.id, exit_page.id))) %>
+
+      <%= f.govuk_collection_radio_buttons :confirm,
+                                           delete_exit_page_input.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_delete_exit_page_input.options.' + "#{option}") },
+                                           legend: { text: t('.radios_legend'), size: 'm' }
+                                           %>
+
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1135,6 +1135,7 @@ en:
     archive_form_confirmation: Your form has been archived
     bulk_options: Enter your list’s options into a text box
     change_name: Name your form
+    confirm_delete_exit_page: Your exit page will be deleted
     confirm_email: Enter the confirmation code
     confirm_email_success: Email address confirmed
     contact_details: Provide contact details for support
@@ -1188,6 +1189,12 @@ en:
   pages:
     answer_settings: Answer settings
     conditions:
+      confirm_delete_exit_page:
+        back_link: Back to edit route 1
+        body_html: |
+          <p> Route 1 currently skips to an exit page, “%{exit_page_heading}”. </p>
+          <p> If you change where the route skips to, the exit page will be deleted. </p>
+        radios_legend: Are you sure you want to delete this exit page?
       delete:
         answered_as_key: is answered as
         any_other_answer_warning: If you delete this route, the route for any other answer will also be deleted

--- a/config/locales/input_objects/confirm_delete_exit_page.yml
+++ b/config/locales/input_objects/confirm_delete_exit_page.yml
@@ -1,0 +1,8 @@
+---
+en:
+  helpers:
+    label:
+      confirm_delete_exit_page_input:
+        options:
+          'no': No, return to edit route 1
+          'yes': Yes, delete the exit page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,8 @@ Rails.application.routes.draw do
           put "/:condition_id" => "pages/conditions#update", as: :update_condition
           get "/:condition_id/delete" => "pages/conditions#delete", as: :delete_condition
           delete "/:condition_id/delete" => "pages/conditions#destroy", as: :destroy_condition
+          get "/:condition_id/confirm-delete-exit-page" => "pages/conditions#confirm_delete_exit_page", as: :confirm_change_exit_page
+          post "/:condition_id/confirm-delete-exit-page" => "pages/conditions#update_change_exit_page", as: :update_change_exit_page
           get "/exit_page/new" => "pages/exit_page#new", as: :new_exit_page
           post "/exit_page/new" => "pages/exit_page#create", as: :create_exit_page
           get "/exit_page/:condition_id" => "pages/exit_page#edit", as: :edit_exit_page

--- a/spec/views/pages/conditions/confirm_delete_exit_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/confirm_delete_exit_page.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe "pages/conditions/confirm_delete_exit_page.html.erb" do
+  let(:form) { build :form, id: 1, pages: [page] }
+  let(:page) { build :page, id: 1, form_id: 1, position: 1 }
+  let(:exit_page_input) { Pages::DeleteExitPageInput.new }
+  let(:exit_page) { build :condition, :with_exit_page, id: 1 }
+
+  before do
+    assign(:current_form, form)
+    assign(:page, page)
+
+    render template: "pages/conditions/confirm_delete_exit_page", locals: {
+      answer_value: "answer",
+      goto_page_id: 1,
+      exit_page: exit_page,
+      delete_exit_page_input: exit_page_input,
+    }
+  end
+
+  it "sets the correct title" do
+    expect(view.content_for(:title)).to eq "Your exit page will be deleted"
+  end
+
+  it "contains page heading and sub-heading" do
+    expect(rendered).to have_css("h1 .govuk-caption-l", text: "Question 1’s routes")
+    expect(rendered).to have_css("h1.govuk-heading-l", text: "Your exit page will be deleted")
+  end
+
+  it "has a submit button" do
+    expect(rendered).to have_css("button[type='submit'].govuk-button", text: I18n.t("save_and_continue"))
+  end
+end


### PR DESCRIPTION
###  Changing a route that goes to an exit page to go to a question deletes the exit page

Trello card: https://trello.com/c/PioTk5zP/2259-add-page-for-deleting-exit-pages

This PR adds an extra screen when a route is changed from being an exit page to being a normal route.

When this happens, the users exit page content will be deleted. The new screen asks the user to confirm the change before their data is deleted.

![image](https://github.com/user-attachments/assets/371c2078-f034-48d5-9289-a9fe6f7d8eef)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
