### PR TITLE
Copy forms models validations from forms-api to forms-admin

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -19,7 +19,69 @@ class Condition < ApplicationRecord
     destroy! && form.update!(question_section_completed: false)
   end
 
+  def validation_errors
+    [
+      warning_goto_page_doesnt_exist,
+      warning_answer_doesnt_exist,
+      warning_routing_to_next_page,
+      warning_goto_page_before_routing_page,
+    ].compact
+  end
+
+  def warning_goto_page_doesnt_exist
+    return nil if is_exit_page?
+    # goto_page_id isn't needed if the route is skipping to the end of the form
+    return nil if is_check_your_answers?
+
+    page = form.pages.find_by(id: goto_page_id)
+    return nil if page.present?
+
+    { name: "goto_page_doesnt_exist" }
+  end
+
+  def warning_answer_doesnt_exist
+    return nil if has_precondition? && answer_value.nil?
+
+    answer_options = check_page&.answer_settings&.dig("selection_options")&.pluck("name")
+    return nil if answer_options.blank? || answer_options.include?(answer_value) || answer_value == :none_of_the_above.to_s && check_page.is_optional?
+
+    { name: "answer_value_doesnt_exist" }
+  end
+
+  def warning_routing_to_next_page
+    return nil if check_page.nil? || goto_page.nil? && !is_check_your_answers?
+
+    routing_page_position = routing_page.position
+    goto_page_position = is_check_your_answers? ? form.pages.last.position + 1 : goto_page.position
+
+    return { name: "cannot_route_to_next_page" } if goto_page_position == (routing_page_position + 1)
+
+    nil
+  end
+
+  def warning_goto_page_before_routing_page
+    if goto_page.present? && (goto_page.position <= routing_page.position)
+      { name: "cannot_have_goto_page_before_routing_page" }
+    end
+  end
+
+  def is_check_your_answers?
+    goto_page.nil? && skip_to_end
+  end
+
+  def is_exit_page?
+    !exit_page_markdown.nil?
+  end
+
+  def has_routing_errors
+    validation_errors.any?
+  end
+
 private
+
+  def has_precondition?
+    check_page_id && check_page_id != routing_page_id && !check_page.routing_conditions.empty?
+  end
 
   def destroy_postconditions
     return if check_page.nil?

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -9,6 +9,11 @@ class Form < ApplicationRecord
     s3: "s3",
   }
 
+  validates :name, presence: true
+  validates :payment_url, url: true, allow_blank: true
+  validate :marking_complete_with_errors
+  validates :submission_type, presence: true
+
   after_create :set_external_id
 
   def has_draft_version
@@ -25,6 +30,10 @@ class Form < ApplicationRecord
 
   def has_routing_errors
     pages.filter(&:has_routing_errors).any?
+  end
+
+  def marking_complete_with_errors
+    errors.add(:base, :has_validation_errors, message: "Form has routing validation errors") if question_section_completed && has_routing_errors
   end
 
   def ready_for_live

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -23,6 +23,10 @@ class Form < ApplicationRecord
     archived? || archived_with_draft?
   end
 
+  def has_routing_errors
+    pages.filter(&:has_routing_errors).any?
+  end
+
   def ready_for_live
     task_status_service.mandatory_tasks_completed?
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -34,6 +34,17 @@ class Page < ApplicationRecord
     true
   end
 
+  def answer_type_changed_from_selection
+    answer_type_previously_was&.to_sym == :selection && answer_type&.to_sym != :selection
+  end
+
+  def answer_settings_changed_from_only_one_option
+    from_only_one_option = ActiveModel::Type::Boolean.new.cast(answer_settings_previously_was.try(:[], "only_one_option"))
+    to_multiple_options = !ActiveModel::Type::Boolean.new.cast(answer_settings.try(:[], "only_one_option"))
+
+    from_only_one_option && to_multiple_options
+  end
+
 private
 
   def destroy_secondary_skip_conditions
@@ -48,16 +59,5 @@ private
       .flat_map(&:check_conditions)
       .filter { |condition| condition.check_page_id != condition.routing_page_id }
       .each(&:destroy!)
