### PR TITLE
Add scrolling wrapper for tables

### DIFF
--- a/app/components/group_list_component/view.html.erb
+++ b/app/components/group_list_component/view.html.erb
@@ -9,17 +9,19 @@
     </p>
   <% end %>
 <% else %>
-  <%= govuk_table do |table| %>
-    <%= table.with_caption(size: 'm', text: @title) %>
 
-    <%= table.with_head do |head|
+  <%= render ScrollingWrapperComponent::View.new(aria_label: @title) do |table| %>
+    <%= govuk_table do |table| %>
+      <%= table.with_caption(size: 'm', text: @title) %>
+
+      <%= table.with_head do |head|
       head.with_row do |row|
         row.with_cell(header: true, text: t('groups.group_list.name'))
         row.with_cell(header: true, text: t('groups.group_list.created_by'), numeric: true)
       end
     end %>
 
-    <%= table.with_body do |body|
+      <%= table.with_body do |body|
       @groups.each do |group|
         body.with_row do |row|
           row.with_cell { govuk_link_to(group.name, group) }
@@ -27,6 +29,6 @@
         end
       end
     end %>
+    <% end %>
   <% end %>
 <% end %>
-

--- a/app/components/last_signed_in_at_report_component/view.rb
+++ b/app/components/last_signed_in_at_report_component/view.rb
@@ -14,12 +14,14 @@ module LastSignedInAtReportComponent
 
     def call
       if @users.present?
-        govuk_table(
-          rows: rows(@users),
-          head:,
-          caption: @caption,
-          first_cell_is_header: true,
-        )
+        render ScrollingWrapperComponent::View.new(aria_label: @caption) do
+          govuk_table(
+            rows: rows(@users),
+            head:,
+            caption: @caption,
+            first_cell_is_header: true,
+          )
+        end
       else
         tag.h(@caption, class: "govuk-heading-m") +
           tag.p(@empty_message, class: "govuk-body")

--- a/app/components/scrolling_wrapper_component/_index.scss
+++ b/app/components/scrolling_wrapper_component/_index.scss
@@ -1,0 +1,9 @@
+.app-scrolling-wrapper {
+  overflow-x: auto;
+}
+
+.app-scrolling-wrapper:focus-visible {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: $govuk-focus-width;
+  box-shadow: 0 0 0 $govuk-focus-width;
+}

--- a/app/components/scrolling_wrapper_component/view.html.erb
+++ b/app/components/scrolling_wrapper_component/view.html.erb
@@ -1,0 +1,3 @@
+<%= tag.div(class: ["app-scrolling-wrapper"], role: "region", tabindex: 0, "aria-label": aria_label) do %>
+  <%= content %>
+<% end %>

--- a/app/components/scrolling_wrapper_component/view.rb
+++ b/app/components/scrolling_wrapper_component/view.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ScrollingWrapperComponent
+  class View < ViewComponent::Base
+    attr_accessor :aria_label
+
+    def initialize(aria_label:)
+      super
+      @aria_label = aria_label
+    end
+  end
+end

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -16,3 +16,4 @@ $govuk-global-styles: true;
 @import "../../components/metrics_summary_component";
 @import "../../components/act_as_user_banner_component";
 @import "../../components/service_navigation_component";
+@import "../../components/scrolling_wrapper_component";

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -73,7 +73,9 @@
 <%= govuk_start_button(text: t("home.create_a_form"), href: new_group_form_path(@group)) %>
 
 <% if @form_list_presenter %>
-  <%= govuk_table(**@form_list_presenter.data) %>
+  <%= render ScrollingWrapperComponent::View.new(aria_label: @form_list_presenter.data[:caption]) do |table| %>
+    <%= govuk_table(**@form_list_presenter.data) %>
+  <% end %>
 <% elsif policy(@group).delete? %>
   <div>
     <%= govuk_button_link_to t(".delete_group"), delete_group_path(@group), warning: true %>

--- a/app/views/mou_signatures/index.html.erb
+++ b/app/views/mou_signatures/index.html.erb
@@ -4,29 +4,31 @@
 <%= t("mou_signatures.index.share_mou_link_html", mou_link: link_to(mou_signature_url, mou_signature_url)) %>
 
 <% if mou_signatures.any? %>
