### PR TITLE
Add notification banner when deleting route with exit page

### DIFF
--- a/app/views/pages/conditions/delete.html.erb
+++ b/app/views/pages/conditions/delete.html.erb
@@ -10,6 +10,10 @@
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
           <% banner.with_heading(text: t(".any_other_answer_warning")) %>
         <% end %>
+      <% elsif delete_condition_input.record.exit_page? %>
+        <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+          <% banner.with_heading(text: t(".exit_page_warning")) %>
+        <% end %>
       <% end %>
 
       <h1 class="govuk-heading-l">
@@ -28,7 +32,7 @@
         end;
         summary_list.with_row do |row|
           row.with_key { t(".skip_to_key") }
-          row.with_value { delete_condition_input.goto_page_question_text }
+          row.with_value { delete_condition_input.record.exit_page? ? delete_condition_input.record.exit_page_heading : delete_condition_input.goto_page_question_text }
         end;
 
       end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1204,6 +1204,7 @@ en:
         answered_as_key: is answered as
         any_other_answer_warning: If you delete this route, the route for any other answer will also be deleted
         delete_condition_legend: Are you sure you want to delete this route?
+        exit_page_warning: If you delete this route, the exit page it goes to will also be deleted
         skip_to_key: skip the person to
       edit:
         back_link: Back to question %{question_number}’s routes

--- a/spec/views/pages/conditions/delete.html.erb_spec.rb
+++ b/spec/views/pages/conditions/delete.html.erb_spec.rb
@@ -93,4 +93,16 @@ describe "pages/conditions/delete.html.erb" do
       end
     end
   end
+
+  context "when the condition has an exit page" do
+    let(:condition) { build :condition, :with_exit_page, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id }
+
+    it "renders a warning about the exit page" do
+      expect(rendered).to have_css ".govuk-notification-banner", text: "If you delete this route, the exit page it goes to will also be deleted"
+    end
+
+    it "shows the exit page heading in the summary list" do
+      expect(rendered).to have_css(".govuk-summary-list__value", text: condition.exit_page_heading)
+    end
+  end
 end


### PR DESCRIPTION
Adds a notification banner to the delete-route page, when there's an exit page for that route.

This commit also uses the exit page heading in place of the goto page question text in the route summary, which would otherwise be blank (as exit page routes have no goto page)

### What problem does this pull request solve?

Trello card: https://trello.com/c/9M6hc0mI/2348-add-a-banner-notification-warning-to-the-confirmation-page-when-deleting-a-route-that-goes-to-an-exit-page

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
**Before**
___
<img width="793" alt="image" src="https://github.com/user-attachments/assets/a44ddcb7-5947-41b2-9aae-defa08325fc5" />
___

**After**
___
<img width="755" alt="image" src="https://github.com/user-attachments/assets/a660d004-a9ef-437b-953a-5c73b669707e" />
___

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
