### PR TITLE
2336 remove feature flag for exit pages

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -27,7 +27,7 @@ class Pages::ConditionsController < PagesController
     condition_input = Pages::ConditionsInput.new(condition_input_params)
 
     if condition_input.submit
-      if condition_input.create_exit_page? && FeatureService.new(group: current_form.group).enabled?(:exit_pages)
+      if condition_input.create_exit_page?
         redirect_to new_exit_page_path(current_form.id, page.id, answer_value: condition_input.answer_value)
       else
         # TODO: Route number is hardcoded whilst we can only have one value for it
@@ -61,7 +61,7 @@ class Pages::ConditionsController < PagesController
     end
 
     if condition_input.update_condition
-      if condition_input.create_exit_page? && FeatureService.new(group: current_form.group).enabled?(:exit_pages)
+      if condition_input.create_exit_page?
         redirect_to edit_exit_page_path(current_form.id, page.id, condition.id)
       else
         redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_updated", question_number: condition_input.page.position)

--- a/app/controllers/pages/exit_page_controller.rb
+++ b/app/controllers/pages/exit_page_controller.rb
@@ -1,6 +1,5 @@
 class Pages::ExitPageController < PagesController
   before_action :can_add_page_routing, only: %i[new create delete destroy]
-  before_action :ensure_exit_pages_enabled
   before_action :ensure_answer_value_present, only: %i[new create]
 
   def new
@@ -82,10 +81,6 @@ private
 
   def can_add_page_routing
     authorize current_form, :can_add_page_routing_conditions?
-  end
-
-  def ensure_exit_pages_enabled
-    raise ActionController::RoutingError, "exit_pages feature not enabled" unless FeatureService.new(group: current_form.group).enabled?(:exit_pages)
   end
 
   def exit_page_input_params

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,6 @@
 class Group < ApplicationRecord
+  self.ignored_columns += [:exit_pages_enabled]
+
   belongs_to :organisation
 
   belongs_to :creator, class_name: "User", optional: true

--- a/app/views/pages/conditions/_routing_options.html.erb
+++ b/app/views/pages/conditions/_routing_options.html.erb
@@ -1,12 +1,4 @@
-<% exit_pages_enabled = FeatureService.new(group: form.group).enabled?(:exit_pages) %>
-
-<% if exit_pages_enabled %>
-  <% body_text = t("routing_page.exit_pages.body_html") %>
-  <% hint_text = t("routing_page.exit_pages.legend_hint_text") %>
-  <% else %>
-  <% body_text = t("routing_page.body_html") %>
-  <% hint_text = t("routing_page.legend_hint_text") %>
-<% end %>
+<% hint_text = t("routing_page.legend_hint_text") %>
 
 <%= form_with(model: routing_page_input, url: set_routing_page_path(form.id), method: 'POST') do |f| %>
   <% if routing_page_input&.errors.any? %>
@@ -18,7 +10,7 @@
     <%= t("page_titles.routing_page") %>
   </h1>
 
-  <%= body_text %>
+  <%= t("routing_page.body_html")  %>
 
   <% if form.qualifying_route_pages.length <= 10 %>
     <%= f.govuk_collection_radio_buttons :routing_page_id,

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -24,38 +24,34 @@
       end %>
 
       <%= f.govuk_collection_select :answer_value, condition_input.routing_answer_options, :value, :label, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_answer_value") } %>
