### PR TITLE
Use made_live_form factory when using a live form in specs

### DIFF
--- a/spec/features/form/archive_a_form_spec.rb
+++ b/spec/features/form/archive_a_form_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 feature "Archive a form", type: :feature do
   let(:form) { build(:form, :live, id: 1) }
   let(:group) { create(:group, organisation: standard_user.organisation) }
+  let(:made_live_form) { build(:made_live_form, id: form.id, name: form.name) }
 
   before do
-    allow(FormRepository).to receive_messages(find: form, pages: form.pages, find_live: form, find_archived: form, archive!: {})
+    allow(FormRepository).to receive_messages(find: form, pages: form.pages, find_live: made_live_form, find_archived: made_live_form, archive!: {})
 
     GroupForm.create! group:, form_id: form.id
     create(:membership, group:, user: standard_user, added_by: standard_user)

--- a/spec/features/form/make_changes_live_spec.rb
+++ b/spec/features/form/make_changes_live_spec.rb
@@ -6,9 +6,10 @@ feature "Make changes live", type: :feature do
   let(:organisation) { build :organisation, id: 1 }
   let(:user) { create :user, organisation: }
   let(:group) { create(:group, name: "Group 1", organisation:, status: "active") }
+  let(:made_live_form) { build(:made_live_form, id: form.id, name: form.name) }
 
   before do
-    allow(FormRepository).to receive_messages(find: form, find_live: form, make_live!: form, pages: pages)
+    allow(FormRepository).to receive_messages(find: form, find_live: made_live_form, make_live!: form, pages: pages)
 
     GroupForm.create!(form_id: form.id, group_id: group.id)
     Membership.create!(user:, group:, added_by: user, role: :group_admin)

--- a/spec/requests/forms/archived_controller_spec.rb
+++ b/spec/requests/forms/archived_controller_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Forms::ArchivedController, type: :request do
   let(:form) { build(:form, :live, id:) }
+  let(:archived_form) { build(:made_live_form, id:) }
   let(:id) { 2 }
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
@@ -11,7 +12,7 @@ RSpec.describe Forms::ArchivedController, type: :request do
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
 
-    allow(FormRepository).to receive_messages(find: form, find_archived: form)
+    allow(FormRepository).to receive_messages(find: form, find_archived: archived_form)
   end
 
   describe "#show_form" do

--- a/spec/requests/forms/live_controller_spec.rb
+++ b/spec/requests/forms/live_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Forms::LiveController, type: :request do
   describe "#show_pages" do
     context "with a live form" do
       before do
-        allow(FormRepository).to receive_messages(find: form, find_live: form)
+        allow(FormRepository).to receive_messages(find: form, find_live: made_live_form)
 
         get live_form_pages_path(2)
       end

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -90,8 +90,10 @@ RSpec.describe Forms::MakeLiveController, type: :request do
   end
 
   describe "#create" do
+    let(:made_live_form) { build(:made_live_form, id: form.id, name: form.name) }
+
     before do
-      allow(FormRepository).to receive_messages(find: form, find_live: form, make_live!: form)
+      allow(FormRepository).to receive_messages(find: form, find_live: made_live_form, make_live!: form)
 
       Membership.create!(group_id: group.id, user:, added_by: user, role: group_role)
       GroupForm.create!(form_id: form.id, group_id: group.id)

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
   let(:user_outside_group) { build :user, id: 2, organisation: }
 
   let(:form) { build :form, id: 1, creator_id: 1 }
+  let(:made_live_form) { build(:made_live_form, id: form.id) }
 
   let(:submission_email_mailer_spy) do
     submission_email_mailer = instance_spy(SubmissionEmailMailer)
@@ -18,7 +19,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   before do
-    allow(FormRepository).to receive_messages(find: form, save!: form, find_live: form)
+    allow(FormRepository).to receive_messages(find: form, save!: form, find_live: made_live_form)
 
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -209,11 +210,10 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
 
     context "when draft version submission email is different from live version" do
       let(:form) { build :form, :live, id: 1, creator_id: 1 }
-      let(:previous_live_version) { form.clone }
+      let(:previous_live_version) { build :made_live_form, creator_id: 1, id: form.id, submission_email: Faker::Internet.email(domain: "test.example.gov.uk") }
 
       before do
