### PR TITLE
Change repositories to return ActiveRecord models instead of ActiveResource

### DIFF
--- a/app/components/page_list_component/error_summary/view.rb
+++ b/app/components/page_list_component/error_summary/view.rb
@@ -30,23 +30,14 @@ module PageListComponent
         )
       end
 
-      def conditions_with_check_pages
-        @pages.flat_map do |page|
-          page.routing_conditions.map do |condition|
-            condition.attributes[:check_page] ||= @pages.find { it.id == condition.check_page_id }
-            condition
-          end
-        end
-      end
-
       def errors_for_summary
-        conditions_with_check_pages
-          .map { |condition_with_check_page|
-            condition_with_check_page.validation_errors.map do |error|
+        @pages.flat_map(&:routing_conditions)
+          .map { |condition|
+            condition.validation_errors.map do |error|
               error_object(
                 error_name: error.name,
-                page: condition_with_check_page.check_page,
-                condition: condition_with_check_page,
+                page: condition.check_page,
+                condition: condition,
               )
             end
           }

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -37,7 +37,7 @@ class Pages::QuestionsController < PagesController
   end
 
   def update
-    page.load(page_params_for_forms_api)
+    page.assign_attributes(page_params_for_update)
 
     @question_input = Pages::QuestionInput.new(page_params_for_form_object)
 
@@ -64,7 +64,7 @@ private
                       guidance_markdown: draft_question.guidance_markdown)
   end
 
-  def page_params_for_forms_api
+  def page_params_for_update
     page_params.merge(form_id: current_form.id,
                       answer_settings: draft_question.answer_settings,
                       page_heading: draft_question.page_heading,

--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -39,7 +39,7 @@ class Pages::ConditionsInput < BaseInput
   end
 
   def routing_answer_options
-    options = page.answer_settings.selection_options.map { |option| OpenStruct.new(value: option.attributes[:name], label: option.attributes[:name]) }
+    options = page.answer_settings.selection_options.map { |option| OpenStruct.new(value: option[:name], label: option[:name]) }
     options << OpenStruct.new(value: :none_of_the_above.to_s, label: I18n.t("page_conditions.none_of_the_above")) if page.is_optional
 
     options

--- a/app/input_objects/pages/delete_secondary_skip_input.rb
+++ b/app/input_objects/pages/delete_secondary_skip_input.rb
@@ -9,9 +9,6 @@ class Pages::DeleteSecondarySkipInput < ConfirmActionInput
     result = true
 
     if confirmed?
-
-      record.prefix_options[:form_id] = form.id
-      record.prefix_options[:page_id] = record.routing_page_id
       result = ConditionRepository.destroy(record)
     end
 

--- a/app/input_objects/pages/routes/delete_confirmation_input.rb
+++ b/app/input_objects/pages/routes/delete_confirmation_input.rb
@@ -20,10 +20,6 @@ private
   def delete_routes
     pages = FormRepository.pages(form)
     page_routes = PageRoutesService.new(form:, pages:, page:).routes
-    page_routes.each do |rc|
-      rc.prefix_options[:form_id] = form.id
-      rc.prefix_options[:page_id] = rc.routing_page_id
-      ConditionRepository.destroy(rc)
-    end
+    page_routes.each { |condition| ConditionRepository.destroy(condition) }
   end
 end

--- a/app/input_objects/pages/secondary_skip_input.rb
+++ b/app/input_objects/pages/secondary_skip_input.rb
@@ -18,18 +18,10 @@ class Pages::SecondarySkipInput < BaseInput
       record.goto_page_id = skip_to_end? ? nil : goto_page_id
       record.skip_to_end = skip_to_end?
 
-      record.prefix_options[:form_id] = form.id
-      record.prefix_options[:page_id] = record.routing_page_id
-
       return ConditionRepository.save!(record)
     end
 
     if record.present?
-      # we need to ensure the prefix options in the condition we are removing
-      # are unchanged as Conditions are accessed through the API with form_id
-      # and page_id
-      record.prefix_options[:form_id] = form.id
-      record.prefix_options[:page_id] = record.routing_page_id
       ConditionRepository.destroy(record)
     end
 

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -73,8 +73,28 @@ class Condition < ApplicationRecord
     !exit_page_markdown.nil?
   end
 
+  alias_method :exit_page?, :is_exit_page?
+
   def has_routing_errors
     validation_errors.any?
+  end
+
+  alias_method :has_routing_errors?, :has_routing_errors
+
+  def secondary_skip?
+    answer_value.blank? && check_page_id != routing_page_id
+  end
+
+  def errors_with_fields
+    error_fields = {
+      answer_value_doesnt_exist: :answer_value,
+      goto_page_doesnt_exist: :goto_page_id,
+      cannot_have_goto_page_before_routing_page: :goto_page_id,
+      cannot_route_to_next_page: :goto_page_id,
+    }
+    validation_errors.map do |error|
+      { name: error[:name], field: error_fields[error[:name].to_sym] || :answer_value }
+    end
   end
 
 private

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -36,7 +36,7 @@ class Condition < ApplicationRecord
     page = form.pages.find_by(id: goto_page_id)
     return nil if page.present?
 
-    { name: "goto_page_doesnt_exist" }
+    DataStruct.new(name: "goto_page_doesnt_exist")
   end
 
   def warning_answer_doesnt_exist
@@ -45,7 +45,7 @@ class Condition < ApplicationRecord
     answer_options = check_page&.answer_settings&.dig("selection_options")&.pluck("name")
     return nil if answer_options.blank? || answer_options.include?(answer_value) || answer_value == :none_of_the_above.to_s && check_page.is_optional?
 
-    { name: "answer_value_doesnt_exist" }
+    DataStruct.new(name: "answer_value_doesnt_exist")
   end
 
   def warning_routing_to_next_page
@@ -54,14 +54,14 @@ class Condition < ApplicationRecord
     routing_page_position = routing_page.position
     goto_page_position = is_check_your_answers? ? form.pages.last.position + 1 : goto_page.position
 
-    return { name: "cannot_route_to_next_page" } if goto_page_position == (routing_page_position + 1)
+    return DataStruct.new(name: "cannot_route_to_next_page") if goto_page_position == (routing_page_position + 1)
 
     nil
   end
 
   def warning_goto_page_before_routing_page
     if goto_page.present? && (goto_page.position <= routing_page.position)
-      { name: "cannot_have_goto_page_before_routing_page" }
+      DataStruct.new(name: "cannot_have_goto_page_before_routing_page")
     end
   end
 

--- a/app/models/data_struct_type.rb
+++ b/app/models/data_struct_type.rb
@@ -1,0 +1,34 @@
+class DataStructType < ActiveModel::Type::Value
+  def type
+    :jsonb
+  end
+
+  # rubocop:disable Style/RescueModifier
+  def cast_value(value)
+    case value
+    when String
+      decoded = ActiveSupport::JSON.decode(value) rescue nil
+      DataStruct.recursive_new(decoded) unless decoded.nil?
+    when Hash
+      DataStruct.recursive_new(value)
+    when ActiveResource::Base
+      DataStruct.recursive_new(value)
+    when DataStruct
+      value
+    end
+  end
+  # rubocop:enable Style/RescueModifier
+
+  def serialize(value)
+    case value
+    when Hash, DataStruct
+      ActiveSupport::JSON.encode(value)
+    else
+      super
+    end
+  end
+
+  def changed_in_place?(raw_old_value, new_value)
+    cast_value(raw_old_value) != new_value
+  end
+end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -83,6 +83,10 @@ class Form < ApplicationRecord
     end
   end
 
+  def has_no_remaining_routes_available?
+    qualifying_route_pages.none? && has_routing_conditions
+  end
+
   def all_incomplete_tasks
     incomplete_tasks.concat(email_task_status_service.incomplete_email_tasks)
   end
@@ -129,6 +133,10 @@ private
 
   def task_status_service
     @task_status_service ||= TaskStatusService.new(form: self)
+  end
+
+  def has_routing_conditions
+    pages.filter { |p| p.routing_conditions.any? }.any?
   end
 
   def group_form

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -53,6 +53,14 @@ class Form < ApplicationRecord
 
   delegate :task_statuses, to: :task_status_service
 
+  def group
+    group_form&.group
+  end
+
+  after_destroy do
+    group_form&.destroy
+  end
+
 private
 
   def set_external_id
@@ -61,5 +69,9 @@ private
 
   def task_status_service
     @task_status_service ||= TaskStatusService.new(form: self)
+  end
+
+  def group_form
+    GroupForm.find_by_form_id(id)
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -87,6 +87,10 @@ class Form < ApplicationRecord
     incomplete_tasks.concat(email_task_status_service.incomplete_email_tasks)
   end
 
+  def all_task_statuses
+    task_statuses.merge(email_task_status_service.email_task_statuses)
+  end
+
   def page_number(page)
     return pages.length + 1 if page.nil?
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -113,6 +113,10 @@ class Form < ApplicationRecord
     end
   end
 
+  def file_upload_question_count
+    pages.count { |p| p.answer_type.to_sym == :file }
+  end
+
   after_destroy do
     group_form&.destroy
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -83,6 +83,10 @@ class Form < ApplicationRecord
     end
   end
 
+  def all_incomplete_tasks
+    incomplete_tasks.concat(email_task_status_service.incomplete_email_tasks)
+  end
+
   def page_number(page)
     return pages.length + 1 if page.nil?
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -24,13 +24,19 @@ class Form < ApplicationRecord
     live? || live_with_draft?
   end
 
+  alias_method :is_live?, :has_live_version
+
   def has_been_archived
     archived? || archived_with_draft?
   end
 
+  alias_method :is_archived?, :has_been_archived
+
   def has_routing_errors
     pages.filter(&:has_routing_errors).any?
   end
+
+  alias_method :has_routing_errors?, :has_routing_errors
 
   def marking_complete_with_errors
     errors.add(:base, :has_validation_errors, message: "Form has routing validation errors") if question_section_completed && has_routing_errors

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -57,6 +57,13 @@ class Form < ApplicationRecord
     group_form&.group
   end
 
+  def page_number(page)
+    return pages.length + 1 if page.nil?
+
+    index = pages.index { |existing_page| existing_page.attributes == page.attributes }
+    (index.nil? ? pages.length : index) + 1
+  end
+
   after_destroy do
     group_form&.destroy
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -46,6 +46,14 @@ class Page < ApplicationRecord
     true
   end
 
+  def next_page
+    lower_item&.id
+  end
+
+  def has_next_page?
+    next_page.present?
+  end
+
   def answer_type_changed_from_selection
     answer_type_previously_was&.to_sym == :selection && answer_type&.to_sym != :selection
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -23,6 +23,8 @@ class Page < ApplicationRecord
   validates :page_heading, length: { maximum: 250 }
   validate :guidance_markdown_length_and_tags
 
+  attribute :answer_settings, DataStructType.new
+
   def destroy_and_update_form!
     form = self.form
     destroy! && form.update!(question_section_completed: false)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -61,6 +61,10 @@ class Page < ApplicationRecord
     routing_conditions.filter(&:has_routing_errors).any?
   end
 
+  def show_optional_suffix?
+    is_optional? && answer_type != "selection"
+  end
+
 private
 
   def guidance_fields_presence

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -61,6 +61,10 @@ class Page < ApplicationRecord
     routing_conditions.filter(&:has_routing_errors).any?
   end
 
+  def question_with_number
+    "#{position}. #{question_text}"
+  end
+
   def show_optional_suffix?
     is_optional? && answer_type != "selection"
   end

--- a/app/services/condition_repository.rb
+++ b/app/services/condition_repository.rb
@@ -21,26 +21,25 @@ class ConditionRepository
         exit_page_markdown:,
       )
       update_and_save_to_database!(condition)
-      condition
     end
 
     def find(condition_id:, form_id:, page_id:)
       condition = Api::V1::ConditionResource.find(condition_id, params: { form_id:, page_id: })
       save_to_database!(condition)
-      condition
     end
 
     def save!(record)
       condition = Api::V1::ConditionResource.new(record.attributes, true)
-      condition.prefix_options = record.prefix_options
+      condition.prefix_options[:form_id] = record.form.id
+      condition.prefix_options[:page_id] = record.routing_page_id
       condition.save!
       update_and_save_to_database!(condition)
-      condition
     end
 
     def destroy(record)
       condition = Api::V1::ConditionResource.new(record.attributes, true)
-      condition.prefix_options = record.prefix_options
+      condition.prefix_options[:form_id] = record.form.id
+      condition.prefix_options[:page_id] = record.routing_page_id
 
       begin
         condition.destroy # rubocop:disable Rails/SaveBang
@@ -57,12 +56,14 @@ class ConditionRepository
 
     def save_to_database!(record)
       Condition.upsert(record.database_attributes)
+      Condition.find(record.id)
     end
 
     def update_and_save_to_database!(record)
       condition = Condition.find_or_initialize_by(id: record.id)
       condition.assign_attributes(record.database_attributes)
       condition.save_and_update_form
+      condition
     end
   end
 end

--- a/lib/data_struct.rb
+++ b/lib/data_struct.rb
@@ -1,0 +1,29 @@
+# When an OpenStruct is converted to json, it inludes @table.
+# We inherit and overide as_json here to use to contain answer_settings, which
+# is a json hash converted into an object by ActiveResource. Using a plain hash
+# for answer_settings means there is no .access to attributes.
+class DataStruct < OpenStruct
+  def self.recursive_new(object)
+    hash = convert_to_hash(object)
+    hash.each_with_object(DataStruct.new) do |(key, value), struct|
+      struct[key] = case value
+                    when Hash
+                      recursive_new(value)
+                    when Array
+                      value.map { recursive_new(it) }
+                    else
+                      value
+                    end
+    end
+  end
+
+  def as_json(*args)
+    super.as_json["table"]
+  end
+
+  def self.convert_to_hash(object)
+    return object.attributes if object.is_a?(ActiveResource::Base)
+
+    object
+  end
+end

--- a/spec/components/page_list_component/error_summary/error_summary_component_preview.rb
+++ b/spec/components/page_list_component/error_summary/error_summary_component_preview.rb
@@ -27,8 +27,8 @@ class PageListComponent::ErrorSummary::ErrorSummaryComponentPreview < ViewCompon
   end
 
   def error_component_with_errors
-    routing_conditions_page_1 = [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3)]
-    routing_conditions_page_2 = [(build :condition, :with_goto_page_missing, id: 2, routing_page_id: 2, check_page_id: 2, answer_value: "Wales")]
+    routing_conditions_page_1 = [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3)]
+    routing_conditions_page_2 = [(build :condition, id: 2, routing_page_id: 2, check_page_id: 2, answer_value: "Wales")]
 
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: routing_conditions_page_1),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: routing_conditions_page_2),

--- a/spec/components/page_list_component/error_summary/error_summary_component_preview.rb
+++ b/spec/components/page_list_component/error_summary/error_summary_component_preview.rb
@@ -11,6 +11,18 @@ class PageListComponent::ErrorSummary::ErrorSummaryComponentPreview < ViewCompon
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions:),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    form = build(:form, id: 0, pages:)
+
+    # We need to build the records rather than create them so that we don't save them to the database when we view the
+    # preview. However, this means that the associations aren't available so we need to manually set the associations
+    # after we've built the conditions
+    routing_conditions.each do |condition|
+      condition.routing_page = pages.select { |page| page.id == condition.routing_page_id }.first
+      condition.check_page = pages.select { |page| page.id == condition.check_page_id }.first
+      condition.goto_page = pages.select { |page| page.id == condition.goto_page_id }.first
+      condition.form = form
+    end
+
     render(PageListComponent::ErrorSummary::View.new(pages:))
   end
 
@@ -21,6 +33,17 @@ class PageListComponent::ErrorSummary::ErrorSummaryComponentPreview < ViewCompon
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: routing_conditions_page_1),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: routing_conditions_page_2),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    form = build(:form, id: 0, pages:)
+
+    # We need to build the records rather than create them so that we don't save them to the database when we view the
+    # preview. However, this means that the associations aren't available so we need to manually set the associations
+    # after we've built the conditions
+    (routing_conditions_page_1 + routing_conditions_page_2).each do |condition|
+      condition.routing_page = pages.select { |page| page.id == condition.routing_page_id }.first
+      condition.check_page = pages.select { |page| page.id == condition.check_page_id }.first
+      condition.goto_page = pages.select { |page| page.id == condition.goto_page_id }.first
+      condition.form = form
+    end
 
     render(PageListComponent::ErrorSummary::View.new(pages:))
   end

--- a/spec/components/page_list_component/error_summary/view_spec.rb
+++ b/spec/components/page_list_component/error_summary/view_spec.rb
@@ -1,69 +1,65 @@
 require "rails_helper"
 
 RSpec.describe PageListComponent::ErrorSummary::View, type: :component do
-  let(:pages) { [] }
-  let(:routing_conditions) { [] }
+  let(:form) { create :form }
+  let(:pages) { form.reload.pages }
   let(:error_summary_component) { described_class.new(pages:) }
 
   describe "rendering component" do
-    before do
-      render_inline(error_summary_component)
-    end
-
     context "when there are no pages" do
       it "is blank" do
+        render_inline(error_summary_component)
+
         expect(page).not_to have_selector("*")
       end
     end
 
