### PR TITLE
Add validation errors to Google analytics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,9 @@ class ApplicationController < ActionController::Base
   before_action :set_paper_trail_whodunnit
   before_action :redirect_if_account_not_completed
 
+  after_action :set_analytics_events
+  before_action :prepare_analytics_events
+
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   add_flash_types :success
@@ -149,5 +152,15 @@ private
     end
     CurrentLoggingAttributes.form_id = params[:form_id] if params[:form_id].present?
     CurrentLoggingAttributes.page_id = params[:page_id] if params[:page_id].present?
+  end
+
+  def set_analytics_events
+    return unless response.redirect?
+
+    flash[:analytics_events] = Current.analytics_events if Current.analytics_events.present?
+  end
+
+  def prepare_analytics_events
+    AnalyticsService.add_events_from_flash(flash[:analytics_events]) if flash[:analytics_events].present?
   end
 end

--- a/app/input_objects/base_input.rb
+++ b/app/input_objects/base_input.rb
@@ -8,5 +8,8 @@ private
 
   def set_validation_error_logging_attributes
     CurrentLoggingAttributes.validation_errors = errors.map { |error| "#{error.attribute}: #{error.type}" } if errors.any?
+    errors.each do |error|
+      AnalyticsService.track_validation_errors(input_object_name: self.class.name, field: error.attribute, error_type: error.type)
+    end
   end
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,16 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :analytics_events
+
+  def initialize_analytics_events
+    self.analytics_events ||= []
+  end
+
+  def add_analytics_event(name, properties = {})
+    initialize_analytics_events
+    self.analytics_events << { name: name, properties: properties }
+  end
+
+  def clear_analytics_events
+    self.analytics_events = []
+  end
+end

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,0 +1,29 @@
+class AnalyticsService
+  class << self
+    def track_validation_errors(input_object_name:, field:, error_type:)
+      add_event("validation_error", {
+        event_name: "validation_error",
+        form_name: input_object_name,
+        error_field: field,
+        error_type: error_type,
+      })
+    end
+
+    def add_events_from_flash(flash)
+      flash.each do |event|
+        add_event(
+          event["name"] || event[:name],
+          event["properties"] || event[:properties],
+        )
+      end
+    end
+
+    delegate :analytics_events, to: :Current
+
+  private
+
+    def add_event(name, properties)
+      Current.add_analytics_event(name, properties)
+    end
+  end
+end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -60,6 +60,19 @@
     <%= vite_client_tag %>
     <%= vite_javascript_tag 'application' %>
 
+    <% if AnalyticsService.analytics_events.present? && @current_user&.collect_analytics? %>
+      <script data-analytics-events>
+        window.dataLayer = window.dataLayer || [];
+
+        <% AnalyticsService.analytics_events.each do |event| %>
+            window.dataLayer.push({
+              event: "event_data",
+              event_data: <%= raw event[:properties].to_json %>,
+            });
+      <% end %>
+      </script>
+    <% end %>
+
     <%= yield :body_end %>
   <% end %>
 </html>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -69,7 +69,7 @@
               event: "event_data",
               event_data: <%= raw event[:properties].to_json %>,
             });
-      <% end %>
+        <% end %>
       </script>
     <% end %>
 

