### PR TITLE
Rename unprocessable_entity to unprocessable_content

### DIFF
--- a/app/controllers/account/names_controller.rb
+++ b/app/controllers/account/names_controller.rb
@@ -16,7 +16,7 @@ module Account
         DefaultGroupService.new.create_user_default_trial_group!(current_user)
         redirect_to next_path
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/account/organisations_controller.rb
+++ b/app/controllers/account/organisations_controller.rb
@@ -16,7 +16,7 @@ module Account
         DefaultGroupService.new.create_user_default_trial_group!(current_user)
         redirect_to next_path
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/account/terms_of_use_controller.rb
+++ b/app/controllers/account/terms_of_use_controller.rb
@@ -15,7 +15,7 @@ module Account
       if @terms_of_use_input.submit
         redirect_to next_path
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/forms/archive_form_controller.rb
+++ b/app/controllers/forms/archive_form_controller.rb
@@ -14,7 +14,7 @@ module Forms
 
       @confirm_archive_input = ConfirmArchiveInput.new(confirm_archive_input_params)
 
-      return render :archive, status: :unprocessable_entity unless @confirm_archive_input.valid?
+      return render :archive, status: :unprocessable_content unless @confirm_archive_input.valid?
       return redirect_to live_form_path(current_form.id) unless user_wants_to_archive_form
 
       ArchiveFormService.new(form: current_form, current_user: @current_user).archive

--- a/app/controllers/forms/contact_details_controller.rb
+++ b/app/controllers/forms/contact_details_controller.rb
@@ -13,7 +13,7 @@ module Forms
       if @contact_details_input.submit
         redirect_to form_path(@contact_details_input.form.id), success: t("banner.success.form.support_details_saved")
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -13,7 +13,7 @@ module Forms
 
       @make_live_input = MakeLiveInput.new(**make_live_input_params)
 
-      return render_new(status: :unprocessable_entity) unless @make_live_input.valid?
+      return render_new(status: :unprocessable_content) unless @make_live_input.valid?
       return redirect_to form_path(@make_live_input.form.id) unless @make_live_input.confirmed?
 
       @make_form_live_service = MakeFormLiveService.call(current_form:, current_user:)

--- a/app/controllers/forms/payment_link_controller.rb
+++ b/app/controllers/forms/payment_link_controller.rb
@@ -16,7 +16,7 @@ module Forms
         success_message = success_message(previous_payment_url, @payment_link_input.payment_url)
         redirect_to form_path(@payment_link_input.form.id), success: success_message
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/forms/receive_csv_controller.rb
+++ b/app/controllers/forms/receive_csv_controller.rb
@@ -16,7 +16,7 @@ module Forms
       if @receive_csv_input.submit
         redirect_to form_path(@receive_csv_input.form.id), success: success_message(previous_submission_type, new_submission_type)
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/forms/share_preview_controller.rb
+++ b/app/controllers/forms/share_preview_controller.rb
@@ -14,7 +14,7 @@ module Forms
         success_message = @share_preview_input.marked_complete? ? t("banner.success.form.share_preview_completed") : nil
         redirect_to form_path(current_form.id), success: success_message
       else
-        render "new", status: :unprocessable_entity
+        render "new", status: :unprocessable_content
       end
     end
 

--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -14,7 +14,7 @@ module Forms
       if @submission_email_input.submit
         redirect_to submission_email_code_sent_path(@submission_email_input.form.id)
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 
@@ -33,7 +33,7 @@ module Forms
       if @submission_email_input.confirm_confirmation_code
         redirect_to submission_email_confirmed_path(@submission_email_input.form.id)
       else
-        render :submission_email_code, status: :unprocessable_entity
+        render :submission_email_code, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/forms/unarchive_controller.rb
+++ b/app/controllers/forms/unarchive_controller.rb
@@ -13,7 +13,7 @@ module Forms
 
       @make_live_input = MakeLiveInput.new(**unarchive_form_params)
 
-      return render "unarchive_form", status: :unprocessable_entity, locals: { current_form: } unless @make_live_input.valid?
+      return render "unarchive_form", status: :unprocessable_content, locals: { current_form: } unless @make_live_input.valid?
       return redirect_to archived_form_path(current_form.id) unless @make_live_input.confirmed?
 
       @make_form_live_service = MakeFormLiveService.call(current_form:, current_user:)

