### PR TITLE
Show selection options in a details component on the readonly questions view

### DIFF
--- a/app/frontend/styles/_app_summary_card.scss
+++ b/app/frontend/styles/_app_summary_card.scss
@@ -12,12 +12,16 @@
     @include govuk-font($size: 16);
   }
 
+  .govuk-summary-list .govuk-details__summary {
+    @include govuk-font($size: 16);
+  }
+
   // Remove last item’s bottom border on mobile
   .govuk-summary-list__row:last-child {
     border-bottom: 0;
   }
 
-  // Remove lsat item’s bottom border on tablet and larger
+  // Remove last item’s bottom border on tablet and larger
   .govuk-summary-list__row:last-child > * {
     border-bottom: 0;
   }

--- a/app/services/page_options_service.rb
+++ b/app/services/page_options_service.rb
@@ -87,12 +87,15 @@ private
     options << I18n.t("page_options_service.selection_type.none_of_the_above") if @page.is_optional?
     formatted_list = html_unordered_list(options)
 
-    return formatted_list if options.length <= 10
-
-    details_summary = I18n.t("page_settings_summary.selection.options_summary", number_of_options: options.length)
-    GovukComponent::DetailsComponent.new(summary_text: details_summary)
-                                    .with_content(formatted_list)
-                                    .call
+    if options.length > 10
+      details_summary = I18n.t("page_settings_summary.selection.options_summary", number_of_options: options.length)
+      GovukComponent::DetailsComponent.new(summary_text: details_summary)
+                                      .with_content(formatted_list)
+                                      .call
+    else
+      caption = content_tag(:p, I18n.t("page_settings_summary.selection.options_count", number_of_options: options.length), class: "govuk-body-s")
+      safe_join([caption, formatted_list])
+    end
   end
 
   def text_options
@@ -183,7 +186,7 @@ private
   end
 
   def html_unordered_list(list_items)
-    content_tag(:ul, html_list_item(list_items), class: "govuk-list")
+    content_tag(:ul, html_list_item(list_items), class: ["govuk-list", "govuk-list--bullet"])
   end
 
   def html_list_item(item)

--- a/app/services/page_options_service.rb
+++ b/app/services/page_options_service.rb
@@ -84,18 +84,23 @@ private
     return @page.show_selection_options unless @page.answer_settings.selection_options.length >= 1
 
     options = @page.answer_settings.selection_options.map { |option| option.attributes[:name] }
-    options << "#{I18n.t('page_options_service.selection_type.none_of_the_above')}</li>" if @page.is_optional?
-    formatted_list = options.join("</li><li>")
+    options << I18n.t("page_options_service.selection_type.none_of_the_above") if @page.is_optional?
+    formatted_list = html_unordered_list(options)
 
-    ActionController::Base.helpers.sanitize("<ul class='govuk-list'><li>#{formatted_list}</li></ul>")
+    return formatted_list if options.length <= 10
+
+    details_summary = I18n.t("page_settings_summary.selection.options_summary", number_of_options: options.length)
+    GovukComponent::DetailsComponent.new(summary_text: details_summary)
+                                    .with_content(formatted_list)
+                                    .call
   end
 
   def text_options
-    [{ key:  { text: I18n.t("page_options_service.answer_type") }, value:  { text: I18n.t("helpers.label.page.text_settings_options.names.#{@page.answer_settings.input_type}") } }]
+    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: I18n.t("helpers.label.page.text_settings_options.names.#{@page.answer_settings.input_type}") } }]
   end
 
   def date_options
-    [{ key:  { text: I18n.t("page_options_service.answer_type") }, value:  { text: date_answer_type_text } }]
+    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: date_answer_type_text } }]
   end
 
   def date_answer_type_text
@@ -105,11 +110,11 @@ private
   end
 
   def address_options
-    [{ key:  { text: I18n.t("page_options_service.answer_type") }, value:  { text: I18n.t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}") } }]
+    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: I18n.t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}") } }]
   end
 
   def name_options
-    [{ key:  { text: I18n.t("page_options_service.answer_type") }, value:  { text: name_answer_type } }]
+    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: name_answer_type } }]
   end
 
   def name_answer_type
@@ -175,6 +180,10 @@ private
 
   def html_ordered_list(list_items)
     content_tag(:ol, html_list_item(list_items), class: ["govuk-list", "govuk-list--number"])
+  end
+
+  def html_unordered_list(list_items)
+    content_tag(:ul, html_list_item(list_items), class: "govuk-list")
   end
 
   def html_list_item(item)