--- a/spec/input_objects/base_input_spec.rb
+++ b/spec/input_objects/base_input_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+class TestInput < BaseInput
+  attr_accessor :name, :email
+
+  validates :name, presence: true
+  validates :email, format: { with: /.*@.*/, message: "must be a valid email address" }
+end
+
+RSpec.describe BaseInput do
+  describe "validation error logging" do
+    let(:analytics_service) { class_double(AnalyticsService).as_stubbed_const }
+
+    before do
+      allow(CurrentLoggingAttributes).to receive(:validation_errors=)
+      allow(analytics_service).to receive(:track_validation_errors)
+    end
+
+    context "when there are no validation errors" do
+      let(:input) { TestInput.new(name: "John Doe", email: "john@example.com") }
+
+      it "is valid" do
+        expect(input).to be_valid
+      end
+
+      it "does not log validation errors" do
+        input.valid?
+        expect(CurrentLoggingAttributes).not_to have_received(:validation_errors=)
+      end
+
+      it "does not track validation errors" do
+        input.valid?
+        expect(analytics_service).not_to have_received(:track_validation_errors)
+      end
+    end
+
+    context "when there are validation errors" do
+      let(:input) { TestInput.new }
+
+      it "is invalid" do
+        expect(input).to be_invalid
+      end
+
+      it "sets validation errors on CurrentLoggingAttributes" do
+        input.valid?
+
+        expect(CurrentLoggingAttributes).to have_received(:validation_errors=)
+          .with(array_including("name: blank", "email: invalid"))
+      end
+
+      it "tracks each validation error through AnalyticsService" do
+        input.valid?
+
+        expect(analytics_service).to have_received(:track_validation_errors)
+          .with(input_object_name: "TestInput", field: :name, error_type: :blank)
+
+        expect(analytics_service).to have_received(:track_validation_errors)
+          .with(input_object_name: "TestInput", field: :email, error_type: :invalid)
+      end
+    end
+  end
+end

--- a/spec/models/current_spec.rb
+++ b/spec/models/current_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe Current do
+  # Reset Current after each test to avoid state leaking between tests
+  after do
+    described_class.reset
+  end
+
+  describe ".initialize_analytics_events" do
+    it "initializes analytics_events as an empty array if nil" do
+      expect(described_class.analytics_events).to be_nil
+      described_class.initialize_analytics_events
+      expect(described_class.analytics_events).to eq([])
+    end
+
+    it "does not overwrite existing analytics_events array" do
+      described_class.analytics_events = ["existing event"]
+      described_class.initialize_analytics_events
+      expect(described_class.analytics_events).to eq(["existing event"])
+    end
+  end
+
+  describe ".add_analytics_event" do
+    it "adds an event with name and properties to analytics_events" do
+      described_class.add_analytics_event("page_view", { url: "/home" })
+
+      expect(described_class.analytics_events).to eq([
+        { name: "page_view", properties: { url: "/home" } },
+      ])
+    end
+
+    it "allows adding multiple events" do
+      described_class.add_analytics_event("login", { user_id: 123 })
+      described_class.add_analytics_event("page_view", { url: "/dashboard" })
+
+      expect(described_class.analytics_events).to eq([
+        { name: "login", properties: { user_id: 123 } },
+        { name: "page_view", properties: { url: "/dashboard" } },
+      ])
+    end
+
+    it "initializes analytics_events if nil" do
+      expect(described_class.analytics_events).to be_nil
+      described_class.add_analytics_event("test")
+      expect(described_class.analytics_events).to be_an(Array)
+      expect(described_class.analytics_events.length).to eq(1)
+    end
+
+    it "accepts an event with no properties" do
+      described_class.add_analytics_event("simple_event")
+      expect(described_class.analytics_events).to eq([
+        { name: "simple_event", properties: {} },
+      ])
+    end
+  end
+
+  describe ".clear_analytics_events" do
+    it "clears all analytics events" do
+      described_class.add_analytics_event("event1")
+      described_class.add_analytics_event("event2")
+
+      expect(described_class.analytics_events.length).to eq(2)
+
+      described_class.clear_analytics_events
+      expect(described_class.analytics_events).to eq([])
+    end
+
+    it "works when analytics_events is nil" do
+      expect(described_class.analytics_events).to be_nil
+      described_class.clear_analytics_events
+      expect(described_class.analytics_events).to eq([])
+    end
+  end
+
+  describe "ActiveSupport::CurrentAttributes behavior" do
+    it "isolates attributes between threads" do
+      # This test demonstrates the core behavior of CurrentAttributes
+      described_class.add_analytics_event("main_thread")
+
+      thread = Thread.new do
+        described_class.add_analytics_event("background_thread")
+        described_class.analytics_events
+      end
+
+      thread_events = thread.value
+
+      # The background thread should have its own isolated events
+      expect(thread_events).to eq([{ name: "background_thread", properties: {} }])
+
+      # The main thread should still have only its events
+      expect(described_class.analytics_events).to eq([{ name: "main_thread", properties: {} }])
+    end
+  end
+end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -69,6 +69,35 @@ RSpec.describe PagesController, type: :request do
         expect(response.status).to eq(403)
       end
     end
