### PR TITLE
Fix DraftQuestion error when no answer type set

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -1,6 +1,8 @@
 class Pages::QuestionsController < PagesController
   before_action do
-    raise "No answer type set for draft question" if draft_question.answer_type.blank?
+    if draft_question.answer_type.blank?
+      redirect_to type_of_answer_new_path(form_id: current_form.id)
+    end
   end
 
   def new

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -73,18 +73,18 @@ RSpec.describe Pages::QuestionsController, type: :request do
       end
 
       include_examples "logging"
-    end
 
-    context "when the form has a draft question with no answer type" do
-      let(:draft_question) do
-        record = create :draft_question_for_new_page, user: standard_user, form_id: 2
-        record.answer_type = nil
-        record.save!(validate: false)
-        record.reload
-      end
+      context "and the draft question has no answer type" do
+        let(:draft_question) do
+          record = create :draft_question_for_new_page, user: standard_user, form_id: 2
+          record.answer_type = nil
+          record.save!(validate: false)
+          record.reload
+        end
 
-      it "raises an error" do
-        expect { get new_question_path(form_id: 2) }.to raise_error("No answer type set for draft question")
+        it "redirects to type of answer" do
+          expect(response).to redirect_to(type_of_answer_new_path(form_id: 2))
+        end
       end
     end
   end
@@ -145,23 +145,18 @@ RSpec.describe Pages::QuestionsController, type: :request do
       it "outputs error message" do
         expect(response.body).to include("Enter a question")
       end
-    end
 
-    context "when the form has a draft question with no answer type" do
-      let(:draft_question) do
-        record = create :draft_question_for_new_page, user: standard_user, form_id: 2
-        record.answer_type = nil
-        record.save!(validate: false)
-        record.reload
-      end
+      context "when the form has a draft question with no answer type" do
+        let(:draft_question) do
+          record = create :draft_question_for_new_page, user: standard_user, form_id: 2
+          record.answer_type = nil
+          record.save!(validate: false)
+          record.reload
+        end
 
-      it "raises an error" do
-        expect {
-          post create_question_path(2), params: { pages_question_input: {
-            hint_text: "This should be the location stated in your contract.",
-            is_optional: false,
-          } }
-        }.to raise_error("No answer type set for draft question")
+        it "redirects to type of answer" do
+          expect(response).to redirect_to(type_of_answer_new_path(form_id: 2))
+        end
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Cv7Df8ho/2414-navigating-to-the-new-page-view-causes-an-error-if-the-answer-type-and-answer-settings-arent-valid

Currently an error is raised if the DraftQuesiton is not valid when creating a new question.

This can happen if the form creator uses the back button, navigates directly to
the new page or has multiple tabs open.

This PR replaces the error with a redirect to set the question type corretly so
that the user can craete a new question.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