-        previous_live_version
-        form.submission_email = Faker::Internet.email(domain: "example.gov.uk")
+        form.submission_email = Faker::Internet.email(domain: "different.gov.uk")
 
         allow(FormRepository).to receive_messages(find: form, find_live: previous_live_version)
 

--- a/spec/requests/forms/unarchive_controller_spec.rb
+++ b/spec/requests/forms/unarchive_controller_spec.rb
@@ -3,11 +3,8 @@ require "rails_helper"
 RSpec.describe Forms::UnarchiveController, type: :request do
   let(:user) { standard_user }
 
-  let(:form) do
-    build(:form,
-          :archived,
-          id: 2)
-  end
+  let(:form) { build(:form, :archived, id: 2) }
+  let(:made_live_form) { build(:made_live_form, id: form.id) }
 
   let(:updated_form) do
     build(:form,
@@ -59,7 +56,7 @@ RSpec.describe Forms::UnarchiveController, type: :request do
 
   describe "#create" do
     before do
-      allow(FormRepository).to receive_messages(find: form, make_live!: form, find_live: form)
+      allow(FormRepository).to receive_messages(find: form, make_live!: form, find_live: made_live_form)
 
       Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user, role: :group_admin)
       GroupForm.create!(form_id: form.id, group_id: group.id)

--- a/spec/services/make_form_live_service_spec.rb
+++ b/spec/services/make_form_live_service_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 describe MakeFormLiveService do
   let(:make_form_live_service) { described_class.call(current_form:, current_user:) }
   let(:current_form) { build :form, :ready_for_live, id: 1 }
-  let(:live_form) { current_form }
+  let(:made_live_form) { build :made_live_form, id: current_form.id, submission_email: current_form.submission_email }
   let(:current_user) { build :user }
 
   describe "#make_live" do
     before do
-      allow(FormRepository).to receive_messages(make_live!: true, find_live: live_form)
+      allow(FormRepository).to receive_messages(make_live!: current_form, find_live: made_live_form)
     end
 
     it "calls make_live! on the Form Repository with the current form" do
@@ -22,10 +22,7 @@ describe MakeFormLiveService do
     end
 
     context "when draft form has live version" do
-      let(:live_form) { build :form, :live }
-      let(:current_form) do
-        live_form.clone
-      end
+      let(:current_form) { build :form, :live_with_draft, id: 1 }
 
       context "when submission email has not been changed" do
         it "does not call the SubmissionEmailMailer" do
@@ -42,8 +39,8 @@ describe MakeFormLiveService do
 
         it "calls the SubmissionEmailMailer" do
           expect(SubmissionEmailMailer).to receive(:alert_email_change).with(
-            live_email: live_form.submission_email,
-            form_name: live_form.name,
+            live_email: made_live_form.submission_email,
+            form_name: made_live_form.name,
             creator_name: current_user.name,
             creator_email: current_user.email,
           ).and_call_original
@@ -60,13 +57,10 @@ describe MakeFormLiveService do
     end
 
     context "when changes to live form are being made live" do
-      let(:live_form) { build :form, :live }
-      let(:current_form) do
-        live_form.clone
-      end
+      let(:current_form) { build :form, :live_with_draft, id: 1 }
 
       before do
-        allow(FormRepository).to receive(:find_live).and_return(live_form)
+        allow(FormRepository).to receive(:find_live).and_return(made_live_form)
       end
 
       it "returns a different page title" do
@@ -81,13 +75,10 @@ describe MakeFormLiveService do
     end
 
     context "when changes to live form are being made live" do
-      let(:live_form) { build :form, :live }
-      let(:current_form) do
-        live_form.clone
-      end
+      let(:current_form) { build :form, :live_with_draft, id: 1 }
 
       before do
-        allow(FormRepository).to receive(:find_live).and_return(live_form)
+        allow(FormRepository).to receive(:find_live).and_return(made_live_form)
       end
 
       it "returns different confirmation page body" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/6hA4UVml/2386-change-repositories-in-forms-admin-to-return-activerecord-models-instead-of-activeresource
Use made live form factory where appropriate across all tests. This is mainly wherever the form repository has the find_live or find_archived method called. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
