### PR TITLE
Drop `default_group_id` column

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,8 +1,6 @@
 class Organisation < ApplicationRecord
   has_paper_trail
 
-  self.ignored_columns += [:default_group_id]
-
   has_many :groups
   has_many :users
 

--- a/db/migrate/20250702152808_remove_default_group_id_from_organisations.rb
+++ b/db/migrate/20250702152808_remove_default_group_id_from_organisations.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultGroupIdFromOrganisations < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :organisations, :default_group_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_23_081911) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_02_152808) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -155,9 +155,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_23_081911) do
     t.datetime "updated_at", null: false
     t.boolean "closed", default: false
     t.string "abbreviation"
-    t.bigint "default_group_id"
     t.boolean "internal", default: false
-    t.index ["default_group_id"], name: "index_organisations_on_default_group_id"
     t.index ["govuk_content_id"], name: "index_organisations_on_govuk_content_id", unique: true
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
@@ -227,7 +225,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_23_081911) do
   add_foreign_key "memberships", "users", column: "added_by_id"
   add_foreign_key "mou_signatures", "organisations"
   add_foreign_key "mou_signatures", "users"
-  add_foreign_key "organisations", "groups", column: "default_group_id"
   add_foreign_key "pages", "forms"
   add_foreign_key "users", "organisations"
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/BIqa290Q/2367-remove-defaultgroupid-from-organisations

The default_group_id column was used when we were migrating forms to belong to groups in organisations. This is no longer used, so we can drop the column.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