+
+    describe "when there are validation errors" do
+      let(:routing_condition) { [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 99, check_page_id: 99, goto_page_id: 101)] }
+      let(:collect_analytics) { true }
+
+      before do
+        allow(standard_user).to receive(:collect_analytics?).and_return(collect_analytics)
+
+        pages.first.routing_conditions = routing_condition
+        group.group_forms.create!(form_id: form.id)
+        get form_pages_path(2)
+      end
+
+      context "when analytics is enabled" do
+        it "sends the validation errors to analytics" do
+          page = Capybara.string(response.body)
+          expect(page).to have_css("[data-analytics-events]", text: /answer_value_doesnt_exist/, visible: :all)
+        end
+      end
+
+      context "when analytics is not enabled" do
+        let(:collect_analytics) { false }
+
+        it "does not send the validation errors to analytics" do
+          page = Capybara.string(response.body)
+          expect(page).not_to have_css("[data-analytics-events]", text: /answer_value_doesnt_exist/, visible: :all)
+        end
+      end
+    end
   end
 
   describe "#start_new_question" do

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -35,8 +35,21 @@ RSpec.describe PagesController, type: :request do
 
     before do
       allow(FormRepository).to receive_messages(find: form, pages: pages)
+    end
 
-      get form_pages_path(2)
+    context "with a form in a group that the user is a member of" do
+      before do
+        group.group_forms.create!(form_id: form.id)
+        get form_pages_path(form.id)
+      end
+
+      it "returns a 200 status code" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the pages#index template" do
+        expect(response).to render_template("pages/index")
+      end
     end
 
     context "with a form in a group that the user is not a member of" do

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe AnalyticsService do
+  describe ".track_validation_errors" do
+    it "adds a validation_error event with correct parameters" do
+      input_object_name = "user_form"
+      field = "email"
+      error_type = "invalid_format"
+      expected_event_name = "validation_error"
+      expected_properties = {
+        form_name: input_object_name,
+        event_name: "validation_error",
+        error_field: field,
+        error_type: error_type,
+      }
+
+      expect(described_class).to receive(:add_event).with(
+        expected_event_name,
+        expected_properties,
+      )
+
+      described_class.track_validation_errors(
+        input_object_name: input_object_name,
+        field: field,
+        error_type: error_type,
+      )
+    end
+  end
+
+  describe ".add_events_from_flash" do
+    context "with string keys in flash" do
+      it "adds each flash event to analytics events" do
+        flash = [
+          {
+            "name" => "flash_event_1",
+            "properties" => { "key1" => "value1" },
+          },
+          {
+            "name" => "flash_event_2",
+            "properties" => { "key2" => "value2" },
+          },
+        ]
+
+        flash.each do |event|
+          expect(described_class).to receive(:add_event).with(
+            event["name"],
+            event["properties"],
+          )
+        end
+
+        described_class.add_events_from_flash(flash)
+      end
+    end
+
+    context "with symbol keys in flash" do
+      it "adds each flash event to analytics events" do
+        flash = [
+          {
+            name: "flash_event_1",
+            properties: { key1: "value1" },
+          },
+          {
+            name: "flash_event_2",
+            properties: { key2: "value2" },
+          },
+        ]
+
+        flash.each do |event|
+          expect(described_class).to receive(:add_event).with(
+            event[:name],
+            event[:properties],
+          )
+        end
+
+        described_class.add_events_from_flash(flash)
+      end
+    end
+
+    context "with mixed string and symbol keys" do
+      it "handles mixed key types correctly" do
+        flash = [
+          {
+            "name" => "flash_event_1",
+            "properties" => { "key1" => "value1" },
+          },
+          {
+            name: "flash_event_2",
+            properties: { key2: "value2" },
+          },
+        ]
+
+        expect(described_class).to receive(:add_event).with(
+          "flash_event_1",
+          { "key1" => "value1" },
+        )
+        expect(described_class).to receive(:add_event).with(
+          "flash_event_2",
+          { key2: "value2" },
+        )
+
+        described_class.add_events_from_flash(flash)
+      end
+    end
+
+    context "with empty flash" do
+      it "does not call add_analytics_event" do
+        flash = []
+
+        expect(described_class).not_to receive(:add_event)
+        described_class.add_events_from_flash(flash)
+      end
+    end
+  end
+
+  describe ".analytics_events" do
+    it "delegates to Current.analytics_events" do
+      mock_events = [{ name: "test_event", properties: { key: "value" } }]
+      allow(Current).to receive(:analytics_events).and_return(mock_events)
+
+      expect(described_class.analytics_events).to eq(mock_events)
+    end
+  end
+
+  describe ".add_event" do
+    it "calls Current.add_analytics_event with the correct parameters" do
+      event_name = "test_event"
+      event_properties = { key: "value" }
+
+      expect(Current).to receive(:add_analytics_event).with(event_name, event_properties)
+
+      described_class.send(:add_event, event_name, event_properties)
+    end
+  end
+end

