### PR TITLE
Explicitly configure vite cache directory

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -30,5 +30,6 @@ export default defineConfig({
   test: {
     globals: true,
     setupFiles: ['test/setup.js']
-  }
+  },
+  cacheDir: '../../node_modules/.vite'
 })


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Something (possibly a recent Vite update) made vitest read the cache directory as relative to the frontend folder.

This meant that it was generating unwanted cache files in `/app/frontend/node_modules/.vite`.

This commit explicitly configures the cache folder to be the expected `/node_modules/.vite`, which is gitignored, to avoid this.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