-  <%= govuk_table do |table| %>
-    <%= table.with_caption(size: 'm', text: t("mou_signatures.index.table_caption")) %>
+  <%= render ScrollingWrapperComponent::View.new(aria_label: t("mou_signatures.index.table_caption")) do |table| %>
+    <%= govuk_table do |table| %>
+      <%= table.with_caption(size: 'm', text: t("mou_signatures.index.table_caption")) %>
 
-    <%= table.with_head do |head|
-      head.with_row do |row|
-        row.with_cell(header: true, text: t("mou_signatures.index.table_headings.name"))
-        row.with_cell(header: true, text: t("mou_signatures.index.table_headings.email"))
-        row.with_cell(header: true, text: t("mou_signatures.index.table_headings.organisation"))
-        row.with_cell(header: true, text: t("mou_signatures.index.table_headings.agreed_at"))
-      end
-    end %>
-
-    <%= table.with_body do |body|
-      mou_signatures.each do |mou_signature|
-        body.with_row do |row|
-          row.with_cell( text: mou_signature.user.name.presence || t("users.index.name_blank") )
-          row.with_cell do
-            govuk_link_to(mou_signature.user.email, edit_user_path(mou_signature.user))
-          end
-          row.with_cell( text: mou_signature.organisation&.name.presence || t("users.index.organisation_blank"))
-          row.with_cell( text: l(mou_signature.created_at.to_date, :format => :long) )
+      <%= table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(header: true, text: t("mou_signatures.index.table_headings.name"))
+          row.with_cell(header: true, text: t("mou_signatures.index.table_headings.email"))
+          row.with_cell(header: true, text: t("mou_signatures.index.table_headings.organisation"))
+          row.with_cell(header: true, text: t("mou_signatures.index.table_headings.agreed_at"))
         end
-      end
-    end %>
+      end %>
+
+      <%= table.with_body do |body|
+        mou_signatures.each do |mou_signature|
+          body.with_row do |row|
+            row.with_cell( text: mou_signature.user.name.presence || t("users.index.name_blank") )
+            row.with_cell do
+              govuk_link_to(mou_signature.user.email, edit_user_path(mou_signature.user))
+            end
+            row.with_cell( text: mou_signature.organisation&.name.presence || t("users.index.organisation_blank"))
+            row.with_cell( text: l(mou_signature.created_at.to_date, :format => :long) )
+          end
+        end
+      end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/reports/add_another_answer.html.erb
+++ b/app/views/reports/add_another_answer.html.erb
@@ -5,22 +5,26 @@
     <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
     <h2 class="govuk-heading-m govuk-visually-hidden"><%= t(".heading") %></h2>
-    <%= govuk_table do |table| %>
 
-      <%= table.with_head do |head| %>
-        <%= head.with_row do |row| %>
-          <%= row.with_cell(text: t(".add_another_answer.table_headings.form_name")) %>
-          <%= row.with_cell(text: t(".add_another_answer.table_headings.question_text")) %>
-          <%= row.with_cell(text: t(".add_another_answer.table_headings.form_state")) %>
+    <%= render ScrollingWrapperComponent::View.new(aria_label: t(".heading")) do |table| %>
+
+      <%= govuk_table do |table| %>
+
+        <%= table.with_head do |head| %>
+          <%= head.with_row do |row| %>
+            <%= row.with_cell(text: t(".add_another_answer.table_headings.form_name")) %>
+            <%= row.with_cell(text: t(".add_another_answer.table_headings.question_text")) %>
+            <%= row.with_cell(text: t(".add_another_answer.table_headings.form_state")) %>
+          <%end%>
         <%end%>
-      <%end%>
-      <%= table.with_body do |body| %>
-        <% data.forms.sort_by(&:state).each do |form| %>
-          <% form.repeatable_pages.each do |question| %>
-            <%= body.with_row do |row| %>
-              <%= row.with_cell(text: govuk_link_to(form.name, form_url(form.form_id))) %>
-              <%= row.with_cell(text: question.question_text) %>
-              <%= row.with_cell(text: form.state.capitalize.gsub("_", " ")) %>
+        <%= table.with_body do |body| %>
+          <% data.forms.sort_by(&:state).each do |form| %>
+            <% form.repeatable_pages.each do |question| %>
+              <%= body.with_row do |row| %>
+                <%= row.with_cell(text: govuk_link_to(form.name, form_url(form.form_id))) %>
+                <%= row.with_cell(text: question.question_text) %>
+                <%= row.with_cell(text: form.state.capitalize.gsub("_", " ")) %>
+              <%end%>
             <%end%>
           <%end%>
         <%end%>

