### PR TITLE
Make sure FormRepository.pages is stubbed in tests

### DIFF
--- a/app/services/form_repository.rb
+++ b/app/services/form_repository.rb
@@ -52,6 +52,10 @@ class FormRepository
     end
 
     def pages(record)
+      if Rails.env.test? && record.attributes.key?("pages")
+        raise "Form response should not include pages, check the spec factories and mocks, or stub .pages instead"
+      end
+
       form = Api::V1::FormResource.new(record.attributes, true)
       form.pages
     end

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -18,7 +18,7 @@
     <h2 class="govuk-heading-l">Your form</h2>
 
     <p>
-      <%= render PreviewLinkComponent::View.new(FormRepository.pages(form), link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: preview_mode)) %>
+      <%= render PreviewLinkComponent::View.new(form.pages, link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: preview_mode)) %>
     </p>
 
     <% if status == :live %>
@@ -31,7 +31,7 @@
     <% end %>
 
     <h3 class="govuk-heading-m"><%= t('made_live_form.questions') %></h3>
-    <p><%= govuk_link_to t('made_live_form.questions_link', count: FormRepository.pages(form).count), questions_path %></p>
+    <p><%= govuk_link_to t('made_live_form.questions_link', count: form.pages.count), questions_path %></p>
 
     <% if form.declaration_text.present? %>
       <h3 class="govuk-heading-m"><%= t('made_live_form.declaration') %></h3>

--- a/app/views/forms/_made_live_form_pages.html.erb
+++ b/app/views/forms/_made_live_form_pages.html.erb
@@ -11,8 +11,8 @@
 
     <%= render FormStatusTagDescriptionComponent::View.new(status: status) %>
 
-    <% FormRepository.pages(form).each_with_index do |page, index| %>
-      <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: FormRepository.pages(form)).build_data)%>
+    <% form.pages.each_with_index do |page, index| %>
+      <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: form.pages).build_data)%>
     <% end %>
 
     <p>

--- a/spec/features/form/add_or_edit_questions/add_branching_to_a_form_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_branching_to_a_form_spec.rb
@@ -8,7 +8,7 @@ feature "Adding branching to a form", type: :feature do
   let(:secondary_skip_condition) { build(:condition, id: 2, form_id: 1, page_id: form.pages[3].id, check_page_id: form.pages.first.id, routing_page_id: form.pages[3].id, goto_page_id: nil, skip_to_end: true) }
 
   before do
-    allow(FormRepository).to receive_messages(find: form)
+    allow(FormRepository).to receive_messages(find: form, pages:)
     allow(ConditionRepository).to receive_messages(create!: true)
 
     pages.each do |page|

--- a/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
+++ b/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
@@ -5,11 +5,7 @@ feature "Editing answer_settings for existing question", type: :feature do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/pages", headers, pages.to_json, 200
-    end
-
-    allow(FormRepository).to receive_messages(find: form)
+    allow(FormRepository).to receive_messages(find: form, pages:)
     allow(PageRepository).to receive_messages(create!: true)
 
     pages.each do |page|

--- a/spec/features/form/archive_a_form_spec.rb
+++ b/spec/features/form/archive_a_form_spec.rb
@@ -5,7 +5,7 @@ feature "Archive a form", type: :feature do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive_messages(find: form, find_live: form, find_archived: form, archive!: {})
+    allow(FormRepository).to receive_messages(find: form, pages: form.pages, find_live: form, find_archived: form, archive!: {})
 
     GroupForm.create! group:, form_id: form.id
     create(:membership, group:, user: standard_user, added_by: standard_user)

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -142,6 +142,10 @@ RSpec.describe Pages::ConditionsInput, type: :model do
   end
 
   describe "#goto_page_options" do
+    before do
+      allow(FormRepository).to receive_messages(pages:)
+    end
+
     context "when routing from the first form page" do
       subject(:goto_page_options) { described_class.new(form:, page: pages.first).goto_page_options }
 
@@ -280,12 +284,13 @@ RSpec.describe Pages::ConditionsInput, type: :model do
     let(:page_routes_service) { instance_double(PageRoutesService) }
 
     before do
+      allow(FormRepository).to receive_messages(pages:)
       allow(PageRoutesService).to receive(:new).and_return(page_routes_service)
       allow(page_routes_service).to receive(:routes).and_return([instance_double(Api::V1::ConditionResource, secondary_skip?: true)])
     end
 
     it "calls the PageRoutesService" do
-      expect(PageRoutesService).to receive(:new).with(form:, pages: FormRepository.pages(form), page:)
+      expect(PageRoutesService).to receive(:new).with(form:, pages:, page:)
       conditions_input.secondary_skip?
     end
   end

--- a/spec/input_objects/pages/delete_condition_input_spec.rb
+++ b/spec/input_objects/pages/delete_condition_input_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Pages::DeleteConditionInput, type: :model do
   end
 
   describe "#goto_page_question_text" do
+    before do
+      allow(FormRepository).to receive_messages(pages:)
+    end
+
     context "when there is a goto_page_id" do
       it "returns the question text for the given page" do
         result = delete_condition_input.goto_page_question_text
@@ -70,6 +74,10 @@ RSpec.describe Pages::DeleteConditionInput, type: :model do
   end
 
   describe "#has_secondary_skip?" do
+    before do
+      allow(FormRepository).to receive_messages(pages:)
+    end
+
     context "when the condition does not have a secondary skip condition" do
       subject(:has_secondary_skip?) { delete_condition_input.has_secondary_skip? }
 

