### PR TITLE
Add model method for moving forms between groups

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -36,6 +36,15 @@ class Form < ApplicationRecord
     errors.add(:base, :has_validation_errors, message: "Form has routing validation errors") if question_section_completed && has_routing_errors
   end
 
+  def move_to_group(group_id)
+    group = Group.find_by!(external_id: group_id)
+    group_form = GroupForm.find_by(form_id: id)
+
+    return if group_form.group == group
+
+    group_form.update!(group:)
+  end
+
   def ready_for_live
     task_status_service.mandatory_tasks_completed?
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -296,4 +296,36 @@ RSpec.describe Form, type: :model do
       end
     end
   end
+
+  describe "#move_to_group" do
+    context "when the form is in an existing group" do
+      let(:form) { create(:form_record) }
+      let(:old_group) { create :group, name: "Group 1" }
+      let(:group_form) { GroupForm.find_by!(form_id: form.id) }
+
+      before do
+        GroupForm.create!(form_id: form.id, group: old_group)
+      end
+
+      context "when the user tries to move the form to a different group" do
+        let(:new_group) { create :group, name: "Group 2" }
+
+        it "moves the form" do
+          expect { form.move_to_group(new_group.external_id) }.to change { GroupForm.find_by!(form_id: form.id).reload.group.id }.to(new_group.id)
+        end
+      end
+
+      context "when the user tries to move the form to its existing group" do
+        it "leaves the form where it is" do
+          expect { form.move_to_group(old_group.external_id) }.not_to(change { group_form.reload.group.id })
+        end
+      end
+
+      context "when the new group does not exist" do
+        it "throws an ActiveRecord::RecordNotFound error" do
+          expect { form.move_to_group("some_nonexistent_external_id") }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/OOpJ005p/2394-add-model-method-and-unit-tests-for-moving-a-form-to-another-group

Adds a method to the form model which allows the form to be moved to a new group.

We'll use this later when we build the UI for moving forms between groups.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