--- a/app/controllers/forms/what_happens_next_controller.rb
+++ b/app/controllers/forms/what_happens_next_controller.rb
@@ -18,13 +18,13 @@ module Forms
         if @what_happens_next_input.valid?
           render :new, status: :ok
         else
-          render :new, status: :unprocessable_entity
+          render :new, status: :unprocessable_content
         end
       when :save_and_continue
         if @what_happens_next_input.submit
           redirect_to form_path(@what_happens_next_input.form.id), success: t("banner.success.form.what_happens_next_saved")
         else
-          render :new, status: :unprocessable_entity
+          render :new, status: :unprocessable_content
         end
       end
     end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -23,7 +23,7 @@ class FormsController < ApplicationController
       redirect_to form_path(current_form.id), success: success_message
     else
       @mark_complete_input.mark_complete = "false"
-      render "pages/index", locals: { current_form: }, status: :unprocessable_entity
+      render "pages/index", locals: { current_form: }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -22,7 +22,7 @@ class GroupFormsController < ApplicationController
 
       redirect_to form_path(@form.id)
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -21,7 +21,7 @@ class GroupMembersController < ApplicationController
       redirect_to group_members_path(@group.external_id),
                   success: t(".success", user_name: @group_member_input.invited_user.name)
     else
-      render :new, status: :unprocessable_entity, locals: { show_role_options: show_role_options? }
+      render :new, status: :unprocessable_content, locals: { show_role_options: show_role_options? }
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -47,7 +47,7 @@ class GroupsController < ApplicationController
     if @group.save
       redirect_to @group
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -67,7 +67,7 @@ class GroupsController < ApplicationController
     if @group.save
       redirect_to @group, success: success_message, status: :see_other
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -92,7 +92,7 @@ class GroupsController < ApplicationController
     @delete_confirmation_input = Groups::DeleteConfirmationInput.new(delete_confirmation_input_params)
 
     unless @delete_confirmation_input.valid?
-      return render :delete, status: :unprocessable_entity
+      return render :delete, status: :unprocessable_content
     end
 
     unless @delete_confirmation_input.confirmed?
@@ -103,7 +103,7 @@ class GroupsController < ApplicationController
       @group.destroy!
     rescue ActiveRecord::DeleteRestrictionError
       @delete_confirmation_input.errors.add(:confirm, :group_has_forms)
-      return render :delete, status: :unprocessable_entity
+      return render :delete, status: :unprocessable_content
     end
 
     redirect_to groups_path, success: t(".success", group_name: @group.name), status: :see_other
@@ -118,7 +118,7 @@ class GroupsController < ApplicationController
     authorize @group
 
     @confirm_upgrade_input = Groups::ConfirmUpgradeInput.new(confirm_upgrade_input_params)
-    return render :confirm_upgrade, status: :unprocessable_entity unless @confirm_upgrade_input.valid?
+    return render :confirm_upgrade, status: :unprocessable_content unless @confirm_upgrade_input.valid?
     return redirect_to @group unless @confirm_upgrade_input.confirmed?
 
     GroupService.new(group: @group, current_user: @current_user, host: request.host).upgrade_group
@@ -148,7 +148,7 @@ class GroupsController < ApplicationController
 
     @confirm_upgrade_input = Groups::ConfirmUpgradeInput.new(confirm_upgrade_input_params)
 
-    return render :review_upgrade, status: :unprocessable_entity unless @confirm_upgrade_input.valid?
+    return render :review_upgrade, status: :unprocessable_content unless @confirm_upgrade_input.valid?
 
     group_service = GroupService.new(group: @group, current_user: @current_user, host: request.host)
     if @confirm_upgrade_input.confirmed?

--- a/app/controllers/mou_signatures_controller.rb
+++ b/app/controllers/mou_signatures_controller.rb
@@ -26,10 +26,10 @@ class MouSignaturesController < ApplicationController
     if @mou_signature.save
       redirect_to confirmation_mou_signature_url
     else
-      render(:new, status: :unprocessable_entity)
+      render(:new, status: :unprocessable_content)
     end
   rescue ActiveRecord::RecordNotUnique
-    render(:new, status: :unprocessable_entity)
+    render(:new, status: :unprocessable_content)
   end
 
   def confirmation

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -14,7 +14,7 @@ class Pages::ConditionsController < PagesController
       routing_page = PageRepository.find(page_id: routing_page_id, form_id: current_form.id)
       redirect_to new_condition_or_show_routes_path(routing_page)
     else
