### PR TITLE
Fix links for draft forms in feature reports

### DIFF
--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -72,7 +72,7 @@ private
 
   def report_forms_table_row(form)
     [
-      govuk_link_to(form["content"]["name"], live_form_pages_path(form_id: form["form_id"])),
+      form_link(form),
       form.dig("group", "organisation", "name") || "",
     ]
   end
@@ -90,5 +90,20 @@ private
       *report_forms_table_row(question["form"]),
       question["data"]["question_text"],
     ]
+  end
+
+  def form_link(form)
+    form_id = form["form_id"]
+    form_name = form["content"]["name"]
+    pages_path = case form["tag"]
+                 when "draft"
+                   form_pages_path(form_id:)
+                 when "live"
+                   live_form_pages_path(form_id:)
+                 else
+                   raise "tag of form record '#{form['tag']}' is not expected"
+                 end
+
+    govuk_link_to(form_name, pages_path)
   end
 end

--- a/spec/helpers/report_helpers_spec.rb
+++ b/spec/helpers/report_helpers_spec.rb
@@ -3,23 +3,23 @@ require "rails_helper"
 RSpec.describe ReportHelper, type: :helper do
   let(:forms) do
     [
-      { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
-      { "form_id" => 3, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Ministry of Tests" } } },
-      { "form_id" => 4, "content" => { "name" => "Skip route form" }, "group" => { "organisation" => { "name" => "Department for Testing" } } },
+      { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
+      { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Ministry of Tests" } } },
+      { "form_id" => 4, "tag" => "live", "content" => { "name" => "Skip route form" }, "group" => { "organisation" => { "name" => "Department for Testing" } } },
     ]
   end
 
   let(:forms_with_routes) do
     [
-      { "form_id" => 3, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Ministry of Tests" } }, "metadata" => { "number_of_routes" => 2, "number_of_branch_routes" => 1 } },
-      { "form_id" => 4, "content" => { "name" => "Skip route form" }, "group" => { "organisation" => { "name" => "Department for Testing" } }, "metadata" => { "number_of_routes" => 1, "number_of_branch_routes" => 0 } },
+      { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Ministry of Tests" } }, "metadata" => { "number_of_routes" => 2, "number_of_branch_routes" => 1 } },
+      { "form_id" => 4, "tag" => "live", "content" => { "name" => "Skip route form" }, "group" => { "organisation" => { "name" => "Department for Testing" } }, "metadata" => { "number_of_routes" => 1, "number_of_branch_routes" => 0 } },
     ]
   end
 
   let(:questions) do
     [
-      { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
-      { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Ministry of Tests" } } } },
+      { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
+      { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Ministry of Tests" } } } },
     ]
   end
 
@@ -129,6 +129,24 @@ RSpec.describe ReportHelper, type: :helper do
       ]
     end
 
+    context "when the form is live" do
+      it "formats a link to the live form pages" do
+        form = forms.first.merge("tag" => "live")
+        expect(helper.report_forms_table_rows([form]).first.first).to eq(
+          "<a class=\"govuk-link\" href=\"/forms/1/live/pages\">All question types form</a>",
+        )
+      end
+    end
+
+    context "when the form is a draft" do
+      it "formats a link to the form pages" do
+        form = forms.first.merge("tag" => "draft")
+        expect(helper.report_forms_table_rows([form]).first.first).to eq(
+          "<a class=\"govuk-link\" href=\"/forms/1/pages\">All question types form</a>",
+        )
+      end
+    end
+
     it "includes the organisation name for each form for the second column of each row" do
       expect(helper.report_forms_table_rows(forms).map(&:second)).to eq [
         "Government Digital Service",
@@ -140,7 +158,7 @@ RSpec.describe ReportHelper, type: :helper do
     context "when form is not in a group" do
       let(:forms) do
         [
-          { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => nil },
+          { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => nil },
         ]
       end
 
@@ -214,7 +232,7 @@ RSpec.describe ReportHelper, type: :helper do
     context "when form is not in a group" do
       let(:forms) do
         [
-          { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => nil },
+          { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => nil },
         ]
       end
 
@@ -268,7 +286,7 @@ RSpec.describe ReportHelper, type: :helper do
     context "when form is not in a group" do
       let(:questions) do
         [
-          { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => nil } },
+          { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => nil } },
         ]
       end
 

--- a/spec/views/reports/feature_report.html.erb_spec.rb
+++ b/spec/views/reports/feature_report.html.erb_spec.rb
@@ -16,8 +16,8 @@ describe "reports/feature_report" do
     let(:report) { "forms_with_csv_submission_enabled" }
     let(:records) do
       [
-        { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
-        { "form_id" => 3, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
+        { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
+        { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
       ]
     end
 
@@ -43,6 +43,28 @@ describe "reports/feature_report" do
           { "Form name" => "Branch route form", "Organisation" => "Government Digital Service" },
         ]
       end
+
+      context "with live forms" do
+        let(:tag) { "live" }
+
+        it "has links for each form" do
+          expect(rendered).to have_table do |table|
+            expect(table).to have_link "All question types form", href: live_form_pages_path(1)
+            expect(table).to have_link "Branch route form", href: live_form_pages_path(3)
+          end
+        end
+      end
+
+      context "with draft forms" do
+        let(:tag) { "draft" }
+
+        it "has links for each form" do
+          expect(rendered).to have_table do |table|
+            expect(table).to have_link "All question types form", href: form_pages_path(1)
+            expect(table).to have_link "Branch route form", href: form_pages_path(3)
+          end
+        end
+      end
     end
   end
 
@@ -50,8 +72,8 @@ describe "reports/feature_report" do
     let(:report) { "forms_with_payments" }
     let(:records) do
       [
-        { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
-        { "form_id" => 3, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
+        { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
+        { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
       ]
     end
 
@@ -77,6 +99,28 @@ describe "reports/feature_report" do
           { "Form name" => "Branch route form", "Organisation" => "Government Digital Service" },
         ]
       end
+
+      context "with live forms" do
+        let(:tag) { "live" }
+
+        it "has links for each form" do
+          expect(rendered).to have_table do |table|
+            expect(table).to have_link "All question types form", href: live_form_pages_path(1)
+            expect(table).to have_link "Branch route form", href: live_form_pages_path(3)
+          end
+        end
+      end
+
+      context "with draft forms" do
+        let(:tag) { "draft" }
+
+        it "has links for each form" do
+          expect(rendered).to have_table do |table|
+            expect(table).to have_link "All question types form", href: form_pages_path(1)
+            expect(table).to have_link "Branch route form", href: form_pages_path(3)
+          end
+        end
+      end
     end
   end
 
@@ -84,8 +128,8 @@ describe "reports/feature_report" do
     let(:report) { "forms_with_routes" }
     let(:records) do
       [
-        { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } }, "metadata" => { "number_of_routes" => 1 } },
-        { "form_id" => 3, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } }, "metadata" => { "number_of_routes" => 2 } },
+        { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } }, "metadata" => { "number_of_routes" => 1 } },
+        { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } }, "metadata" => { "number_of_routes" => 2 } },
       ]
     end
 
@@ -111,6 +155,28 @@ describe "reports/feature_report" do
           { "Form name" => "Branch route form", "Organisation" => "Government Digital Service", "Number of routes" => "2" },
         ]
       end
+
+      context "with live forms" do
+        let(:tag) { "live" }
+
+        it "has links for each form" do
+          expect(rendered).to have_table do |table|
+            expect(table).to have_link "All question types form", href: live_form_pages_path(1)
+            expect(table).to have_link "Branch route form", href: live_form_pages_path(3)
+          end
+        end
+      end
+
+      context "with draft forms" do
+        let(:tag) { "draft" }
+
+        it "has links for each form" do
+          expect(rendered).to have_table do |table|
+            expect(table).to have_link "All question types form", href: form_pages_path(1)
+            expect(table).to have_link "Branch route form", href: form_pages_path(3)
+          end
+        end
+      end
     end
   end
 
@@ -118,8 +184,8 @@ describe "reports/feature_report" do
     let(:report) { "questions_with_add_another_answer" }
     let(:records) do
       [
-        { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
-        { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
+        { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
+        { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
       ]
     end
 
@@ -153,6 +219,28 @@ describe "reports/feature_report" do
           { "Form name" => "All question types form", "Organisation" => "Government Digital Service", "Question text" => "Email address" },
           { "Form name" => "Branch route form", "Organisation" => "Government Digital Service", "Question text" => "What’s your email address?" },
         ]
+      end
+
+      context "with live forms" do
+        let(:tag) { "live" }
+
+        it "has links for each form" do
+          expect(rendered).to have_table do |table|
+            expect(table).to have_link "All question types form", href: live_form_pages_path(1)
+            expect(table).to have_link "Branch route form", href: live_form_pages_path(3)
+          end
+        end
+      end
+
+      context "with draft forms" do
+        let(:tag) { "draft" }
+
+        it "has links for each form" do
+          expect(rendered).to have_table do |table|
+            expect(table).to have_link "All question types form", href: form_pages_path(1)
+            expect(table).to have_link "Branch route form", href: form_pages_path(3)
+          end
+        end
       end
     end
   end

--- a/spec/views/reports/feature_report.html.erb_spec.rb
+++ b/spec/views/reports/feature_report.html.erb_spec.rb
@@ -36,25 +36,12 @@ describe "reports/feature_report" do
       expect(rendered).to have_link("Download data about all live forms with CSV submission enabled as a CSV file", href: report_forms_with_csv_submission_enabled_path(format: :csv))
     end
 
-    describe "questions table" do
-      it "has the correct headers" do
-        page = Capybara.string(rendered.html)
-        within(page.find(".govuk-table__head")) do
-          expect(page.find_all(".govuk-table__header"[0])).to have_text "Form name"
-          expect(page.find_all(".govuk-table__header"[1])).to have_text "Organisation"
-        end
-      end
-
-      it "has rows for each question" do
-        page = Capybara.string(rendered.html)
-        within(page.find_all(".govuk-table__row")[1]) do
-          expect(page.find_all(".govuk-table__cell"[0])).to have_text "All question types form"
-          expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
-        end
-        within(page.find_all(".govuk-table__row")[2]) do
-          expect(page.find_all(".govuk-table__cell"[0])).to have_text "Branch route form"
-          expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
-        end
+    describe "forms table" do
+      it "has rows for each form" do
+        expect(rendered).to have_table with_rows: [
+          { "Form name" => "All question types form", "Organisation" => "Government Digital Service" },
+          { "Form name" => "Branch route form", "Organisation" => "Government Digital Service" },
+        ]
       end
     end
   end
@@ -83,25 +70,12 @@ describe "reports/feature_report" do
       expect(rendered).to have_link("Download data about all live forms with payments as a CSV file", href: report_forms_with_payments_path(format: :csv))
     end
 
-    describe "questions table" do
-      it "has the correct headers" do
-        page = Capybara.string(rendered.html)
-        within(page.find(".govuk-table__head")) do
-          expect(page.find_all(".govuk-table__header"[0])).to have_text "Form name"
-          expect(page.find_all(".govuk-table__header"[1])).to have_text "Organisation"
-        end
-      end
-
-      it "has rows for each question" do
-        page = Capybara.string(rendered.html)
-        within(page.find_all(".govuk-table__row")[1]) do
-          expect(page.find_all(".govuk-table__cell"[0])).to have_text "All question types form"
-          expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
-        end
-        within(page.find_all(".govuk-table__row")[2]) do
-          expect(page.find_all(".govuk-table__cell"[0])).to have_text "Branch route form"
-          expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
-        end
+    describe "forms table" do
+      it "has rows for each form" do
+        expect(rendered).to have_table with_rows: [
+          { "Form name" => "All question types form", "Organisation" => "Government Digital Service" },
+          { "Form name" => "Branch route form", "Organisation" => "Government Digital Service" },
+        ]
       end
     end
   end
@@ -130,28 +104,12 @@ describe "reports/feature_report" do
       expect(rendered).to have_link("Download data about all live forms with routes as a CSV file", href: report_forms_with_routes_path(format: :csv))
     end
 
-    describe "questions table" do
-      it "has the correct headers" do
-        page = Capybara.string(rendered.html)
-        within(page.find(".govuk-table__head")) do
-          expect(page.find_all(".govuk-table__header"[0])).to have_text "Form name"
-          expect(page.find_all(".govuk-table__header"[1])).to have_text "Organisation"
-          expect(page.find_all(".govuk-table__header"[2])).to have_text "Number of routes"
-        end
-      end
-
-      it "has rows for each question" do
-        page = Capybara.string(rendered.html)
-        within(page.find_all(".govuk-table__row")[1]) do
-          expect(page.find_all(".govuk-table__cell"[0])).to have_text "All question types form"
-          expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
-          expect(page.find_all(".govuk-table__cell"[2])).to have_text "1"
-        end
-        within(page.find_all(".govuk-table__row")[2]) do
-          expect(page.find_all(".govuk-table__cell"[0])).to have_text "Branch route form"
-          expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
-          expect(page.find_all(".govuk-table__cell"[2])).to have_text "2"
-        end
+    describe "forms table" do
+      it "has rows for each forms" do
+        expect(rendered).to have_table with_rows: [
+          { "Form name" => "All question types form", "Organisation" => "Government Digital Service", "Number of routes" => "1" },
+          { "Form name" => "Branch route form", "Organisation" => "Government Digital Service", "Number of routes" => "2" },
+        ]
       end
     end
   end
@@ -160,8 +118,8 @@ describe "reports/feature_report" do
     let(:report) { "questions_with_add_another_answer" }
     let(:records) do
       [
-        { "type" => "question_page", "data" => { "question_text" => "email address" }, "form" => { "form_id" => 1, "content" => { "name" => "all question types form" }, "group" => { "organisation" => { "name" => "government digital service" } } } },
-        { "type" => "question_page", "data" => { "question_text" => "what’s your email address?" }, "form" => { "form_id" => 3, "content" => { "name" => "branch route form" }, "group" => { "organisation" => { "name" => "government digital service" } } } },
+        { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
+        { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
       ]
     end
 
@@ -184,24 +142,17 @@ describe "reports/feature_report" do
       it "has the correct headers" do
         page = Capybara.string(rendered.html)
         within(page.find(".govuk-table__head")) do
-          expect(page.find_all(".govuk-table__header"[0])).to have_text "Form name"
-          expect(page.find_all(".govuk-table__header"[1])).to have_text "Organisation"
-          expect(page.find_all(".govuk-table__header"[2])).to have_text "Question text"
+          expect(page.find_all(".govuk-table__header")[0]).to have_text "Form name"
+          expect(page.find_all(".govuk-table__header")[1]).to have_text "Organisation"
+          expect(page.find_all(".govuk-table__header")[2]).to have_text "Question text"
         end
       end
 
       it "has rows for each question" do
-        page = Capybara.string(rendered.html)
-        within(page.find_all(".govuk-table__row")[1]) do
-          expect(page.find_all(".govuk-table__cell"[0])).to have_text "All question types form"
-          expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
-          expect(page.find_all(".govuk-table__cell"[2])).to have_text "Email address"
-        end
-        within(page.find_all(".govuk-table__row")[2]) do
-          expect(page.find_all(".govuk-table__cell"[0])).to have_text "Branch route form"
-          expect(page.find_all(".govuk-table__cell"[1])).to have_text "Government Digital Service"
-          expect(page.find_all(".govuk-table__cell"[2])).to have_text "What's your email address?"
-        end
+        expect(rendered).to have_table with_rows: [
+          { "Form name" => "All question types form", "Organisation" => "Government Digital Service", "Question text" => "Email address" },
+          { "Form name" => "Branch route form", "Organisation" => "Government Digital Service", "Question text" => "What’s your email address?" },
+        ]
       end
     end
   end

--- a/spec/views/reports/questions_with_answer_type.html.erb_spec.rb
+++ b/spec/views/reports/questions_with_answer_type.html.erb_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "reports/questions_with_answer_type" do
   let(:questions) do
     [
-      { "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
-      { "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
+      { "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
+      { "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
     ]
   end
   let(:tag) { "live" }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/moEwoMm8/2242-add-usage-report-for-branching-feature <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Previously we were using the live form pages path for all forms in feature reports tables, but for draft forms this is a 404, and forms which are live with draft this might have the wrong information.

Instead we should link to the form pages path.

This PR changes our code to use the correct path, it also fixes a bug in our specs I found while working on this.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?