--- a/app/views/reports/add_another_answer.html.erb
+++ b/app/views/reports/add_another_answer.html.erb
@@ -4,12 +4,11 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-    <h2 class="govuk-heading-m govuk-visually-hidden"><%= t(".heading") %></h2>
-
     <%= render ScrollingWrapperComponent::View.new(aria_label: t(".heading")) do |table| %>
 
       <%= govuk_table do |table| %>
 
+        <%= table.with_caption(size: 'm', text: t(".heading")) %>
         <%= table.with_head do |head| %>
           <%= head.with_row do |row| %>
             <%= row.with_cell(text: t(".add_another_answer.table_headings.form_name")) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,35 +2,38 @@
 <h1 class="govuk-heading-l"><%= t("users.index.title") %></h1>
 
 <% if users.any? %>
-  <%= govuk_table do |table| %>
-    <%= table.with_caption(size: 'm', text: t("users.index.users_caption")) %>
+  <%= render ScrollingWrapperComponent::View.new(aria_label: t("users.index.users_caption")) do |table| %>
 
-    <%= table.with_head do |head|
-      head.with_row do |row|
-        row.with_cell(header: true, text: t("users.index.table_headings.name"))
-        row.with_cell(header: true, text: t("users.index.table_headings.email"))
-        row.with_cell(header: true, text: t("users.index.table_headings.organisation"))
-        row.with_cell(header: true, text: t("users.index.table_headings.role"))
-        row.with_cell(header: true, text: t("users.index.table_headings.access"))
-        row.with_cell(header: true, text: t("users.index.table_headings.act_as_user"), width: "govuk-!-width-one-quarter") if Settings.act_as_user_enabled
-      end
-    end %>
+    <%= govuk_table do |table| %>
+      <%= table.with_caption(size: 'm', text: t("users.index.users_caption")) %>
 
-    <%= table.with_body do |body|
-      users.each do |user|
-        body.with_row do |row|
-          row.with_cell( text: user.name || t("users.index.name_blank"))
-          row.with_cell do
-            govuk_link_to(user.email, edit_user_path(user))
-          end
-          row.with_cell( text: user.organisation&.name || t("users.index.organisation_blank"))
-          row.with_cell( text: t("users.roles.#{user.role}.name"))
-          row.with_cell( text: t("users.has_access.#{user.has_access}.name"))
-          row.with_cell do
-            govuk_button_to(t("users.act_as_user_html", user_email: user.email), act_as_user_start_path(user.id), method: :post, secondary: true) unless user.super_admin? || !user.has_access?
-          end if Settings.act_as_user_enabled
+      <%= table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(header: true, text: t("users.index.table_headings.name"))
+          row.with_cell(header: true, text: t("users.index.table_headings.email"))
+          row.with_cell(header: true, text: t("users.index.table_headings.organisation"))
+          row.with_cell(header: true, text: t("users.index.table_headings.role"))
+          row.with_cell(header: true, text: t("users.index.table_headings.access"))
+          row.with_cell(header: true, text: t("users.index.table_headings.act_as_user"), width: "govuk-!-width-one-quarter") if Settings.act_as_user_enabled
         end
-      end
-    end %>
+      end %>
+
+      <%= table.with_body do |body|
+        users.each do |user|
+          body.with_row do |row|
+            row.with_cell( text: user.name || t("users.index.name_blank"))
+            row.with_cell do
+              govuk_link_to(user.email, edit_user_path(user))
+            end
+            row.with_cell( text: user.organisation&.name || t("users.index.organisation_blank"))
+            row.with_cell( text: t("users.roles.#{user.role}.name"))
+            row.with_cell( text: t("users.has_access.#{user.has_access}.name"))
+            row.with_cell do
+              govuk_button_to(t("users.act_as_user_html", user_email: user.email), act_as_user_start_path(user.id), method: :post, secondary: true) unless user.super_admin? || !user.has_access?
+            end if Settings.act_as_user_enabled
+          end
+        end
+      end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/spec/components/group_list_component/view_spec.rb
+++ b/spec/components/group_list_component/view_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe GroupListComponent::View, type: :component do
       expect(page).to have_css("caption", text: title)
     end
 