--- a/spec/views/layouts/base.html.erb_spec.rb
+++ b/spec/views/layouts/base.html.erb_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+describe "layouts/base.html.erb" do
+  let(:analytics_events) { [] }
+  let(:user) { instance_double(User, collect_analytics?: true) }
+
+  before do
+    without_partial_double_verification do
+      allow(view).to receive_messages(
+        success: false,
+      )
+    end
+    allow(AnalyticsService).to receive(:analytics_events).and_return(analytics_events)
+    assign(:current_user, user)
+  end
+
+  context "when analytics events are present and user allows analytics collection" do
+    let(:analytics_events) do
+      [
+        { properties: { action: "view_page", page: "home" } },
+        { properties: { action: "click_button", button: "submit" } },
+      ]
+    end
+
+    it "renders the analytics script tag" do
+      render
+      expect(rendered).to have_css("script[data-analytics-events]", visible: :all)
+    end
+
+    it "includes the correct datalayer events" do
+      render
+
+      analytics_script = Capybara.string(rendered).find("script[data-analytics-events]", visible: :all).text
+
+      expect(analytics_script).to include("\"view_page\"")
+      expect(analytics_script).to include("\"home\"")
+
+      expect(analytics_script).to include("\"click_button\"")
+      expect(analytics_script).to include("\"submit\"")
+    end
+  end
+
+  context "when analytics events are not present" do
+    let(:analytics_events) { [] }
+
+    it "does not render the analytics script tag" do
+      render
+      expect(rendered).not_to have_selector("script[data-analytics-events]")
+    end
+  end
+
+  context "when collect_analytics? is false" do
+    let(:analytics_events) do
+      [{ properties: { action: "view_page", page: "home" } }]
+    end
+    let(:user) { instance_double(User, collect_analytics?: false) }
+
+    it "does not render the analytics script tag" do
+      render
+      expect(rendered).not_to have_selector("script[data-analytics-events]")
+    end
+  end
+
+  context "when user is nil" do
+    let(:analytics_events) do
+      [{ properties: { action: "view_page", page: "home" } }]
+    end
+
+    before do
+      assign(:current_user, nil)
+    end
+
+    it "does not render the analytics script tag" do
+      render
+      expect(rendered).not_to have_selector("script[data-analytics-events]")
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/b6jmnphx/2288-track-branching-validation-errors

This PR adds a way to pass analytics events from backend code to the frontend. It then uses this to add validation error tracking to all `input objects` and the routing and condition errors found on the pagelist.

This is marked as WIP because I think we need Anne to review the event names and properties before merging.

I think we can still review the technical approach though.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
