### PR TITLE
Improve payment link success banner

### DIFF
--- a/app/controllers/forms/payment_link_controller.rb
+++ b/app/controllers/forms/payment_link_controller.rb
@@ -10,9 +10,11 @@ module Forms
     def create
       authorize current_form, :can_view_form?
       @payment_link_input = PaymentLinkInput.new(payment_link_input_params)
+      previous_payment_url = current_form.payment_url
 
       if @payment_link_input.submit
-        redirect_to form_path(@payment_link_input.form.id), success: t("banner.success.form.payment_link_saved")
+        success_message = success_message(previous_payment_url, @payment_link_input.payment_url)
+        redirect_to form_path(@payment_link_input.form.id), success: success_message
       else
         render :new, status: :unprocessable_entity
       end
@@ -22,6 +24,13 @@ module Forms
 
     def payment_link_input_params
       params.require(:forms_payment_link_input).permit(:payment_url).merge(form: current_form)
+    end
+
+    def success_message(previous_payment_url, new_payment_url)
+      return t("banner.success.form.payment_link_saved") if new_payment_url.present? && new_payment_url != previous_payment_url
+      return t("banner.success.form.payment_link_removed") if new_payment_url.blank? && previous_payment_url.present?
+
+      nil
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,7 @@ en:
         page_moved: "‘%{question_text}’ has moved %{direction} to number %{question_number}"
         pages_saved: Your questions have been saved
         pages_saved_and_section_completed: Your questions have been saved and marked as complete
+        payment_link_removed: Your payment link has been removed
         payment_link_saved: Your payment link has been saved
         privacy_details_saved: Your privacy information link has been saved
         receive_csv_disabled: Completed form emails will not include a CSV file


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/jqw4cWbh/2380-misleading-success-banner-when-you-dont-add-a-payment-link

Don't show the banner when no payment link has been added, or the payment link is unchanged.

If there was a payment link and it has been removed, display a success banner indicating this.

New success banner when a payment link is removed:

<img width="1028" alt="Screenshot 2025-06-23 at 10 28 44" src="https://github.com/user-attachments/assets/2ad4bc3f-bd2e-4478-9bde-8156fdf5100c" />

Existing success banner when a payment link is added or changed:

<img width="1028" alt="Screenshot 2025-06-23 at 10 28 30" src="https://github.com/user-attachments/assets/db91c01b-097a-4890-8cab-cb26664ea894" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
