### PR TITLE
Add default_group_id to ignored_columns

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,8 @@
 class Organisation < ApplicationRecord
   has_paper_trail
 
+  self.ignored_columns += [:default_group_id]
+
   has_many :groups
   has_many :users
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/BIqa290Q/2367-remove-defaultgroupid-from-organisations

To prevent any cache issues, we need to add default_group_id to the ignored_columns list before dropping the column.

The column is no longer used throughout the app. After this commit any use will raise an error.

The column will be removed in a later PR.

See this these links for more information:

https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-ignored_columns-3D https://github.com/ankane/strong_migrations?tab=readme-ov-file#removing-a-column

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
