### PR TITLE
WIP: Include page heading from guidance in the read only file upload question when the form is live

### DIFF
--- a/app/services/page_options_service.rb
+++ b/app/services/page_options_service.rb
@@ -16,7 +16,12 @@ class PageOptionsService
   def all_options_for_answer_type
     options = []
 
-    options.concat(page_heading_options) if @page.respond_to?(:page_heading) && @page.page_heading.present?
+    options.concat(page_heading_options) if @page.respond_to?(:page_heading) && @page.page_heading.present? && @page.answer_type != "file"
+
+    # if a file upload question has guidance text, we want to display the question text here. Otherwise we display the page heading
+    options.concat(page_heading_options) if @page.respond_to?(:page_heading) && @page.page_heading.present? && @page.answer_type == "file" && @page.guidance_markdown.blank?
+    options.concat(question_text_options) if @page.answer_type == "file" && @page.guidance_markdown.present?
+
     options.concat(guidance_markdown_options) if @page.respond_to?(:guidance_markdown) && @page.guidance_markdown.present?
 
     options.concat(hint_options) if @page.hint_text?.present?
@@ -37,6 +42,13 @@ private
     [{
       key: { text: I18n.t("page_options_service.page_heading") },
       value: { text: @page.page_heading },
+    }]
+  end
+
+  def question_text_options
+    [{
+      key: { text: I18n.t("reports.form_or_questions_list_table.headings.question_text") },
+      value: { text: @page.question_text },
     }]
   end
 

--- a/app/services/page_summary_card_data_service.rb
+++ b/app/services/page_summary_card_data_service.rb
@@ -24,6 +24,9 @@ class PageSummaryCardDataService
 private
 
   def build_title
+    # if a file upload question has guidance text, we want to display the guidance text in the title. Otherwise we display the question text
+    # TODO: what do we do about questions that are optional?
+    return "#{page_number(@page)}. #{@page.page_heading}" if @page.answer_type == "file" && @page.page_heading && @page.guidance_markdown.present?
     return "#{page_number(@page)}. #{@page.question_text}" unless @page.is_optional? && @page.answer_type != "selection"
 
     "#{page_number(@page)}. #{@page.question_text} (optional)"


### PR DESCRIPTION
### What problem does this pull request solve?

In read only mode: when a file upload question has guidance, we want to include the guidance page header in the title of the card so that it provides context to the question text


Trello card: https://trello.com/c/kuJBDdoU/2308-include-page-heading-from-guidance-in-the-read-only-file-upload-question-when-the-form-is-live

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