-      
-      <% unless FeatureService.new(group: condition_input.form.group).enabled?(:exit_pages) %>
-        <%= f.govuk_collection_select :goto_page_id, condition_input.goto_page_options, :id, :question_text, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") } %>
-      <% else %>
-        <%= f.govuk_select(:goto_page_id, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") }) do %>
-          <% condition_input.goto_page_options.each do |option| %>
-            <option value=<%= option.id %> <% if condition_input.record.goto_page_id == option.id || (condition_input.record.skip_to_end? && option.id == "check_your_answers") %>selected<% end %>>
-              <%= option.question_text %>
-            </option>
-          <% end %>
-          <% unless condition_input.secondary_skip? %>
-            <optgroup label="<%= I18n.t("page_conditions.exit_page_label") %>">
-              <% if condition_input.record.exit_page? %>
-                <option value="exit_page" <% if condition_input.record.exit_page? %>selected<% end %>>
-                  <%= condition_input.record.exit_page_heading %>
-                </option>
-              <% else %>
-                <option value="create_exit_page">
-                  <%= I18n.t("page_conditions.exit_page") %>
-                </option>
-              <% end %>
-            </optgroup>
-          <% end %>
-        <% end %>
 
-        <% if condition_input.record.exit_page? %>
-          <p class="govuk-body">
-            <%= govuk_link_to t("page_conditions.edit_exit_page", exit_page_heading: condition_input.record.exit_page_heading), edit_exit_page_path(condition_input.form.id, condition_input.page.id, condition_input.record.id) %>
-          </p>
+      <%= f.govuk_select(:goto_page_id, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") }) do %>
+        <% condition_input.goto_page_options.each do |option| %>
+          <option value=<%= option.id %> <% if condition_input.record.goto_page_id == option.id || (condition_input.record.skip_to_end? && option.id == "check_your_answers") %>selected<% end %>>
+          <%= option.question_text %>
+          </option>
+        <% end %>
+        <% unless condition_input.secondary_skip? %>
+          <optgroup label="<%= I18n.t("page_conditions.exit_page_label") %>">
+            <% if condition_input.record.exit_page? %>
+              <option value="exit_page" <% if condition_input.record.exit_page? %>selected<% end %>>
+              <%= condition_input.record.exit_page_heading %>
+              </option>
+            <% else %>
+              <option value="create_exit_page">
+              <%= I18n.t("page_conditions.exit_page") %>
+              </option>
+            <% end %>
+          </optgroup>
         <% end %>
       <% end %>
-      
+
+      <% if condition_input.record.exit_page? %>
+        <p class="govuk-body">
+          <%= govuk_link_to t("page_conditions.edit_exit_page", exit_page_heading: condition_input.record.exit_page_heading), edit_exit_page_path(condition_input.form.id, condition_input.page.id, condition_input.record.id) %>
+        </p>
+      <% end %>
+
       <%= f.govuk_submit t("save_and_continue") do
         govuk_button_link_to "Delete route", delete_condition_path(condition_input.form.id, condition_input.page.id, condition_input.record.id), warning: true
       end %>

--- a/app/views/pages/conditions/new.html.erb
+++ b/app/views/pages/conditions/new.html.erb
@@ -25,21 +25,17 @@
       end %>
 
       <%= f.govuk_collection_select :answer_value, condition_input.routing_answer_options, :value, :label, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_answer_value") } %>
-      <% unless FeatureService.new(group: condition_input.form.group).enabled?(:exit_pages) %>
-        <%= f.govuk_collection_select :goto_page_id, condition_input.goto_page_options, :id, :question_text, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") } %> 
-      <% else %>
-        <%= f.govuk_select(:goto_page_id, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") }) do %>
-          <% condition_input.goto_page_options.each do |option| %>
-            <option value=<%= option.id %>>
-              <%= option.question_text %>
-            </option>
-          <% end %>
-          <optgroup label="<%= I18n.t("page_conditions.exit_page_label") %>">
-            <option value="create_exit_page">
-              <%= I18n.t("page_conditions.exit_page") %>
-            </option>
-          </optgroup>
+      <%= f.govuk_select(:goto_page_id, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") }) do %>
+        <% condition_input.goto_page_options.each do |option| %>
+          <option value=<%= option.id %>>
+          <%= option.question_text %>
+          </option>
         <% end %>
+        <optgroup label="<%= I18n.t("page_conditions.exit_page_label") %>">
+          <option value="create_exit_page">
+          <%= I18n.t("page_conditions.exit_page") %>
+          </option>
+        </optgroup>
       <% end %>
 
       <%= f.govuk_submit t("save_and_continue") %>

--- a/app/views/pages/conditions/routing_page.html.erb
+++ b/app/views/pages/conditions/routing_page.html.erb
@@ -2,13 +2,6 @@
 <% content_for :back_link, govuk_back_link_to(form_pages_path(form.id)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% exit_pages_enabled = FeatureService.new(group: form.group).enabled?(:exit_pages) %>
-
-    <% if exit_pages_enabled %>
-      <% prefix = 'exit_pages.' %>
-    <% else %>
-      <% prefix = '' %>
-    <% end %>
 
     <% if policy(form).can_add_page_routing_conditions? %>
       <%= render partial: "pages/conditions/routing_options", locals: {form:, routing_page_input:} %>
@@ -18,9 +11,9 @@
         <%= t("page_titles.routing_page") %>
       </h1>
 
-      <%= t("routing_page.#{prefix}body_html") %>
+      <%= t("routing_page.body_html") %>
 
-      <%= t("routing_page.#{prefix}#{form.has_no_remaining_routes_available? ? 'no_remaining_routes' : 'routing_requirements_not_met'}_html") %>
+      <%= t("routing_page.#{form.has_no_remaining_routes_available? ? 'no_remaining_routes' : 'routing_requirements_not_met'}_html") %>
     <% end %>
 
     <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1494,53 +1494,25 @@ en:
       title: Number of users per organisation
   routing_page:
     body_html: |
-      <p>You can add a route to a question so if someone selects one specific
-      answer, they’ll be skipped forward to a later question, or the end of
-      the form.</p>
+      <p> You can add a route to a question so if someone selects one specific answer, they’ll be skipped to: </p>
 
-      <p>People who select any other answer will continue to the next question
-      and through the rest of the form. If you need to, you can add a second
-      route to make them skip some of the questions you sent the first route
-      to.</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li> a later question </li>
+        <li> the end of the form </li>
+        <li> an ‘exit page’ to remove them from the form - for example, because they’re not eligible </li>
+      </ul>
 
-      <p>These two routes can only start from a question where people select
-      one option from a list.</p>
+      <p> People who select any other answer will continue to the next question and through the rest of the form. </p>
     dropdown_default_text: Select a question to start your route from
-    exit_pages:
-      body_html: |
-        <p> You can add a route to a question so if someone selects one specific answer, they’ll be skipped to: </p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li> a later question </li>
-          <li> the end of the form </li>
-          <li> an ‘exit page’ to remove them from the form - for example, because they’re not eligible </li>
-        </ul>
-
-        <p> People who select any other answer will continue to the next question and through the rest of the form. </p>
-      legend_hint_text: A route can only start from a question where people select one option from a list. Go back to your questions if you need to edit an existing route.
-      no_remaining_routes_html: |
-        <h2 class="govuk-heading-m">You have no more questions to add a route from</h2>
-        <p>A route can only start from a question where people select one option from a list. If you need to edit an existing route, go back to your questions.</p>
-      routing_requirements_not_met_html: |
-        <h2 class="govuk-heading-m">You cannot add a route yet</h2>
-
-        <p>A route can only start from a question that:</p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>asks people to select only one option from a list</li>
-          <li>has at least one question after it</li>
-        </ul>
-
-        <p>It’s usually easiest to create all your form’s questions first, then add the routes you need.</p>
-    legend_hint_text: A route can only start from a question where people select one item from a list. You can only add one route from each question.
+    legend_hint_text: A route can only start from a question where people select one option from a list. Go back to your questions if you need to edit an existing route.
     legend_text: Which question do you want to add a route from?
     no_remaining_routes_html: |
       <h2 class="govuk-heading-m">You have no more questions to add a route from</h2>
-      <p>You can only add a route from a question that does not already have 2 routes. If you need to edit an existing route, go back to your questions.</p>
+      <p>A route can only start from a question where people select one option from a list. If you need to edit an existing route, go back to your questions.</p>
     routing_requirements_not_met_html: |
       <h2 class="govuk-heading-m">You cannot add a route yet</h2>
 
-      <p>Before you can add a route, your form needs to have a question that:</p>
+      <p>A route can only start from a question that:</p>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>asks people to select only one option from a list</li>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,3 @@
-features:
-  exit_pages: true
-
 forms_api:
   # URL to form-api endpoints
   base_url: http://localhost:9292

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,6 +1,3 @@
-features:
-  exit_pages: true
-
 # Use real authentication
 auth_provider: gds_sso
 

--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -56,7 +56,7 @@ namespace :groups do
 
   desc "List enabled features for groups"
   task features: :environment do
-    feature_flags = %i[exit_pages_enabled welsh_enabled]
+    feature_flags = %i[welsh_enabled]
     query = feature_flags.map { "#{it} IS TRUE" }.join(" OR ")
 
     Group.where(query).find_each do |group|
@@ -67,24 +67,6 @@ namespace :groups do
         **group.slice(feature_flags),
       }.to_json)
     end
-  end
-
-  desc "Enable exit_pages feature for group"
-  task :enable_exit_pages, %i[group_id] => :environment do |_, args|
-    usage_message = "usage: rake groups:enable_exit_pages[<group_external_id>]".freeze
-    abort usage_message if args[:group_id].blank?
-
-    Group.find_by(external_id: args[:group_id]).update!(exit_pages_enabled: true)
-    Rails.logger.info("Updated exit_pages_enabled to true for group #{args[:group_id]}")
-  end
-
-  desc "Disable exit_pages feature for group"
-  task :disable_exit_pages, %i[group_id] => :environment do |_, args|
-    usage_message = "usage: rake groups:disable_exit_pages[<group_external_id>]".freeze
-    abort usage_message if args[:group_id].blank?
-
-    Group.find_by(external_id: args[:group_id]).update!(exit_pages_enabled: false)
-    Rails.logger.info("Updated exit_pages_enabled to false for group #{args[:group_id]}")
   end
 
   desc "Enable welsh feature for group"

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,7 +22,6 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    include_examples expected_value_test, :exit_pages, features, { "enabled_by_group" => true }
     include_examples expected_value_test, :welsh, features, { "enabled_by_group" => true }
   end
 

--- a/spec/factories/models/groups.rb
+++ b/spec/factories/models/groups.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     organisation { association :organisation, id: 1, slug: "test-org" }
     creator { association :user, organisation: }
     status { :trial }
-    exit_pages_enabled { false }
 
     trait :org_has_org_admin do
       organisation { association :organisation, :with_org_admin, id: 1, slug: "test-org" }

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
     context "when the goto page is an exit page" do
       let(:params) { { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: "create_exit_page", answer_value: "Wales" } } }
-      let(:group) { create(:group, organisation: standard_user.organisation, exit_pages_enabled: true) }
+      let(:group) { create(:group, organisation: standard_user.organisation) }
 
       it "redirects to the new exit page" do
         expect(response).to redirect_to new_exit_page_path(form:, page:, answer_value: "Wales")
@@ -297,7 +297,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     context "when the form is submitted creates an exit page" do
-      let(:group) { create(:group, organisation: standard_user.organisation, exit_pages_enabled: true) }
+      let(:group) { create(:group, organisation: standard_user.organisation) }
       let(:params) { { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: "create_exit_page", answer_value: "Wales" } } }
 
       it "redirects to the edit exit page" do

--- a/spec/requests/pages/exit_page_controller_spec.rb
+++ b/spec/requests/pages/exit_page_controller_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
   let(:selected_page) { page }
   let(:answer_value) { "Option 1" }
 
-  let(:exit_pages_enabled) { true }
-
-  let(:group) { create(:group, organisation: standard_user.organisation, exit_pages_enabled:) }
+  let(:group) { create(:group, organisation: standard_user.organisation) }
   let(:user) { standard_user }
   let(:condition) { build(:condition, id: 1, form_id: form.id, page_id: page.id, exit_page_heading: "Exit Page Heading") }
 
@@ -51,14 +49,6 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
       it "Returns a 403 status" do
         expect(response.status).to eq(403)
-      end
-    end
-
-    context "when group the form is in should not be allowed to add exit pages" do
-      let(:exit_pages_enabled) { false }
-
-      it "Returns a 404 status" do
-        expect(response.status).to eq(404)
       end
     end
 
@@ -122,14 +112,6 @@ RSpec.describe Pages::ExitPageController, type: :request do
         expect(response.status).to eq(403)
       end
     end
-
-    context "when group the form is in should not be allowed to add exit pages" do
-      let(:exit_pages_enabled) { false }
-
-      it "Returns a 404 status" do
-        expect(response.status).to eq(404)
-      end
-    end
   end
 
   describe "#edit" do
@@ -143,14 +125,6 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
     it "renders the edit exit page template" do
       expect(response).to render_template("pages/exit_page/edit")
-    end
-
-    context "when the group the form is in should not be allowed to manipulate exit pages" do
-      let(:exit_pages_enabled) { false }
-
-      it "Returns a 404 status" do
-        expect(response.status).to eq(404)
-      end
     end
   end
 
@@ -171,14 +145,6 @@ RSpec.describe Pages::ExitPageController, type: :request do
     it "displays success message" do
       follow_redirect!
       expect(response.body).to include(I18n.t("banner.success.exit_page_updated"))
-    end
-
-    context "when the group the form is in should not be allowed to manipulate exit pages" do
-      let(:exit_pages_enabled) { false }
-
-      it "Returns a 404 status" do
-        expect(response.status).to eq(404)
-      end
     end
 
     context "when form submit fails" do
@@ -224,14 +190,6 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
       it "returns a 403 status" do
         expect(response.status).to eq(403)
-      end
-    end
-
-    context "when group the form is in should not be allowed to add/delete exit pages" do
-      let(:exit_pages_enabled) { false }
-
-      it "returns a 404 status" do
-        expect(response.status).to eq(404)
       end
     end
   end
@@ -301,14 +259,6 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
       it "returns a 403 status" do
         expect(response.status).to eq(403)
-      end
-    end
-
-    context "when group the form is in should not be allowed to add/delete exit pages" do
-      let(:exit_pages_enabled) { false }
-
-      it "returns a 404 status" do
-        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/views/pages/conditions/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/edit.html.erb_spec.rb
@@ -60,31 +60,27 @@ describe "pages/conditions/edit.html.erb" do
     end
   end
 
-  context "with exit pages enabled" do
-    let(:group) { build :group, exit_pages_enabled: true }
+  context "when the condition does not have an exit page" do
+    let(:condition) { build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
 
-    context "when the condition does not have an exit page" do
-      let(:condition) { build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
-
-      it "has an 'add exit page' option" do
-        expect(rendered).to have_content("Add an exit page")
-      end
+    it "has an 'add exit page' option" do
+      expect(rendered).to have_content("Add an exit page")
     end
+  end
 
-    context "when the condition has an exit page" do
-      let(:condition) { build :condition, :with_exit_page, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales" }
+  context "when the condition has an exit page" do
+    let(:condition) { build :condition, :with_exit_page, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales" }
 
-      it "has the exit page heading" do
-        expect(rendered).to have_content(condition.exit_page_heading)
-      end
+    it "has the exit page heading" do
+      expect(rendered).to have_content(condition.exit_page_heading)
     end
+  end
 
-    context "when the page already has a secondary skip route" do
-      let(:secondary_skip) { true }
+  context "when the page already has a secondary skip route" do
+    let(:secondary_skip) { true }
 
-      it "does not have an 'add exit page' option" do
-        expect(rendered).not_to have_content("Add an exit page")
-      end
+    it "does not have an 'add exit page' option" do
+      expect(rendered).not_to have_content("Add an exit page")
     end
   end
 end

--- a/spec/views/pages/conditions/new.html.erb_spec.rb
+++ b/spec/views/pages/conditions/new.html.erb_spec.rb
@@ -36,11 +36,7 @@ describe "pages/conditions/new.html.erb" do
     expect(rendered).to have_css("button[type='submit'].govuk-button", text: I18n.t("save_and_continue"))
   end
 
-  context "when the exit page feature is enabled" do
-    let(:group) { build :group, exit_pages_enabled: true }
-
-    it "has an exit page option" do
-      expect(rendered).to have_css("option[value='create_exit_page']", text: I18n.t("page_conditions.exit_page"))
-    end
+  it "has an exit page option" do
+    expect(rendered).to have_css("option[value='create_exit_page']", text: I18n.t("page_conditions.exit_page"))
   end
 end

--- a/spec/views/pages/conditions/routing_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/routing_page.html.erb_spec.rb
@@ -24,14 +24,12 @@ describe "pages/conditions/routing_page.html.erb" do
     expect(rendered).to have_css("h1.govuk-heading-l", text: t("page_titles.routing_page"))
   end
 
-  it "contains content explaining branch routing" do
-    expect(rendered).to have_text "You can add a route to a question so if someone selects one specific answer, they’ll be skipped forward to a later question, or the end of the form.", normalize_ws: true
+  it "contains content explaining branch routing and exit pages" do
+    expect(rendered).to have_text "You can add a route to a question so if someone selects one specific answer, they’ll be skipped to: ", normalize_ws: true
   end
 
-  context "when exit pages are enabled", :feature_exit_pages do
-    it "contains content for exit pages" do
-      expect(rendered).to have_text "an ‘exit page’ to remove them from the form - for example, because they’re not eligible ", normalize_ws: true
-    end
+  it "contains content for exit pages" do
+    expect(rendered).to have_text "an ‘exit page’ to remove them from the form - for example, because they’re not eligible ", normalize_ws: true
   end
 
   context "with fewer than 10 options" do
@@ -99,22 +97,6 @@ describe "pages/conditions/routing_page.html.erb" do
       it "explains to the user that they have created all available routes" do
         guidance = Capybara.string(I18n.t("routing_page.no_remaining_routes_html").to_s).text(normalize_ws: true)
         expect(rendered).to have_text(guidance, normalize_ws: true)
-      end
-    end
-
-    context "when exit_pages is enabled", :feature_exit_pages do
-      it "explains to the user what is required for them to be able to add a new routes" do
-        guidance = Capybara.string(I18n.t("routing_page.exit_pages.routing_requirements_not_met_html")).text(normalize_ws: true)
-        expect(rendered).to have_text(guidance, normalize_ws: true)
-      end
-
-      context "when all qualifying questions have a route" do
-        let(:all_routes_created) { true }
-
-        it "explains to the user that they have created all available routes" do
-          guidance = Capybara.string(I18n.t("routing_page.exit_pages.no_remaining_routes_html")).text(normalize_ws: true)
-          expect(rendered).to have_text(guidance, normalize_ws: true)
-        end
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/y7g5N9Yn/2336-remove-feature-flag-for-exit-pages

Remove the exit_pages feature flag now the feature has been released.

This PR ignores the column on groups for the feature flag.

A later PR will actually drop the column.

When reviewing, we should double check this works the way we expect it to. The PR to remove the branch_routing feature flag caused an incident when deployed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
