### PR TITLE
Omit secondary skip questions from route options

### DIFF
--- a/app/resources/api/v1/form_resource.rb
+++ b/app/resources/api/v1/form_resource.rb
@@ -24,7 +24,9 @@ class Api::V1::FormResource < ActiveResource::Base
     conditions = pages.flat_map(&:routing_conditions).compact_blank
     condition_counts = conditions.group_by(&:check_page_id).transform_values(&:length)
 
-    Api::V1::PageResource.qualifying_route_pages(pages).filter { |page| condition_counts.fetch(page.id, 0) < max_routes_per_page }
+    Api::V1::PageResource.qualifying_route_pages(pages).filter do |page|
+      condition_counts.fetch(page.id, 0) < max_routes_per_page && page.routing_conditions.none?(&:secondary_skip?)
+    end
   end
 
   def has_no_remaining_routes_available?

--- a/spec/resources/api/v1/form_resource_spec.rb
+++ b/spec/resources/api/v1/form_resource_spec.rb
@@ -145,7 +145,7 @@ describe Api::V1::FormResource, type: :model do
 
     let(:selection_pages_with_routes) do
       (4..5).map do |index|
-        build :page, :with_selection_settings, id: index, position: index, routing_conditions: [(build :condition, id: index, check_page_id: index, goto_page_id: index + 2)]
+        build :page, :with_selection_settings, id: index, position: index, routing_conditions: [(build :condition, id: index, routing_page_id: index, check_page_id: index, goto_page_id: index + 2)]
       end
     end
 
@@ -157,13 +157,13 @@ describe Api::V1::FormResource, type: :model do
 
     let(:selection_pages_with_secondary_skips) do
       (10..12).map do |index|
-        build :page, :with_selection_settings, id: index, position: index, routing_conditions: [(build :condition, id: index, check_page_id: index, goto_page_id: index + 2)]
+        build :page, :with_selection_settings, id: index, position: index, routing_conditions: [(build :condition, id: index, routing_page_id: index, check_page_id: index, goto_page_id: index + 2)]
       end
     end
 
     let!(:secondary_skip_pages) do
       (13..16).map do |index|
-        build :page, :with_simple_answer_type, id: index, position: index, routing_conditions: [(build :condition, id: index, routing_page_id: index, check_page_id: index - 3, goto_page_id: index + 2)]
+        build :page, :with_selection_settings, id: index, position: index, routing_conditions: [(build :condition, id: index, routing_page_id: index, check_page_id: index - 3, goto_page_id: index + 2)]
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/rWs8nitM

On the page to add a new route for a form, do not include questions which already have a secondary skip condition associated with them in the options for adding a new route.

Previously, it was possible to select questions with a secondary skip, and then the user was shown a page to add a new secondary skip. When the "Set questions to skip" button on this page was clicked, they were taken back to the questions list page with no error message.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
