### PR TITLE
Drop column exit_pages_enabled from groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,4 @@
 class Group < ApplicationRecord
-  self.ignored_columns += [:exit_pages_enabled]
-
   belongs_to :organisation
 
   belongs_to :creator, class_name: "User", optional: true

--- a/db/migrate/20250623081911_remove_exit_pages_enabled_from_groups.rb
+++ b/db/migrate/20250623081911_remove_exit_pages_enabled_from_groups.rb
@@ -1,0 +1,5 @@
+class RemoveExitPagesEnabledFromGroups < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :groups, :exit_pages_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_05_141500) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_23_081911) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -110,7 +110,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_141500) do
     t.string "status", default: "trial"
     t.bigint "creator_id"
     t.bigint "upgrade_requester_id"
-    t.boolean "exit_pages_enabled", default: false
     t.boolean "welsh_enabled", default: false
     t.index ["creator_id"], name: "index_groups_on_creator_id"
     t.index ["external_id"], name: "index_groups_on_external_id", unique: true


### PR DESCRIPTION
Trello card: https://trello.com/c/y7g5N9Yn/2336-remove-feature-flag-for-exit-pages

The feature is now fully enabled by default. The feature flag has been removed from the codebase.

The column has been ignored in the model so there should be no caching issues when the PR is deployed.


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
