### PR TITLE
Bump bundler from 2.6.3 to 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ gem "after_commit_everywhere", "~> 1.6"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[mri mingw x64_mingw]
+  gem "debug", platforms: %i[mri windows], require: "debug/prelude"
 
   gem "factory_bot_rails"
   gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,4 +628,4 @@ RUBY VERSION
    ruby 3.4.1p0
 
 BUNDLED WITH
-   2.6.3
+   2.7.1


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Bumps [bundler](https://bundler.io/) from 2.6.3 to 2.7.1.

When using Bundler 2.6.3 with RubyGems 3.7.1 a number of `redefined constant` errors are produced, so this PR bumps Bundler.

- [Release notes](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.7.1)
- [Changelog](https://github.com/rubygems/rubygems/blob/bundler-v2.7.1/bundler/CHANGELOG.md)
- [Commits](https://github.com/rubygems/rubygems/compare/bundler-v2.6.3...bundler-v2.7.1)

Note that this bump drops support for Ruby 3.1.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?