### PR TITLE
Find user by email using case insensitive search

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,7 +53,7 @@ class User < ApplicationRecord
 
   def self.find_for_auth(attributes)
     user = where(provider: attributes[:provider], uid: attributes[:uid]).first ||
-      where(email: attributes[:email]).first
+      where("lower(email) = ?", attributes[:email].downcase).first
 
     if user
       user.assign_attributes(attributes)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -142,7 +142,7 @@ describe User, type: :model do
 
   describe ".find_for_auth" do
     let!(:user) do
-      create :user, provider: "test", uid: "123456", name: "Test User", email: "test@example.com"
+      create :user, provider: "test", uid: "123456", name: "Test User", email: "test.User@example.com"
     end
 
     it "finds a user by uid" do
@@ -155,8 +155,8 @@ describe User, type: :model do
         .not_to eq user
     end
 
-    it "finds a user by email address if no user with uid is found" do
-      expect(described_class.find_for_auth(uid: "111111", email: "test@example.com"))
+    it "finds a user by email address, ignoring the case, when no user is found with uid" do
+      expect(described_class.find_for_auth(uid: "111111", email: "Test.user@example.com"))
         .to eq user
 
       expect(user.reload.uid).to eq "111111"
@@ -192,7 +192,7 @@ describe User, type: :model do
         provider: "test",
         uid: "111111",
         name: "Test A. User",
-        email: "test@example.com",
+        email: "test.User@example.com",
       )
 
       expect(Rails.logger).to have_received(:info).with("User attributes updated upon authorisation", {


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/JP626N1I/2604-consistently-treat-emails-as-case-insensitive-in-forms-admin

On the User model, we have a constraint `uniqueness: { case_sensitive: false }` which treats emails case insensitively. However, we are looking up users using the email from the authentication provider case sensitively.

This inconsistency led to an incident on 12 Dec 2024 where a user had two user accounts with different cases - i.e. a.user@example.gov.uk and a.User@example.gov.uk, and this meant that when they tried to log in they received an error and could not proceed.

We want to prevent things like this happening in future. We decided that the solution was to always treat the email as case insensitive. While email addresses are technically case-senstive, we decided that this was the best solution because:

Auth0 already lowercases most emails by default (so the email addresses that we recieve are already being treated as case insensitive in some places)

We think it is very likely that most government email accounts are already case insensitive, as this is how common email providers treat email addresses

We think this matches how most users perceive email addresses

We already treat emails as case-insensitive in other places (for example, when adding users to groups).

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