-      render template: "pages/conditions/routing_page", locals: { form: current_form, routing_page_input: }, status: :unprocessable_entity
+      render template: "pages/conditions/routing_page", locals: { form: current_form, routing_page_input: }, status: :unprocessable_content
     end
   end
 
@@ -34,7 +34,7 @@ class Pages::ConditionsController < PagesController
         redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_created", route_number: 1)
       end
     else
-      render template: "pages/conditions/new", locals: { condition_input: }, status: :unprocessable_entity
+      render template: "pages/conditions/new", locals: { condition_input: }, status: :unprocessable_content
     end
   end
 
@@ -67,7 +67,7 @@ class Pages::ConditionsController < PagesController
         redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_updated", question_number: condition_input.page.position)
       end
     else
-      render template: "pages/conditions/edit", locals: { condition_input: }, status: :unprocessable_entity
+      render template: "pages/conditions/edit", locals: { condition_input: }, status: :unprocessable_content
     end
   end
 
@@ -93,7 +93,7 @@ class Pages::ConditionsController < PagesController
         redirect_to edit_condition_path(current_form.id, page.id, condition.id)
       end
     else
-      render template: "pages/conditions/delete", locals: { delete_condition_input: }, status: :unprocessable_entity
+      render template: "pages/conditions/delete", locals: { delete_condition_input: }, status: :unprocessable_content
     end
   end
 
@@ -122,7 +122,7 @@ class Pages::ConditionsController < PagesController
         goto_page_id: params.require(:goto_page_id),
         exit_page: condition,
         delete_exit_page_input: delete_exit_page_input,
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
     end
 
     unless delete_exit_page_input.confirmed?
@@ -141,7 +141,7 @@ class Pages::ConditionsController < PagesController
     if condition_input.update_condition
       redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_updated", question_number: condition_input.page.position)
     else
-      render template: "pages/conditions/edit", locals: { condition_input: }, status: :unprocessable_entity
+      render template: "pages/conditions/edit", locals: { condition_input: }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/pages/exit_page_controller.rb
+++ b/app/controllers/pages/exit_page_controller.rb
@@ -15,7 +15,7 @@ class Pages::ExitPageController < PagesController
       # TODO: Route number is hardcoded whilst we can only have one value for it
       redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.exit_page_created")
     else
-      render template: "pages/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: true }, status: :unprocessable_entity
+      render template: "pages/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: true }, status: :unprocessable_content
     end
   end
 
@@ -37,7 +37,7 @@ class Pages::ExitPageController < PagesController
     if update_exit_page_input.submit
       redirect_to edit_condition_path(form_id: current_form.id, page_id: page.id, condition_id: update_exit_page_input.record.id), success: t("banner.success.exit_page_updated")
     else
-      render template: "pages/exit_page/edit", locals: { update_exit_page_input:, preview_html: preview_html(update_exit_page_input), check_preview_validation: true }, status: :unprocessable_entity
+      render template: "pages/exit_page/edit", locals: { update_exit_page_input:, preview_html: preview_html(update_exit_page_input), check_preview_validation: true }, status: :unprocessable_content
     end
   end
 
@@ -57,7 +57,7 @@ class Pages::ExitPageController < PagesController
     @delete_exit_page_input = Pages::DeleteExitPageInput.new(params.require(:pages_delete_exit_page_input).permit(:confirm))
 
     unless @delete_exit_page_input.valid?
-      return render :delete, status: :unprocessable_entity
+      return render :delete, status: :unprocessable_content
     end
 
     unless @delete_exit_page_input.confirmed?

--- a/app/controllers/pages/guidance_controller.rb
+++ b/app/controllers/pages/guidance_controller.rb
@@ -18,7 +18,7 @@ class Pages::GuidanceController < PagesController
       if guidance_input.submit
         redirect_to new_question_path(current_form.id)
       else
-        render :guidance, locals: view_locals(nil, guidance_input, back_link), status: :unprocessable_entity
+        render :guidance, locals: view_locals(nil, guidance_input, back_link), status: :unprocessable_content
       end
     end
   end
@@ -43,7 +43,7 @@ class Pages::GuidanceController < PagesController
       if guidance_input.submit
         redirect_to edit_question_path(current_form.id, page.id)
       else