-  end
-
-  def answer_type_changed_from_selection
-    answer_type_previously_was&.to_sym == :selection && answer_type&.to_sym != :selection
-  end
-
-  def answer_settings_changed_from_only_one_option
-    from_only_one_option = ActiveModel::Type::Boolean.new.cast(answer_settings_previously_was.try(:[], "only_one_option"))
-    to_multiple_options = !ActiveModel::Type::Boolean.new.cast(answer_settings.try(:[], "only_one_option"))
-
-    from_only_one_option && to_multiple_options
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -45,6 +45,10 @@ class Page < ApplicationRecord
     from_only_one_option && to_multiple_options
   end
 
+  def has_routing_errors
+    routing_conditions.filter(&:has_routing_errors).any?
+  end
+
 private
 
   def destroy_secondary_skip_conditions

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -13,6 +13,16 @@ class Page < ApplicationRecord
 
   ANSWER_TYPES_WITH_SETTINGS = %w[selection text date address name].freeze
 
+  validates :question_text, presence: true
+  validates :question_text, length: { maximum: 250 }
+
+  validates :hint_text, length: { maximum: 500 }
+
+  validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
+  validate :guidance_fields_presence
+  validates :page_heading, length: { maximum: 250 }
+  validate :guidance_markdown_length_and_tags
+
   def destroy_and_update_form!
     form = self.form
     destroy! && form.update!(question_section_completed: false)
@@ -50,6 +60,31 @@ class Page < ApplicationRecord
   end
 
 private
+
+  def guidance_fields_presence
+    if page_heading.present? && guidance_markdown.blank?
+      errors.add(:guidance_markdown, "must be present when Page Heading is present")
+    elsif guidance_markdown.present? && page_heading.blank?
+      errors.add(:page_heading, "must be present when Guidance Markdown is present")
+    end
+  end
+
+  def guidance_markdown_length_and_tags
+    return true if guidance_markdown.blank?
+
+    markdown_validation = GovukFormsMarkdown.validate(guidance_markdown)
+
+    return true if markdown_validation[:errors].empty?
+
+    if markdown_validation[:errors].include?(:too_long)
+      errors.add(:guidance_markdown, :too_long, count: 4999)
+    end
+
+    tag_errors = markdown_validation[:errors].excluding(:too_long)
+    if tag_errors.any?
+      errors.add(:guidance_markdown, :unsupported_markdown_syntax, message: "can only contain formatting for links, subheadings(##), bulleted listed (*), or numbered lists(1.)")
+    end
+  end
 
   def destroy_secondary_skip_conditions
     return if goto_conditions.empty?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,15 @@ en:
           attributes:
             agreed:
               accepted: You must agree to the memorandum of understanding
+        page:
+          attributes:
+            hint_text:
+              too_long: Hint text must be %{count} characters or less
+            page_heading:
+              too_long: Page heading must be %{count} characters or less
+            question_text:
+              blank: Enter a question
+              too_long: Question text must be %{count} characters or less
         user:
           attributes:
             name:

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -46,4 +46,440 @@ RSpec.describe Condition, type: :model do
       end
     end
   end
