### PR TITLE
Make ActiveRecord model factories similar to ActiveResource factories

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -40,6 +40,10 @@ class Form < ApplicationRecord
     task_status_service.mandatory_tasks_completed?
   end
 
+  delegate :incomplete_tasks, to: :task_status_service
+
+  delegate :task_statuses, to: :task_status_service
+
 private
 
   def set_external_id

--- a/spec/factories/models/condition_record.rb
+++ b/spec/factories/models/condition_record.rb
@@ -1,9 +1,50 @@
 FactoryBot.define do
   factory :condition_record, class: "Condition" do
-    routing_page { build :page_record }
+    transient do
+      form { build(:form_record) }
+    end
+
+    routing_page { association :page_record, form: }
     check_page { nil }
     goto_page { nil }
     answer_value { nil }
     skip_to_end { false }
+    exit_page_heading { nil }
+    exit_page_markdown { nil }
+
+    trait :with_answer_value_missing do
+      goto_page { association :page_record, form: }
+
+      check_page { association :page_record, :with_selection_settings, form: }
+      answer_value { nil }
+    end
+
+    trait :with_goto_page_missing do
+      goto_page { nil }
+    end
+
+    trait :with_goto_page_before_check_page do
+      check_page { association :page_record, form:, position: 5 }
+      goto_page { association :page_record, form:, position: 3 }
+    end
+
+    trait :with_goto_page_immediately_after_check_page do
+      routing_page { association :page_record, form:, position: 5 }
+      check_page { routing_page }
+      goto_page { association :page_record, form:, position: 6 }
+    end
+
+    trait :with_answer_value_and_goto_page_missing do
+      goto_page { nil }
+
+      check_page { association :page_record, :with_selection_settings, form: }
+      answer_value { nil }
+    end
+
+    trait :with_exit_page do
+      goto_page { nil }
+      exit_page_heading { "Exit page heading" }
+      exit_page_markdown { "Exit page markdown" }
+    end
   end
 end

--- a/spec/factories/models/condition_resource.rb
+++ b/spec/factories/models/condition_resource.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :condition_resource, class: "Api::V1::ConditionResource" do
     routing_page_id { nil }
     check_page_id { nil }
-    answer_value { nil }
     goto_page_id { nil }
+    answer_value { nil }
     skip_to_end { false }
     validation_errors { [] }
     has_routing_errors { false }

--- a/spec/factories/models/form_resource.rb
+++ b/spec/factories/models/form_resource.rb
@@ -38,6 +38,18 @@ FactoryBot.define do
       sequence(:id) { |n| n }
     end
 
+    trait :with_pages do
+      transient do
+        pages_count { 5 }
+      end
+
+      pages do
+        Array.new(pages_count) { association(:page_resource) }
+      end
+
+      question_section_completed { true }
+    end
+
     trait :ready_for_live do
       with_pages
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
@@ -78,18 +90,6 @@ FactoryBot.define do
 
     trait :with_active_resource do
       task_statuses { statuses }
-    end
-
-    trait :with_pages do
-      transient do
-        pages_count { 5 }
-      end
-
-      pages do
-        Array.new(pages_count) { association(:page_resource) }
-      end
-
-      question_section_completed { true }
     end
 
     trait :with_support do

--- a/spec/factories/models/page_record.rb
+++ b/spec/factories/models/page_record.rb
@@ -12,32 +12,39 @@ FactoryBot.define do
   factory :page_record, class: "Page" do
     association :form, factory: :form_record
 
-    question_text { Faker::Lorem.question }
-    answer_type { Page::ANSWER_TYPES.sample }
+    question_text { Faker::Lorem.question.truncate(250) }
+    answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }
     is_optional { false }
     answer_settings { nil }
+    hint_text { nil }
     sequence(:position)
     routing_conditions { [] }
     check_conditions { [] }
     goto_conditions { [] }
     page_heading { nil }
     guidance_markdown { nil }
+    is_repeatable { false }
+
+    trait :with_hints do
+      hint_text { Faker::Quote.yoda.truncate(500) }
+    end
 
     trait :with_guidance do
-      page_heading { Faker::Quote.yoda }
+      page_heading { Faker::Quote.yoda.truncate(250) }
       guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
     end
 
-    trait :with_hints do
-      hint_text { Faker::Quote.yoda }
+    trait :with_simple_answer_type do
+      answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }
     end
 
-    trait :with_selections_settings do
+    trait :with_selection_settings do
       transient do
         only_one_option { "true" }
         selection_options { [{ name: "Option 1" }, { name: "Option 2" }] }
       end
 
+      question_text { Faker::Lorem.question }
       answer_type { "selection" }
       answer_settings { DataStruct.new(only_one_option:, selection_options:) }
     end
@@ -70,6 +77,44 @@ FactoryBot.define do
           selection_options: [{ name: "Option 1" }, { name: "Option 2" }],
         }
       end