-    it "renders a table with the groups" do
-      expect(page).to have_css("table")
-      expect(page).to have_css("tr", count: 4)
+    it "renders a table with the groups inside a scrolling wrapper" do
+      scrolling_wrapper_component = page.find(".app-scrolling-wrapper")
+      expect(scrolling_wrapper_component).to have_css("table")
+      expect(scrolling_wrapper_component).to have_css("tr", count: 4)
     end
 
     context "when there are no groups" do

--- a/spec/components/scrolling_wrapper_component/scrolling_wrapper_component_preview.rb
+++ b/spec/components/scrolling_wrapper_component/scrolling_wrapper_component_preview.rb
@@ -1,0 +1,11 @@
+class ScrollingWrapperComponent::ScrollingWrapperComponentPreview < ViewComponent::Preview
+  def default
+    render(ScrollingWrapperComponent::View.new(aria_label: "A scrolling wrapper with no content"))
+  end
+
+  def with_overflowing_content
+    render(ScrollingWrapperComponent::View.new(aria_label: "A scrolling wrapper containing something wide")) do
+      tag.a("http://localhost:3000/preview/a_long_url_that_is_far_far_too_long_to_the_extent_that_it_is_almost_certainly_going_to_overflow_the_wrapper_horizontally_which_is_useful_for_demonstrating_the_scrolling_wrapper_component")
+    end
+  end
+end

--- a/spec/components/scrolling_wrapper_component/view_spec.rb
+++ b/spec/components/scrolling_wrapper_component/view_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe ScrollingWrapperComponent::View, type: :component do
+  let(:aria_label) { "An accessible name for the contents of the component" }
+
+  let(:scrolling_wrapper_component) do
+    described_class.new(aria_label:)
+  end
+
+  let(:contents) do
+    '<p class="govuk-body">Some content</p>'.html_safe
+  end
+
+  let(:current_page) { "/" }
+
+  before do
+    render_inline scrolling_wrapper_component do
+      contents
+    end
+  end
+
+  describe "render" do
+    it "has the app-scrolling-wrapper class" do
+      expect(page).to have_css(".app-scrolling-wrapper")
+    end
+
+    it "has tabindex set to 0 so it can be focused and scrolled by keyboard users" do
+      expect(page).to have_css("[tabindex=0]")
+    end
+
+    it "has a region role and a label so that the purpose of the container is clear to assistive technology users" do
+      expect(page).to have_css("[role='region'][aria-label='#{aria_label}']")
+    end
+
+    it "yields the content passed into it" do
+      expect(page).to have_css("p", text: "Some content")
+    end
+  end
+end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -83,9 +83,10 @@ RSpec.describe "groups/show", type: :view do
       ]
     end
 
-    it "renders a table listing the forms" do
-      expect(rendered).to have_table "Forms in ‘My Group’"
-      expect(rendered).to have_css "tbody .govuk-table__row", count: 3
+    it "renders a table listing the forms in a scrollable wrapper" do
+      wrapper = Capybara.string(rendered.html).find(".app-scrolling-wrapper")
+      expect(wrapper).to have_table "Forms in ‘My Group’"
+      expect(wrapper).to have_css "tbody .govuk-table__row", count: 3
     end
 
     it "renders a link for each form" do

--- a/spec/views/mou_signatures/index.html.erb_spec.rb
+++ b/spec/views/mou_signatures/index.html.erb_spec.rb
@@ -15,6 +15,10 @@ describe "mou_signatures/index.html.erb" do
     expect(rendered).to have_css("h1.govuk-heading-l", text: I18n.t("page_titles.mou_signatures"))
   end
 
+  it "contains a scrollable wrapper with a table in it" do
+    expect(rendered).to have_css(".app-scrolling-wrapper > table")
+  end
+
   it "contains the user's name" do
     expect(rendered).to have_text(mou_signatures.first.user.name)
   end

--- a/spec/views/reports/add_another_answer.html.erb_spec.rb
+++ b/spec/views/reports/add_another_answer.html.erb_spec.rb
@@ -26,6 +26,10 @@ describe "reports/add_another_answer.html.erb" do
     expect(view.content_for(:back_link)).to have_link("Back to reports", href: reports_path)
   end
 
