### PR TITLE
Add payment links to live view of form

### DIFF
--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -46,6 +46,11 @@
     </div>
     <%= govuk_details(summary_text: t('made_live_form.what_is_what_happens_next'), text: t('made_live_form.what_happens_next_description')) %>
 
+    <% if form.respond_to?(:payment_url) && form.payment_url.present? %>
+      <h3 class="govuk-heading-m"><%= t("made_live_form.payment_link") %></h3>
+      <p><%= govuk_link_to(form.payment_url, form.payment_url) %></p>
+    <% end %>
+
     <h3 class="govuk-heading-m"><%= t("made_live_form.how_you_get_completed_forms") %></h3>
 
     <h4 class="govuk-heading-s"><%= t('made_live_form.submission_email') %></h4>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -882,6 +882,7 @@ en:
     draft_edit: Edit the draft of this form
     how_you_get_completed_forms: How you get completed forms
     make_this_form_live: Make this form live
+    payment_link: GOV.UK Pay payment link
     previous_form_url: Previous form URL
     privacy_policy_link: Privacy policy link
     questions: Questions

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -232,4 +232,14 @@ describe "forms/_made_live_form.html.erb" do
       expect(view.content_for(:back_link)).to have_link("Back to your forms", href: "/")
     end
   end
+
+  context "when the form has a payment link" do
+    let(:payment_url) { "https://www.gov.uk/payments/your-payment-link" }
+    let(:form) { build(:form, :live, id: 2, payment_url:) }
+
+    it "contains a link to the payment url" do
+      expect(rendered).to have_css("h3", text: "GOV.UK Pay payment link")
+      expect(rendered).to have_link(payment_url, href: payment_url)
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hbtuJ3ty/2379-show-if-a-payment-link-has-been-added-or-not-to-the-live-form-view-page

When displaying a live form, we don't show any information about payment
links.

This commit adds a payment link to the live view of a form if one is
present.

We have to be slightly careful to not rely on payment_url? as it may not
exist for forms published before we added the payment_url field.

<img width="907" height="261" alt="image" src="https://github.com/user-attachments/assets/f358a342-a1a0-417e-9138-7054854736b8" />


### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
