### PR TITLE
Allow org admins to delete empty groups

### DIFF
--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -16,7 +16,7 @@ class GroupPolicy < ApplicationPolicy
   alias_method :add_editor?, :edit?
 
   def delete?
-    user.super_admin?
+    organisation_admin_or_super_admin?
   end
 
   alias_method :destroy?, :delete?

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe GroupPolicy do
     let(:organisation) { group.organisation }
 
     context "and in the same organisation as the group" do
-      it "forbids only request_upgrade, review_upgrade, delete and destroy" do
-        expect(policy).to forbid_only_actions(%i[request_upgrade review_upgrade delete destroy])
+      it "forbids only request_upgrade and review_upgrade" do
+        expect(policy).to forbid_only_actions(%i[request_upgrade review_upgrade])
       end
     end
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -401,7 +401,22 @@ RSpec.describe "/groups", type: :request do
       end
     end
 
-    context "when user is not a super admin" do
+    context "when user is an organisation admin" do
+      before do
+        login_as_organisation_admin_user
+        get delete_group_url(group)
+      end
+
+      it "returns a successful response" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders a view to confirm delete" do
+        expect(response).to render_template(:delete)
+      end
+    end
+
+    context "when user is not a super admin or org admin" do
       it "is forbidden" do
         get delete_group_url(group)
         expect(response).to have_http_status(:forbidden)
@@ -513,7 +528,95 @@ RSpec.describe "/groups", type: :request do
       end
     end
 
-    context "when user is not a super admin" do
+    context "when user is an org admin" do
+      before do
+        login_as_organisation_admin_user
+      end
+
+      context "when user confirms they want to delete the group" do
+        let(:params) { { groups_delete_confirmation_input: { confirm: "yes" } } }
+
+        it "deletes the group" do
+          expect {
+            delete(group_url(group), params:)
+          }.to change(Group, :count).by(-1)
+        end
+
+        it "redirects to the list of groups" do
+          delete(group_url(group), params:)
+          expect(response).to have_http_status(:see_other)
+          expect(response).to redirect_to(groups_path)
+        end
+
+        it "displays a success flash message" do
+          delete(group_url(group), params:)
+          expect(flash[:success]).to eq "Successfully deleted ‘Test Group’"
+        end
+
+        context "but group has forms in it" do
+          before do
+            GroupForm.create! group:, form_id: 1
+            GroupForm.create! group:, form_id: 2
+          end
+
+          it "does not delete the group" do
+            expect {
+              delete(group_url(group), params:)
+            }.not_to change(Group, :count)
+          end
+
+          it "returns an error" do
+            delete(group_url(group), params:)
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it "re-renders the confirm delete view with an error" do
+            delete(group_url(group), params:)
+            expect(response).to render_template(:delete)
+            expect(response.body).to include "This group cannot be deleted because it has forms in it"
+          end
+        end
+      end
+
+      context "when user confirms that they do not want to delete the group" do
+        let(:params) { { groups_delete_confirmation_input: { confirm: "no" } } }
+
+        it "does not delete the group" do
+          expect {
+            delete(group_url(group), params:)
+          }.not_to change(Group, :count)
+        end
+
+        it "redirects to the list of groups" do
+          delete(group_url(group), params:)
+          expect(response).to have_http_status(:see_other)
+          expect(response).to redirect_to(groups_path)
+        end
+      end
+
+      context "when user does not confirm whether they want to delete the group or not" do
+        let(:params) { { groups_delete_confirmation_input: { confirm: nil } } }
+
+        it "does not delete the group" do
+          expect {
+            delete(group_url(group), params:)
+          }.not_to change(Group, :count)
+        end
+
+        it "returns an error" do
+          delete(group_url(group), params:)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "re-renders the confirm delete view with an error" do
+          delete(group_url(group), params:)
+          expect(response).to render_template(:delete)
+          expect(response.body).to include "Select ‘Yes’ to delete the group"
+        end
+      end
+    end
+
+    context "when user is not a super admin or org admin" do
       it "is forbidden" do
         delete group_url(member_group)
         expect(response).to have_http_status(:forbidden)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/Xfye5rPT/2398-enable-deleting-a-group-for-org-admins

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We previously implemented the ability for super admins to delete empty groups. This PR updates the permissions to allow org admins to do the same thing.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