+  it "contains a scrollable wrapper with a table in it" do
+    expect(rendered).to have_css(".app-scrolling-wrapper > table")
+  end
+
   it "includes the form name" do
     expect(rendered).to have_link(name, href: form_url(form_id))
   end

--- a/spec/views/reports/add_another_answer.html.erb_spec.rb
+++ b/spec/views/reports/add_another_answer.html.erb_spec.rb
@@ -30,6 +30,10 @@ describe "reports/add_another_answer.html.erb" do
     expect(rendered).to have_css(".app-scrolling-wrapper > table")
   end
 
+  it "contains a caption" do
+    expect(rendered).to have_css("caption", text: "All forms with add another answer")
+  end
+
   it "includes the form name" do
     expect(rendered).to have_link(name, href: form_url(form_id))
   end

--- a/spec/views/reports/last_signed_in_at.html.erb_spec.rb
+++ b/spec/views/reports/last_signed_in_at.html.erb_spec.rb
@@ -15,10 +15,26 @@ RSpec.describe "reports/last_signed_in_at" do
     render
   end
 
-  describe "tables of when users last signed in" do
-    specify "users who are in one table are not duplicated in another" do
-      users.each do |user|
-        expect(rendered).to have_text(user.email, maximum: 1)
+  describe "last signed in at report" do
+    describe "page title" do
+      it "matches the heading" do
+        expect(view.content_for(:title)).to eq "When users last signed in"
+      end
+    end
+
+    it "has a back link to the reports page" do
+      expect(view.content_for(:back_link)).to have_link("Back to reports", href: reports_path)
+    end
+
+    it "contains a scrollable wrapper with a table in it" do
+      expect(rendered).to have_css(".app-scrolling-wrapper > table")
+    end
+
+    describe "tables of when users last signed in" do
+      specify "users who are in one table are not duplicated in another" do
+        users.each do |user|
+          expect(rendered).to have_text(user.email, maximum: 1)
+        end
       end
     end
   end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -18,6 +18,10 @@ describe "users/index.html.erb" do
     expect(rendered).to have_css("h1.govuk-heading-l", text: /Users/)
   end
 
+  it "contains a scrollable wrapper with a table in it" do
+    expect(rendered).to have_css(".app-scrolling-wrapper > table")
+  end
+
   it "contains the user's name" do
     expect(rendered).to have_text(users.first.name)
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->part of https://trello.com/c/O48UNuIf/2364-switch-to-new-type-scale-for-admin

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Some of our tables can overflow the screen at some screen widths and cause the page to scroll horizontally.

This PR:
- adds a new 'scrolling wrapper' component which stops the whole page scrolling horizontally, instead limiting the scrolling behaviour to the table it's wrapping
- adds the wrapper component to tables on:
  - the ['your groups' page](https://pr-2075.admin.review.forms.service.gov.uk/)
  - the [MOU signatures list](https://pr-2075.admin.review.forms.service.gov.uk/mous)
  - the [users list](https://pr-2075.admin.review.forms.service.gov.uk/users)
  - the [add another answer report](https://pr-2075.admin.review.forms.service.gov.uk/reports/add_another_answer)
  - the ['last signed in at' report](https://pr-2075.admin.review.forms.service.gov.uk/reports/last-signed-in-at)
  - the [list of forms for a group
](https://pr-2075.admin.review.forms.service.gov.uk/groups/vwC2xjSG)- also includes a slight markup change to the 'Add another answer report' page to use a table caption instead of an h2.

There may be other places where we need to do this, but it should be straightforward to add the new component to those pages if necessary.

### Screenshots
When the contents of the container aren't overflowing, there should be no visual difference.

When the contents of the container overflow, you should now see the container becaome scrollable (you'll see a different scrollbar depending on your operating system):
<img width="438" height="227" alt="image" src="https://github.com/user-attachments/assets/871983fe-3f0e-4775-9123-58f32d8acc43" />

The container is focusable so it can be scrolled by keyboard users. As a result, if you tab to it you'll see a visual focus indicator:
<img width="814" height="271" alt="image" src="https://github.com/user-attachments/assets/9fc87f83-88b9-4788-b34f-04ac91d55566" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