+
+  describe "#is_exit_page?" do
+    it "returns false when exit_page_markdown is nil" do
+      condition.exit_page_markdown = nil
+      expect(condition.is_exit_page?).to be false
+    end
+
+    it "returns true when exit_page_markdown is not nil" do
+      condition.exit_page_markdown = ""
+      expect(condition.is_exit_page?).to be true
+    end
+  end
+
+  describe "validations" do
+    it "validates" do
+      page = create :page_record
+      condition.routing_page_id = page.id
+      expect(condition).to be_valid
+    end
+
+    it "requires routing_page_id" do
+      expect(condition).to be_invalid
+      expect(condition.errors[:routing_page]).to include("must exist")
+    end
+  end
+
+  describe "#validation_errors" do
+    let(:form) { create :form_record }
+    let(:routing_page) { create :page_record, form: }
+    let(:goto_page) { nil }
+    let(:condition) { create :condition_record, routing_page_id: routing_page.id, goto_page_id: nil }
+
+    it "returns array of validation error objects" do
+      expect(condition.validation_errors).to eq([{ name: "goto_page_doesnt_exist" }])
+    end
+
+    it "calls each validation method" do
+      %i[warning_goto_page_doesnt_exist
+         warning_answer_doesnt_exist
+         warning_routing_to_next_page
+         warning_goto_page_before_routing_page ].each do |validation_methods|
+        expect(condition).to receive(validation_methods)
+      end
+      condition.validation_errors
+    end
+
+    it "calls warning_goto_page_doesnt_exist" do
+      expect(condition).to receive(:warning_goto_page_doesnt_exist)
+      condition.validation_errors
+    end
+
+    context "when no validation errors" do
+      let(:goto_page) { create :page_record, form: }
+      let(:condition) { create :condition_record, routing_page_id: routing_page.id, goto_page_id: goto_page.id }
+
+      it "returns empty array if there are no validation errors" do
+        expect(condition.validation_errors).to be_empty
+      end
+    end
+  end
+
+  describe "#warning_goto_page_doesnt_exist" do
+    let(:form) { create :form_record }
+    let(:routing_page) { create :page_record, form: }
+    let(:goto_page) { create :page_record, form: }
+    let(:condition) { create :condition_record, routing_page_id: routing_page.id, goto_page_id: goto_page.id }
+
+    it "returns nil if goto page exists" do
+      expect(condition.warning_goto_page_doesnt_exist).to be_nil
+    end
+
+    context "when goto page is null and skip_to_end is true" do
+      let(:condition) { create :condition_record, routing_page_id: routing_page.id, goto_page_id: nil, skip_to_end: true }
+
+      it "returns nil" do
+        expect(condition.warning_goto_page_doesnt_exist).to be_nil
+      end
+    end
+
+    context "when goto page has been deleted" do
+      let(:condition) { create :condition_record, routing_page_id: routing_page.id, goto_page_id: 999 }
+
+      it "returns object with error short name code" do
+        expect(condition.warning_goto_page_doesnt_exist).to eq({ name: "goto_page_doesnt_exist" })
+      end
+    end
+
+    context "when goto page may belong to another form" do
+      let(:goto_page) { create :page_record }
+
+      it "returns object with error short name code" do
+        expect(condition.warning_goto_page_doesnt_exist).to eq({ name: "goto_page_doesnt_exist" })
+      end
+    end
+
+    context "when is_exit_page?" do
+      let(:condition) { create :condition_record, routing_page_id: routing_page.id, goto_page_id: nil, exit_page_markdown: "exit page" }
+
+      it "returns nil" do
+        expect(condition.warning_goto_page_doesnt_exist).to be_nil
+      end
+    end
+  end
+
+  describe "#warning_answer_doesnt_exist" do
+    let(:form) { create :form_record }
+    let(:check_page) { create :page_record, :with_selections_settings, form: }
+    let(:goto_page) { create :page_record, form: }
+    let(:condition) do
+      create(
+        :condition_record,
+        routing_page_id: check_page.id,
+        check_page_id: check_page.id,
+        goto_page_id: goto_page.id,
+        answer_value: check_page.answer_settings["selection_options"].first["name"],
+      )
+    end
+
+    it "returns nil if answer exists" do
+      expect(condition.warning_answer_doesnt_exist).to be_nil
+    end
+
+    context "when answer has been deleted from page" do
+      it "returns object with error short name code" do
+        condition.check_page.answer_settings["selection_options"].shift
+        expect(condition.warning_answer_doesnt_exist).to eq({ name: "answer_value_doesnt_exist" })
+      end
+    end
+
+    context "when answer on the page has been updated" do
+      it "returns object with error short name code" do
+        condition.check_page.answer_settings["selection_options"].first["name"] = "Option 1.2"
+        expect(condition.warning_answer_doesnt_exist).to eq({ name: "answer_value_doesnt_exist" })
+      end
+    end
+
+    context "when answer_value is 'None of the above" do
+      let(:condition) { create :condition_record, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, answer_value: :none_of_the_above.to_s }
+      let(:check_page) { create :page_record, :with_selections_settings, form:, is_optional: }
+
+      context "and routing page has 'None of the above' as an option" do
+        let(:is_optional) { true }
+
+        it "returns nil" do
+          expect(condition.warning_answer_doesnt_exist).to be_nil
+        end
+      end
+
+      context "and routing page does not have 'None of the above' as an option" do
+        let(:is_optional) { false }
+
+        it "returns object with error short name code" do
+          expect(condition.warning_answer_doesnt_exist).to eq({ name: "answer_value_doesnt_exist" })
+        end
+      end
+    end
+
+    context "when condition is a after another condition for a branch route" do
+      let(:routing_page) { create :page_record, form: }
+      let(:after_condition) do
+        create(
+          :condition_record,
+          answer_value: nil,
+          check_page_id: condition.check_page_id,
+          routing_page_id: routing_page.id,
+          skip_to_end: true,
+        )
+      end
+
+      it "returns nil" do
+        expect(after_condition.warning_answer_doesnt_exist).to be_nil
+      end
+    end
+  end
+
+  describe "#warning_routing_to_next_page" do
+    let(:form) { build :form_record, pages: [check_page, current_page, next_page, last_page] }
+    let(:check_page) { build :page_record, position: 1 }
+    let(:current_page) { build :page_record, position: 2 }
+    let(:next_page) { build :page_record, position: 3 }
+    let(:last_page) { build :page_record, position: 4 }
+
+    shared_examples "returns no warning" do
+      it "returns nil" do
+        expect(condition.warning_routing_to_next_page).to be_nil
+      end
+    end
+
+    shared_examples "returns routing warning" do
+      it "returns cannot_route_to_next_page warning" do
+        expect(condition.warning_routing_to_next_page).to eq({ name: "cannot_route_to_next_page" })
+      end
+    end
+
+    context "when routing to a non-adjacent page" do
+      let(:condition) do
+        create :condition_record,
+               routing_page: current_page,
+               check_page: check_page,
+               goto_page: last_page
+      end
+
+      it_behaves_like "returns no warning"
+    end
+
+    context "when routing to the next sequential page" do
+      let(:condition) do
+        create :condition_record,
+               routing_page: current_page,
+               check_page: check_page,
+               goto_page: next_page
+      end
+
+      it_behaves_like "returns routing warning"
+    end
+
+    context "with nil values" do
+      context "when goto_page is nil" do
+        let(:condition) do
+          create :condition_record,
+                 routing_page: current_page,
+                 check_page: check_page,
+                 goto_page: nil
+        end
+
+        it_behaves_like "returns no warning"
+      end
+
+      context "when check_page is nil" do
+        let(:condition) do
+          create :condition_record,
+                 routing_page: current_page,
+                 check_page: nil,
+                 goto_page: next_page
+        end
+
+        it_behaves_like "returns no warning"
+      end
+    end
+
+    context "with skip_to_end functionality" do
+      context "when routing from the last page" do
+        let(:condition) do
+          create :condition_record,
+                 routing_page: last_page,
+                 check_page: check_page,
+                 goto_page: nil,
+                 skip_to_end: true
+        end
+
+        it_behaves_like "returns routing warning"
+      end
+
+      context "when routing from a non-last page" do
+        let(:condition) do
+          create :condition_record,
+                 routing_page: current_page,
+                 check_page: check_page,
+                 goto_page: nil,
+                 skip_to_end: false
+        end
+
+        it_behaves_like "returns no warning"
+      end
+    end
+
+    context "with non-sequential page positions" do
+      let(:current_page) { build :page_record, position: 2 }
+      let(:next_page) { build :page_record, position: 4 }
+      let(:condition) do
+        create :condition_record,
+               routing_page: current_page,
+               check_page: check_page,
+               goto_page: next_page
+      end
+
+      it_behaves_like "returns no warning"
+    end
+  end
+
+  describe "#warning_goto_page_before_routing_page" do
+    let(:form) { build :form_record, pages: [previous_page, current_page, next_page, last_page] }
+    let(:check_page) { build :page_record, position: 1 }
+    let(:previous_page) { build :page_record, position: 2 }
+    let(:current_page) { build :page_record, position: 3 }
+    let(:next_page) { build :page_record, position: 4 }
+    let(:last_page) { build :page_record, position: 5 }
+
+    shared_examples "returns no warning" do
+      it "returns nil" do
+        expect(condition.warning_goto_page_before_routing_page).to be_nil
+      end
+    end
+
+    shared_examples "returns routing warning" do
+      it "returns cannot_have_goto_page_before_routing_page warning" do
+        expect(condition.warning_goto_page_before_routing_page).to(
+          eq({ name: "cannot_have_goto_page_before_routing_page" }),
+        )
+      end
+    end
+
+    context "when routing to a later page" do
+      let(:condition) do
+        create :condition_record,
+               routing_page: current_page,
+               check_page: current_page,
+               goto_page: last_page
+      end
+
+      it_behaves_like "returns no warning"
+    end
+
+    context "when routing to a previous page" do
+      let(:condition) do
+        create :condition_record,
+               routing_page: current_page,
+               check_page: current_page,
+               goto_page: previous_page
+      end
+
+      it_behaves_like "returns routing warning"
+    end
+
+    context "with nil values" do
+      context "when goto_page is nil" do
+        context "with skip_to_end false" do
+          let(:condition) do
+            create :condition_record,
+                   routing_page: current_page,
+                   check_page: current_page,
+                   goto_page: nil,
+                   skip_to_end: false
+          end
+
+          it_behaves_like "returns no warning"
+        end
+
+        context "with skip_to_end true" do
+          let(:condition) do
+            create :condition_record,
+                   routing_page: current_page,
+                   check_page: current_page,
+                   goto_page: nil,
+                   skip_to_end: true
+          end
+
+          it_behaves_like "returns no warning"
+        end
+      end
+    end
+
+    context "when routing to the same position" do
+      let(:same_position_page) { build :page_record, position: 3 }
+      let(:condition) do
+        create :condition_record,
+               routing_page: current_page,
+               check_page: current_page,
+               goto_page: same_position_page
+      end
+
+      it_behaves_like "returns routing warning"
+    end
+
+    context "with non-sequential page positions" do
+      let(:gap_page) { build :page_record, position: 6 }
+      let(:condition) do
+        create :condition_record,
+               routing_page: current_page,
+               check_page: current_page,
+               goto_page: gap_page
+      end
+
+      it_behaves_like "returns no warning"
+    end
+  end
+
+  describe "#is_check_your_answers?" do
+    let(:form) { create :form_record }
+    let(:check_page) { create :page_record, :with_selections_settings, form: }
+    let(:goto_page) { create :page_record, form: }
+
+    context "when goto page is nil and skip_to_end is false" do
+      let(:condition) { create :condition_record, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: nil, skip_to_end: false }
+
+      it "returns nil" do
+        expect(condition.is_check_your_answers?).to be false
+      end
+    end
+
+    context "when goto page is nil and skip_to_end is true" do
+      let(:condition) { create :condition_record, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: nil, skip_to_end: true }
+
+      it "returns nil" do
+        expect(condition.is_check_your_answers?).to be true
+      end
+    end
+
+    context "when goto page has a value and skip_to_end is false" do
+      let(:condition) { create :condition_record, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, skip_to_end: false }
+
+      it "returns nil" do
+        expect(condition.is_check_your_answers?).to be false
+      end
+    end
+
+    context "when goto page has a value and skip_to_end is true" do
+      let(:condition) { create :condition_record, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, skip_to_end: true }
+
+      it "returns nil" do
+        expect(condition.is_check_your_answers?).to be false
+      end
+    end
+  end
+
+  describe "#has_routing_errors" do
+    let(:form) { create :form_record }
+    let(:goto_page) { create :page_record, form: }
+    let(:goto_page_id) { goto_page.id }
+    let(:routing_page) { create :page_record, form: }
+    let(:condition) { create :condition_record, routing_page_id: routing_page.id, goto_page_id: }
+
+    context "when there are no validation errors" do
+      it "returns false" do
+        expect(condition.has_routing_errors).to be false
+      end
+    end
+
+    context "when there are validation errors" do
+      let(:goto_page_id) { nil }
+
+      it "returns true" do
+        expect(condition.has_routing_errors).to be true
+      end
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -110,6 +110,31 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "#has_routing_errors" do
+    let(:form) { create :form_record, pages: [routing_page, goto_page] }
+    let(:routing_page) do
+      new_routing_page = create :page_record
+      new_routing_page.routing_conditions = [(create :condition_record, routing_page_id: new_routing_page.id, goto_page_id:)]
+      new_routing_page
+    end
+    let(:goto_page) { create :page_record }
+    let(:goto_page_id) { goto_page.id }
+
+    context "when there are no validation errors" do
+      it "returns false" do
+        expect(form.has_routing_errors).to be false
+      end
+    end
+
+    context "when there are validation errors" do
+      let(:goto_page_id) { nil }
+
+      it "returns true" do
+        expect(form.has_routing_errors).to be true
+      end
+    end
+  end
+
   describe "#ready_for_live" do
     context "when a form is complete and ready to be made live" do
       let(:completed_form) { create(:form_record, :live) }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -8,6 +8,73 @@ RSpec.describe Form, type: :model do
     expect(form).to be_valid
   end
 
