### PR TITLE
Allow email addresses to wrap rather than oveflow

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -157,7 +157,7 @@ module ApplicationHelper
 
     content_tag :ul, class: "govuk-list govuk-list--bullet" do
       admin_emails.map { |email|
-        content_tag :li do
+        content_tag :li, class: "govuk-!-text-break-word" do
           mail_to(email)
         end
       }.join.html_safe

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -48,7 +48,7 @@
     <h3 class="govuk-heading-m"><%= t("made_live_form.how_you_get_completed_forms") %></h3>
 
     <h4 class="govuk-heading-s"><%= t('made_live_form.submission_email') %></h4>
-    <p><%= form.submission_email %></p>
+    <p class="govuk-!-text-break-word"><%= form.submission_email %></p>
 
     <h4 class="govuk-heading-s"><%= t("made_live_form.csv") %></h4>
     <p><%= t("made_live_form.submission_type.#{form.submission_type}") %></p>
@@ -60,7 +60,7 @@
 
     <% if form.support_email %>
       <h4 class="govuk-heading-s"><%= t('made_live_form.support_email') %></h4>
-      <p><%= form.support_email %></p>
+      <p class="govuk-!-text-break-word"><%= form.support_email %></p>
     <% end %>
 
     <% if form.support_phone %>

--- a/app/views/forms/submission_email/submission_email_code_sent.html.erb
+++ b/app/views/forms/submission_email/submission_email_code_sent.html.erb
@@ -1,11 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(title_text:  t("page_titles.email_code_sent")) %>
-    <%= t('email_code_sent.body_html', temp_email: @submission_email_input.temporary_submission_email) %>
+    <p><%= t('email_code_sent.body_html', temp_email: @submission_email_input.temporary_submission_email) %></p>
 
     <h2 class="govuk-heading-m"><%= t("email_code_sent.sub_heading") %></h2>
 
-    <%= t("email_code_sent.what_happens_next_body_html") %>
+    <p><%= t("email_code_sent.what_happens_next") %></p>
 
     <p><%= govuk_link_to "Enter the email address confirmation code", submission_email_code_path(@submission_email_input.form.id) %></p>
 

--- a/app/views/forms/submission_email/submission_email_confirmed.html.erb
+++ b/app/views/forms/submission_email/submission_email_confirmed.html.erb
@@ -5,7 +5,7 @@
     <% if live_submission_email_updated %>
       <%= simple_format(t("email_code_success.live_submission_email_changed_body_html", new_submission_email: @submission_email_input.form.submission_email)) %>
     <% else %>
-      <%= simple_format(t('email_code_success.body_html', submission_email: @submission_email_input.form.submission_email)) %>
+      <%= simple_format(t('email_code_success.body_html', submission_email: @submission_email_input.form.submission_email), class: "govuk-!-text-break-word") %>
     <% end %>
 
     <p><%= govuk_link_to(t('email_code_success.continue'), form_path) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,7 +171,7 @@ en:
         <ul class="govuk-list govuk-list--bullet">
           <li>links to the form will no longer work - make sure any links to the form have been removed</li>
           <li>anyone who is part way through completing the form will lose their progress and get an error page</li>
-          <li>we’ll send an email to %{submission_email} to let them know the form has been archived</li>
+          <li>we’ll send an email to <span class="govuk-!-text-break-word">%{submission_email}</span> to let them know the form has been archived</li>
         </ul>
         <p>You will still be able to preview the form and see its information and settings. You can also make a new draft of the form and make it live again if you need to.</p>
       radios_legend: Are you sure you want to archive this form?
@@ -274,15 +274,15 @@ en:
           knowledge, the answers you’re providing are correct.
         </div>
   email_code_sent:
-    body_html: "<p>We’ve sent a confirmation code and your email address to %{temp_email}.</p>\n"
+    body_html: We’ve sent a confirmation code and your email address to <span class="govuk-!-text-break-word">%{temp_email}</span>.
     continue: Continue creating a form
     sub_heading: What you need to do next
-    what_happens_next_body_html: "<p>The recipient will be asked to give you the code. You need to enter the code to confirm the email address.</p>\n"
+    what_happens_next: The recipient will be asked to give you the code. You need to enter the code to confirm the email address.
   email_code_success:
-    body_html: Completed forms will be sent to %{submission_email}.
+    body_html: Completed forms will be sent to <span class="govuk-!-text-break-word">%{submission_email}</span>.
     continue: Continue creating a form
     live_submission_email_changed_body_html: |
-      When you make this draft form live, completed forms will be sent to %{new_submission_email}.
+      When you make this draft form live, completed forms will be sent to <span class="govuk-!-text-break-word">%{new_submission_email}</span>.
 
       When you make the form live, we’ll send an email to the previous email address to let them know they’ll no longer receive completed forms.
   environment_names:
@@ -363,7 +363,7 @@ en:
       email_address_section:
         confirm_email: Enter the email address confirmation code
         email: Set the email address completed forms will be sent to
-        hint_text_html: Completed forms will be sent to:<br> %{submission_email}
+        hint_text_html: Completed forms will be sent to:<br> <span class="govuk-!-text-break-word">%{submission_email}</span>
         title: Set up how you get completed forms
       make_form_live_section:
         group_not_active:
@@ -406,7 +406,7 @@ en:
       email_address_section:
         confirm_email: Enter the email address confirmation code
         email: Edit the email address completed forms will be sent to
-        hint_text_html: Completed forms will be sent to:<br> %{submission_email}
+        hint_text_html: Completed forms will be sent to:<br> <span class="govuk-!-text-break-word">%{submission_email}</span>
         title: Change how you get completed forms
       make_form_live_section:
         make_live: Make your changes live
@@ -890,7 +890,7 @@ en:
         </p>
 
         <p>
-          After you have made your form live, completed forms will be sent to %{submission_email}.
+          After you have made your form live, completed forms will be sent to <span class="govuk-!-text-break-word">%{submission_email}</span>.
         </p>
   make_changes_live:
     confirmation:
@@ -925,7 +925,7 @@ en:
         </p>
 
         <p>
-          After you have made your form live, completed forms will be sent to %{submission_email}.
+          After you have made your form live, completed forms will be sent to <span class="govuk-!-text-break-word">%{submission_email}</span>.
         </p>
   mark_complete:
     'false': No, I’ll come back later
@@ -1638,7 +1638,7 @@ en:
         </p>
 
         <p>
-          After you have made your form live, completed forms will be sent to %{submission_email}.
+          After you have made your form live, completed forms will be sent to <span class="govuk-!-text-break-word">%{submission_email}</span>.
         </p>
   users:
     act_as_user_html: Act as this user <span class="govuk-visually-hidden">%{user_email}</span>


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/O48UNuIf

So that email addresses don't overflow the page on small displays, add the `govuk-!-text-break-word` class wherever we display email addresses.

This works in all places other than in the draft form task list where emails still cause the task list to overflow.

Before:

<img width="341" alt="Screenshot 2025-06-18 at 12 04 21" src="https://github.com/user-attachments/assets/55c31e22-d40a-478f-9f01-482bcc75b0ed" />

After:

<img width="341" alt="Screenshot 2025-06-18 at 12 03 51" src="https://github.com/user-attachments/assets/b8703ce1-b55d-453f-a2cf-d7bf413c9a52" />

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