--- a/spec/input_objects/pages/routes/delete_confirmation_input_spec.rb
+++ b/spec/input_objects/pages/routes/delete_confirmation_input_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe Pages::Routes::DeleteConfirmationInput, type: :model do
       end
 
       it "deletes routes when confirmed" do
+        allow(FormRepository).to receive_messages(pages: form.pages)
+
         delete_confirmation_input.confirm = "yes"
         delete_confirmation_input.submit
 

--- a/spec/input_objects/pages/secondary_skip_input_spec.rb
+++ b/spec/input_objects/pages/secondary_skip_input_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Pages::SecondarySkipInput, type: :model do
   end
   let(:condition) { nil }
 
+  before do
+    allow(FormRepository).to receive_messages(pages:)
+  end
+
   describe "validations" do
     it "is valid given valid params" do
       secondary_skip_input.routing_page_id = form.pages.first.id.to_s

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -13,6 +13,8 @@ describe FormPolicy do
     if group.present?
       GroupForm.create!(form_id: form.id, group_id: group.id)
     end
+
+    allow(FormRepository).to receive_messages(pages: form.pages)
   end
 
   describe "#can_view_form?" do

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -15,6 +15,7 @@ describe RouteSummaryCardDataPresenter do
   end
 
   before do
+    allow(FormRepository).to receive_messages(pages: form.pages)
     allow(form).to receive(:group).and_return(build(:group))
   end
 

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -97,12 +97,6 @@ RSpec.describe FormsController, type: :request do
       build(:form, id: 2, pages:, question_section_completed: "false")
     end
 
-    let(:updated_form) do
-      new_form = form
-      new_form.question_section_completed = "true"
-      new_form
-    end
-
     let(:user) do
       standard_user
     end

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe FormsController, type: :request do
       let(:params) { {} }
 
       before do
-        allow(FormRepository).to receive(:find).and_return(form)
+        allow(FormRepository).to receive_messages(find: form, pages: form.pages)
 
         get form_path(2, params)
       end
@@ -102,7 +102,7 @@ RSpec.describe FormsController, type: :request do
     end
 
     before do
-      allow(FormRepository).to receive_messages(find: form, save!: form)
+      allow(FormRepository).to receive_messages(find: form, pages:, save!: form)
 
       login_as user
 

--- a/spec/views/forms/show.html.erb_spec.rb
+++ b/spec/views/forms/show.html.erb_spec.rb
@@ -16,6 +16,8 @@ describe "forms/show.html.erb" do
       GroupForm.create!(form_id: form.id, group_id: group.id)
     end
 
+    allow(FormRepository).to receive_messages(pages: form.pages)
+
     render template: "forms/show"
   end
 

--- a/spec/views/pages/conditions/delete.html.erb_spec.rb
+++ b/spec/views/pages/conditions/delete.html.erb_spec.rb
@@ -11,6 +11,7 @@ describe "pages/conditions/delete.html.erb" do
   before do
     page.position = 1
     secondary_skip_condition
+    allow(FormRepository).to receive_messages(pages:)
     render template: "pages/conditions/delete", locals: { delete_condition_input: }
   end
 

--- a/spec/views/pages/conditions/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/edit.html.erb_spec.rb
@@ -22,6 +22,7 @@ describe "pages/conditions/edit.html.erb" do
     allow(view).to receive_messages(form_pages_path: "/forms/1/pages", create_condition_path: "/forms/1/pages/1/conditions/new", delete_condition_path: "/forms/1/pages/1/conditions/2/delete")
     allow(form).to receive_messages(group: group, qualifying_route_pages: pages)
     allow(condition_input).to receive(:secondary_skip?).and_return(secondary_skip)
+    allow(FormRepository).to receive_messages(pages:)
     condition_input.check_errors_from_api
 
     render template: "pages/conditions/edit", locals: { condition_input: }

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -22,6 +22,7 @@ describe "pages/routes/show.html.erb" do
   let(:route_summary_card_data_service) { instance_double(RouteSummaryCardDataPresenter, summary_card_data: route_cards, errors:, routes:, next_page:, pages:, page:, form:) }
 
   before do
+    allow(FormRepository).to receive_messages(pages:)
     allow(form).to receive(:group).and_return(build(:group))
     render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: route_summary_card_data_service }
   end

--- a/spec/views/pages/secondary_skip/new.html.erb_spec.rb
+++ b/spec/views/pages/secondary_skip/new.html.erb_spec.rb
@@ -22,6 +22,7 @@ describe "pages/secondary_skip/new.html.erb" do
   let(:secondary_skip_input) { Pages::SecondarySkipInput.new(form:, page:) }
 
   before do
+    allow(FormRepository).to receive_messages(pages: form.pages)
     render template: "pages/secondary_skip/new", locals: { back_link_url: "/back", secondary_skip_input: }
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/CMLGnkYl/2333-change-repositories-in-forms-admin-to-replicate-to-database <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

I found when working on PR #2049 that some tests were failing because FormRepository.pages was getting called and trying to write to the database, but the other FormRepository calls were stubbed so the things expected in the database weren't there.

To fix things, it's easiest to just stub FormRepository.pages in specs; rather than doing that in PR #2049, I've split this work out into this separate PR.

This PR finds all the cases where FormRepository.pages should be stubbed but isn't by adding a bit of code test-only code to raise an error if is called during a test. I also found a couple of places where we used FormRepository.pages but we probably shouldn't, so I fixed those.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?