### PR TITLE
Order users list in the database rather than in memory

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,15 +9,7 @@ class UsersController < WebController
   def index
     authorize current_user, :can_manage_user?
 
-    roles = User.roles.keys
-    @users = policy_scope(User).includes(:organisation).sort_by do |user|
-      [
-        user.organisation&.name || "",
-        user.has_access ? 0 : 1,
-        roles.index(user.role),
-        user.name || "",
-      ]
-    end
+    @users = policy_scope(User).for_users_list
 
     render template: "users/index", locals: { users: @users }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,14 @@ class User < ApplicationRecord
     standard: "standard",
   }
 
+  scope :for_users_list, lambda {
+    includes(:organisation)
+      .order(Arel.sql("organisation.name ASC NULLS FIRST"))
+      .order({ has_access: :desc })
+      .in_order_of(:role, roles.keys)
+      .order({ name: :asc })
+  }
+
   validates :name, presence: true, if: :requires_name?
   validates :role, presence: true
   validates :organisation_id, presence: true, if: :requires_organisation?


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/UXjZG0ZG/2946-improve-load-speed-on-users-page

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
This is an attempt to fix the performance issue we see on the Users page doing the ordering in the database query, rather than ordering the items in memory in the app after they've been fetched from the database.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