+  describe "validations" do
+    it "validates" do
+      form.name = "test"
+      expect(form).to be_valid
+    end
+
+    it "requires name" do
+      expect(form).to be_invalid
+      expect(form.errors[:name]).to include("can't be blank")
+    end
+
+    context "when the form has validation errors" do
+      let(:form) { create :form_record, pages: [routing_page, goto_page] }
+      let(:routing_page) do
+        new_routing_page = create :page_record
+        new_routing_page.routing_conditions = [(create :condition_record, routing_page_id: new_routing_page.id, goto_page_id: nil)]
+        new_routing_page
+      end
+      let(:goto_page) { create :page_record }
+      let(:goto_page_id) { goto_page.id }
+
+      context "when the form is marked complete" do
+        it "returns invalid" do
+          form.question_section_completed = true
+
+          expect(form).to be_invalid
+          expect(form.errors[:base]).to include("Form has routing validation errors")
+        end
+      end
+
+      context "when the form is not marked complete" do
+        it "returns valid" do
+          form.question_section_completed = false
+          expect(form).to be_valid
+        end
+      end
+
+      context "when the payment url is not a url" do
+        it "returns invalid" do
+          form.payment_url = "not a url"
+          expect(form).to be_invalid
+        end
+      end
+
+      context "when the payment url is a url" do
+        it "returns valid" do
+          form.payment_url = "https://example.com/"
+          expect(form).to be_valid
+        end
+      end
+
+      context "when there is no payment url" do
+        it "returns valid" do
+          form.payment_url = nil
+          expect(form).to be_valid
+        end
+      end
+
+      context "when there is no submission type" do
+        it "returns invalid" do
+          form.submission_type = nil
+          expect(form).to be_invalid
+        end
+      end
+    end
+  end
+
   describe "external_id" do
     it "intialises a new form with an external id matching its id" do
       form = create :form_record

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -226,4 +226,29 @@ RSpec.describe Page, type: :model do
       end
     end
   end