-        render :guidance, locals: view_locals(page, guidance_input, back_link), status: :unprocessable_entity
+        render :guidance, locals: view_locals(page, guidance_input, back_link), status: :unprocessable_content
       end
     end
   end

--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -22,7 +22,7 @@ class Pages::QuestionsController < PagesController
       clear_draft_questions_data
       redirect_to edit_question_path(current_form.id, @page.id), success: "Your changes have been saved"
     else
-      render :new, locals: { current_form:, draft_question: }, status: :unprocessable_entity
+      render :new, locals: { current_form:, draft_question: }, status: :unprocessable_content
     end
   end
 
@@ -45,7 +45,7 @@ class Pages::QuestionsController < PagesController
       clear_draft_questions_data
       redirect_to edit_question_path(current_form.id, @page.id), success: "Your changes have been saved"
     else
-      render :edit, locals: { current_form:, draft_question: }, status: :unprocessable_entity
+      render :edit, locals: { current_form:, draft_question: }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/pages/routes_controller.rb
+++ b/app/controllers/pages/routes_controller.rb
@@ -19,7 +19,7 @@ class Pages::RoutesController < PagesController
         return redirect_to form_pages_path, success: t("banner.success.page_routes_deleted", question_number: current_form.page_number(page))
       end
     else
-      return render :delete, locals: { current_form:, page:, delete_confirmation_input: @delete_confirmation_input }, status: :unprocessable_entity
+      return render :delete, locals: { current_form:, page:, delete_confirmation_input: @delete_confirmation_input }, status: :unprocessable_content
     end
 
     redirect_to show_routes_path(form_id: current_form.id, page_id: page.id)

