### PR TITLE
Fix tests passing with false positive

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -88,7 +88,7 @@ class Pages::ConditionsController < PagesController
 
     if delete_condition_input.submit
       if delete_condition_input.confirmed?
-        redirect_to form_pages_path(current_form.id, page.id), success: t("banner.success.route_deleted", question_number: delete_condition_input.page.position)
+        redirect_to form_pages_path(current_form.id), success: t("banner.success.route_deleted", question_number: delete_condition_input.page.position)
       else
         redirect_to edit_condition_path(current_form.id, page.id, condition.id)
       end

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     it "redirects to the page list" do
-      expect(response).to redirect_to show_routes_path(form:, page:)
+      expect(response).to redirect_to show_routes_path(form_id: form.id, page_id: page.id)
     end
 
     it "displays success message" do
@@ -159,7 +159,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       let(:group) { create(:group, organisation: standard_user.organisation) }
 
       it "redirects to the new exit page" do
-        expect(response).to redirect_to new_exit_page_path(form:, page:, answer_value: "Wales")
+        expect(response).to redirect_to new_exit_page_path(form_id: form.id, page_id: page.id, answer_value: "Wales")
       end
     end
 
@@ -196,7 +196,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
       it "does not create the condition and redirects the user to the question routes page" do
         expect(ConditionRepository).not_to have_received(:create!)
-        expect(response).to redirect_to show_routes_path(form.id, selected_page.id)
+        expect(response).to redirect_to show_routes_path(form_id: form.id, page_id: selected_page.id)
       end
     end
   end
@@ -276,7 +276,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     it "redirects to the page list" do
-      expect(response).to redirect_to show_routes_path(form:, page:)
+      expect(response).to redirect_to show_routes_path(form_id: form.id, page_id: page.id)
     end
 
     it "displays success message" do
@@ -301,7 +301,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       let(:params) { { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: "create_exit_page", answer_value: "Wales" } } }
 
       it "redirects to the edit exit page" do
-        expect(response).to redirect_to edit_exit_page_path(form:, page:, condition:)
+        expect(response).to redirect_to edit_exit_page_path(form_id: form.id, page_id: page.id, condition_id: condition.id)
       end
     end
 
@@ -342,7 +342,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
         end
 
         it "redirects to the confirm exit page deletion page" do
-          expect(response).to redirect_to confirm_change_exit_page_path(form.id, selected_page.id, condition.id, params: { answer_value: "Wales", goto_page_id: 3 })
+          expect(response).to redirect_to confirm_change_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params: { answer_value: "Wales", goto_page_id: 3 })
         end
 
         it "does not call save! for the condition" do
@@ -354,7 +354,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
         let(:params) { { pages_conditions_input: { routing_page_id: 1, check_page_id: 1, goto_page_id: "exit_page", answer_value: "Wales" } } }
 
         it "redirects to the edit exit page" do
-          expect(response).to redirect_to show_routes_path(form:, page:, condition:)
+          expect(response).to redirect_to show_routes_path(form_id: form.id, page_id: page.id)
         end
       end
     end
@@ -418,7 +418,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     it "redirects to the page list" do
-      expect(response).to redirect_to form_pages_path(form.id, selected_page.id)
+      expect(response).to redirect_to form_pages_path(form_id: form.id)
     end
 
     it "displays success message" do
@@ -430,7 +430,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       let(:confirm) { "no" }
 
       it "redirects to edit the condition" do
-        expect(response).to redirect_to edit_condition_path(form.id, selected_page.id, condition.id)
+        expect(response).to redirect_to edit_condition_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id)
       end
     end
 
@@ -548,14 +548,14 @@ RSpec.describe Pages::ConditionsController, type: :request do
     end
 
     it "redirects to the question routes page" do
-      expect(response).to redirect_to show_routes_path(form_id: form.id, page_id: selected_page.id)
+      expect(response).to redirect_to show_routes_path(form_id: form.id, page_id: page.id)
     end
 
     context "when confirm is not 'yes'" do
       let(:confirm) { "no" }
 
       it "redirects to the edit condition page" do
-        expect(response).to redirect_to edit_condition_path(form.id, selected_page.id, condition.id)
+        expect(response).to redirect_to edit_condition_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id)
       end
     end
 
@@ -587,7 +587,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       let(:condition) { build :condition, id: 1, check_page_id: selected_page.id, goto_page_id: 3 }
 
       it "redirects to the form pages path" do
-        expect(response).to redirect_to form_pages_path(form.id)
+        expect(response).to redirect_to form_pages_path(form_id: form.id)
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The arguments to a Rails path helper should be either an object such as a record that implements ActiveModel::Naming ActiveModel::Conversions, or a keyword argument [[1]]; if an object `o` is passed as an argument then `o.model_name.route_key` will be used to work out what parameter in the path `o.to_param` should be used for, and if a keyword argument is given then the name of that keyword will be used for the path parameter.

If an object is given as a keyword argument, the model name is not used for the path parameter; only the keyword argument name is used.

These tests have a subtle bug, where the record objects were mistakenly passed as keyword arguments to path helpers in the spec expectations. The tests passed because the value of `#to_param` was `nil`, because the records were not persisted (see the definition of ActiveModel::Conversion#to_param [[2]]), and thus were ignored by the path helper, but the correct path parameters were accessible from the request. If the records had been persisted then a URL parameter named after the keyword would have been appended as a query parameter; not the desired behaviour.

This commit fixes these tests so they pass for the right reason.

[1]: https://guides.rubyonrails.org/routing.html#creating-paths-and-urls-from-objects
[2]: https://api.rubyonrails.org/classes/ActiveModel/Conversion.html#method-i-to_param

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?