### PR TITLE
Fix creating draft question from existing page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -126,7 +126,7 @@ private
     if edit_draft_question.new_record?
       attributes = page.attributes
         .slice(*edit_draft_question.attribute_names)
-        .except(:id)
+        .except("id")
       edit_draft_question.attributes = attributes
       edit_draft_question.save!(validate: false)
     end

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -120,6 +120,8 @@ RSpec.describe Pages::QuestionsController, type: :request do
 
   describe "#edit" do
     describe "Given a page" do
+      let(:page) { create :page, id: 99_999_999, form_id: form.id }
+
       before do
         # Setup a draft_question so that edit question action doesn't need to create a completely new records
         draft_question
@@ -129,6 +131,18 @@ RSpec.describe Pages::QuestionsController, type: :request do
 
       it "Reads the page from the page repository" do
         expect(PageRepository).to have_received(:find)
+      end
+
+      it "creates a draft question in the database" do
+        expect(DraftQuestion.last).to have_attributes(
+          question_text: page.question_text,
+          is_optional: page.is_optional,
+          answer_type: page.answer_type,
+        )
+      end
+
+      it "does not use the page id when assigning attributes to the draft question" do
+        expect(DraftQuestion.last.id).not_to eq(page.id)
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

When creating a draft question from an existing page, we want to copy across all of the existing page's attributes except for its id. As part of the change over to using ActiveRecord objects, the way we identify the id using a symbol meant that we weren't correctly excepting it from our draft question attribute assignment.

This has been changed into a string, so that it is correctly excepted when creating a draft question.


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