--- a/app/controllers/pages/secondary_skip_controller.rb
+++ b/app/controllers/pages/secondary_skip_controller.rb
@@ -20,7 +20,7 @@ class Pages::SecondarySkipController < PagesController
       render template: "pages/secondary_skip/new", locals: {
         secondary_skip_input:,
         back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
     end
   end
 
@@ -42,7 +42,7 @@ class Pages::SecondarySkipController < PagesController
       render template: "pages/secondary_skip/edit", locals: {
         secondary_skip_input:,
         back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
     end
   end
 
@@ -64,7 +64,7 @@ class Pages::SecondarySkipController < PagesController
       render template: "pages/secondary_skip/delete", locals: {
         delete_secondary_skip_input:,
         back_link_url: show_routes_path(form_id: current_form.id, page_id: page.id),
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
     if UserUpdateService.new(user, user_params).update_user
       redirect_to users_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/spec/requests/account/names_controller_spec.rb
+++ b/spec/requests/account/names_controller_spec.rb
@@ -68,7 +68,7 @@ describe Account::NamesController do
 
       it "renders the edit template" do
         put account_name_path, params: invalid_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/requests/account/organisations_controller_spec.rb
+++ b/spec/requests/account/organisations_controller_spec.rb
@@ -70,7 +70,7 @@ describe Account::OrganisationsController do
 
       it "re-renders the edit template" do
         put account_organisation_path, params: invalid_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/requests/account/terms_of_use_controller_spec.rb
+++ b/spec/requests/account/terms_of_use_controller_spec.rb
@@ -64,7 +64,7 @@ describe Account::TermsOfUseController do
 
       it "renders the edit template" do
         put account_terms_of_use_path, params: invalid_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/requests/forms/archive_form_controller_spec.rb
+++ b/spec/requests/forms/archive_form_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Forms::ArchiveFormController, type: :request do
       let(:confirm) { nil }
 
       it "returns 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "re-renders the archive this form page with an error" do

--- a/spec/requests/forms/contact_details_controller_spec.rb
+++ b/spec/requests/forms/contact_details_controller_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Forms::ContactDetailsController, type: :request do
         expect(response).to render_template(:new)
         expect(response.body).to include I18n.t("error_summary.heading")
         expect(response.body).to include I18n.t("errors.messages.non_government_email")
-        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_http_status :unprocessable_content
       end
     end
 

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
       let(:form_params) { { forms_make_live_input: { confirm: "yes", form: } } }
 
       it "returns 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "does not make the form live" do

--- a/spec/requests/forms/receive_csv_controller_spec.rb
+++ b/spec/requests/forms/receive_csv_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Forms::ReceiveCsvController, type: :request do
       let(:submission_type) { nil }
 
       it "returns 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "does not update the form" do

--- a/spec/requests/forms/share_preview_controller_spec.rb
+++ b/spec/requests/forms/share_preview_controller_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Forms::SharePreviewController, type: :request do
       end
 
       it "returns an 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "re-renders the page with an error" do

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
       it "does not accept the submission email address" do
         expect(response.body).to include I18n.t("error_summary.heading")
         expect(response.body).to include I18n.t("errors.messages.non_government_email")
-        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_http_status :unprocessable_content
       end
     end
 
@@ -172,7 +172,7 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
 
       it "responds with an error" do
         expect(response.body).to include I18n.t("error_summary.heading")
-        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_http_status :unprocessable_content
       end
     end
 

--- a/spec/requests/forms/unarchive_controller_spec.rb
+++ b/spec/requests/forms/unarchive_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Forms::UnarchiveController, type: :request do
       let(:form_params) { { forms_make_live_input: { confirm: :"" } } }
 
       it "returns 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "does not make the form live" do

--- a/spec/requests/forms/what_happens_next_controller_spec.rb
+++ b/spec/requests/forms/what_happens_next_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
         end
 
         it "returns 422" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
 
@@ -127,7 +127,7 @@ RSpec.describe Forms::WhatHappensNextController, type: :request do
         let(:what_happens_next_markdown) { "# A level one heading" }
 
         it "returns 422" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "renders the template" do

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
 
       it "renders a response with 422 status" do
         post group_forms_url(group), params: { forms_name_input: invalid_attributes }
-        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_http_status :unprocessable_content
       end
 
       it "renders the change name form with an error" do

--- a/spec/requests/group_members_controller_spec.rb
+++ b/spec/requests/group_members_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "/groups/:group_id/members", type: :request do
           post group_members_url(group), params: { group_member_input: { member_email_address: "invalid" } }
         }.not_to change(Membership, :count)
 
-        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_http_status :unprocessable_content
         expect(response).to render_template :new
       end
     end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe "/groups", type: :request do
 
       it "renders a response with 422 status (i.e. to display the 'new' template)" do
         post groups_url, params: { group: invalid_attributes }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -346,7 +346,7 @@ RSpec.describe "/groups", type: :request do
       context "with invalid parameters" do
         it "renders a response with 422 status (i.e. to display the 'edit' template)" do
           patch group_url(member_group), params: { group: invalid_attributes }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end
@@ -503,7 +503,7 @@ RSpec.describe "/groups", type: :request do
 
           it "returns an error" do
             delete(group_url(group), params:)
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
 
           it "re-renders the confirm delete view with an error" do
@@ -541,7 +541,7 @@ RSpec.describe "/groups", type: :request do
 
         it "returns an error" do
           delete(group_url(group), params:)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "re-renders the confirm delete view with an error" do
@@ -591,7 +591,7 @@ RSpec.describe "/groups", type: :request do
 
           it "returns an error" do
             delete(group_url(group), params:)
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
 
           it "re-renders the confirm delete view with an error" do
@@ -629,7 +629,7 @@ RSpec.describe "/groups", type: :request do
 
         it "returns an error" do
           delete(group_url(group), params:)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "re-renders the confirm delete view with an error" do
@@ -734,7 +734,7 @@ RSpec.describe "/groups", type: :request do
         end
 
         it "returns 422" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "re-renders the confirm upgrade page with an error" do
@@ -948,7 +948,7 @@ RSpec.describe "/groups", type: :request do
         end
 
         it "returns 422" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "re-renders the confirm upgrade page with an error" do

--- a/spec/requests/mou_signatures_controller_spec.rb
+++ b/spec/requests/mou_signatures_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe MouSignaturesController, type: :request do
             agreed: "1",
           },
         }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
         let(:params) { { pages_conditions_input: { routing_page_id: nil, check_page_id: nil, goto_page_id: nil, answer_value: nil } } }
 
         it "return 422 error code" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "renders new page" do
@@ -307,7 +307,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       let(:params) { { pages_conditions_input: { routing_page_id: nil, check_page_id: nil, goto_page_id: nil, answer_value: nil } } }
 
       it "return 422 error code" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders new page" do
