### PR TITLE
Change primary key sequence for forms tables to be less weird looking

### DIFF
--- a/db/migrate/20250815135356_set_pk_sequence_forms_pages_conditions2.rb
+++ b/db/migrate/20250815135356_set_pk_sequence_forms_pages_conditions2.rb
@@ -1,0 +1,30 @@
+class SetPkSequenceFormsPagesConditions2 < ActiveRecord::Migration[8.0]
+  def up
+    reset_pk_sequence_with_gap2!("forms")
+    reset_pk_sequence_with_gap2!("pages")
+    reset_pk_sequence_with_gap2!("conditions")
+  end
+
+  def down
+    reset_pk_sequence_with_gap!("forms")
+    reset_pk_sequence_with_gap!("pages")
+    reset_pk_sequence_with_gap!("conditions")
+  end
+
+private
+
+  def reset_pk_sequence_with_gap!(table)
+    max_id = table.classify.constantize.select("max(id)")[0].max || 0
+    # heuristic to detect whether any records were created since the pk sequence was last changed
+    if max_id >= 1_000_000
+      set_pk_sequence!(table, max_id)
+    else
+      set_pk_sequence!(table, 10**(max_id.digits.length + 2))
+    end
+  end
+
+  def reset_pk_sequence_with_gap2!(table)
+    max_id = table.classify.constantize.select("max(id)")[0].max || 0
+    set_pk_sequence!(table, 2**(max_id.bit_length + 4))
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_15_090717) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_15_135356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/dGcFbmNo/2412-test-usedatabaseastruth-for-forms-admin-in-dev <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We found after some testing that having IDs that started at a high power of 10 looked weird because they had a lot of 0s; we worried that this would result in a negative user experience.

Instead set the primary key sequence to start from a high base 2 number, this has the advantage of having a more even distribution of digits (looking less weird and having fewer 0s), whilst still being recognisably different that we can see at a glance that the change has worked when needed.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?