--- a/spec/services/page_options_service_spec.rb
+++ b/spec/services/page_options_service_spec.rb
@@ -110,8 +110,8 @@ describe PageOptionsService do
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
-          { key:  { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list, one option only" } },
-          { key:  { text: I18n.t("page_options_service.options_title") }, value: { text: "<ul class=\"govuk-list\"><li>Option 1</li><li>Option 2</li></ul>" } },
+          { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list, one option only" } },
+          { key: { text: I18n.t("page_options_service.options_title") }, value: { text: "<ul class=\"govuk-list\"><li>Option 1</li><li>Option 2</li></ul>" } },
         ])
       end
     end
@@ -128,8 +128,34 @@ describe PageOptionsService do
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
-          { key:  { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list" } },
-          { key:  { text: "Options" }, value: { text: "<ul class=\"govuk-list\"><li>Option 1</li><li>Option 2</li></ul>" } },
+          { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list" } },
+          { key: { text: "Options" }, value: { text: "<ul class=\"govuk-list\"><li>Option 1</li><li>Option 2</li></ul>" } },
+        ])
+      end
+    end
+
+    context "with selection with more than ten options" do
+      let(:option_names) { Array.new(11).each_with_index.map { |_element, index| "Option #{index}" } }
+      let(:selection_options) { option_names.map { |option| OpenStruct.new(attributes: { name: option }) } }
+      let(:page) do
+        build :page,
+              is_optional: "false",
+              answer_type: "selection",
+              answer_settings: OpenStruct.new(only_one_option: "false", selection_options:)
+      end
+
+      it "returns the options in a details component" do
+        expected_list_items = "<li>#{option_names.join('</li><li>')}</li>"
+
+        expected_options_html = "<details class=\"govuk-details\"><summary class=\"govuk-details__summary\">" \
+          "<span class=\"govuk-details__summary-text\">Show 11 options</span></summary>" \
+          "<div class=\"govuk-details__text\"><ul class=\"govuk-list\">" \
+          "#{expected_list_items}" \
+          "</ul></div></details>"
+
+        expect(page_options_service.all_options_for_answer_type).to eq([
+          { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list" } },
+          { key: { text: "Options" }, value: { text: expected_options_html } },
         ])
       end
     end
@@ -173,7 +199,7 @@ describe PageOptionsService do
 
         it "returns the correct options" do
           expect(page_options_service.all_options_for_answer_type).to eq([
-            { key:  { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: I18n.t("helpers.label.page.answer_type_options.names.#{answer_type}") } },
+            { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: I18n.t("helpers.label.page.answer_type_options.names.#{answer_type}") } },
           ])
         end
       end
@@ -193,7 +219,7 @@ describe PageOptionsService do
 
         it "returns the correct options" do
           expect(page_options_service.all_options_for_answer_type).to include(
-            { key:  { text: "Answer type" }, value: { text: "Email address" } },
+            { key: { text: "Answer type" }, value: { text: "Email address" } },
           )
         end
       end
@@ -203,7 +229,7 @@ describe PageOptionsService do
 
         it "returns the correct options" do
           expect(page_options_service.all_options_for_answer_type).to include(
-            { key:  { text: "Answer type" }, value: { text: "Email address" } },
+            { key: { text: "Answer type" }, value: { text: "Email address" } },
           )
         end
       end

--- a/spec/services/page_options_service_spec.rb
+++ b/spec/services/page_options_service_spec.rb
@@ -111,7 +111,7 @@ describe PageOptionsService do
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list, one option only" } },
-          { key: { text: I18n.t("page_options_service.options_title") }, value: { text: "<ul class=\"govuk-list\"><li>Option 1</li><li>Option 2</li></ul>" } },
+          { key: { text: I18n.t("page_options_service.options_title") }, value: { text: "<p class=\"govuk-body-s\">2 options:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Option 1</li><li>Option 2</li></ul>" } },
         ])
       end
     end
@@ -129,7 +129,7 @@ describe PageOptionsService do
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list" } },
-          { key: { text: "Options" }, value: { text: "<ul class=\"govuk-list\"><li>Option 1</li><li>Option 2</li></ul>" } },
+          { key: { text: "Options" }, value: { text: "<p class=\"govuk-body-s\">2 options:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Option 1</li><li>Option 2</li></ul>" } },
         ])
       end
     end
@@ -149,7 +149,7 @@ describe PageOptionsService do
 
         expected_options_html = "<details class=\"govuk-details\"><summary class=\"govuk-details__summary\">" \
           "<span class=\"govuk-details__summary-text\">Show 11 options</span></summary>" \
-          "<div class=\"govuk-details__text\"><ul class=\"govuk-list\">" \
+          "<div class=\"govuk-details__text\"><ul class=\"govuk-list govuk-list--bullet\">" \
           "#{expected_list_items}" \
           "</ul></div></details>"
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

On the readonly questions page for a live form, show the options for a "Select from a list of options" question in a details component if there are more than 10 options.

The count for the number of options includes the "None of the above" option, if one is present, as we include that in the list.

Also, as we do on the edit question page, display the list of options for a selection question as a bulleted list.

When there are 10 or fewer options and we do not use the details component, have a paragraph before the list stating the number of options as we do on the edit question page.

Before:

<img width="594" alt="Screenshot 2025-06-23 at 14 29 24" src="https://github.com/user-attachments/assets/84234827-29e6-4634-b437-c92cdc91e6ec" />

After:

<img width="672" alt="Screenshot 2025-06-23 at 12 54 43" src="https://github.com/user-attachments/assets/c1fa26ef-a2ab-4ac2-a06f-89a60451105b" />

<img width="676" alt="Screenshot 2025-06-23 at 12 54 48" src="https://github.com/user-attachments/assets/87d51880-8f01-4ac0-adc6-5e2a7726f2a7" />


<img width="709" alt="Screenshot 2025-06-23 at 12 55 00" src="https://github.com/user-attachments/assets/3cb33acf-cd8f-4b14-8e23-df9678468c2b" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