@@ -448,7 +448,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       let(:destroy_bool) { false }
 
       it "return 422 error code" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -456,7 +456,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       let(:confirm) { nil }
 
       it "return 422 error code" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders the delete page" do
@@ -570,7 +570,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       let(:confirm) { nil }
 
       it "returns a 422 error code" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders the confirm_delete template" do
@@ -582,7 +582,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
       let(:update_condition_result) { false }
 
       it "returns a 422 error code" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders the conditions/edit template" do

--- a/spec/requests/pages/exit_page_controller_spec.rb
+++ b/spec/requests/pages/exit_page_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
       let(:params) { { pages_exit_page_input: { exit_page_heading: nil, exit_page_markdown: nil, answer_value: } } }
 
       it "return 422 error code" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders new page" do
@@ -151,7 +151,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
       let(:params) { { pages_update_exit_page_input: { exit_page_heading: nil, exit_page_markdown: nil } } }
 
       it "return 422 error code" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders edit page" do

--- a/spec/requests/pages/guidance_controller_spec.rb
+++ b/spec/requests/pages/guidance_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Pages::GuidanceController, type: :request do
         let(:page_heading) { nil }
 
         it "returns 422" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "renders the template" do
@@ -242,7 +242,7 @@ RSpec.describe Pages::GuidanceController, type: :request do
         let(:page_heading) { nil }
 
         it "returns 422" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "renders the template" do

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
       end
 
       it "returns 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders new template" do
@@ -260,7 +260,7 @@ RSpec.describe Pages::QuestionsController, type: :request do
       end
 
       it "returns 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders edit template" do

--- a/spec/requests/pages/routes_controller_spec.rb
+++ b/spec/requests/pages/routes_controller_spec.rb
@@ -121,7 +121,7 @@ describe Pages::RoutesController, type: :request do
       it "renders the delete page" do
         delete destroy_routes_path(form_id: form.id, page_id: page.id, pages_routes_delete_confirmation_input: { confirm: nil })
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template("pages/routes/delete")
       end
     end

--- a/spec/requests/pages/secondary_skip_controller_spec.rb
+++ b/spec/requests/pages/secondary_skip_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
         it "renders the new template" do
           post_create
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response).to render_template("pages/secondary_skip/new")
         end
       end
@@ -249,7 +249,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
           it "renders the edit template" do
             post_update
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
             expect(response).to render_template("pages/secondary_skip/edit")
           end
         end
@@ -356,7 +356,7 @@ RSpec.describe Pages::SecondarySkipController, type: :request do
 
           it "renders the delete template" do
             delete destroy_secondary_skip_path(form_id: form.id, page_id: page.id), params: invalid_params
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
             expect(response).to render_template("pages/secondary_skip/delete")
           end
         end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe UsersController, type: :request do
 
       it "does not update user if role is invalid" do
         put user_path(user), params: { user: { role: nil } }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include "Select a role for the user"
         expect(user.reload.role).not_to be_nil
       end
@@ -140,7 +140,7 @@ RSpec.describe UsersController, type: :request do
       context "when user has a name" do
         it "does not update user if name is cleared" do
           put user_path(user), params: { user: { name: nil } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include "Enter the user’s name"
           expect(user.reload.organisation).not_to be_nil
         end
@@ -149,7 +149,7 @@ RSpec.describe UsersController, type: :request do
       context "when user belongs to an organistion" do
         it "does not update user if organisation is not chosen" do
           put user_path(user), params: { user: { organisation_id: nil } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include "Select the user’s organisation"
           expect(user.reload.organisation).not_to be_nil
         end
@@ -176,7 +176,7 @@ RSpec.describe UsersController, type: :request do
 
         it "returns an error if organisation is not chosen and role is changed to organisation_admin" do
           put user_path(user), params: { user: { role: "organisation_admin", organisation_id: nil } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(user.reload.role).to eq("standard")
         end
       end


### PR DESCRIPTION
### What problem does this pull request solve?
When the 422 status was initially proposed in [RFC4918](https://datatracker.ietf.org/doc/html/rfc4918) (2007), it was called 'Unprocessable entity'.

When it became a standard in [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110) (2022), it was renamed 'Unprocessable content'.

Rack now supports it as `:unprocessable_content` and [deprecated `:unprocessable_entity` in v3.1.0](https://github.com/rack/rack/blob/main/CHANGELOG.md#deprecated-1). This commit updates it to use the new name.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