+    end
+
+    trait :with_text_settings do
+      transient do
+        input_type { Pages::TextSettingsInput::INPUT_TYPES.sample }
+      end
+
+      answer_type { "text" }
+      answer_settings { DataStruct.new(input_type:) }
+    end
+
+    trait :with_date_settings do
+      transient do
+        input_type { Pages::DateSettingsInput::INPUT_TYPES.sample }
+      end
+
+      answer_type { "date" }
+      answer_settings { DataStruct.new(input_type:) }
+    end
+
+    trait :with_address_settings do
+      transient do
+        uk_address { "true" }
+        international_address { "true" }
+      end
+
+      answer_type { "address" }
+      answer_settings { DataStruct.new(input_type: DataStruct.new(uk_address:, international_address:)) }
+    end
+
+    trait :with_name_settings do
+      transient do
+        input_type { Pages::NameSettingsInput::INPUT_TYPES.sample }
+        title_needed { Pages::NameSettingsInput::TITLE_NEEDED.sample }
+      end
+
+      answer_type { "name" }
+      answer_settings { DataStruct.new(input_type:, title_needed:) }
     end
   end
 end

--- a/spec/factories/models/page_resource.rb
+++ b/spec/factories/models/page_resource.rb
@@ -11,13 +11,14 @@ end
 FactoryBot.define do
   factory :page_resource, class: "Api::V1::PageResource" do
     sequence(:id) { |n| n }
+
     question_text { Faker::Lorem.question.truncate(250) }
     answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }
     is_optional { false }
     answer_settings { {} }
     hint_text { nil }
-    routing_conditions { [] }
     sequence(:position) { |n| n }
+    routing_conditions { [] }
     question_with_text { "#{position}. #{question_text}" }
     has_routing_errors { false }
     page_heading { nil }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -3,9 +3,57 @@ require "rails_helper"
 RSpec.describe Form, type: :model do
   subject(:form) { described_class.new }
 
-  it "has a valid factory" do
-    form = create :form_record
-    expect(form).to be_valid
+  describe "factory" do
+    it "has a valid factory" do
+      form = create :form_record
+      expect(form).to be_valid
+    end
+
+    it "has a ready for live trait" do
+      form = build :form_record, :ready_for_live
+      expect(form.ready_for_live).to be true
+      expect(form.incomplete_tasks).to be_empty
+      expect(form.task_statuses).to include(
+        declaration_status: :completed,
+        make_live_status: :not_started,
+        name_status: :completed,
+        pages_status: :completed,
+        privacy_policy_status: :completed,
+        support_contact_details_status: :completed,
+        what_happens_next_status: :completed,
+      )
+    end
+
+    it "has a live trait" do
+      form = build :form_record, :live
+      expect(form.state).to eq "live"
+    end
+
+    it "has a live with draft trait" do
+      form = build :form_record, :live_with_draft
+      expect(form.state).to eq "live_with_draft"
+    end
+
+    it "has an archived trait" do
+      form = build :form_record, :archived
+      expect(form.state).to eq "archived"
+    end
+
+    it "has an archived with draft trait" do
+      form = build :form_record, :archived_with_draft
+      expect(form.state).to eq "archived_with_draft"
+    end
+
+    it "has a ready for routing trait" do
+      form = create :form_record, :ready_for_routing
+      expect(form.pages).to be_present
+      expect(form.pages.map(&:position)).to eq [1, 2, 3, 4, 5]
+    end
+
+    it "has a missing pages trait" do
+      form = build :form_record, :missing_pages
+      expect(form.incomplete_tasks).to eq %i[missing_pages]
+    end
   end
 
   describe "validations" do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Page, type: :model do
-  subject(:page) { create :page_record, :with_selections_settings, form:, routing_conditions:, check_conditions: }
+  subject(:page) { create :page_record, :with_selection_settings, form:, routing_conditions:, check_conditions: }
 
   let(:form) { create :form_record }
   let(:routing_conditions) { [] }
@@ -394,7 +394,7 @@ RSpec.describe Page, type: :model do
   end
 
   describe "#has_routing_errors" do
-    subject(:page) { build :page_record, :with_selections_settings, routing_conditions: [condition] }
+    subject(:page) { build :page_record, :with_selection_settings, routing_conditions: [condition] }
 
     let(:condition) { build :condition_record }
     let(:has_routing_errors) { false }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/6hA4UVml/2386-change-repositories-in-forms-admin-to-return-activerecord-models-instead-of-activeresource <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to start returning Active Record models from our forms models repositories. This means we also need to swap out the factories used in our specs, and to allow that we need to make sure that the same traits are present with the same behaviours across both sets of factories.

This PR makes the `*_record` factories more similar to the `*_resource` factories, by adding missing traits and tweaking the existing ones where there is a mismatch. In some cases we can't use the exact same code to implement the trait, and for those we have added tests of the traits.

This PR also copies across some code from forms-api for the `Form` model, as it is needed for the factory traits to work.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?