+
+  describe "#has_routing_errors" do
+    subject(:page) { build :page_record, :with_selections_settings, routing_conditions: [condition] }
+
+    let(:condition) { build :condition_record }
+    let(:has_routing_errors) { false }
+
+    before do
+      allow(condition).to receive(:has_routing_errors).and_return(has_routing_errors)
+    end
+
+    context "when there are no validation errors" do
+      it "returns false" do
+        expect(page.has_routing_errors).to be false
+      end
+    end
+
+    context "when there are validation errors" do
+      let(:has_routing_errors) { true }
+
+      it "returns true" do
+        expect(page.has_routing_errors).to be true
+      end
+    end
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -144,6 +144,172 @@ RSpec.describe Page, type: :model do
     end
   end
 
+  describe "validations" do
+    it "validates" do
+      page.question_text = "Example question"
+      page.answer_type = "national_insurance_number"
+      expect(page).to be_valid
+    end
+
+    describe "#question_text" do
+      let(:page) { build :page_record, question_text: }
+      let(:question_text) { "What is your address?" }
+
+      it "is required" do
+        page.question_text = nil
+        expect(page).to be_invalid
+        expect(page.errors[:question_text]).to include("Enter a question")
+      end
+
+      it "is valid if question text below 250 characters" do
+        expect(page).to be_valid
+      end
+
+      context "when question text 250 characters" do
+        let(:question_text) { "A" * 250 }
+
+        it "is valid" do
+          expect(page).to be_valid
+        end
+      end
+
+      context "when question text more 250 characters" do
+        let(:question_text) { "A" * 251 }
+
+        it "is invalid" do
+          expect(page).not_to be_valid
+        end
+
+        it "has an error message" do
+          page.valid?
+          expect(page.errors[:question_text]).to include("Question text must be 250 characters or less")
+        end
+      end
+    end
+
+    describe "#hint_text" do
+      let(:page) { build :page_record, hint_text: }
+      let(:hint_text) { "Enter your full name as it appears in your passport" }
+
+      it "is valid if hint text is empty" do
+        page.hint_text = nil
+        expect(page).to be_valid
+      end
+
+      it "is valid if hint text below 500 characters" do
+        expect(page).to be_valid
+      end
+
+      context "when hint text 500 characters" do
+        let(:hint_text) { "A" * 500 }
+
+        it "is valid" do
+          expect(page).to be_valid
+        end
+      end
+
+      context "when hint text more than 500 characters" do
+        let(:hint_text) { "A" * 501 }
+
+        it "is invalid" do
+          expect(page).not_to be_valid
+        end
+
+        it "has an error message" do
+          page.valid?
+          expect(page.errors[:hint_text]).to include("Hint text must be 500 characters or less")
+        end
+      end
+    end
+
+    it "requires form" do
+      page.form_id = nil
+      expect(page).to be_invalid
+      expect(page.errors[:form]).to include("must exist")
+    end
+
+    it "requires answer_type" do
+      page.answer_type = nil
+      expect(page).to be_invalid
+      expect(page.errors[:answer_type]).to include("can't be blank")
+    end
+
+    it "requires answer_type to be in list" do
+      page.answer_type = "unknown_type"
+      expect(page).to be_invalid
+      expect(page.errors[:answer_type]).to include("is not included in the list")
+    end
+
+    context "when guidance_fields are provided" do
+      it "requires guidance_markdown if page_heading is present" do
+        page.page_heading = "My new page heading"
+        expect(page).to be_invalid
+        expect(page.errors[:guidance_markdown]).to include("must be present when Page Heading is present")
+      end
+
+      it "requires page_heading if guidance_markdown is present" do
+        page.guidance_markdown = "Some extra guidance for this question"
+        expect(page).to be_invalid
+        expect(page.errors[:page_heading]).to include("must be present when Guidance Markdown is present")
+      end
+
+      describe "page_heading length validations" do
+        let(:page) { build :page_record, :with_guidance, page_heading: }
+        let(:page_heading) { "What is your address?" }
+
+        it "is valid if page heading below 500 characters" do
+          expect(page).to be_valid
+        end
+
+        context "when page heading 250 characters" do
+          let(:page_heading) { "A" * 250 }
+
+          it "is valid" do
+            expect(page).to be_valid
+          end
+        end
+
+        context "when page_heading more than 250 characters" do
+          let(:page_heading) { "A" * 251 }
+
+          it "is invalid" do
+            expect(page).not_to be_valid
+          end
+
+          it "has an error message" do
+            page.valid?
+            expect(page.errors[:page_heading]).to include("Page heading must be 250 characters or less")
+          end
+        end
+      end
+
+      context "when markdown is too long" do
+        it "adds an error to guidance_markdown" do
+          page.guidance_markdown = "ABC" * 5000
+          expect(page).to be_invalid
+          expect(page.errors[:guidance_markdown]).to include("is too long (maximum is 4999 characters)")
+        end
+      end
+
+      context "when markdown is using unsupported syntax" do
+        it "adds error to guidance_markdown" do
+          page.guidance_markdown = "# Heading level 1"
+          expect(page).to be_invalid
+          expect(page.errors[:guidance_markdown]).to include("can only contain formatting for links, subheadings(##), bulleted listed (*), or numbered lists(1.)")
+        end
+      end
+
+      context "when markdown is using unsupported syntax which is too long" do
+        it "adds error to guidance_markdown" do
+          page.guidance_markdown = "# Heading level 1\n\n" * 5000
+          expect(page).to be_invalid
+          expect(page.errors[:guidance_markdown]).to include("can only contain formatting for links, subheadings(##), bulleted listed (*), or numbered lists(1.)")
+          expect(page.errors[:guidance_markdown]).to include("is too long (maximum is 4999 characters)")
+        end
+      end
+    end
+  end
+
   describe "#destroy_and_update_form!" do
     let(:page) { create :page_record }
     let(:form) { page.form }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/XLRGkfC9/2385-copy-forms-models-validations-from-forms-api-to-forms-admin <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Copies all the validations on `Form`, `Page` and `Condition` models from forms-api to here, in preparation to deleting them from forms-api.

With the exception of the routing errors, we have all these validations in forms-admin anyway, but it's easiest if we copy everything over so we can confidently remove the validation from forms-api, then refactor here later.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?