-    context "when there are no errors" do
-      let(:routing_conditions) do
-        [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3),
-         (build :condition, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England", goto_page_id: 2)]
-      end
-      let(:pages) do
-        [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions:),
-         (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
-         (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    context "when there are no conditions with errors" do
+      let(:form) { create :form, :ready_for_routing }
+
+      before do
+        create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.last.id
+        pages.first.reload
       end
 
       it "is blank" do
+        render_inline(error_summary_component)
+
         expect(page).not_to have_selector("*")
       end
     end
 
     context "when the form has a route with an error" do
-      let(:routing_conditions) do
-        [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3),
-         (build :condition, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England", goto_page_id: 2)]
-      end
-      let(:pages) do
-        [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions:),
-         (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
-         (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+      let(:form) { create :form, :ready_for_routing }
+      let!(:condition) { create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: nil, goto_page_id: pages.last.id }
+
+      before do
+        pages.first.reload
       end
 
       it "renders the error_summary" do
+        render_inline(error_summary_component)
+
         expect(page).to have_css(".govuk-error-summary")
       end
 
       it "renders the error link" do
+        render_inline(error_summary_component)
+
         condition_answer_value_error = I18n.t("errors.page_conditions.answer_value_doesnt_exist", question_number: 1, route_number: 1)
-        expect(page).to have_link(condition_answer_value_error, href: "##{described_class.error_id(routing_conditions[0].id)}")
+        expect(page).to have_link(condition_answer_value_error, href: "##{described_class.error_id(condition.id)}")
       end
     end
 
     context "when the form has multiple routes with errors" do
-      let(:routing_conditions_page_with_answer_value_missing) do
-        [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3)]
-      end
-      let(:routing_conditions_page_with_goto_page_missing) do
-        [(build :condition, :with_goto_page_missing, id: 2, routing_page_id: 2, check_page_id: 2, answer_value: "Wales")]
-      end
-      let(:pages) do
-        [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: routing_conditions_page_with_answer_value_missing),
-         (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: routing_conditions_page_with_goto_page_missing),
-         (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+      let(:form) { create :form, :ready_for_routing }
+      let!(:condition_with_answer_value_missing) { create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, goto_page_id: pages.third.id, answer_value: nil }
+      let!(:condition_with_goto_page_missing) { create :condition, routing_page_id: pages.second.id, check_page_id: pages.second.id, goto_page_id: nil, answer_value: "Option 1" }
+
+      before do
+        pages.each(&:reload)
+
+        render_inline(error_summary_component)
       end
 
       it "renders the error_summary" do
@@ -73,41 +69,48 @@ RSpec.describe PageListComponent::ErrorSummary::View, type: :component do
       it "renders both error links" do
         condition_answer_value_error = I18n.t("errors.page_conditions.answer_value_doesnt_exist", question_number: 1, route_number: 1)
         condition_goto_page_error = I18n.t("errors.page_conditions.goto_page_doesnt_exist", question_number: 2, route_number: 1)
-        expect(page).to have_link(condition_answer_value_error, href: "##{described_class.error_id(routing_conditions_page_with_answer_value_missing[0].id)}")
-        expect(page).to have_link(condition_goto_page_error, href: "##{described_class.error_id(routing_conditions_page_with_goto_page_missing[0].id)}")
+        expect(page).to have_link(condition_answer_value_error, href: "##{described_class.error_id(condition_with_answer_value_missing.id)}")
+        expect(page).to have_link(condition_goto_page_error, href: "##{described_class.error_id(condition_with_goto_page_missing.id)}")
       end
     end
 
     context "when the form has a branch route" do
-      include_examples "with pages with routing"
+      let(:form) { create :form, :ready_for_routing }
+
+      before do
+        create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.last.id
+        pages.each(&:reload)
+      end
 
       context "and there is an error with the any other answer route" do
+        let!(:secondary_skip_condition) { create :condition, routing_page_id: pages.second.id, check_page_id: pages.first.id, answer_value: nil, goto_page_id: pages.third.id }
+
         before do
-          branch_any_other_answer_route.has_routing_errors = true
-          branch_any_other_answer_route.validation_errors = [OpenStruct.new(name: "cannot_route_to_next_page")]
+          pages.each(&:reload)
 
           render_inline(error_summary_component)
         end
 
         it "renders the error summary" do
-          error_message = I18n.t("errors.page_conditions.cannot_route_to_next_page", question_number: 2, route_number: "for any other answer")
+          error_message = I18n.t("errors.page_conditions.cannot_route_to_next_page", question_number: 1, route_number: "for any other answer")
           expect(page).to have_css ".govuk-error-summary", text: error_message
-          expect(page).to have_link error_message, href: "#condition_#{branch_any_other_answer_route.id}"
+          expect(page).to have_link error_message, href: "#condition_#{secondary_skip_condition.id}"
         end
       end
 
       context "and the any other answer route skip to question has been moved to before the skip from question" do
+        let!(:secondary_skip_condition) { create :condition, routing_page_id: pages.second.id, check_page_id: pages.first.id, answer_value: nil, goto_page_id: pages.first.id }
+
         before do
-          branch_any_other_answer_route.has_routing_errors = true
-          branch_any_other_answer_route.validation_errors = [OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")]
+          pages.each(&:reload)
 
           render_inline(error_summary_component)
         end
 
         it "renders an error message" do
-          error_message = I18n.t("errors.page_conditions.any_other_answer_route.cannot_have_goto_page_before_routing_page", question_number: 2, route_number: "for any other answer")
+          error_message = I18n.t("errors.page_conditions.any_other_answer_route.cannot_have_goto_page_before_routing_page", question_number: 1, route_number: "for any other answer")
           expect(page).to have_css ".govuk-error-summary", text: error_message
-          expect(page).to have_link error_message, href: "#condition_#{branch_any_other_answer_route.id}"
+          expect(page).to have_link error_message, href: "#condition_#{secondary_skip_condition.id}"
         end
       end
     end

--- a/spec/components/page_list_component/page_list_component_preview.rb
+++ b/spec/components/page_list_component/page_list_component_preview.rb
@@ -57,8 +57,8 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
   end
 
   def with_pages_and_conditions_with_errors
-    routing_conditions_1 = [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3),
-                            (build :condition, :with_goto_page_missing, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England"),
+    routing_conditions_1 = [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3),
+                            (build :condition, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England"),
                             (build :condition, id: 3, routing_page_id: 1, check_page_id: 1),
                             (build :condition, id: 5, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 2)]
     routing_conditions_2 = [(build :condition, id: 4, routing_page_id: 2, check_page_id: 2, answer_value: "England", goto_page_id: 1)]

--- a/spec/components/page_list_component/page_list_component_preview.rb
+++ b/spec/components/page_list_component/page_list_component_preview.rb
@@ -2,29 +2,38 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
   include FactoryBot::Syntax::Methods
 
   def default
-    form = build(:form, id: 0)
-    render(PageListComponent::View.new(pages: [], form:))
+    pages = []
+    form = build(:form, id: 0, pages:)
+    render(PageListComponent::View.new(pages:, form:))
   end
 
   def with_pages_and_no_conditions
-    form = build(:form, id: 0)
     pages = [build(:page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: []),
              build(:page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
              build(:page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    form = build(:form, id: 0, pages:)
     render(PageListComponent::View.new(pages:, form:))
   end
 
   def with_pages_and_one_condition
-    form = build(:form, id: 0)
-    routing_conditions = [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3)]
-    pages = [build(:page, id: 1, position: 1, question_text: "Enter your name", routing_conditions:),
+    condition = (build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3)
+    pages = [build(:page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: [condition]),
              build(:page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
              build(:page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    form = build(:form, id: 0, pages:)
+
+    # We need to build the records rather than create them so that we don't save them to the database when we view the
+    # preview. However, this means that the associations aren't available so we need to manually set the associations
+    # after we've built the conditions
+    condition.routing_page = pages[0]
+    condition.check_page = pages[0]
+    condition.goto_page = pages[2]
+    condition.form = form
+
     render(PageListComponent::View.new(pages:, form:))
   end
 
   def with_pages_and_multiple_conditions
-    form = build(:form, id: 0)
     routing_conditions_1 = [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3),
                             (build :condition, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England", goto_page_id: 2)]
     routing_conditions_2 = [(build :condition, id: 3, routing_page_id: 2, check_page_id: 2, answer_value: "Wales", goto_page_id: 3),
@@ -32,19 +41,42 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: routing_conditions_1),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: routing_conditions_2),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    form = build(:form, id: 0, pages:)
+
+    # We need to build the records rather than create them so that we don't save them to the database when we view the
+    # preview. However, this means that the associations aren't available so we need to manually set the associations
+    # after we've built the conditions
+    (routing_conditions_1 + routing_conditions_2).each do |condition|
+      condition.routing_page = pages.select { |page| page.id == condition.routing_page_id }.first
+      condition.check_page = pages.select { |page| page.id == condition.check_page_id }.first
+      condition.goto_page = pages.select { |page| page.id == condition.goto_page_id }.first
+      condition.form = form
+    end
+
     render(PageListComponent::View.new(pages:, form:))
   end
 
   def with_pages_and_conditions_with_errors
-    form = build(:form, id: 0)
     routing_conditions_1 = [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3),
                             (build :condition, :with_goto_page_missing, id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "England"),
-                            (build :condition, :with_answer_value_and_goto_page_missing, id: 3, routing_page_id: 1, check_page_id: 1),
-                            (build :condition, :with_goto_page_immediately_after_check_page, id: 5, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 2)]
-    routing_conditions_2 = [(build :condition, :with_goto_page_before_check_page, id: 4, routing_page_id: 2, check_page_id: 2, answer_value: "England", goto_page_id: 1)]
+                            (build :condition, id: 3, routing_page_id: 1, check_page_id: 1),
+                            (build :condition, id: 5, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 2)]
+    routing_conditions_2 = [(build :condition, id: 4, routing_page_id: 2, check_page_id: 2, answer_value: "England", goto_page_id: 1)]
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: routing_conditions_1),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: routing_conditions_2),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
+    form = build(:form, id: 1, pages:)
+
+    # We need to build the records rather than create them so that we don't save them to the database when we view the
+    # preview. However, this means that the associations aren't available so we need to manually set the associations
+    # after we've built the conditions
+    (routing_conditions_1 + routing_conditions_2).each do |condition|
+      condition.routing_page = pages.select { |page| page.id == condition.routing_page_id }.first
+      condition.check_page = pages.select { |page| page.id == condition.check_page_id }.first
+      condition.goto_page = pages.select { |page| page.id == condition.goto_page_id }.first
+      condition.form = form
+    end
+
     render(PageListComponent::View.new(pages:, form:))
   end
 end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -1,31 +1,34 @@
 require "rails_helper"
 
 RSpec.describe PageListComponent::View, type: :component do
-  let(:form) { build :form, id: 1 }
-  let(:pages) { [] }
-  let(:routing_conditions) { [] }
+  let(:form) { create :form }
+  let(:pages) { form.reload.pages }
   let(:page_list_component) { described_class.new(pages:, form:) }
 
   describe "rendering component" do
-    before do
-      render_inline(page_list_component)
-    end
-
     context "when there are no pages" do
+      before do
+        render_inline(page_list_component)
+      end
+
       it "is blank" do
         expect(page).not_to have_selector("*")
       end
     end
 
     context "when the form has a single page" do
-      let(:pages) { [(build :page, id: 1, position: 1, question_text: "Enter your name?")] }
+      let!(:single_page) { create :page, form: }
+
+      before do
+        render_inline(page_list_component)
+      end
 
       it "renders the question number" do
-        expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
+        expect(page).to have_css("dt.govuk-summary-list__key", text: single_page.position.to_s)
       end
 
       it "renders question title" do
-        expect(page).to have_content("Enter your name")
+        expect(page).to have_content(single_page.question_text.to_s)
       end
 
       it "renders link" do
@@ -38,61 +41,67 @@ RSpec.describe PageListComponent::View, type: :component do
       end
 
       it "includes the page id in the id for the row" do
-        expect(page).to have_css "#page_1.govuk-summary-list__row"
+        expect(page).to have_css "#page_#{single_page.id}.govuk-summary-list__row"
       end
     end
 
     context "when the form has multiple pages" do
-      let(:pages) { [(build :page, id: 1, position: 1, question_text: "Enter your name?"), (build :page, id: 2, position: 2, question_text: "What is you pet's name?")] }
+      let(:form) { create :form, :with_pages }
+      let(:first_page) { form.pages.first }
+      let(:second_page) { form.pages.second }
 
-      it "renders the question numbers" do
-        expect(page).to have_css("dt.govuk-summary-list__key", text: "1")
-        expect(page).to have_css("dt.govuk-summary-list__key", text: "2")
-      end
+      context "when there are no conditions" do
+        before do
+          render_inline(page_list_component)
+        end
 
-      it "renders a move up link" do
-        expect(page).to have_button("Move up")
-      end
+        it "renders the question numbers" do
+          expect(page).to have_css("dt.govuk-summary-list__key", text: first_page.position)
+          expect(page).to have_css("dt.govuk-summary-list__key", text: second_page.position)
+        end
 
-      it "renders a move down link" do
-        expect(page).to have_button("Move down")
-      end
+        it "renders a move up link" do
+          expect(page).to have_button("Move up")
+        end
 
-      it "includes the page id in the id for each row" do
-        expect(page).to have_css "#page_1.govuk-summary-list__row"
-        expect(page).to have_css "#page_2.govuk-summary-list__row"
+        it "renders a move down link" do
+          expect(page).to have_button("Move down")
+        end
+
+        it "includes the page id in the id for each row" do
+          expect(page).to have_css "#page_#{first_page.id}.govuk-summary-list__row"
+          expect(page).to have_css "#page_#{second_page.id}.govuk-summary-list__row"
+        end
+
+        it "conditions section is not present" do
+          expect(page).to have_css(".govuk-summary-list__row", count: pages.length)
+        end
       end
 
       context "when the form has conditions" do
-        let(:pages) do
-          [(build :page, id: 1, position: 1, question_text: "What country do you live in?", routing_conditions:),
-           (build :page, id: 2, position: 2, question_text: "What is your name?", routing_conditions:),
-           (build :page, id: 3, position: 3, question_text: "What is your pet's name?", routing_conditions:)]
-        end
+        let(:form) { create :form, :ready_for_routing }
         let(:edit_condition_path) { "/forms/0/pages/1/conditions/1" }
 
-        context "when there are no conditions" do
-          it "conditions section is not present" do
-            expect(page).to have_css(".govuk-summary-list__row", count: pages.length)
-          end
-        end
-
         context "when the page has a single condition" do
-          let(:routing_conditions) { [(build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3)] }
+          let!(:condition) { create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.third.id }
+
+          before do
+            render_inline(page_list_component)
+          end
 
           it "does not render any errors" do
             expect(page).not_to have_css(".app-page_list__route-text--error")
           end
 
           it "renders the condition description" do
-            condition_description = page_list_component.condition_description(routing_conditions.first)
-            expect(condition_description).to be_present
+            condition_description = "If “#{pages.first.question_text}” is answered as “#{condition.answer_value}” go to #{pages.third.position}, “#{pages.third.question_text}”"
+
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_description)
           end
 
           it "renders the routing details" do
-            condition_answer_value_text = I18n.t("page_conditions.condition_answer_value_text", answer_value: "Wales")
-            condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_question_number: 3, goto_page_question_text: "What is your pet's name?")
+            condition_answer_value_text = I18n.t("page_conditions.condition_answer_value_text", answer_value: condition.answer_value)
+            condition_goto_page_text = I18n.t("page_conditions.condition_goto_page_text", goto_page_question_number: pages.third.position, goto_page_question_text: pages.third.question_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_answer_value_text)
             expect(page).to have_css("dd.govuk-summary-list__value", text: condition_goto_page_text)
           end
@@ -102,58 +111,28 @@ RSpec.describe PageListComponent::View, type: :component do
           end
         end
 
-        context "when the page has a condition with no answer_value" do
-          let(:routing_conditions) { [(build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3)] }
+        context "when the condition has an exit page heading" do
+          let!(:condition) { create :condition, :with_exit_page, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1" }
 
-          it "renders the errors in an unordered list" do
-            condition_answer_value_error = I18n.t("errors.page_conditions.answer_value_doesnt_exist", question_number: 1, route_number: 1)
-            expect(page).to have_css("ul > li", text: condition_answer_value_error)
+          before do
+            render_inline(page_list_component)
           end
 
           it "renders the condition description" do
-            condition_description = page_list_component.condition_description(routing_conditions.first)
-            expect(condition_description).to be_present
-            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_description)
-          end
-
-          it "renders link" do
-            expect(page).to have_link("Edit")
-          end
-        end
-
-        context "when the page has a condition with no goto_page set" do
-          let(:routing_conditions) { [(build :condition, :with_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales")] }
-
-          it "renders the errors in an unordered list" do
-            condition_goto_page_error = I18n.t("errors.page_conditions.goto_page_doesnt_exist", question_number: 1)
-            expect(page).to have_css("ul > li", text: condition_goto_page_error)
-          end
-
-          it "renders the condition description" do
-            condition_description = page_list_component.condition_description(routing_conditions.first)
-            expect(condition_description).to be_present
-            expect(page).to have_css("dd.govuk-summary-list__value", text: condition_description)
-          end
-
-          it "renders link" do
-            expect(page).to have_link("Edit")
-          end
-
-          context "when the condition has an exit page heading" do
-            let(:routing_conditions) { [(build :condition, :with_exit_page, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales")] }
-
-            it "renders the condition description" do
-              expect(page).to have_css("dd.govuk-summary-list__value", text: "If “What country do you live in?” is answered as “Wales” go to exit page, “#{routing_conditions.first.exit_page_heading}”")
-            end
+            expect(page).to have_css("dd.govuk-summary-list__value", text: "If “#{pages.first.question_text}” is answered as “#{condition.answer_value}” go to exit page, “#{condition.exit_page_heading}”")
           end
         end
 
         context "when the page has a condition with multiple errors" do
-          let(:routing_conditions) { [(build :condition, :with_answer_value_and_goto_page_missing, id: 1, routing_page_id: 1, check_page_id: 1)] }
+          before do
+            create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: nil, goto_page_id: nil
+
+            render_inline(page_list_component)
+          end
 
           it "renders the errors in an unordered list" do
-            condition_answer_value_error = I18n.t("errors.page_conditions.answer_value_doesnt_exist", question_number: 1, route_number: 1)
-            condition_goto_page_error = I18n.t("errors.page_conditions.goto_page_doesnt_exist", question_number: 1, route_number: 1)
+            condition_answer_value_error = I18n.t("errors.page_conditions.answer_value_doesnt_exist", question_number: pages.first.position, route_number: 1)
+            condition_goto_page_error = I18n.t("errors.page_conditions.goto_page_doesnt_exist", question_number: pages.first.position, route_number: 1)
             expect(page).to have_css("ul > li", text: condition_answer_value_error)
             expect(page).to have_css("ul > li", text: condition_goto_page_error)
           end
@@ -164,54 +143,47 @@ RSpec.describe PageListComponent::View, type: :component do
         end
       end
 
-      context "when the form has a branch route" do
-        include_examples "with pages with routing"
+      context "when the form has a valid branch route" do
+        let(:form) { create :form, :ready_for_routing }
+        let!(:secondary_skip_condition) { create :condition, routing_page_id: pages.second.id, check_page_id: pages.first.id, answer_value: nil, goto_page_id: pages.fourth.id }
+
+        before do
+          create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.third.id
+          pages.each(&:reload)
+
+          render_inline(page_list_component)
+        end
 
         it "renders a summary list row for the any other answer route" do
-          expect(page).to have_css("#condition_2.govuk-summary-list__row", text: "Question 2’s routes") do |summary_list_row|
-            expect(summary_list_row).to have_link(href: show_routes_path(form_id: 1, page_id: 2)) do |link|
-              expect(link).to have_content("Edit Question 2’s routes")
+          expect(page).to have_css("#condition_#{secondary_skip_condition.id}.govuk-summary-list__row", text: "Question #{pages.first.position}’s routes") do |summary_list_row|
+            expect(summary_list_row).to have_link(href: show_routes_path(form_id: form.id, page_id: pages.first.id)) do |link|
+              expect(link).to have_content("Edit Question #{pages.first.position}’s routes")
             end
           end
         end
+      end
 
-        context "and there is an error with the any other answer route" do
-          before do
-            branch_any_other_answer_route.has_routing_errors = true
-            branch_any_other_answer_route.validation_errors = [OpenStruct.new(name: "cannot_route_to_next_page")]
+      context "when the form has a branch route with an error" do
+        let(:form) { create :form, :ready_for_routing }
 
-            render_inline(page_list_component)
-          end
+        before do
+          create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.third.id
+          create :condition, routing_page_id: pages.second.id, check_page_id: pages.first.id, answer_value: nil, goto_page_id: pages.third.id
+          pages.each(&:reload)
 
-          it "renders an error message" do
-            error_message = I18n.t("errors.page_conditions.cannot_route_to_next_page", question_number: 2, route_number: "for any other answer")
-            expect(page).to have_css ".app-page_list__route-text--error", text: error_message
-          end
+          render_inline(page_list_component)
         end
 
-        context "and the any other answer route skip to question has been moved to before the skip from question" do
-          before do
-            branch_any_other_answer_route.has_routing_errors = true
-            branch_any_other_answer_route.validation_errors = [OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")]
-
-            render_inline(page_list_component)
-          end
-
-          it "renders an error message" do
-            error_message = I18n.t("errors.page_conditions.any_other_answer_route.cannot_have_goto_page_before_routing_page", question_number: 2, route_number: "for any other answer")
-            expect(page).to have_css ".app-page_list__route-text--error", text: error_message
-          end
+        it "renders an error message" do
+          error_message = I18n.t("errors.page_conditions.cannot_route_to_next_page", question_number: pages.first.position, route_number: "for any other answer")
+          expect(page).to have_css ".app-page_list__route-text--error", text: error_message
         end
       end
     end
   end
 
   describe "class methods" do
-    let(:pages) do
-      [(build :page, id: 1, position: 1, question_text: "What country do you live in?", routing_conditions:),
-       (build :page, id: 2, position: 2, question_text: "What is your name?", routing_conditions:),
-       (build :page, id: 3, position: 3, question_text: "What is your pet's name?", routing_conditions:)]
-    end
+    let(:form) { create :form, :with_pages }
 
     describe "show_up_button" do
       it "returns false when index is 0" do
@@ -235,7 +207,7 @@ RSpec.describe PageListComponent::View, type: :component do
 
     describe "#page_row_id" do
       it "returns the corrrect id text for a given page" do
-        expect(page_list_component.page_row_id(pages.second)).to eq "page_2"
+        expect(page_list_component.page_row_id(pages.second)).to eq "page_#{pages.second.id}"
       end
     end
 
@@ -246,109 +218,106 @@ RSpec.describe PageListComponent::View, type: :component do
     end
 
     describe "#condition_description" do
-      let(:pages) do
-        [
-          (build :page, id: 1, position: 1, question_text: "What country do you live in?", routing_conditions:),
-          (build :page, id: 2, position: 2, question_text: "What is your name?", routing_conditions:),
-          (build :page, id: 3, position: 3, question_text: "What is your pet's name?", routing_conditions:),
-          (build :page, id: 4, position: 4, question_text: "What is your email address?", routing_conditions:),
-        ]
-      end
-
       context "when condition has all values set" do
         let(:condition) do
-          build(:condition, id: 1,
-                            routing_page_id: 1,
-                            check_page_id: 1,
-                            answer_value: "Wales",
-                            goto_page_id: 3)
+          create(
+            :condition,
+            routing_page_id: pages.first.id,
+            check_page_id: pages.first.id,
+            answer_value: "Option 1",
+            goto_page_id: pages.third.id,
+          )
         end
 
         it "returns complete condition description" do
-          expected_text = "If “What country do you live in?” is answered as “Wales” go to 3, “What is your pet's name?”"
+          expected_text = "If “#{pages.first.question_text}” is answered as “#{condition.answer_value}” go to #{pages.third.position}, “#{pages.third.question_text}”"
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
         end
       end
 
       context "when answer value is 'none_of_the_above'" do
         let(:condition) do
-          build(:condition,
-                id: 1,
-                routing_page_id: 1,
-                check_page_id: 1,
-                answer_value: "none_of_the_above",
-                goto_page_id: 3)
+          create(
+            :condition,
+            routing_page_id: pages.first.id,
+            check_page_id: pages.first.id,
+            answer_value: "none_of_the_above",
+            goto_page_id: pages.third.id,
+          )
         end
 
         it "returns description with 'None of the above' text" do
-          expected_text = "If “What country do you live in?” is answered as “None of the above” go to 3, “What is your pet's name?”"
+          expected_text = "If “#{pages.first.question_text}” is answered as “None of the above” go to #{pages.third.position}, “#{pages.third.question_text}”"
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
         end
       end
 
       context "when answer value is missing" do
         let(:condition) do
-          build(:condition,
-                id: 1,
-                routing_page_id: 1,
-                check_page_id: 1,
-                answer_value: nil,
-                goto_page_id: 3)
+          create(
+            :condition,
+            routing_page_id: pages.first.id,
+            check_page_id: pages.first.id,
+            answer_value: nil,
+            goto_page_id: pages.third.id,
+          )
         end
 
         it "returns description with error text for missing answer" do
-          expected_text = "If “What country do you live in?” is answered as [Answer not selected] go to 3, “What is your pet's name?”"
+          expected_text = "If “#{pages.first.question_text}” is answered as [Answer not selected] go to #{pages.third.position}, “#{pages.third.question_text}”"
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
         end
       end
 
       context "when skip_to_end is true" do
         let(:condition) do
-          build(:condition,
-                id: 1,
-                routing_page_id: 1,
-                check_page_id: 1,
-                answer_value: "Wales",
-                goto_page_id: nil,
-                skip_to_end: true)
+          create(
+            :condition,
+            routing_page_id: pages.first.id,
+            check_page_id: pages.first.id,
+            answer_value: "Option 1",
+            goto_page_id: nil,
+            skip_to_end: true,
+          )
         end
 
         it "returns description with 'Check your answers' text" do
-          expected_text = "If “What country do you live in?” is answered as “Wales” go to “Check your answers before submitting”."
+          expected_text = "If “#{pages.first.question_text}” is answered as “#{condition.answer_value}” go to “Check your answers before submitting”."
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
         end
       end
 
       context "when goto page is missing and skip_to_end is false" do
         let(:condition) do
-          build(:condition,
-                id: 1,
-                routing_page_id: 1,
-                check_page_id: 1,
-                answer_value: "Wales",
-                goto_page_id: nil,
-                skip_to_end: false)
+          create(
+            :condition,
+            routing_page_id: pages.first.id,
+            check_page_id: pages.first.id,
+            answer_value: "Option 1",
+            goto_page_id: nil,
+            skip_to_end: false,
+          )
         end
 
         it "returns description with error text for missing goto page" do
-          expected_text = "If “What country do you live in?” is answered as “Wales” go to [Question not selected]"
+          expected_text = "If “#{pages.first.question_text}” is answered as “#{condition.answer_value}” go to [Question not selected]"
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
         end
       end
 
       context "when showing a secondary_skip" do
         let(:condition) do
-          build(:condition,
-                id: 1,
-                routing_page_id: 2,
-                check_page_id: 1,
-                answer_value: nil,
-                goto_page_id: 4,
-                secondary_skip: true)
+          create(
+            :condition,
+            routing_page_id: pages.second.id,
+            check_page_id: pages.first.id,
+            answer_value: nil,
+            goto_page_id: pages.fourth.id,
+          )
         end
 
         it "returns correct description" do
-          expected_text = "After 2, “What is your name?” go to 4, “What is your email address?”"
+          expected_text = "After #{pages.second.position}, “#{pages.second.question_text}” go to #{pages.fourth.position}, “#{pages.fourth.question_text}”"
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
         end
       end

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 describe ApplicationController, type: :controller do
   subject(:application_controller) { described_class.new }
 
-  let(:id) { 1 }
-  let(:form) { build :form }
+  let(:form) { create :form }
 
   describe "#user_ip" do
     [
@@ -82,22 +81,21 @@ describe ApplicationController, type: :controller do
   end
 
   describe "#current_form" do
-    it "returns the current form" do
-      params = ActionController::Parameters.new(form_id: id)
-      allow(Api::V1::FormResource).to receive(:find).with(id).and_return(form)
+    before do
+      allow(FormRepository).to receive(:find).with(form_id: form.id).and_return(form)
+      params = ActionController::Parameters.new(form_id: form.id)
       allow(controller).to receive(:params).and_return(params)
+    end
 
+    it "returns the current form" do
       expect(controller.current_form).to eq form
     end
 
     it "memorizes the find form request so it doesn't have to repeat the calls" do
-      params = ActionController::Parameters.new(form_id: id)
-      allow(Api::V1::FormResource).to receive(:find).with(id).and_return(form)
-      allow(controller).to receive(:params).and_return(params)
       controller.current_form
       controller.current_form
 
-      expect(Api::V1::FormResource).to have_received(:find).exactly(1).times
+      expect(FormRepository).to have_received(:find).exactly(1).times
     end
   end
 

--- a/spec/factories/models/condition_record.rb
+++ b/spec/factories/models/condition_record.rb
@@ -12,35 +12,6 @@ FactoryBot.define do
     exit_page_heading { nil }
     exit_page_markdown { nil }
 
-    trait :with_answer_value_missing do
-      goto_page { association :page_record, form: }
-
-      check_page { association :page_record, :with_selection_settings, form: }
-      answer_value { nil }
-    end
-
-    trait :with_goto_page_missing do
-      goto_page { nil }
-    end
-
-    trait :with_goto_page_before_check_page do
-      check_page { association :page_record, form:, position: 5 }
-      goto_page { association :page_record, form:, position: 3 }
-    end
-
-    trait :with_goto_page_immediately_after_check_page do
-      routing_page { association :page_record, form:, position: 5 }
-      check_page { routing_page }
-      goto_page { association :page_record, form:, position: 6 }
-    end
-
-    trait :with_answer_value_and_goto_page_missing do
-      goto_page { nil }
-
-      check_page { association :page_record, :with_selection_settings, form: }
-      answer_value { nil }
-    end
-
     trait :with_exit_page do
       goto_page { nil }
       exit_page_heading { "Exit page heading" }

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -1,3 +1,3 @@
 FactoryBot.define do
-  factory :condition, parent: :condition_resource
+  factory :condition, parent: :condition_record
 end

--- a/spec/factories/models/form_record.rb
+++ b/spec/factories/models/form_record.rb
@@ -60,6 +60,10 @@ FactoryBot.define do
       share_preview_completed { true }
     end
 
+    trait :with_submission_email do
+      association :form_submission_email
+    end
+
     trait :live do
       ready_for_live
       state { :live }

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -1,3 +1,3 @@
 FactoryBot.define do
-  factory :form, parent: :form_resource
+  factory :form, parent: :form_record
 end

--- a/spec/factories/models/made_live_form.rb
+++ b/spec/factories/models/made_live_form.rb
@@ -22,5 +22,9 @@ FactoryBot.define do
     pages do
       Array.new(5) { association(:made_live_page) }
     end
+
+    trait :with_one_page do
+      pages { [association(:made_live_page)] }
+    end
   end
 end

--- a/spec/factories/models/page_record.rb
+++ b/spec/factories/models/page_record.rb
@@ -1,13 +1,3 @@
-# When an OpenStruct is converted to json, it inludes @table.
-# We inherit and overide as_json here to use to contain answer_settings, which
-# is a json hash converted into an object by ActiveResource. Using a plain hash
-# for answer_settings means there is no .access to attributes.
-class DataStruct < OpenStruct
-  def as_json(*args)
-    super.as_json["table"]
-  end
-end
-
 FactoryBot.define do
   factory :page_record, class: "Page" do
     association :form, factory: :form_record

--- a/spec/factories/models/page_resource.rb
+++ b/spec/factories/models/page_resource.rb
@@ -1,13 +1,3 @@
-# When an OpenStruct is converted to json, it inludes @table.
-# We inherit and overide as_json here to use to contain answer_settings, which
-# is a json hash converted into an object by ActiveResource. Using a plain hash
-# for answer_settings means there is no .access to attributes.
-class DataStruct < OpenStruct
-  def as_json(*args)
-    super.as_json["table"]
-  end
-end
-
 FactoryBot.define do
   factory :page_resource, class: "Api::V1::PageResource" do
     sequence(:id) { |n| n }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :page, parent: :page_resource
+  factory :page, parent: :page_record
 
   trait :with_file_upload_answer_type do
     answer_type { "file" }

--- a/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
+++ b/spec/features/form/add_or_edit_questions/edit_answer_settings_for_existing_questions_spec.rb
@@ -1,15 +1,22 @@
 require "rails_helper"
 
 feature "Editing answer_settings for existing question", type: :feature do
-  let(:form) { build :form, id: 1, pages: }
+  let(:form) { create :form }
   let(:group) { create(:group, organisation: standard_user.organisation) }
+  let(:pages) { form.reload.pages }
 
   before do
+    create(:page, :with_address_settings, form:)
+    create(:page, :with_date_settings, form:, input_type: "date_of_birth")
+    create(:page, :with_name_settings, form:, input_type: "first_middle_and_last_name", title_needed: "true")
+    create(:page, :with_selection_settings, form:, is_optional: true)
+    create(:page, :with_text_settings, form:, input_type: "long_text")
+
     allow(FormRepository).to receive_messages(find: form, pages:)
     allow(PageRepository).to receive_messages(create!: true)
 
     pages.each do |page|
-      allow(PageRepository).to receive(:find).with(page_id: page.id.to_s, form_id: 1).and_return(page)
+      allow(PageRepository).to receive(:find).with(page_id: page.id.to_s, form_id: form.id).and_return(page)
     end
     allow(PageRepository).to receive(:create!).with(hash_including(form_id: 1))
 
@@ -20,13 +27,6 @@ feature "Editing answer_settings for existing question", type: :feature do
   end
 
   context "when a form has existing pages with answer types" do
-    let(:address_question) { build(:page, :with_address_settings, form_id: 1) }
-    let(:date_question) { build(:page, :with_date_settings, form_id: 1, input_type: "date_of_birth") }
-    let(:name_question) { build(:page, :with_name_settings, form_id: 1, input_type: "first_middle_and_last_name", title_needed: "true") }
-    let(:selection_question) { build(:page, :with_selection_settings, form_id: 1, is_optional: true) }
-    let(:text_question) { build(:page, :with_text_settings, form_id: 1, input_type: "long_text") }
-    let(:pages) { [address_question, date_question, name_question, selection_question, text_question] }
-
     scenario "view answer_settings for each answer type and check the values are set" do
       when_i_viewing_an_existing_form
       and_i_view_a_list_of_existing_questions

--- a/spec/input_objects/forms/make_live_input_spec.rb
+++ b/spec/input_objects/forms/make_live_input_spec.rb
@@ -13,12 +13,24 @@ RSpec.describe Forms::MakeLiveInput, type: :model do
       )
     end
 
-    context "when form is being made live but not all the required sections have been completed" do
-      let(:make_live_input) { build :make_live_input }
+    context "when all the required sections have been completed" do
+      let(:form) { create :form, :ready_for_live, :with_submission_email }
+      let(:make_live_input) { build :make_live_input, form: }
 
       before do
-        make_live_input.form.ready_for_live = false
+        make_live_input.confirm = "yes"
+      end
 
+      it "is valid" do
+        expect(make_live_input).to be_valid
+      end
+    end
+
+    context "when form is being made live but not all the required sections have been completed" do
+      let(:form) { create :form, :ready_for_live }
+      let(:make_live_input) { build :make_live_input, form: }
+
+      before do
         make_live_input.confirm = "yes"
       end
 
@@ -29,12 +41,9 @@ RSpec.describe Forms::MakeLiveInput, type: :model do
         expect(make_live_input.errors.full_messages_for(:confirm)).to include("Confirm #{I18n.t('activemodel.errors.models.forms/make_live_input.attributes.confirm.missing_submission_email')}")
       end
 
-      context "when the API returns incomplete tasks" do
+      context "when there are incomplete tasks" do
+        let(:form) { create :form, :new_form }
         let(:incomplete_tasks) { %i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed] }
-
-        before do
-          make_live_input.form.incomplete_tasks = incomplete_tasks
-        end
 
         it "shows a validation message for the incomplete task" do
           expect(make_live_input).not_to be_valid

--- a/spec/input_objects/forms/mark_pages_section_complete_input_spec.rb
+++ b/spec/input_objects/forms/mark_pages_section_complete_input_spec.rb
@@ -1,18 +1,23 @@
 require "rails_helper"
 
 RSpec.describe Forms::MarkPagesSectionCompleteInput, type: :model do
-  let(:form) { build :form }
+  let(:form) { create :form }
   let(:mark_complete_input) { described_class.new(mark_complete:, form:) }
   let(:mark_complete) { "true" }
 
   describe "validations" do
     context "when form has routing validation errors" do
-      let(:form) { build :form, :ready_for_routing, has_routing_errors: true }
+      let(:form) { create :form, :ready_for_routing }
+
+      before do
+        create :condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, goto_page_id: form.pages.third.id, answer_value: "Doesn't exist"
+        form.reload
+      end
 
       context "when mark_complete is true" do
         let(:mark_complete) { "true" }
 
-        it "is valid" do
+        it "is not valid" do
           error_message = I18n.t("activemodel.errors.models.forms/mark_pages_section_complete_input.attributes.base.has_routing_errors")
           expect(mark_complete_input).not_to be_valid
           expect(mark_complete_input.errors.full_messages_for(:base)).to include(error_message)
@@ -42,7 +47,7 @@ RSpec.describe Forms::MarkPagesSectionCompleteInput, type: :model do
 
       it "sets the forms question section completed" do
         mark_complete_input.submit
-        expect(mark_complete_input.form.question_section_completed).to eq mark_complete_input.mark_complete
+        expect(mark_complete_input.form.question_section_completed).to be true
       end
     end
 

--- a/spec/input_objects/forms/share_preview_input_spec.rb
+++ b/spec/input_objects/forms/share_preview_input_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Forms::SharePreviewInput, type: :model do
 
       it "sets the forms question section completed" do
         mark_complete_input.submit
-        expect(mark_complete_input.form.share_preview_completed).to eq mark_complete_input.mark_complete
+        expect(mark_complete_input.form.share_preview_completed).to be true
       end
     end
 

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
   end
 
   describe "#check_errors_from_api" do
-    let(:condition) { create :condition, :with_answer_value_missing, routing_page_id: page.id, answer_value: "England", check_page_id: page.id, goto_page_id: pages.third.id }
+    let(:condition) { create :condition, routing_page_id: page.id, answer_value: "England", check_page_id: page.id, goto_page_id: pages.third.id }
 
     it "is invalid if there are validation errors" do
       error_message = I18n.t("activemodel.errors.models.pages/conditions_input.attributes.answer_value.answer_value_doesnt_exist")

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Pages::ConditionsInput, type: :model do
   let(:conditions_input) { described_class.new(form:, page:, record: condition) }
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:form) { create :form, :ready_for_routing }
   let(:pages) { form.pages }
   let(:is_optional) { false }
   let(:page) do
@@ -11,7 +11,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       second_page.answer_type = "selection"
       second_page.answer_settings = DataStruct.new(
         only_one_option: true,
-        selection_options: [OpenStruct.new(attributes: { name: "Option 1" }), OpenStruct.new(attributes: { name: "Option 2" })],
+        selection_options: [DataStruct.new({ name: "Option 1" }), DataStruct.new({ name: "Option 2" })],
       )
     end
   end
@@ -74,21 +74,13 @@ RSpec.describe Pages::ConditionsInput, type: :model do
 
   describe "#update_condition" do
     context "when validation pass" do
-      let(:condition) { build :condition, id: 3, form_id: 1, page_id: 2, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
+      let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, answer_value: "Wales", goto_page_id: pages.third.id }
 
       before do
         allow(ConditionRepository).to receive(:save!)
 
         conditions_input.answer_value = "England"
-        conditions_input.goto_page_id = 4
-      end
-
-      it "calls assign_skip_to_end" do
-        allow(conditions_input).to receive(:assign_skip_to_end)
-
-        conditions_input.update_condition
-
-        expect(conditions_input).to have_received(:assign_skip_to_end).exactly(1).times
+        conditions_input.goto_page_id = pages.fourth.id
       end
 
       it "updates a condition" do
@@ -202,9 +194,9 @@ RSpec.describe Pages::ConditionsInput, type: :model do
   end
 
   describe "#check_errors_from_api" do
-    let(:condition) { build :condition, :with_answer_value_missing, id: 3, page_id: 2, routing_page_id: 1, answer_value: "England", check_page_id: 1, goto_page_id: 3 }
+    let(:condition) { create :condition, :with_answer_value_missing, routing_page_id: page.id, answer_value: "England", check_page_id: page.id, goto_page_id: pages.third.id }
 
-    it "is invalid if there are API validation errors" do
+    it "is invalid if there are validation errors" do
       error_message = I18n.t("activemodel.errors.models.pages/conditions_input.attributes.answer_value.answer_value_doesnt_exist")
       conditions_input.check_errors_from_api
       expect(conditions_input.errors.full_messages_for(:answer_value)).to include("Answer value #{error_message}")
@@ -213,7 +205,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
 
   describe "#assign_condition_values" do
     let(:conditions_input) { described_class.new(form:, page:, record: condition, answer_value: condition.answer_value, goto_page_id: condition.goto_page_id, skip_to_end: condition.skip_to_end) }
-    let(:condition) { build :condition, id: 3, page_id: 2, routing_page_id: 1, answer_value: "England", check_page_id: 1, goto_page_id:, skip_to_end: }
+    let(:condition) { create :condition, routing_page_id: page.id, answer_value: "England", check_page_id: page.id, goto_page_id:, skip_to_end: }
     let(:goto_page_id) { nil }
     let(:skip_to_end) { false }
 

--- a/spec/input_objects/pages/delete_condition_input_spec.rb
+++ b/spec/input_objects/pages/delete_condition_input_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe Pages::DeleteConditionInput, type: :model do
   let(:delete_condition_input) { described_class.new(form:, page:, record: condition) }
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:form) { create :form, :ready_for_routing }
   let(:pages) { form.pages }
   let(:page) { pages.second }
   let(:goto_page) { pages.last }
-  let(:answer_value) { "Wales" }
+  let(:answer_value) { "Option 1" }
   let(:goto_page_id) { goto_page.id }
   let(:skip_to_end) { false }
-  let(:condition) { build :condition, id: 2, form_id: form.id, page_id: page.id, routing_page_id: page.id, check_page_id: page.id, answer_value:, goto_page_id:, skip_to_end: }
+  let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, answer_value:, goto_page_id:, skip_to_end: }
 
   describe "validations" do
     it "is invalid if confirm is nil" do

--- a/spec/input_objects/pages/routing_page_input_spec.rb
+++ b/spec/input_objects/pages/routing_page_input_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Pages::RoutingPageInput, type: :model do
   let(:routing_page_input) { described_class.new({ routing_page_id: }) }
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:form) { create :form, :ready_for_routing }
   let(:pages) { form.pages }
   let(:routing_page_id) { pages.first.id }
 

--- a/spec/input_objects/pages/secondary_skip_input_spec.rb
+++ b/spec/input_objects/pages/secondary_skip_input_spec.rb
@@ -3,19 +3,10 @@ require "rails_helper"
 RSpec.describe Pages::SecondarySkipInput, type: :model do
   let(:secondary_skip_input) { described_class.new(form:, page:) }
 
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:form) { create :form, :ready_for_routing }
   let(:pages) { form.pages }
   let(:is_optional) { false }
-  let(:page) do
-    pages.second.tap do |second_page|
-      second_page.is_optional = is_optional
-      second_page.answer_type = "selection"
-      second_page.answer_settings = DataStruct.new(
-        only_one_option: true,
-        selection_options: [OpenStruct.new(attributes: { name: "Option 1" }), OpenStruct.new(attributes: { name: "Option 2" })],
-      )
-    end
-  end
+  let(:page) { pages.second }
   let(:condition) { nil }
 
   before do

--- a/spec/input_objects/pages/type_of_answer_input_spec.rb
+++ b/spec/input_objects/pages/type_of_answer_input_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe Pages::TypeOfAnswerInput, type: :model do
   let(:type_of_answer_input) { build :type_of_answer_input, draft_question:, current_form: }
-  let(:draft_question) { build :draft_question, form_id: 1 }
-  let(:current_form) { build :form, id: 1 }
+  let(:draft_question) { build :draft_question, form_id: current_form.id }
+  let(:current_form) { create :form }
 
   it "has a valid factory" do
     expect(type_of_answer_input).to be_valid

--- a/spec/input_objects/pages/update_exit_page_input_spec.rb
+++ b/spec/input_objects/pages/update_exit_page_input_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe Pages::UpdateExitPageInput, type: :model do
   let(:update_exit_page_input) { described_class.new(form:, page:, record: condition) }
-  let(:condition) { build :condition, :with_exit_page, form:, page: }
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:form) { create :form, :ready_for_routing }
   let(:page) { form.pages.first }
+  let(:condition) { create :condition, :with_exit_page, routing_page_id: page.id, check_page_id: page.id }
 
   describe "validations" do
     it "is invalid if exit_page_heading is nil" do

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -8,47 +8,6 @@ RSpec.describe Condition, type: :model do
       condition = create :condition_record
       expect(condition).to be_valid
     end
-
-    it "has a trait with answer value missing" do
-      condition = create :condition_record, :with_answer_value_missing
-      expect(condition.has_routing_errors).to be true
-      expect(condition.validation_errors).to eq [
-        DataStruct.new(name: "answer_value_doesnt_exist"),
-      ]
-    end
-
-    it "has a trait with goto page missing" do
-      condition = create :condition_record, :with_goto_page_missing
-      expect(condition.has_routing_errors).to be true
-      expect(condition.validation_errors).to eq [
-        DataStruct.new(name: "goto_page_doesnt_exist"),
-      ]
-    end
-
-    it "has a trait with goto page before check page" do
-      condition = create :condition_record, :with_goto_page_before_check_page
-      expect(condition.has_routing_errors).to be true
-      expect(condition.validation_errors).to eq [
-        DataStruct.new(name: "cannot_have_goto_page_before_routing_page"),
-      ]
-    end
-
-    it "has a trait with goto page immediately after check page" do
-      condition = create :condition_record, :with_goto_page_immediately_after_check_page
-      expect(condition.has_routing_errors).to be true
-      expect(condition.validation_errors).to eq [
-        DataStruct.new(name: "cannot_route_to_next_page"),
-      ]
-    end
-
-    it "has a trait with answer value and goto page missing" do
-      condition = create :condition_record, :with_answer_value_and_goto_page_missing
-      expect(condition.has_routing_errors).to be true
-      expect(condition.validation_errors).to contain_exactly(
-        DataStruct.new(name: "answer_value_doesnt_exist"),
-        DataStruct.new(name: "goto_page_doesnt_exist"),
-      )
-    end
   end
 
   describe "destroying" do

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Condition, type: :model do
       condition = create :condition_record, :with_answer_value_missing
       expect(condition.has_routing_errors).to be true
       expect(condition.validation_errors).to eq [
-        { name: "answer_value_doesnt_exist" },
+        DataStruct.new(name: "answer_value_doesnt_exist"),
       ]
     end
 
@@ -21,7 +21,7 @@ RSpec.describe Condition, type: :model do
       condition = create :condition_record, :with_goto_page_missing
       expect(condition.has_routing_errors).to be true
       expect(condition.validation_errors).to eq [
-        { name: "goto_page_doesnt_exist" },
+        DataStruct.new(name: "goto_page_doesnt_exist"),
       ]
     end
 
@@ -29,7 +29,7 @@ RSpec.describe Condition, type: :model do
       condition = create :condition_record, :with_goto_page_before_check_page
       expect(condition.has_routing_errors).to be true
       expect(condition.validation_errors).to eq [
-        { name: "cannot_have_goto_page_before_routing_page" },
+        DataStruct.new(name: "cannot_have_goto_page_before_routing_page"),
       ]
     end
 
@@ -37,7 +37,7 @@ RSpec.describe Condition, type: :model do
       condition = create :condition_record, :with_goto_page_immediately_after_check_page
       expect(condition.has_routing_errors).to be true
       expect(condition.validation_errors).to eq [
-        { name: "cannot_route_to_next_page" },
+        DataStruct.new(name: "cannot_route_to_next_page"),
       ]
     end
 
@@ -45,8 +45,8 @@ RSpec.describe Condition, type: :model do
       condition = create :condition_record, :with_answer_value_and_goto_page_missing
       expect(condition.has_routing_errors).to be true
       expect(condition.validation_errors).to contain_exactly(
-        { name: "answer_value_doesnt_exist" },
-        { name: "goto_page_doesnt_exist" },
+        DataStruct.new(name: "answer_value_doesnt_exist"),
+        DataStruct.new(name: "goto_page_doesnt_exist"),
       )
     end
   end
@@ -122,7 +122,7 @@ RSpec.describe Condition, type: :model do
     let(:condition) { create :condition_record, routing_page_id: routing_page.id, goto_page_id: nil }
 
     it "returns array of validation error objects" do
-      expect(condition.validation_errors).to eq([{ name: "goto_page_doesnt_exist" }])
+      expect(condition.validation_errors).to eq([DataStruct.new(name: "goto_page_doesnt_exist")])
     end
 
     it "calls each validation method" do
@@ -172,7 +172,7 @@ RSpec.describe Condition, type: :model do
       let(:condition) { create :condition_record, routing_page_id: routing_page.id, goto_page_id: 999 }
 
       it "returns object with error short name code" do
-        expect(condition.warning_goto_page_doesnt_exist).to eq({ name: "goto_page_doesnt_exist" })
+        expect(condition.warning_goto_page_doesnt_exist).to eq(DataStruct.new(name: "goto_page_doesnt_exist"))
       end
     end
 
@@ -180,7 +180,7 @@ RSpec.describe Condition, type: :model do
       let(:goto_page) { create :page_record }
 
       it "returns object with error short name code" do
-        expect(condition.warning_goto_page_doesnt_exist).to eq({ name: "goto_page_doesnt_exist" })
+        expect(condition.warning_goto_page_doesnt_exist).to eq(DataStruct.new(name: "goto_page_doesnt_exist"))
       end
     end
 
@@ -214,14 +214,14 @@ RSpec.describe Condition, type: :model do
     context "when answer has been deleted from page" do
       it "returns object with error short name code" do
         condition.check_page.answer_settings["selection_options"].shift
-        expect(condition.warning_answer_doesnt_exist).to eq({ name: "answer_value_doesnt_exist" })
+        expect(condition.warning_answer_doesnt_exist).to eq(DataStruct.new(name: "answer_value_doesnt_exist"))
       end
     end
 
     context "when answer on the page has been updated" do
       it "returns object with error short name code" do
         condition.check_page.answer_settings["selection_options"].first["name"] = "Option 1.2"
-        expect(condition.warning_answer_doesnt_exist).to eq({ name: "answer_value_doesnt_exist" })
+        expect(condition.warning_answer_doesnt_exist).to eq(DataStruct.new(name: "answer_value_doesnt_exist"))
       end
     end
 
@@ -241,7 +241,7 @@ RSpec.describe Condition, type: :model do
         let(:is_optional) { false }
 
         it "returns object with error short name code" do
-          expect(condition.warning_answer_doesnt_exist).to eq({ name: "answer_value_doesnt_exist" })
+          expect(condition.warning_answer_doesnt_exist).to eq(DataStruct.new(name: "answer_value_doesnt_exist"))
         end
       end
     end
@@ -279,7 +279,7 @@ RSpec.describe Condition, type: :model do
 
     shared_examples "returns routing warning" do
       it "returns cannot_route_to_next_page warning" do
-        expect(condition.warning_routing_to_next_page).to eq({ name: "cannot_route_to_next_page" })
+        expect(condition.warning_routing_to_next_page).to eq(DataStruct.new(name: "cannot_route_to_next_page"))
       end
     end
 
@@ -386,7 +386,7 @@ RSpec.describe Condition, type: :model do
     shared_examples "returns routing warning" do
       it "returns cannot_have_goto_page_before_routing_page warning" do
         expect(condition.warning_goto_page_before_routing_page).to(
-          eq({ name: "cannot_have_goto_page_before_routing_page" }),
+          eq(DataStruct.new(name: "cannot_have_goto_page_before_routing_page")),
         )
       end
     end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -525,4 +525,15 @@ RSpec.describe Condition, type: :model do
       end
     end
   end
+
+  describe "#errors_with_fields" do
+    let(:condition) { create(:condition_record, check_page:, answer_value: nil, goto_page_id: nil) }
+    let(:check_page) { create(:page_record, :with_selection_settings) }
+
+    context "when the error is a known error" do
+      it "returns the correct values for each error type" do
+        expect(condition.errors_with_fields).to contain_exactly({ field: :answer_value, name: "answer_value_doesnt_exist" }, { field: :goto_page_id, name: "goto_page_doesnt_exist" })
+      end
+    end
+  end
 end

--- a/spec/models/data_struct_type_spec.rb
+++ b/spec/models/data_struct_type_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe DataStructType do
+  context "when converting a JSON string" do
+    it "returns a DataStruct" do
+      json_string = "{\"a\": \"b\", \"c\": [{ \"d\": \"e\" }, { \"f\": \"g\" }]}"
+      expect(described_class.new.cast_value(json_string)).to eq(
+        DataStruct.new({ a: "b", c: [DataStruct.new(d: "e"), DataStruct.new(f: "g")] }),
+      )
+    end
+  end
+
+  context "when converting a hash" do
+    it "returns a DataStruct" do
+      hash = {
+        a: "b",
+        c: [
+          { d: "e" },
+          { f: "g" },
+        ],
+      }
+      expect(described_class.new.cast_value(hash)).to eq(
+        DataStruct.new({ a: "b", c: [DataStruct.new(d: "e"), DataStruct.new(f: "g")] }),
+      )
+    end
+  end
+
+  context "when converting an ActiveResource" do
+    it "returns a DataStruct" do
+      hash = {
+        a: "b",
+        c: [
+          { d: "e" },
+          { f: "g" },
+        ],
+      }
+      active_resource = Api::V1::PageResource.new(hash, false)
+      expect(described_class.new.cast_value(active_resource)).to eq(
+        DataStruct.new({ a: "b", c: [DataStruct.new(d: "e"), DataStruct.new(f: "g")] }),
+      )
+    end
+  end
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -288,6 +288,24 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "#all_incomplete_tasks" do
+    context "when a form is complete and ready to be made live" do
+      let(:completed_form) { build :form_record, :live }
+
+      it "returns no missing sections" do
+        expect(completed_form.all_incomplete_tasks).to be_empty
+      end
+    end
+
+    context "when a form is incomplete and should still be in draft state" do
+      let(:new_form) { build :form_record, :new_form }
+
+      it "returns a set of keys related to missing fields" do
+        expect(new_form.all_incomplete_tasks).to match_array(%i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed])
+      end
+    end
+  end
+
   describe "submission type" do
     describe "enum" do
       it "returns a list of submission types" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -379,6 +379,28 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "#all_task_statuses" do
+    let(:completed_form) { build :form_record, :live }
+
+    it "returns a hash with each of the task statuses" do
+      expected_hash = {
+        name_status: :completed,
+        pages_status: :completed,
+        declaration_status: :completed,
+        what_happens_next_status: :completed,
+        submission_email_status: :completed,
+        confirm_submission_email_status: :completed,
+        privacy_policy_status: :completed,
+        payment_link_status: :optional,
+        receive_csv_status: :optional,
+        support_contact_details_status: :completed,
+        share_preview_status: :completed,
+        make_live_status: :completed,
+      }
+      expect(completed_form.all_task_statuses).to eq expected_hash
+    end
+  end
+
   describe "#page_number" do
     let(:completed_form) { build :form_resource, :live }
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -552,4 +552,19 @@ RSpec.describe Form, type: :model do
       end
     end
   end
+
+  describe "#file_upload_question_count" do
+    let(:form) { create :form_record }
+
+    before do
+      create_list :page_record, 3, form:, answer_type: :file
+      Page::ANSWER_TYPES.each do |answer_type|
+        create(:page_record, form:, answer_type:)
+      end
+    end
+
+    it "returns the number of file upload questions" do
+      expect(form.file_upload_question_count).to eq(4)
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -507,6 +507,50 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "#has_no_remaining_routes_available?" do
+    context "when the form has routes" do
+      let(:form) { create :form_record }
+      let(:pages) do
+        [
+          create(:page_record, :with_selection_settings, form:, position: 1),
+          create(:page_record, :with_selection_settings, form:, position: 2),
+          create(:page_record, :with_selection_settings, form:, position: 3),
+        ]
+      end
+
+      before do
+        create :condition_record, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", skip_to_end: true
+        form.pages.each(&:reload)
+      end
+
+      context "when there is a page that a route can be added to" do
+        it "returns false" do
+          expect(form.has_no_remaining_routes_available?).to be(false)
+        end
+      end
+
+      context "when there are no pages that a route can be added to" do
+        before do
+          create :condition_record, routing_page_id: pages.second.id, check_page_id: pages.first.id, skip_to_end: true
+          form.pages.each(&:reload)
+        end
+
+        it "returns true" do
+          expect(form.has_no_remaining_routes_available?).to be(true)
+        end
+      end
+    end
+
+    context "when the form does not have routes" do
+      let(:form) { create :form_record }
+      let(:pages) { create_list :page_record, 3, :with_selection_settings, form: }
+
+      it "returns false" do
+        expect(form.has_no_remaining_routes_available?).to be(false)
+      end
+    end
+  end
+
   describe "#group" do
     let(:form) { create :form_record }
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -322,6 +322,32 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "#page_number" do
+    let(:completed_form) { build :form_resource, :live }
+
+    context "with an existing page" do
+      let(:page) { completed_form.pages.first }
+
+      it "returns the page position" do
+        expect(completed_form.page_number(page)).to eq(1)
+      end
+    end
+
+    context "with an new page" do
+      let(:page) { build :page_resource }
+
+      it "returns the position for a new page" do
+        expect(completed_form.page_number(page)).to eq(completed_form.pages.count + 1)
+      end
+    end
+
+    context "with an unspecified page" do
+      it "returns the position for a new page" do
+        expect(completed_form.page_number(nil)).to eq(completed_form.pages.count + 1)
+      end
+    end
+  end
+
   describe "#group" do
     let(:form) { create :form_record }
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -450,4 +450,32 @@ RSpec.describe Page, type: :model do
       end
     end
   end
+
+  describe "#show_optional_suffix?" do
+    let(:page) { described_class.new(is_optional:, answer_type:) }
+    let(:is_optional) { "true" }
+    let(:answer_type) { "national_insurance_number" }
+
+    context "when question is optional and answer type is not selection" do
+      it "returns true" do
+        expect(page.show_optional_suffix?).to be true
+      end
+    end
+
+    context "when question is optional and has answer_type selection" do
+      let(:answer_type) { "selection" }
+
+      it "returns false" do
+        expect(page.show_optional_suffix?).to be false
+      end
+    end
+
+    context "when question is not optional and answer type is not selection" do
+      let(:is_optional) { "false" }
+
+      it "returns false" do
+        expect(page.show_optional_suffix?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -393,6 +393,40 @@ RSpec.describe Page, type: :model do
     end
   end
 
+  describe "next_page" do
+    context "when there is no next page" do
+      it "returns nil" do
+        expect(page.next_page).to be_nil
+      end
+    end
+
+    context "when there is a next page" do
+      let!(:next_page) { create :page_record, form: page.form }
+
+      it "returns the next page" do
+        expect(page.next_page).to eq(next_page.id)
+      end
+    end
+  end
+
+  describe "#has_next_page?" do
+    context "when there is no next page" do
+      it "returns false" do
+        expect(page.has_next_page?).to be false
+      end
+    end
+
+    context "when there is a next page" do
+      before do
+        create :page_record, form: page.form
+      end
+
+      it "returns true" do
+        expect(page.has_next_page?).to be true
+      end
+    end
+  end
+
   describe "#has_routing_errors" do
     subject(:page) { build :page_record, :with_selection_settings, routing_conditions: [condition] }
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -451,6 +451,14 @@ RSpec.describe Page, type: :model do
     end
   end
 
+  describe "#question_with_number" do
+    let(:page) { described_class.new(question_text: "What's your name?", position: 5) }
+
+    it "returns the page number and question text as a string" do
+      expect(page.question_with_number).to eq("#{page.position}. #{page.question_text}")
+    end
+  end
+
   describe "#show_optional_suffix?" do
     let(:page) { described_class.new(is_optional:, answer_type:) }
     let(:is_optional) { "true" }

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -5,14 +5,9 @@ describe RouteSummaryCardDataPresenter do
 
   subject(:service) { described_class.new(form:, page:) }
 
-  include_context "with pages with routing"
-
-  let(:form) { build :form, id: 99, pages: }
-  let(:page) { page_with_skip_route }
-
-  let(:routes) do
-    PageRoutesService.new(form:, pages:, page:).routes
-  end
+  let(:form) { create :form, :ready_for_routing }
+  let(:pages) { form.pages }
+  let(:page) { pages.first }
 
   before do
     allow(FormRepository).to receive_messages(pages: form.pages)
@@ -21,22 +16,28 @@ describe RouteSummaryCardDataPresenter do
 
   describe "#summary_card_data" do
     context "with conditional routes" do
-      it "returns an array of route cards" do
-        result = service.summary_card_data
-        expect(result.length).to eq(1) # 1 conditional route
+      before do
+        pages.each(&:reload)
+      end
 
-        # conditional route
-        expect(result[0][:card][:title]).to eq("Route 1")
-        expect(result[0][:card][:actions].first).to have_link("Edit", href: "/forms/99/pages/10/conditions/3")
-        expect(result[0][:rows][0][:value][:text]).to eq("Skip")
-        expect(result[0][:rows][1][:value][:text]).to eq("12. Question")
+      context "when there is a valid condition" do
+        let!(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.last.id, answer_value: "Option 1" }
+
+        it "returns an array of route cards" do
+          result = service.summary_card_data
+          expect(result.length).to eq(1) # 1 conditional route
+
+          # conditional route
+          expect(result[0][:card][:title]).to eq("Route 1")
+          expect(result[0][:card][:actions].first).to have_link("Edit", href: "/forms/#{form.id}/pages/#{page.id}/conditions/#{condition.id}")
+          expect(result[0][:rows][0][:value][:text]).to eq("Option 1")
+          expect(result[0][:rows][1][:value][:text]).to eq("#{pages.last.position}. #{pages.last.question_text}")
+        end
       end
 
       context "when the goto_page does not exist" do
         before do
-          page.routing_conditions.first.tap do |condition|
-            condition.goto_page_id = 999
-          end
+          create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: 127, answer_value: "Option 1"
         end
 
         it "uses placeholder text instead of question text" do
@@ -47,25 +48,22 @@ describe RouteSummaryCardDataPresenter do
     end
 
     context "when the condition has an exit page data" do
+      let!(:condition) { create :condition, :with_exit_page, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1" }
+
       before do
-        page.routing_conditions.first.tap do |condition|
-          condition.exit_page_heading = "Exit page"
-          condition.exit_page_markdown = "This is the exit page"
-        end
+        pages.each(&:reload)
       end
 
       it "uses the exit page heading in the summary card" do
         result = service.summary_card_data
-        expect(result[0][:rows][1][:value][:text]).to eq("Exit page")
+        expect(result[0][:rows][1][:value][:text]).to eq(condition.exit_page_heading)
       end
     end
 
     context "with skip to end condition" do
       before do
-        page.routing_conditions.first.tap do |condition|
-          condition.goto_page_id = nil
-          condition.skip_to_end = true
-        end
+        create :condition, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1", skip_to_end: true
+        pages.each(&:reload)
       end
 
       it 'shows "Check your answers" as destination' do
@@ -75,29 +73,36 @@ describe RouteSummaryCardDataPresenter do
     end
 
     context "with conditional routes and secondary skip routes" do
-      let(:page) { page_with_skip_and_secondary_skip }
+      let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.fourth.id, answer_value: "Option 1" }
+      let(:secondary_skip_condition) { create :condition, routing_page_id: pages.third.id, check_page_id: page.id, goto_page_id: pages.last.id }
+
+      before do
+        condition
+        secondary_skip_condition
+        pages.each(&:reload)
+      end
 
       it "shows the destination of the secondary skip route" do
         result = service.summary_card_data
-        expect(result[1][:rows][0][:value][:text]).to eq("3. Question in branch 1")
-        expect(result[1][:rows][1][:value][:text]).to eq("4. Question at the end of branch 1 (start of a secondary skip)")
-        expect(result[1][:rows][2][:value][:text]).to eq("8. Question after a branch route (end of a secondary skip)")
+        expect(result[1][:rows][0][:value][:text]).to eq("#{pages.second.position}. #{pages.second.question_text}")
+        expect(result[1][:rows][1][:value][:text]).to eq("#{pages.third.position}. #{pages.third.question_text}")
+        expect(result[1][:rows][2][:value][:text]).to eq("#{pages.last.position}. #{pages.last.question_text}")
       end
 
       it "shows the edit secondary skip link" do
         result = service.summary_card_data
-        expect(result[1][:card][:actions].first).to have_link("Edit", href: "/forms/99/pages/2/routes/any-other-answer/questions-to-skip")
+        expect(result[1][:card][:actions].first).to have_link("Edit", href: "/forms/#{form.id}/pages/#{page.id}/routes/any-other-answer/questions-to-skip")
       end
 
       it "shows the delete secondary skip link" do
         result = service.summary_card_data
-        expect(result[1][:card][:actions].second).to have_link("Delete", href: "/forms/99/pages/2/routes/any-other-answer/questions-to-skip/delete")
+        expect(result[1][:card][:actions].second).to have_link("Delete", href: "/forms/#{form.id}/pages/#{page.id}/routes/any-other-answer/questions-to-skip/delete")
       end
 
       context "when the route's check answer does not exist" do
-        it "shows an error message" do
-          branch_route_1.validation_errors << OpenStruct.new(name: "answer_value_doesnt_exist")
+        let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.fourth.id, answer_value: "Non-existent-option" }
 
+        it "shows an error message" do
           result = service.summary_card_data
           expect(result[0][:rows][0][:value][:text]).to include("The answer that route 1 is based on no longer exists - edit or delete this route")
           expect(result[0][:rows][0][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
@@ -105,9 +110,9 @@ describe RouteSummaryCardDataPresenter do
       end
 
       context "when route 1 does not skip any questions" do
-        it "shows an error message" do
-          branch_route_1.validation_errors << OpenStruct.new(name: "cannot_route_to_next_page")
+        let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.second.id, answer_value: "Option 1" }
 
+        it "shows an error message" do
           result = service.summary_card_data
           expect(result[0][:rows][1][:value][:text]).to include("Route 1 is not skipping any questions - edit or delete this route")
           expect(result[0][:rows][1][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
@@ -115,9 +120,10 @@ describe RouteSummaryCardDataPresenter do
       end
 
       context "when route 1 routes to a previous question" do
-        it "shows an error message" do
-          branch_route_1.validation_errors << OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")
+        let(:page) { pages.second }
+        let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.first.id, answer_value: "Option 1" }
 
+        it "shows an error message" do
           result = service.summary_card_data
           expect(result[0][:rows][1][:value][:text]).to include("The question route 1 skips to cannot be before question 2 - edit or delete this route")
           expect(result[0][:rows][1][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
@@ -125,9 +131,9 @@ describe RouteSummaryCardDataPresenter do
       end
 
       context "when the any other answer route does not skip a question" do
-        it "shows an error message" do
-          branch_any_other_answer_route.validation_errors << OpenStruct.new(name: "cannot_route_to_next_page")
+        let(:secondary_skip_condition) { create :condition, routing_page_id: pages.third.id, check_page_id: page.id, goto_page_id: pages.fourth.id }
 
+        it "shows an error message" do
           result = service.summary_card_data
           expect(result[1][:rows][2][:value][:text]).to include("The route for any other answer is not skipping any questions - edit or delete this route")
           expect(result[1][:rows][2][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
@@ -135,9 +141,9 @@ describe RouteSummaryCardDataPresenter do
       end
 
       context "when the any other answer route skips to a previous question" do
-        it "shows an error message" do
-          branch_any_other_answer_route.validation_errors << OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")
+        let(:secondary_skip_condition) { create :condition, routing_page_id: pages.third.id, check_page_id: page.id, goto_page_id: pages.second.id }
 
+        it "shows an error message" do
           result = service.summary_card_data
           expect(result[1][:rows][2][:value][:text]).to include("The question the route for any other answer skips to cannot be before the question it skips from - edit or delete this route")
           expect(result[1][:rows][2][:value][:text]).to include("class=\"govuk-summary-list__value--error\"")
@@ -146,8 +152,6 @@ describe RouteSummaryCardDataPresenter do
     end
 
     context "with no conditional routes" do
-      let(:page) { page_with_no_routes }
-
       it "returns an empty array" do
         result = service.summary_card_data
         expect(result).to eq []
@@ -174,49 +178,62 @@ describe RouteSummaryCardDataPresenter do
   describe "#next_page" do
     it "returns the next page" do
       allow(FormRepository).to receive(:pages).and_return(pages)
-      expect(service.next_page).to eq(pages[10])
+      expect(service.next_page).to eq(pages.second)
     end
   end
 
   describe "#errors" do
-    let(:page) { page_with_skip_and_secondary_skip }
+    let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.fourth.id, answer_value: "Option 1" }
+    let(:secondary_skip_condition) { create :condition, routing_page_id: pages.third.id, check_page_id: page.id, goto_page_id: pages.last.id }
+
+    before do
+      condition
+      secondary_skip_condition
+      pages.each(&:reload)
+    end
 
     it "returns an array of errors" do
       expect(service.errors).to be_empty
     end
 
     context "when there is a check error" do
+      let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.fourth.id, answer_value: "Non-existent-answer" }
+
       it "contains the check error link and message" do
-        branch_route_1.validation_errors << OpenStruct.new(name: "answer_value_doesnt_exist")
-        expect(service.errors).to eq([OpenStruct.new(link: "#check-#{branch_route_1.id}", message: I18n.t("page_route_card.errors.answer_value_doesnt_exist"))])
+        expect(service.errors).to eq([OpenStruct.new(link: "#check-#{condition.id}", message: I18n.t("page_route_card.errors.answer_value_doesnt_exist"))])
       end
     end
 
     context "when there is a next page error" do
+      let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.second.id, answer_value: "Option 1" }
+
       it "contains the next page error link and message" do
-        branch_route_1.validation_errors << OpenStruct.new(name: "cannot_route_to_next_page")
-        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{branch_route_1.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page"))])
+        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{condition.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page"))])
       end
     end
 
     context "when there is a next page error for the secondary skip" do
+      let(:secondary_skip_condition) { create :condition, routing_page_id: pages.third.id, check_page_id: page.id, goto_page_id: pages.fourth.id }
+
       it "contains the secondary skip next page error link and message" do
-        branch_any_other_answer_route.validation_errors << OpenStruct.new(name: "cannot_route_to_next_page")
-        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{branch_any_other_answer_route.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page_secondary_skip"))])
+        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{secondary_skip_condition.id}", message: I18n.t("page_route_card.errors.cannot_route_to_next_page_secondary_skip"))])
       end
     end
 
     context "when there is a goto page before routing page error" do
+      let(:page) { pages.second }
+      let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.first.id, answer_value: "Option 1" }
+
       it "contains the goto page before routing page error link and message" do
-        branch_route_1.validation_errors << OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")
-        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{branch_route_1.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page", question_number: 2))])
+        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{condition.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page", question_number: 2))])
       end
     end
 
     context "when there is a goto page before routing page error for the secondary skip" do
+      let(:secondary_skip_condition) { create :condition, routing_page_id: pages.third.id, check_page_id: page.id, goto_page_id: pages.second.id }
+
       it "contains the secondary skip goto page before routing page error link and message" do
-        branch_any_other_answer_route.validation_errors << OpenStruct.new(name: "cannot_have_goto_page_before_routing_page")
-        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{branch_any_other_answer_route.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page_secondary_skip"))])
+        expect(service.errors).to eq([OpenStruct.new(link: "#goto-#{secondary_skip_condition.id}", message: I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page_secondary_skip"))])
       end
     end
   end

--- a/spec/requests/forms/delete_confirmation_controller_spec.rb
+++ b/spec/requests/forms/delete_confirmation_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
         end
 
         it "does not delete the form on the API" do
-          expect(form).not_to have_been_deleted
+          expect(FormRepository).not_to have_received(:destroy)
         end
       end
     end

--- a/spec/requests/forms/receive_csv_controller_spec.rb
+++ b/spec/requests/forms/receive_csv_controller_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe Forms::ReceiveCsvController, type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it "does not update the form on the API" do
-        expect(form).not_to have_been_updated
+      it "does not update the form" do
+        expect(FormRepository).not_to have_received(:save!)
       end
 
       it "re-renders the page with an error" do

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
     end
 
     context "when draft version submission email is different from live version" do
-      let(:form) { build :form, :live, id: 1, creator_id: 1 }
+      let(:form) { create :form, :live, creator_id: 1 }
       let(:previous_live_version) { build :made_live_form, creator_id: 1, id: form.id, submission_email: Faker::Internet.email(domain: "test.example.gov.uk") }
 
       before do

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -1,17 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Forms::WhatHappensNextController, type: :request do
-  let(:form_response_data) do
-    {
-      id: 2,
-      name: "Form name",
-      submission_email: "submission@email.com",
-      start_page: 1,
-      what_happens_next_markdown: "Good things come to those who wait",
-      live_at: nil,
-    }.to_json
-  end
-
   let(:form) do
     build(
       :form,
@@ -19,7 +8,6 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
       submission_email: "submission@email.com",
       id: 2,
       what_happens_next_markdown: "",
-      live_at: nil,
     )
   end
 

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe FormsController, type: :request do
 
   describe "#mark_pages_section_completed" do
     let(:pages) do
-      [build(:page, page_id: 99)]
+      [build(:page, id: 99)]
     end
 
     let(:form) do

--- a/spec/requests/pages/exit_page_controller_spec.rb
+++ b/spec/requests/pages/exit_page_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Pages::ExitPageController, type: :request do
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:form) { create :form, :ready_for_routing, id: 1 }
   let(:pages) { form.pages }
   let(:page) do
     pages.first.tap do |first_page|
@@ -19,7 +19,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
   let(:user) { standard_user }
-  let(:condition) { build(:condition, id: 1, form_id: form.id, page_id: page.id, exit_page_heading: "Exit Page Heading") }
+  let(:condition) { build(:condition, id: 1, routing_page_id: selected_page.id, exit_page_heading: "Exit Page Heading") }
 
   before do
     allow(FormRepository).to receive_messages(find: form, pages: pages)
@@ -40,8 +40,8 @@ RSpec.describe Pages::ExitPageController, type: :request do
     end
 
     context "when user should not be allowed to add routes to pages" do
-      let(:form) { build :form, id: 1 }
-      let(:pages) { [build(:page)] }
+      let(:form) { create :form, id: 1 }
+      let(:pages) { [create(:page)] }
 
       it "Renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")
@@ -72,7 +72,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
     end
 
     it "redirects to the show routes page" do
-      expect(response).to redirect_to show_routes_path(form:, page:)
+      expect(response).to redirect_to show_routes_path(form_id: form.id, page_id: selected_page.id)
     end
 
     it "displays success message" do
@@ -101,8 +101,8 @@ RSpec.describe Pages::ExitPageController, type: :request do
     end
 
     context "when user should not be allowed to add routes to pages" do
-      let(:form) { build :form, id: 1 }
-      let(:pages) { [build(:page)] }
+      let(:form) { create :form, id: 1 }
+      let(:pages) { [create(:page)] }
 
       it "Renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")
@@ -115,7 +115,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
   end
 
   describe "#edit" do
-    let(:condition) { build :condition, :with_exit_page, id: 3, form:, page: selected_page }
+    let(:condition) { create :condition, :with_exit_page, form:, routing_page_id: selected_page.id }
 
     before do
       allow(ConditionRepository).to receive(:find).and_return(condition)
@@ -129,7 +129,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
   end
 
   describe "#update" do
-    let(:condition) { build :condition, :with_exit_page, id: 3, form:, page: selected_page }
+    let(:condition) { create :condition, :with_exit_page, routing_page_id: selected_page.id }
     let(:params) { { pages_update_exit_page_input: { exit_page_heading: "Exit Page Heading", exit_page_markdown: "Exit Page Markdown" } } }
 
     before do
@@ -139,7 +139,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
     end
 
     it "redirects to the edit condition page" do
-      expect(response).to redirect_to edit_condition_path(form:, page:, condition:)
+      expect(response).to redirect_to edit_condition_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id)
     end
 
     it "displays success message" do
@@ -181,8 +181,8 @@ RSpec.describe Pages::ExitPageController, type: :request do
     end
 
     context "when user should not be allowed to add/delete routes to pages" do
-      let(:form) { build :form, id: 1 }
-      let(:pages) { [build(:page)] }
+      let(:form) { create :form, id: 1 }
+      let(:pages) { [create(:page)] }
 
       it "renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")
@@ -250,8 +250,8 @@ RSpec.describe Pages::ExitPageController, type: :request do
     end
 
     context "when user should not be allowed to add/delete routes to pages" do
-      let(:form) { build :form, id: 1 }
-      let(:pages) { [build(:page)] }
+      let(:form) { create :form, id: 1 }
+      let(:pages) { [create(:page)] }
 
       it "renders the forbidden page" do
         expect(response).to render_template("errors/forbidden")

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Pages::GuidanceController, type: :request do
-  let(:form) { build :form, id: 1 }
-  let(:pages) { build_list :page, 5, form_id: form.id }
+  let(:form) { create :form, id: 1 }
+  let(:pages) { create_list :page, 5, form_id: form.id }
   let(:page) { pages.first }
   let(:draft_question) { build :draft_question }
   let(:page_heading) { "Page heading" }
@@ -166,7 +166,7 @@ RSpec.describe Pages::GuidanceController, type: :request do
   end
 
   describe "#update" do
-    let(:pages) { build_list :page, 5, :with_guidance, form_id: form.id }
+    let(:pages) { create_list :page, 5, :with_guidance, form_id: form.id }
     let(:route_to) { "preview" }
 
     before do

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -1,23 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Pages::QuestionsController, type: :request do
-  let(:form) { build :form, id: 2, pages: }
+  let(:form) { create :form }
 
-  let(:draft_question) { create :draft_question_for_new_page, user: standard_user, form_id: 2 }
+  let(:draft_question) { create :draft_question_for_new_page, user: standard_user, form_id: form.id }
 
-  let(:page) do
-    build(:page,
-          id: 1,
-          form_id: 2,
-          question_text: draft_question.question_text,
-          hint_text: draft_question.hint_text,
-          answer_type: draft_question.answer_type,
-          answer_settings: nil,
-          is_optional: false,
-          is_repeatable: false,
-          page_heading: nil,
-          guidance_markdown: nil)
-  end
+  let(:page) { create(:page, form_id: form.id) }
 
   let(:pages) do
     [page]
@@ -48,7 +36,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
 
   describe "#new" do
     let(:draft_question) do
-      record = create :draft_question_for_new_page, user: standard_user, form_id: 2
+      record = create :draft_question_for_new_page, user: standard_user, form_id: form.id
       record.question_text = nil
       record.save!(validate: false)
       record.reload
@@ -57,7 +45,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
     before do
       draft_question
 
-      get new_question_path(form_id: 2)
+      get new_question_path(form_id: form.id)
     end
 
     it "Reads the form" do
@@ -86,11 +74,11 @@ RSpec.describe Pages::QuestionsController, type: :request do
         # Setup a draft_question so that create question action doesn't need to create a completely new records
         draft_question
 
-        post create_question_path(2), params:
+        post create_question_path(form.id), params:
       end
 
       it "Redirects you to edit page for new question" do
-        expect(response).to redirect_to(edit_question_path(form_id: 2, page_id: 1))
+        expect(response).to redirect_to(edit_question_path(form_id: form.id, page_id: page.id))
       end
 
       it "displays a notification banner with call to action links" do
@@ -98,8 +86,8 @@ RSpec.describe Pages::QuestionsController, type: :request do
         results = Capybara.string(response.body)
         banner_contents = results.find(".govuk-notification-banner .govuk-notification-banner__content")
 
-        expect(banner_contents).to have_link(text: "Add a question", href: start_new_question_path(form_id: 2))
-        expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: 2))
+        expect(banner_contents).to have_link(text: "Add a question", href: start_new_question_path(form_id: form.id))
+        expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: form.id))
       end
 
       include_examples "logging"
@@ -110,7 +98,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
         # Setup a draft_question so that create question action doesn't need to create a completely new records
         draft_question
 
-        post create_question_path(2), params: { pages_question_input: {
+        post create_question_path(form.id), params: { pages_question_input: {
           hint_text: "This should be the location stated in your contract.",
           is_optional: false,
         } }
@@ -136,50 +124,27 @@ RSpec.describe Pages::QuestionsController, type: :request do
         # Setup a draft_question so that edit question action doesn't need to create a completely new records
         draft_question
 
-        get edit_question_path(form_id: 2, page_id: 1)
+        get edit_question_path(form_id: form.id, page_id: page.id)
       end
 
       it "Reads the page from the page repository" do
         expect(PageRepository).to have_received(:find)
-      end
-
-      context "when page has unrecognised attributes" do
-        let(:page) do
-          build(:page,
-                id: 1,
-                form_id: 2,
-                question_text: draft_question.question_text,
-                hint_text: draft_question.hint_text,
-                answer_type: draft_question.answer_type,
-                answer_settings: nil,
-                is_optional: false,
-                page_heading: nil,
-                guidance_markdown: nil,
-                newly_added_to_api: "some value")
-        end
-
-        it "renders successfully" do
-          expect(response).to have_http_status(:ok)
-        end
-
-        include_examples "logging"
       end
     end
   end
 
   describe "#update" do
     let(:draft_question) do
-      record = create :draft_question, user: standard_user, form_id: 2
+      record = create :draft_question, user: standard_user, form_id: form.id
       record.question_text = nil
       record.save!(validate: false)
       record.reload
     end
 
     let(:page) do
-      build(
+      create(
         :page,
-        id: 1,
-        form_id: 2,
+        form_id: form.id,
         question_text: "What is your work address?",
         hint_text: "This should be the location stated in your contract.",
         answer_type: "address",
@@ -194,7 +159,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
     describe "Given a page" do
       let(:params) do
         { pages_question_input: {
-          form_id: 2,
+          form_id: form.id,
           question_text: "What is your home address?",
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",
@@ -208,7 +173,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
       before do
         allow(PageRepository).to receive_messages(find: page, save!: page)
 
-        post update_question_path(form_id: 2, page_id: 1), params:
+        post update_question_path(form_id: form.id, page_id: page.id), params:
       end
 
       it "Reads the page from the PageRepository" do
@@ -220,7 +185,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
       end
 
       it "Redirects you to edit page for question that was updated" do
-        expect(response).to redirect_to(edit_question_path(form_id: 2, page_id: 1))
+        expect(response).to redirect_to(edit_question_path(form_id: form.id, page_id: page.id))
       end
 
       it "displays a notification banner with call to action links" do
@@ -228,8 +193,8 @@ RSpec.describe Pages::QuestionsController, type: :request do
         results = Capybara.string(response.body)
         banner_contents = results.find(".govuk-notification-banner .govuk-notification-banner__content")
 
-        expect(banner_contents).to have_link(text: "Add a question", href: start_new_question_path(form_id: 2))
-        expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: 2))
+        expect(banner_contents).to have_link(text: "Add a question", href: start_new_question_path(form_id: form.id))
+        expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: form.id))
       end
 
       it "logs the answer type from the page" do
@@ -237,12 +202,12 @@ RSpec.describe Pages::QuestionsController, type: :request do
       end
 
       context "when question being updated has a question after it" do
-        let(:pages) { [page, build(:page, id: 4)] }
+        let!(:next_page) { create(:page, form_id: form.id) }
 
         let(:params) do
           { pages_question_input: {
-            page_id: 1,
-            form_id: 2,
+            page_id: page.id,
+            form_id: form.id,
             question_text: "What is your home address?",
             hint_text: "This should be the location stated in your contract.",
             answer_type: "address",
@@ -254,7 +219,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
         end
 
         it "Redirects you to edit page for new question" do
-          expect(response).to redirect_to(edit_question_path(form_id: 2, page_id: 1))
+          expect(response).to redirect_to(edit_question_path(form_id: form.id, page_id: page.id))
         end
 
         it "displays a notification banner with call to action links" do
@@ -262,16 +227,16 @@ RSpec.describe Pages::QuestionsController, type: :request do
           results = Capybara.string(response.body)
           banner_contents = results.find(".govuk-notification-banner .govuk-notification-banner__content")
 
-          expect(banner_contents).to have_link(text: "Edit next question", href: edit_question_path(form_id: 2, page_id: 4))
-          expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: 2))
+          expect(banner_contents).to have_link(text: "Edit next question", href: edit_question_path(form_id: form.id, page_id: next_page.id))
+          expect(banner_contents).to have_link(text: "Back to your questions", href: form_pages_path(form_id: form.id))
         end
       end
     end
 
     context "when question_input has invalid data" do
       before do
-        post update_question_path(form_id: 2, page_id: 1), params: { pages_question_input: {
-          form_id: 2,
+        post update_question_path(form_id: form.id, page_id: page.id), params: { pages_question_input: {
+          form_id: form.id,
           question_text: nil,
           hint_text: "This should be the location stated in your contract.",
           answer_type: "address",

--- a/spec/requests/pages/routes_controller_spec.rb
+++ b/spec/requests/pages/routes_controller_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
 describe Pages::RoutesController, type: :request do
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:form) { create :form, :ready_for_routing }
   let(:pages) { form.pages }
   let(:page) do
     pages.first.tap do |first_page|
-      first_page.id = 101
       first_page.is_optional = false
       first_page.answer_type = "selection"
       first_page.answer_settings = DataStruct.new(
@@ -15,8 +14,6 @@ describe Pages::RoutesController, type: :request do
       )
     end
   end
-
-  let(:selected_page) { page }
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
   let(:user) { standard_user }
@@ -32,9 +29,9 @@ describe Pages::RoutesController, type: :request do
 
   describe "#show" do
     before do
-      allow(PageRepository).to receive(:find).with(page_id: "101", form_id: 1).and_return(selected_page)
+      allow(PageRepository).to receive(:find).with(page_id: page.id, form_id: form.id).and_return(page)
 
-      get show_routes_path(form_id: form.id, page_id: selected_page.id)
+      get show_routes_path(form_id: form.id, page_id: page.id)
     end
 
     it "Reads the form" do
@@ -48,7 +45,6 @@ describe Pages::RoutesController, type: :request do
     context "when the page is at the end of the form" do
       let(:page) do
         pages.last.tap do |last_page|
-          last_page.id = 101
           last_page.is_optional = false
           last_page.answer_type = "selection"
           last_page.answer_settings = DataStruct.new(
@@ -67,9 +63,9 @@ describe Pages::RoutesController, type: :request do
 
   describe "#delete" do
     before do
-      allow(PageRepository).to receive(:find).with(page_id: "101", form_id: 1).and_return(selected_page)
+      allow(PageRepository).to receive(:find).with(page_id: page.id, form_id: form.id).and_return(page)
 
-      get delete_routes_path(form_id: form.id, page_id: selected_page.id)
+      get delete_routes_path(form_id: form.id, page_id: page.id)
     end
 
     it "renders the delete confirmation for routes template" do
@@ -79,29 +75,29 @@ describe Pages::RoutesController, type: :request do
   end
 
   describe "#destroy" do
-    let(:condition) { build :condition, id: 1, routing_page_id: selected_page.id, check_page_id: selected_page.id, goto_page_id: pages.last.id, answer_value: "Option 1" }
+    let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.last.id, answer_value: "Option 1" }
     let(:secondary_skip_page) { form.pages[2] }
-    let(:secondary_skip) { build :condition, id: 2, routing_page_id: secondary_skip_page.id, check_page_id: selected_page.id, goto_page_id: pages[3].id }
+    let!(:secondary_skip) { create :condition, routing_page_id: secondary_skip_page.id, check_page_id: page.id, goto_page_id: pages[3].id }
 
     before do
-      allow(PageRepository).to receive(:find).with(page_id: "101", form_id: 1).and_return(selected_page)
+      allow(PageRepository).to receive(:find).with(page_id: page.id, form_id: form.id).and_return(page)
       allow(ConditionRepository).to receive(:find).and_return(condition)
       allow(ConditionRepository).to receive(:destroy)
 
-      selected_page.routing_conditions = [condition]
-      secondary_skip_page.routing_conditions = [secondary_skip]
+      page.reload
+      secondary_skip_page.reload
     end
 
     context "when confirmed" do
       it "redirects to page list" do
-        delete destroy_routes_path(form_id: form.id, page_id: selected_page.id, pages_routes_delete_confirmation_input: { confirm: "yes" })
+        delete destroy_routes_path(form_id: form.id, page_id: page.id, pages_routes_delete_confirmation_input: { confirm: "yes" })
         expect(response).to redirect_to form_pages_path(form_id: form.id)
       end
 
       it "calls destroy on conditions" do
         expect(ConditionRepository).to receive(:destroy).with(have_attributes(id: condition.id))
         expect(ConditionRepository).to receive(:destroy).with(have_attributes(id: secondary_skip.id))
-        delete destroy_routes_path(form_id: form.id, page_id: selected_page.id, pages_routes_delete_confirmation_input: { confirm: "yes" })
+        delete destroy_routes_path(form_id: form.id, page_id: page.id, pages_routes_delete_confirmation_input: { confirm: "yes" })
       end
 
       context "but one of the routes is already deleted" do
@@ -109,13 +105,13 @@ describe Pages::RoutesController, type: :request do
           # forms-api may choose to delete the secondary skip when the condition is deleted
           allow(ConditionRepository).to receive(:destroy).and_call_original
           ActiveResource::HttpMock.respond_to do |mock|
-            mock.delete "/api/v1/forms/#{form.id}/pages/#{selected_page.id}/conditions/#{condition.id}", delete_headers, nil, 204
+            mock.delete "/api/v1/forms/#{form.id}/pages/#{page.id}/conditions/#{condition.id}", delete_headers, nil, 204
             mock.delete "/api/v1/forms/#{form.id}/pages/#{secondary_skip_page.id}/conditions/#{secondary_skip.id}", delete_headers, nil, 404
           end
         end
 
         it "does not render an error page" do
-          delete destroy_routes_path(form_id: form.id, page_id: selected_page.id, pages_routes_delete_confirmation_input: { confirm: "yes" })
+          delete destroy_routes_path(form_id: form.id, page_id: page.id, pages_routes_delete_confirmation_input: { confirm: "yes" })
           expect(response).not_to be_client_error
         end
       end
@@ -123,7 +119,7 @@ describe Pages::RoutesController, type: :request do
 
     context "when given invalid params" do
       it "renders the delete page" do
-        delete destroy_routes_path(form_id: form.id, page_id: selected_page.id, pages_routes_delete_confirmation_input: { confirm: nil })
+        delete destroy_routes_path(form_id: form.id, page_id: page.id, pages_routes_delete_confirmation_input: { confirm: nil })
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template("pages/routes/delete")
@@ -132,13 +128,13 @@ describe Pages::RoutesController, type: :request do
 
     context "when not confirmed" do
       it "redirects to routes page" do
-        delete destroy_routes_path(form_id: form.id, page_id: selected_page.id, pages_routes_delete_confirmation_input: { confirm: "no" })
-        expect(response).to redirect_to show_routes_path(form_id: form.id, page_id: selected_page.id)
+        delete destroy_routes_path(form_id: form.id, page_id: page.id, pages_routes_delete_confirmation_input: { confirm: "no" })
+        expect(response).to redirect_to show_routes_path(form_id: form.id, page_id: page.id)
       end
 
       it "does no call destroy on conditions" do
         expect(ConditionRepository).not_to receive(:destroy)
-        delete destroy_routes_path(form_id: form.id, page_id: selected_page.id, pages_routes_delete_confirmation_input: { confirm: "no" })
+        delete destroy_routes_path(form_id: form.id, page_id: page.id, pages_routes_delete_confirmation_input: { confirm: "no" })
       end
     end
   end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -1,13 +1,23 @@
 require "rails_helper"
 
 RSpec.describe Pages::SecondarySkipController, type: :request do
-  let(:form) { build :form, id: 2, pages: }
+  let(:form) { create :form, :with_pages }
+  let(:pages) { form.pages }
+  let(:page) do
+    pages.first.tap do |first_page|
+      first_page.is_optional = false
+      first_page.answer_type = "selection"
+      first_page.answer_settings = DataStruct.new(
+        only_one_option: true,
+        selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
+                            OpenStruct.new(attributes: { name: "Option 2" })],
+      )
+    end
+  end
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
   RSpec.shared_examples "requires condition" do |action|
-    let(:pages) { build_pages }
-
     it "redirects to the page list" do
       send(action)
       expect(response).to redirect_to(form_pages_path(form.id))
@@ -25,284 +35,332 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
   end
 
   describe "#new" do
-    subject(:get_new) { get new_secondary_skip_path(form_id: 2, page_id: 1) }
+    subject(:get_new) { get new_secondary_skip_path(form_id: form.id, page_id: page.id) }
 
-    let(:pages) { build_pages_with_skip_condition }
-
-    it_behaves_like "requires condition", :subject
-
-    it "returns 200" do
-      get_new
-      expect(response).to have_http_status(:success)
+    context "when no condition exists on the page" do
+      it_behaves_like "requires condition", :subject
     end
 
-    context "when a secondary skip condition already exists on the page" do
-      let(:pages) { build_pages_with_existing_secondary_skip }
+    context "when a condition exists on the page" do
+      before do
+        create(:condition, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false)
+        page.reload
+      end
 
-      it "redirects to the show routes page" do
+      it "returns 200" do
         get_new
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+        expect(response).to have_http_status(:success)
+      end
+
+      context "when a secondary skip condition already exists on the page" do
+        before do
+          create(:condition, routing_page_id: pages[1].id, check_page_id: page.id, goto_page_id: pages[4].id)
+          page.reload
+          pages[1].reload
+        end
+
+        it "redirects to the show routes page" do
+          get_new
+          expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+        end
       end
     end
   end
 
   describe "#create" do
-    subject(:post_create) { post create_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params }
-
-    let(:pages) { build_pages_with_skip_condition }
+    subject(:post_create) { post create_secondary_skip_path(form_id: form.id, page_id: page.id), params: valid_params }
 
     let(:valid_params) do
       {
-        form_id: "2",
-        page_id: "1",
+        form_id: form.id.to_s,
+        page_id: page.id.to_s,
         pages_secondary_skip_input: {
-          routing_page_id: "3",
-          goto_page_id: "5",
+          routing_page_id: pages[1].id.to_s,
+          goto_page_id: pages[4].id.to_s,
         },
       }
     end
 
-    it_behaves_like "requires condition", :subject
-
-    context "when the submission is successful" do
-      it "redirects to the show routes page" do
-        post_create
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
-      end
+    context "when no condition exists on the page" do
+      it_behaves_like "requires condition", :subject
     end
 
-    context "when a secondary skip condition already exists on the page" do
-      let(:pages) { build_pages_with_existing_secondary_skip }
-
-      it "redirects to the show routes page" do
-        post_create
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
-      end
-    end
-
-    context "when the submission fails" do
-      subject(:post_create) { post create_secondary_skip_path(form_id: 2, page_id: 1), params: invalid_params }
-
-      let(:invalid_params) do
-        {
-          form_id: "2",
-          page_id: "1",
-          pages_secondary_skip_input: {
-            routing_page_id: "3",
-            goto_page_id: "3",
-          },
-        }
+    context "when a condition exists on the page" do
+      before do
+        create(:condition, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false)
+        page.reload
       end
 
-      it "renders the new template" do
-        post_create
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response).to render_template("pages/secondary_skip/new")
+      context "when the submission is successful" do
+        it "redirects to the show routes page" do
+          post_create
+          expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+        end
+      end
+
+      context "when a secondary skip condition already exists on the page" do
+        before do
+          create(:condition, routing_page_id: pages[1].id, check_page_id: page.id, goto_page_id: pages[4].id)
+          page.reload
+          pages[1].reload
+        end
+
+        it "redirects to the show routes page" do
+          post_create
+          expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+        end
+      end
+
+      context "when the submission fails" do
+        subject(:post_create) { post create_secondary_skip_path(form_id: 2, page_id: 1), params: invalid_params }
+
+        let(:invalid_params) do
+          {
+            form_id: form.id.to_s,
+            page_id: page.id.to_s,
+            pages_secondary_skip_input: {
+              routing_page_id: page.id.to_s,
+              goto_page_id: page.id.to_s,
+            },
+          }
+        end
+
+        it "renders the new template" do
+          post_create
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to render_template("pages/secondary_skip/new")
+        end
       end
     end
   end
 
   describe "#edit" do
-    subject(:get_edit) { get edit_secondary_skip_path(form_id: 2, page_id: 1) }
+    subject(:get_edit) { get edit_secondary_skip_path(form_id: form.id, page_id: page.id) }
 
-    let(:pages) { build_pages_with_existing_secondary_skip }
-
-    it_behaves_like "requires condition", :subject
-
-    it "renders the edit template" do
-      get_edit
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template("pages/secondary_skip/edit")
+    context "when no condition exists on the page" do
+      it_behaves_like "requires condition", :subject
     end
 
-    context "when no secondary_skip exists on the page" do
-      let(:pages) { build_pages_with_skip_condition }
+    context "when a condition exists on the page" do
+      before do
+        create(:condition, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false)
+        page.reload
+      end
 
-      it "redirects to the show routes page" do
-        get_edit
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+      context "when no secondary_skip exists on the page" do
+        it "redirects to the show routes page" do
+          get_edit
+          expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+        end
+      end
+
+      context "when a secondary_skip exists on the page" do
+        before do
+          create(:condition, routing_page_id: pages[1].id, check_page_id: page.id, goto_page_id: pages[4].id)
+          page.reload
+          pages[1].reload
+        end
+
+        it "renders the edit template" do
+          get_edit
+          expect(response).to have_http_status(:success)
+          expect(response).to render_template("pages/secondary_skip/edit")
+        end
       end
     end
   end
 
   describe "#update" do
-    subject(:post_update) { post update_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params }
-
-    let(:pages) { build_pages_with_existing_secondary_skip }
+    subject(:post_update) { post update_secondary_skip_path(form_id: form.id, page_id: page.id), params: valid_params }
 
     let(:valid_params) do
       {
-        form_id: "2",
-        page_id: "1",
+        form_id: form.id.to_s,
+        page_id: page.id.to_s,
         pages_secondary_skip_input: {
-          routing_page_id: "2",
-          goto_page_id: "5",
+          routing_page_id: pages[1].id.to_s,
+          goto_page_id: pages[4].id.to_s,
         },
       }
     end
 
-    it_behaves_like "requires condition", :subject
-
-    context "when the submission is successful without changing the routing_page_id" do
-      it "redirects to the show routes page" do
-        post_update
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
-      end
+    context "when no condition exists on the page" do
+      it_behaves_like "requires condition", :subject
     end
 
-    context "when no secondary_skip exists on the page" do
-      let(:pages) { build_pages_with_skip_condition }
-
-      it "redirects to the show routes page" do
-        post_update
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
-      end
-    end
-
-    context "when the submission is successful and changes the routing_page_id" do
-      let(:valid_params) do
-        {
-          form_id: "2",
-          page_id: "1",
-          pages_secondary_skip_input: {
-            routing_page_id: "3",
-            goto_page_id: "5",
-          },
-        }
+    context "when a condition exists on the page" do
+      before do
+        create(:condition, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false)
+        page.reload
       end
 
-      it "redirects to the show routes page" do
-        post_update
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
-      end
-    end
-
-    context "when the submission fails" do
-      subject(:post_update) { post update_secondary_skip_path(form_id: 2, page_id: 1), params: invalid_params }
-
-      let(:invalid_params) do
-        {
-          form_id: "2",
-          page_id: "1",
-          pages_secondary_skip_input: {
-            routing_page_id: "3",
-            goto_page_id: "3",
-          },
-        }
+      context "when no secondary_skip exists on the page" do
+        it "redirects to the show routes page" do
+          post_update
+          expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+        end
       end
 
-      it "renders the edit template" do
-        post_update
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response).to render_template("pages/secondary_skip/edit")
+      context "when a secondary_skip exists on the page" do
+        before do
+          create(:condition, routing_page_id: pages[1].id, check_page_id: page.id, goto_page_id: pages[4].id)
+          page.reload
+          pages[1].reload
+        end
+
+        context "when the submission is successful without changing the routing_page_id" do
+          it "redirects to the show routes page" do
+            post_update
+            expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+          end
+        end
+
+        context "when the submission is successful and changes the routing_page_id" do
+          let(:valid_params) do
+            {
+              form_id: form.id.to_s,
+              page_id: page.id.to_s,
+              pages_secondary_skip_input: {
+                routing_page_id: pages[2].id.to_s,
+                goto_page_id: pages[4].id.to_s,
+              },
+            }
+          end
+
+          it "redirects to the show routes page" do
+            post_update
+            expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+          end
+        end
+
+        context "when the submission fails" do
+          subject(:post_update) { post update_secondary_skip_path(form_id: form.id, page_id: page.id), params: invalid_params }
+
+          let(:invalid_params) do
+            {
+              form_id: form.id.to_s,
+              page_id: page.id.to_s,
+              pages_secondary_skip_input: {
+                routing_page_id: pages[2].id.to_s,
+                goto_page_id: pages[2].id.to_s,
+              },
+            }
+          end
+
+          it "renders the edit template" do
+            post_update
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to render_template("pages/secondary_skip/edit")
+          end
+        end
       end
     end
   end
 
   describe "#delete" do
-    let(:condition) do
-      build(:condition, id: 2, check_page_id: 1, routing_page_id: pages[2].id, goto_page_id: pages[4].id)
-    end
-
-    let(:pages) { build_pages_with_existing_secondary_skip }
-
-    it "returns 200" do
-      get delete_secondary_skip_path(form_id: 2, page_id: 1)
-      expect(response).to have_http_status(:success)
-    end
-
-    it "renders the delete template" do
-      get delete_secondary_skip_path(form_id: 2, page_id: 1)
-      expect(response).to render_template("pages/secondary_skip/delete")
-    end
-
     context "when no condition exists on the page" do
-      let(:pages) { build_pages }
-
       it "redirects to the page list" do
-        get delete_secondary_skip_path(form_id: 2, page_id: 1)
+        get delete_secondary_skip_path(form_id: form.id, page_id: page.id)
         expect(response).to redirect_to(form_pages_path(form.id))
       end
     end
 
-    context "when no secondary_skip exists on the page" do
-      let(:pages) { build_pages_with_skip_condition }
+    context "when a condition exists on the page" do
+      before do
+        create(:condition, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false)
+        page.reload
+      end
 
-      it "redirects to the page list" do
-        get delete_secondary_skip_path(form_id: 2, page_id: 1)
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+      context "when no secondary_skip exists on the page" do
+        it "redirects to the show routes page" do
+          get delete_secondary_skip_path(form_id: form.id, page_id: page.id)
+          expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+        end
+      end
+
+      context "when a secondary_skip exists on the page" do
+        before do
+          create(:condition, routing_page_id: pages[1].id, check_page_id: page.id, goto_page_id: pages[4].id)
+          page.reload
+          pages[1].reload
+        end
+
+        it "returns 200" do
+          get delete_secondary_skip_path(form_id: form.id, page_id: page.id)
+          expect(response).to have_http_status(:success)
+        end
+
+        it "renders the delete template" do
+          get delete_secondary_skip_path(form_id: form.id, page_id: page.id)
+          expect(response).to render_template("pages/secondary_skip/delete")
+        end
       end
     end
   end
 
   describe "#destroy" do
-    let(:condition) do
-      build(:condition, id: 2, check_page_id: 1, routing_page_id: pages[2].id, goto_page_id: pages[4].id)
-    end
-
-    let(:pages) { build_pages_with_existing_secondary_skip }
-
-    context "when the submission is successful and deletes the secondary skip condition" do
-      let(:valid_params) do
-        {
-          form_id: "2",
-          page_id: "1",
-          pages_delete_secondary_skip_input: {
-            confirm: "yes",
-          },
-        }
-      end
-
-      it "redirects to the show routes page" do
-        delete destroy_secondary_skip_path(form_id: 2, page_id: 1), params: valid_params
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
-      end
-    end
-
     context "when no condition exists on the page" do
-      let(:pages) { build_pages }
-
       it "redirects to the page list" do
-        delete destroy_secondary_skip_path(form_id: 2, page_id: 1)
+        delete destroy_secondary_skip_path(form_id: form.id, page_id: page.id)
         expect(response).to redirect_to(form_pages_path(form.id))
       end
     end
 
-    context "when no secondary_skip exists on the page" do
-      let(:pages) { build_pages_with_skip_condition }
-
-      it "redirects to the page list" do
-        delete destroy_secondary_skip_path(form_id: 2, page_id: 1)
-        expect(response).to redirect_to(show_routes_path(form_id: 2, page_id: 1))
+    context "when a condition exists on the page" do
+      before do
+        create(:condition, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false)
+        page.reload
       end
-    end
-  end
 
-  def build_pages
-    build_list(:page, 5).each_with_index do |page, index|
-      page.id = index + 1
-    end
-  end
+      context "when no secondary_skip exists on the page" do
+        it "redirects to the show routes page" do
+          delete destroy_secondary_skip_path(form_id: form.id, page_id: page.id)
+          expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+        end
+      end
 
-  def build_pages_with_skip_condition
-    build_pages.tap do |pages|
-      pages[0] = build :page, :with_selection_settings, id: 1, routing_conditions: [
-        build(:condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages[2].id, skip_to_end: false),
-      ]
-    end
-  end
+      context "when a secondary_skip exists on the page" do
+        before do
+          create(:condition, routing_page_id: pages[1].id, check_page_id: page.id, goto_page_id: pages[4].id)
+          page.reload
+          pages[1].reload
+        end
 
-  def build_pages_with_existing_secondary_skip
-    build_pages_with_skip_condition.tap do |pages|
-      existing_secondary_skip = build(
-        :condition,
-        id: 2,
-        routing_page_id: pages[1].id,
-        check_page_id: pages[0].id,
-        goto_page_id: pages[4].id,
-        secondary_skip: true,
-      )
-      pages[1].routing_conditions = [existing_secondary_skip]
+        context "when the submission is successful and deletes the secondary skip condition" do
+          let(:valid_params) do
+            {
+              form_id: form.id.to_s,
+              page_id: page.id.to_s,
+              pages_delete_secondary_skip_input: {
+                confirm: "yes",
+              },
+            }
+          end
+
+          it "redirects to the show routes page" do
+            delete destroy_secondary_skip_path(form_id: form.id, page_id: page.id), params: valid_params
+            expect(response).to redirect_to(show_routes_path(form_id: form.id, page_id: page.id))
+          end
+        end
+
+        context "when the submission fails" do
+          let(:invalid_params) do
+            {
+              form_id: form.id.to_s,
+              page_id: page.id.to_s,
+              pages_delete_secondary_skip_input: {
+                confirm: "maybe",
+              },
+            }
+          end
+
+          it "renders the delete template" do
+            delete destroy_secondary_skip_path(form_id: form.id, page_id: page.id), params: invalid_params
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to render_template("pages/secondary_skip/delete")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/condition_repository_spec.rb
+++ b/spec/services/condition_repository_spec.rb
@@ -1,29 +1,19 @@
 require "rails_helper"
 
 describe ConditionRepository do
-  let(:form_id) { form.id }
-  let(:form_attributes) { attributes_for(:form) }
-  let(:form) do
-    form = build(:form_resource, **form_attributes)
-    form.id = Form.create!(form.database_attributes).id
-    form
-  end
-
-  let(:routing_page_id) { routing_page.id }
-  let(:routing_page) do
-    page = build(:page_resource, form_id:)
-    page.id = Page.create!(page.database_attributes).id
-    page
-  end
+  let(:form) { create(:form_record) }
+  let(:routing_page) { create(:page_record, form:) }
+  let(:goto_page) { create(:page_record, form:) }
 
   describe "#create!" do
+    let(:created_condition_id) { 4 }
     let(:condition_params) do
-      { form_id:,
-        page_id: routing_page_id,
-        check_page_id: routing_page_id,
-        routing_page_id:,
+      { form_id: form.id,
+        page_id: routing_page.id,
+        check_page_id: routing_page.id,
+        routing_page_id: routing_page.id,
         answer_value: "Yes",
-        goto_page_id: 3,
+        goto_page_id: goto_page.id,
         skip_to_end: false,
         exit_page_heading: nil,
         exit_page_markdown: nil }
@@ -31,7 +21,7 @@ describe ConditionRepository do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.post "/api/v1/forms/#{form_id}/pages/#{routing_page_id}/conditions", post_headers, { id: 4 }.to_json, 200
+        mock.post "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions", post_headers, { id: created_condition_id }.to_json, 200
       end
     end
 
@@ -49,182 +39,175 @@ describe ConditionRepository do
         }.to change(Condition, :count).by(1)
       end
 
+      it "returns a condition record" do
+        expect(described_class.create!(**condition_params)).to be_a(Condition)
+      end
+
       context "when the form question section is complete" do
-        let(:form_attributes) { attributes_for(:form, question_section_completed: true) }
+        let(:form) { create(:form_record, question_section_completed: true) }
 
         it "updates the form to mark the question section as incomplete" do
           expect {
             described_class.create!(**condition_params)
-          }.to change { Form.find(form_id).question_section_completed }.to(false)
+          }.to change { Form.find(form.id).question_section_completed }.to(false)
         end
       end
 
       it "associates the condition with pages" do
         described_class.create!(**condition_params)
-        expect(Condition.last).to have_attributes(routing_page_id:, check_page_id: routing_page_id, goto_page_id: 3)
+        expect(Condition.last).to have_attributes(routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id)
       end
     end
 
     it "has the same ID in the database and for the API" do
-      condition = described_class.create!(**condition_params)
-      expect(Condition.last.id).to eq condition.id
+      described_class.create!(**condition_params)
+      expect(Condition.last.id).to eq created_condition_id
     end
   end
 
   describe "#find" do
-    let(:condition) { build(:condition_resource, id: 4, form_id: form_id, page_id: routing_page_id, routing_page_id:, check_page_id: routing_page_id, goto_page_id: 3) }
+    let(:condition) { build(:condition_resource, id: 4, routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id) }
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{form_id}/pages/#{routing_page_id}/conditions/#{condition.id}", headers, condition.to_json, 200
+        mock.get "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", headers, condition.to_json, 200
       end
     end
 
     describe "api" do
       it "finds the condition through ActiveResource" do
-        described_class.find(condition_id: condition.id, form_id:, page_id: routing_page_id)
-        expect(Api::V1::ConditionResource.new(id: 4, form_id:, page_id: routing_page_id)).to have_been_read
+        described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)
+        expect(Api::V1::ConditionResource.new(id: condition.id, form_id: form.id, page_id: routing_page.id)).to have_been_read
       end
     end
 
     describe "database" do
       it "saves the condition to the database" do
         expect {
-          described_class.find(condition_id: condition.id, form_id:, page_id: routing_page_id)
+          described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)
         }.to change(Condition, :count).by(1)
       end
 
+      it "returns a condition record" do
+        expect(described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)).to be_a(Condition)
+      end
+
       it "associates the condition with pages" do
-        described_class.find(condition_id: condition.id, form_id:, page_id: routing_page_id)
-        expect(Condition.last).to have_attributes(routing_page_id:, check_page_id: routing_page_id, goto_page_id: 3)
+        described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)
+        expect(Condition.last).to have_attributes(routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id)
+      end
+
+      context "when the condition already exists in the database" do
+        let!(:existing_condition) { create(:condition_record, id: condition.id, routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id) }
+
+        it "does not create a new condition" do
+          expect {
+            described_class.find(condition_id: existing_condition.id, form_id: form.id, page_id: routing_page.id)
+          }.not_to change(Condition, :count)
+        end
+
+        it "returns the existing condition" do
+          expect(described_class.find(condition_id: existing_condition.id, form_id: form.id, page_id: routing_page.id)).to eq(existing_condition)
+        end
       end
     end
   end
 
   describe "#save!" do
-    let(:condition) { build(:condition_resource, id: 4, skip_to_end: false, form_id:, page_id: routing_page_id, routing_page_id:) }
+    let(:condition) { create(:condition_record, skip_to_end: false, routing_page_id: routing_page.id) }
+    let(:updated_condition_resource) { build(:condition_resource, id: condition.id, routing_page_id: routing_page.id, skip_to_end: true) }
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{form_id}/pages/#{routing_page_id}/conditions/4", headers, condition.to_json, 200
-        mock.put "/api/v1/forms/#{form_id}/pages/#{routing_page_id}/conditions/4", post_headers
+        mock.put "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", post_headers, updated_condition_resource.to_json, 200
       end
     end
 
     describe "api" do
       it "updates the condition through ActiveResource" do
-        condition = described_class.find(condition_id: 4, form_id:, page_id: routing_page_id)
         condition.skip_to_end = true
         described_class.save!(condition)
-        expect(Api::V1::ConditionResource.new(id: 4, skip_to_end: true, form_id:, page_id: routing_page_id)).to have_been_updated
+        expect(Api::V1::ConditionResource.new(id: condition.id, skip_to_end: true, form_id: form.id, page_id: routing_page.id)).to have_been_updated
+        expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("skip_to_end" => true)
       end
     end
 
     describe "database" do
       it "saves the condition to the repository" do
-        condition = described_class.find(condition_id: 4, form_id:, page_id: routing_page_id)
         condition.skip_to_end = true
-
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form_id}/pages/#{routing_page_id}/conditions/4", put_headers, condition.to_json
-        end
 
         expect {
           described_class.save!(condition)
-        }.to change { Condition.find(4).skip_to_end }.to(true)
+        }.to change { Condition.find(condition.id).skip_to_end }.to(true)
+      end
+
+      it "returns a condition record" do
+        expect(described_class.save!(condition)).to be_a(Condition)
       end
 
       context "when the form question section is complete" do
-        let(:form_attributes) { attributes_for(:form, question_section_completed: true) }
+        let(:form) { create(:form_record, question_section_completed: true) }
 
         it "updates the form to mark the question section as incomplete" do
-          condition = described_class.find(condition_id: 4, form_id:, page_id: routing_page_id)
-
           expect {
             described_class.save!(condition)
-          }.to change { Form.find(form_id).question_section_completed }.to(false)
+          }.to change { Form.find(form.id).question_section_completed }.to(false)
         end
       end
     end
   end
 
   describe "#destroy" do
-    let(:condition) { build(:condition_resource, id: 4, form_id:, page_id: routing_page_id, routing_page_id:) }
+    let(:condition) { create(:condition_record, routing_page_id: routing_page.id) }
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{form_id}/pages/#{routing_page_id}/conditions/4", headers, condition.to_json, 200
-        mock.delete "/api/v1/forms/#{form_id}/pages/#{routing_page_id}/conditions/4", delete_headers, nil, 204
+        mock.delete "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", delete_headers, nil, 204
       end
     end
 
     describe "api" do
       it "destroys the condition through ActiveResource" do
-        condition = described_class.find(condition_id: 4, form_id:, page_id: routing_page_id)
         described_class.destroy(condition)
-        expect(Api::V1::ConditionResource.new(id: 4, form_id:, page_id: routing_page_id)).to have_been_deleted
+        expect(Api::V1::ConditionResource.new(id: condition.id, form_id: form.id, page_id: routing_page.id)).to have_been_deleted
       end
 
       context "when the condition has already been deleted" do
         it "does not raise an error" do
-          condition = described_class.find(condition_id: 4, form_id:, page_id: routing_page_id)
-          described_class.destroy(condition)
-
           ActiveResource::HttpMock.respond_to do |mock|
-            mock.delete "/api/v1/forms/#{form_id}/pages/#{routing_page_id}/conditions/4", delete_headers, nil, 404
+            mock.delete "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", delete_headers, nil, 404
           end
 
           expect {
             described_class.destroy(condition)
           }.not_to raise_error
-        end
-
-        it "returns the deleted condition" do
-          condition = described_class.find(condition_id: 4, form_id:, page_id: routing_page_id)
-          described_class.destroy(condition)
-
-          ActiveResource::HttpMock.respond_to do |mock|
-            mock.delete "/api/v1/forms/#{form_id}/pages/#{routing_page_id}/conditions/4", delete_headers, nil, 404
-          end
-
-          expect(described_class.destroy(condition)).to eq condition
         end
       end
     end
 
     describe "database" do
       it "removes the condition from the database" do
-        condition = described_class.find(condition_id: 4, form_id:, page_id: routing_page_id)
-
         expect {
           described_class.destroy(condition)
         }.to change(Condition, :count).by(-1)
       end
 
-      context "when the form question section is complete" do
-        let(:form_attributes) { attributes_for(:form, question_section_completed: true) }
-
-        it "updates the form to mark the question section as incomplete" do
-          condition = described_class.find(condition_id: 4, form_id:, page_id: routing_page_id)
-
-          expect {
-            described_class.destroy(condition)
-          }.to change { Form.find(form_id).question_section_completed }.to(false)
-        end
+      it "returns a condition record" do
+        expect(described_class.destroy(condition)).to be_a(Condition)
       end
 
-      context "when the condition is not already in the database" do
-        it "does not raise an error" do
-          condition = Api::V1::ConditionResource.new(id: 4, form_id:, page_id: routing_page_id)
+      context "when the form question section is complete" do
+        let(:form) { create(:form_record, question_section_completed: true) }
+
+        it "updates the form to mark the question section as incomplete" do
           expect {
             described_class.destroy(condition)
-          }.not_to raise_error
+          }.to change { Form.find(form.id).question_section_completed }.to(false)
         end
       end
     end
 
     it "returns the deleted condition" do
-      condition = described_class.find(condition_id: 4, form_id:, page_id: routing_page_id)
       expect(described_class.destroy(condition)).to eq condition
     end
   end

--- a/spec/services/page_repository_spec.rb
+++ b/spec/services/page_repository_spec.rb
@@ -143,10 +143,10 @@ describe PageRepository do
         it "saves the answer settings to the database" do
           described_class.create!(**page_params)
           expect(Page.last).to have_attributes(
-            "answer_settings" => {
+            "answer_settings" => DataStruct.new({
               "only_one_option" => "true",
               "selection_options" => [],
-            },
+            }),
           )
         end
       end

--- a/spec/support/shared_context/pages_with_routing.rb
+++ b/spec/support/shared_context/pages_with_routing.rb
@@ -4,127 +4,110 @@ RSpec.shared_context "with pages with routing" do
   end
 
   let(:pages_with_routing) do
-    link_pages_list([
-      build(
+    pages = [
+      create(
         :page,
-        id: 1,
         question_text: "Question",
       ),
-      build(
+      create(
         :page,
         :with_selection_settings,
-        id: 2,
         question_text: "Branch question (start of a route)",
         selection_options: [{ name: "First branch" }, { name: "Second branch" }],
-        routing_conditions: [
-          build(
-            :condition,
-            id: 1,
-            answer_value: "Second branch",
-            check_page_id: 2,
-            goto_page_id: 5,
-            routing_page_id: 2,
-            exit_page_heading: nil,
-            exit_page_markdown: nil,
-          ),
-        ],
       ),
-      build(
+      create(
         :page,
-        id: 3,
         question_text: "Question in branch 1",
       ),
-      build(
+      create(
         :page,
-        id: 4,
         question_text: "Question at the end of branch 1 (start of a secondary skip)",
-        routing_conditions: [
-          build(
-            :condition,
-            id: 2,
-            answer_value: nil,
-            check_page_id: 2,
-            goto_page_id: 8,
-            routing_page_id: 4,
-            exit_page_heading: nil,
-            exit_page_markdown: nil,
-          ),
-        ],
       ),
-      build(
+      create(
         :page,
-        id: 5,
         question_text: "Question at the start of branch 2 (end of a route)",
       ),
-      build(
+      create(
         :page,
-        id: 6,
         question_text: "Question in branch 2",
       ),
-      build(
+      create(
         :page,
-        id: 7,
         question_text: "Question at the end of branch 2",
       ),
-      build(
+      create(
         :page,
-        id: 8,
         question_text: "Question after a branch route (end of a secondary skip)",
       ),
-      build(
+      create(
         :page,
-        id: 9,
         question_text: "Question",
       ),
-      build(
+      create(
         :page,
         :with_selection_settings,
-        id: 10,
         question_text: "Skip question",
         selection_options: [{ name: "Skip" }, { name: "Don't skip" }],
-        routing_conditions: [
-          build(
-            :condition,
-            id: 3,
-            answer_value: "Skip",
-            check_page_id: 10,
-            goto_page_id: 12,
-            routing_page_id: 10,
-            exit_page_heading: nil,
-            exit_page_markdown: nil,
-          ),
-        ],
       ),
-      build(
+      create(
         :page,
-        id: 11,
         question_text: "Question to be skipped",
       ),
-      build(
+      create(
         :page,
-        id: 12,
         question_text: "Question",
       ),
-      build(
+      create(
         :page,
         :with_selection_settings,
-        id: 13,
         question_text: "Exit page question",
         selection_options: [{ name: "Exit" }, { name: "Don't exit" }],
-        routing_conditions: [
-          build(
-            :condition,
-            id: 4,
-            answer_value: "Exit",
-            check_page_id: 13,
-            goto_page_id: nil,
-            routing_page_id: 13,
-            exit_page_heading: "Exit page heading",
-            exit_page_markdown: "Exit page markdown",
-          ),
-        ],
       ),
-    ])
+    ]
+
+    # Create conditions separately
+    create(
+      :condition,
+      answer_value: "Second branch",
+      check_page_id: pages[1].id,
+      goto_page_id: pages[4].id,
+      routing_page_id: pages[1].id,
+      exit_page_heading: nil,
+      exit_page_markdown: nil,
+    )
+
+    create(
+      :condition,
+      answer_value: nil,
+      check_page_id: pages[1].id,
+      goto_page_id: pages[7].id,
+      routing_page_id: pages[3].id,
+      exit_page_heading: nil,
+      exit_page_markdown: nil,
+    )
+
+    create(
+      :condition,
+      answer_value: "Skip",
+      check_page_id: pages[9].id,
+      goto_page_id: pages[11].id,
+      routing_page_id: pages[9].id,
+      exit_page_heading: nil,
+      exit_page_markdown: nil,
+    )
+
+    create(
+      :condition,
+      answer_value: "Exit",
+      check_page_id: pages[12].id,
+      goto_page_id: nil,
+      routing_page_id: pages[12].id,
+      exit_page_heading: "Exit page heading",
+      exit_page_markdown: "Exit page markdown",
+    )
+
+    pages.each(&:reload)
+    pages
   end
 
   let(:branch_route_1) do

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe "forms/_made_live_form.html.erb" do
   let(:metrics_data) { { weekly_submissions: 125, weekly_starts: 256 } }
   let(:what_happens_next) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:form_metadata) { OpenStruct.new(has_draft_version: false) }
-  let(:form) { build(:form, :live, id: 2, declaration_text: declaration, what_happens_next_markdown: what_happens_next, live_at: 1.week.ago, submission_type:) }
+  let(:form) { build(:made_live_form, id: 2, declaration_text: declaration, what_happens_next_markdown: what_happens_next, live_at: 1.week.ago, submission_type:) }
   let(:group) { create(:group, name: "Group 1") }
   let(:status) { :live }
   let(:preview_mode) { :preview_live }
@@ -102,7 +102,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "with only a single question" do
-    let(:form) { build(:form, :live, id: 2, pages_count: 1) }
+    let(:form) { build(:made_live_form, :with_one_page, id: 2) }
 
     it "contains a link to view questions with correct pluralization" do
       expect(rendered).to have_link("1 question", href: questions_path)
@@ -157,7 +157,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "with a support email address" do
-    let(:form) { build(:form, :live, id: 2, support_email: "support@example.gov.uk") }
+    let(:form) { build(:made_live_form, id: 2, support_email: "support@example.gov.uk") }
 
     it "shows the support email address" do
       expect(rendered).to have_xpath("//h3[text()='#{I18n.t('made_live_form.contact_details')}']/following-sibling::h4", text: "Email")
@@ -166,7 +166,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "with a support phone" do
-    let(:form) { build(:form, :live, id: 2, support_phone: "phone details") }
+    let(:form) { build(:made_live_form, id: 2, support_phone: "phone details") }
 
     it "shows the support phone number" do
       expect(rendered).to have_css("h4", text: "Phone")
@@ -175,7 +175,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "with a support online" do
-    let(:form) { build(:form, :live, id: 2, support_url_text: "website", support_url: "www.example.gov.uk") }
+    let(:form) { build(:made_live_form, id: 2, support_url_text: "website", support_url: "www.example.gov.uk") }
 
     it "shows the support contact online" do
       expect(rendered).to have_css("h4", text: "Support contact online")
@@ -184,7 +184,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "with no support information set" do
-    let(:form) { build(:form, :live, id: 2, support_email: nil, support_phone: nil, support_url_text: nil, support_url: nil) }
+    let(:form) { build(:made_live_form, id: 2, support_email: nil, support_phone: nil, support_url_text: nil, support_url: nil) }
 
     it "does not include support details if they are not set" do
       expect(rendered).not_to have_xpath("//h3[text()='#{I18n.t('made_live_form.contact_details')}']/following-sibling::h4", text: "Email")
@@ -235,7 +235,7 @@ describe "forms/_made_live_form.html.erb" do
 
   context "when the form has a payment link" do
     let(:payment_url) { "https://www.gov.uk/payments/your-payment-link" }
-    let(:form) { build(:form, :live, id: 2, payment_url:) }
+    let(:form) { build(:made_live_form, id: 2, payment_url:) }
 
     it "contains a link to the payment url" do
       expect(rendered).to have_css("h3", text: "GOV.UK Pay payment link")

--- a/spec/views/forms/archived/show_form.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_form.html.erb_spec.rb
@@ -24,17 +24,7 @@ describe "archived/show_form.html.erb" do
     expect(rendered).to have_link("#{form.pages.count} questions", href: "/forms/#{form.id}/archived/pages")
   end
 
-  context "when the form state is :archived" do
-    it "contains a link to make the form live again" do
-      expect(rendered).to have_link("Make this form live", href: "/forms/#{form.id}/unarchive")
-    end
-  end
-
-  context "when the form state is :archived_with_draft" do
-    let(:form) { build(:form, :archived_with_draft, id: 1) }
-
-    it "does not contain a link to make the form live again" do
-      expect(rendered).to have_link("Make this form live", href: "/forms/#{form.id}/unarchive")
-    end
+  it "contains a link to make the form live again" do
+    expect(rendered).to have_link("Make this form live", href: "/forms/#{form.id}/unarchive")
   end
 end

--- a/spec/views/pages/conditions/delete.html.erb_spec.rb
+++ b/spec/views/pages/conditions/delete.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "pages/conditions/delete.html.erb" do
   let(:delete_condition_input) { Pages::DeleteConditionInput.new(form:, page:, record: condition) }
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:form) { create :form, :ready_for_routing }
   let(:condition) { build :condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Wales", goto_page_id: pages.last.id }
   let(:secondary_skip_condition) { nil }
   let(:pages) { form.pages }

--- a/spec/views/pages/conditions/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/edit.html.erb_spec.rb
@@ -42,7 +42,7 @@ describe "pages/conditions/edit.html.erb" do
   end
 
   context "with a validation error" do
-    let(:condition) { create :condition, :with_answer_value_missing, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.third.id }
+    let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.third.id }
 
     it "has an error link that matches the field with errors" do
       field_id = "pages-conditions-input-answer-value-field-error"

--- a/spec/views/pages/conditions/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/edit.html.erb_spec.rb
@@ -2,24 +2,16 @@ require "rails_helper"
 
 describe "pages/conditions/edit.html.erb" do
   let(:condition_input) { Pages::ConditionsInput.new(form:, page:, record: condition) }
-  let(:form) { build :form, :ready_for_routing, id: 1 }
+  let(:form) { create :form, :ready_for_routing }
   let(:group) { build :group }
-  let(:condition) { build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
-  let(:pages) { form.pages << page }
+  let(:pages) { form.pages }
+  let(:page) { pages.first }
+  let(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1", goto_page_id: pages.third.id }
   let(:secondary_skip) { false }
-  let(:page) do
-    build :page,
-          form_id: form.id,
-          is_optional: "false",
-          answer_type: "selection",
-          answer_settings: OpenStruct.new(only_one_option: "true",
-                                          selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
-                                                              OpenStruct.new(attributes: { name: "Option 2" })])
-  end
 
   before do
+    pages.each(&:reload)
     page.position = 1
-    allow(view).to receive_messages(form_pages_path: "/forms/1/pages", create_condition_path: "/forms/1/pages/1/conditions/new", delete_condition_path: "/forms/1/pages/1/conditions/2/delete")
     allow(form).to receive_messages(group: group, qualifying_route_pages: pages)
     allow(condition_input).to receive(:secondary_skip?).and_return(secondary_skip)
     allow(FormRepository).to receive_messages(pages:)
@@ -46,11 +38,11 @@ describe "pages/conditions/edit.html.erb" do
   end
 
   it "has a delete route link" do
-    expect(rendered).to have_link(text: "Delete route", href: "/forms/1/pages/1/conditions/2/delete")
+    expect(rendered).to have_link(text: "Delete route", href: "/forms/#{form.id}/pages/#{page.id}/conditions/#{condition.id}/delete")
   end
 
   context "with a validation error" do
-    let(:condition) { build :condition, :with_answer_value_missing, id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3 }
+    let(:condition) { create :condition, :with_answer_value_missing, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.third.id }
 
     it "has an error link that matches the field with errors" do
       field_id = "pages-conditions-input-answer-value-field-error"
@@ -62,15 +54,13 @@ describe "pages/conditions/edit.html.erb" do
   end
 
   context "when the condition does not have an exit page" do
-    let(:condition) { build :condition, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 }
-
     it "has an 'add exit page' option" do
       expect(rendered).to have_content("Add an exit page")
     end
   end
 
   context "when the condition has an exit page" do
-    let(:condition) { build :condition, :with_exit_page, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Wales" }
+    let(:condition) { create :condition, :with_exit_page, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1" }
 
     it "has the exit page heading" do
       expect(rendered).to have_content(condition.exit_page_heading)

--- a/spec/views/pages/conditions/new.html.erb_spec.rb
+++ b/spec/views/pages/conditions/new.html.erb_spec.rb
@@ -1,15 +1,9 @@
 require "rails_helper"
 
 describe "pages/conditions/new.html.erb" do
-  let(:form) { build :form, id: 1, pages: }
+  let(:form) { create :form, :ready_for_routing }
   let(:group) { build :group }
-  let(:pages) do
-    build_list(:page, 3) do |page, i|
-      page.id = i
-      page.form_id = 1
-      page.answer_settings = OpenStruct.new(only_one_option: "true", selection_options: [OpenStruct.new(attributes: { name: "Option 1" }), OpenStruct.new(attributes: { name: "Option 2" })])
-    end
-  end
+  let(:pages) { form.pages }
   let(:condition_input) { Pages::ConditionsInput.new(form:, page: pages.first) }
 
   before do

--- a/spec/views/pages/exit_page/edit.html.erb_spec.rb
+++ b/spec/views/pages/exit_page/edit.html.erb_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
 
 describe "pages/exit_page/edit.html.erb" do
-  let(:form) { build :form, id: 1 }
+  let(:form) { create :form, :with_pages }
   let(:group) { build :group }
-  let(:pages) do
-    build_list(:page, 3)
-  end
-  let(:condition) { build :condition, :with_exit_page, id: 3, form:, page: pages.first }
+  let(:pages) { form.pages }
+  let(:condition) { create :condition, :with_exit_page, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1" }
   let(:update_exit_page_input) { Pages::UpdateExitPageInput.new(form:, page: pages.first, record: condition).assign_condition_values }
 
   before do

--- a/spec/views/pages/exit_page/new.html.erb_spec.rb
+++ b/spec/views/pages/exit_page/new.html.erb_spec.rb
@@ -1,11 +1,8 @@
 require "rails_helper"
 
 describe "pages/exit_page/new.html.erb" do
-  let(:form) { build :form, id: 1 }
-  let(:group) { build :group }
-  let(:pages) do
-    build_list(:page, 3)
-  end
+  let(:form) { create :form, :ready_for_routing }
+  let(:pages) { form.pages }
   let(:exit_page_input) { Pages::ExitPageInput.new(form:, page: pages.first, answer_value: "Option 1") }
 
   before do

--- a/spec/views/pages/new.html.erb_spec.rb
+++ b/spec/views/pages/new.html.erb_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "pages/new" do
-  let(:current_form) { build :form, :with_active_resource, id: 1, pages: [] }
+  let(:form) { create :form }
   let(:draft_question) { build :draft_question }
   let(:question_input) { build :question_input, draft_question:, answer_type: draft_question.answer_type, question_text: draft_question.question_text, answer_settings: draft_question.answer_settings, is_optional: draft_question.is_optional, is_repeatable: draft_question.is_repeatable }
 
   before do
     assign(:question_input, question_input)
 
-    render locals: { current_form:, draft_question: }
+    render locals: { current_form: form, draft_question: }
   end
 
   it "renders" do
@@ -16,7 +16,7 @@ RSpec.describe "pages/new" do
   end
 
   it "has a back link to the add and edit questions page" do
-    expect(view.content_for(:back_link)).to have_link "Back", href: form_pages_path(form_id: 1)
+    expect(view.content_for(:back_link)).to have_link "Back", href: form_pages_path(form_id: form.id)
   end
 
   it "has a page title" do
@@ -34,10 +34,10 @@ RSpec.describe "pages/new" do
 
     describe "question number" do
       context "when the current form already has some pages" do
-        let(:current_form) { build :form, :with_active_resource, id: 1, pages: build_list(:page, 3) }
+        let(:form) { create :form, :with_pages }
 
         it "is one greater than the number of existing pages" do
-          expect(rendered).to have_css "h1.govuk-heading-l .govuk-caption-l", text: "Question 4"
+          expect(rendered).to have_css "h1.govuk-heading-l .govuk-caption-l", text: "Question 6"
         end
       end
     end
@@ -49,11 +49,11 @@ RSpec.describe "pages/new" do
 
   describe "form" do
     it "saves the new question" do
-      expect(rendered).to have_element "form", action: create_question_path(form_id: 1)
+      expect(rendered).to have_element "form", action: create_question_path(form_id: form.id)
     end
 
     it "has a link to add guidance" do
-      expect(rendered).to have_link href: guidance_new_path(form_id: 1)
+      expect(rendered).to have_link href: guidance_new_path(form_id: form.id)
     end
 
     it "does not have a button to delete the question" do

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
 describe "pages/routes/show.html.erb" do
-  let(:form) { build :form, id: 1, pages: }
-  let(:pages) { [page, next_page] }
-  let(:page) { build :page, id: 1, routing_conditions: [build(:condition)] }
-  let(:next_page) { build :page, id: 2 }
+  let(:form) { create :form, :ready_for_routing }
+  let(:pages) { form.pages }
+  let(:page) { pages.first }
   let(:routes) { PageRoutesService.new(form:, pages:, page:).routes }
   let(:errors) { [] }
 
@@ -19,71 +18,87 @@ describe "pages/routes/show.html.erb" do
     ]
   end
 
-  let(:route_summary_card_data_service) { instance_double(RouteSummaryCardDataPresenter, summary_card_data: route_cards, errors:, routes:, next_page:, pages:, page:, form:) }
+  let(:route_summary_card_data_service) { instance_double(RouteSummaryCardDataPresenter, summary_card_data: route_cards, errors:, routes:, next_page: pages.second, pages:, page:, form:) }
 
   before do
     allow(FormRepository).to receive_messages(pages:)
     allow(form).to receive(:group).and_return(build(:group))
-    render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: route_summary_card_data_service }
   end
 
-  it "has the correct title" do
-    expect(view.content_for(:title)).to have_content("Question 1’s routes")
-  end
+  context "when there are no routes" do
+    before do
+      render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: route_summary_card_data_service }
+    end
 
-  it "has the correct back link" do
-    expect(view.content_for(:back_link)).to have_link(I18n.t("pages.go_to_your_questions"), href: "/back")
-  end
+    it "has the correct title" do
+      expect(view.content_for(:title)).to have_content("Question 1’s routes")
+    end
 
-  it "has the correct heading and caption" do
-    expect(rendered).to have_selector("h1", text: form.name)
-    expect(rendered).to have_selector("h1", text: I18n.t("page_titles.routes_show", question_number: page.position))
-  end
+    it "has the correct back link" do
+      expect(view.content_for(:back_link)).to have_link(I18n.t("pages.go_to_your_questions"), href: "/back")
+    end
 
-  it "shows the page title as a summary list" do
-    expect(rendered).to have_css(".govuk-summary-list__key", text: "Question #{page.position}")
-    expect(rendered).to have_css(".govuk-summary-list__value", text: page.question_text)
-  end
+    it "has the correct heading and caption" do
+      expect(rendered).to have_selector("h1", text: form.name)
+      expect(rendered).to have_selector("h1", text: I18n.t("page_titles.routes_show", question_number: page.position))
+    end
 
-  it "shows the correct route cards" do
-    expect(rendered).to have_css(".govuk-summary-list__key", text: "route 1 key")
-    expect(rendered).to have_css(".govuk-summary-list__value", text: "route 1 value")
-  end
+    it "shows the page title as a summary list" do
+      expect(rendered).to have_css(".govuk-summary-list__key", text: "Question #{page.position}")
+      expect(rendered).to have_css(".govuk-summary-list__value", text: page.question_text)
+    end
 
-  it "has a back to questions link" do
-    expect(rendered).to have_link(I18n.t("pages.go_to_your_questions"), href: form_pages_path(form.id))
-  end
+    it "shows the correct route cards" do
+      expect(rendered).to have_css(".govuk-summary-list__key", text: "route 1 key")
+      expect(rendered).to have_css(".govuk-summary-list__value", text: "route 1 value")
+    end
 
-  context "when the page has a single skip route" do
-    include_context "with pages with routing"
-
-    let(:route_summary_card_data_service) { RouteSummaryCardDataPresenter.new form:, page: }
-    let(:page) { page_with_skip_route }
+    it "has a back to questions link" do
+      expect(rendered).to have_link(I18n.t("pages.go_to_your_questions"), href: form_pages_path(form.id))
+    end
 
     it "does not have a link to delete all routes" do
       expect(rendered).not_to have_link(I18n.t("page_route_card.delete_route"), href: delete_routes_path(form.id, page.id))
     end
   end
 
-  context "when the page does not have a secondary skip route" do
-    include_context "with pages with routing"
-
+  context "when the page has a single route" do
     let(:route_summary_card_data_service) { RouteSummaryCardDataPresenter.new form:, page: }
-    let(:page) { page_with_skip_route }
+
+    before do
+      create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.third.id
+      pages.each(&:reload)
+
+      render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: route_summary_card_data_service }
+    end
+
+    it "does not have a link to delete all routes" do
+      expect(rendered).not_to have_link(I18n.t("page_route_card.delete_route"), href: delete_routes_path(form.id, page.id))
+    end
 
     it "has an any other answer section" do
       expect(rendered).to have_css "h2.govuk-heading-m", text: "If people select any other answer"
     end
 
+    it "has a link to set questions to skip" do
+      expect(rendered).to have_link(
+        "Set questions to skip",
+        class: "govuk-button--secondary",
+        href: new_secondary_skip_path(form.id, page.id),
+      )
+    end
+
     describe "any other answer section" do
       it "shows the number of the next question in the form" do
-        expect(rendered).to have_text "People who select any other answer will continue to question 11 and through the rest of the form"
+        expect(rendered).to have_text "People who select any other answer will continue to question #{pages.second.position} and through the rest of the form"
       end
 
       context "when the page is the last question" do
-        let(:pages) do
-          pages_with_routing.delete(page)
-          pages_with_routing.append(page)
+        let(:page) { pages.last }
+
+        before do
+          create :condition, routing_page_id: pages.last.id, check_page_id: pages.last.id, answer_value: "Option 1", goto_page_id: nil, skip_to_end: true
+          pages.each(&:reload)
         end
 
         it "shows the check your answers page as the next question in the form" do
@@ -98,34 +113,36 @@ describe "pages/routes/show.html.erb" do
           )
         end
       end
+    end
+  end
 
-      it "has a link to set questions to skip" do
-        expect(rendered).to have_link(
-          "Set questions to skip",
-          class: "govuk-button--secondary",
-          href: new_secondary_skip_path(form.id, page.id),
-        )
-      end
+  context "when the page has a route that leads to an exit page" do
+    before do
+      create :condition, :with_exit_page, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1"
+      pages.each(&:reload)
 
-      context "when the route leads to an exit page" do
-        let(:page) { page_with_exit_page }
+      render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: route_summary_card_data_service }
+    end
 
-        it "does not show the link to set questions to skip" do
-          expect(rendered).not_to have_link(
-            "Set questions to skip",
-            class: "govuk-button--secondary",
-            href: new_secondary_skip_path(form.id, page.id),
-          )
-        end
-      end
+    it "does not show the link to set questions to skip" do
+      expect(rendered).not_to have_link(
+        "Set questions to skip",
+        class: "govuk-button--secondary",
+        href: new_secondary_skip_path(form.id, page.id),
+      )
     end
   end
 
   context "when the page has a skip and a secondary skip" do
-    include_context "with pages with routing"
-
     let(:route_summary_card_data_service) { RouteSummaryCardDataPresenter.new form:, page: }
-    let(:page) { page_with_skip_and_secondary_skip }
+
+    before do
+      create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.third.id
+      create :condition, routing_page_id: pages.second.id, check_page_id: pages.first.id, goto_page_id: pages.fourth.id
+      pages.each(&:reload)
+
+      render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: route_summary_card_data_service }
+    end
 
     it "has a link to delete all routes" do
       expect(rendered).to have_link(I18n.t("page_route_card.delete_route"), href: delete_routes_path(form.id, page.id))
@@ -139,6 +156,10 @@ describe "pages/routes/show.html.erb" do
 
   context "when there is an error" do
     let(:errors) { [OpenStruct.new(link: "goto-1", message: "Error text")] }
+
+    before do
+      render template: "pages/routes/show", locals: { current_form: form, page:, back_link_url: "/back", route_summary_card_data_presenter: route_summary_card_data_service }
+    end
 
     it "shows the error message" do
       expect(rendered).to have_text("Error text")

--- a/spec/views/pages/selection/bulk_options.html.erb_spec.rb
+++ b/spec/views/pages/selection/bulk_options.html.erb_spec.rb
@@ -1,16 +1,18 @@
 require "rails_helper"
 
 describe "pages/selection/bulk_options.html.erb", type: :view do
-  let(:form) { build :form, id: 1, pages: [page] }
+  let(:form) { create :form }
+  let(:page) { create :page, :with_selection_settings, answer_settings: }
   let(:bulk_options_input) { build :bulk_options_input, draft_question: page }
-  let(:page) { OpenStruct.new(answer_type: "selection", answer_settings:) }
-  let(:answer_settings) { OpenStruct.new(only_one_option:, selection_options:) }
+  let(:answer_settings) { DataStruct.new(only_one_option:, selection_options:) }
   let(:only_one_option) { "true" }
   let(:selection_options) { [] }
   let(:page_number) { 1 }
   let(:back_link_url) { "/a-back-link-url" }
 
   before do
+    form.reload
+
     # # mock the form.page_number method
     allow(form).to receive(:page_number).and_return(page_number)
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/6hA4UVml

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to use ActiveRecord instead of ActiveResource, so we can change forms-admin to using the database as the source of truth instead of forms-api. This PR shouldn't have any effect on users. We've tested it in dev.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
