### PR TITLE
Fix PageRepository.move_page when use_database_as_truth is true

### DIFF
--- a/app/services/page_repository.rb
+++ b/app/services/page_repository.rb
@@ -85,15 +85,14 @@ class PageRepository
     end
 
     def move_page(record, direction)
+      page = Api::V1::PageResource.new(record.attributes, true)
+      page.prefix_options[:form_id] = record.form.id
+
       if Settings.use_database_as_truth
         record.move_page(direction)
-        page = Api::V1::PageResource.new(record.attributes, true)
-        page.prefix_options[:form_id] = record.form.id
-        page.save!
+        page.move_page(direction)
         record
       else
-        page = Api::V1::PageResource.new(record.attributes, true)
-        page.prefix_options[:form_id] = record.form.id
         page.move_page(direction)
         update_and_save_to_database!(page)
       end

--- a/spec/services/page_repository_spec.rb
+++ b/spec/services/page_repository_spec.rb
@@ -723,14 +723,15 @@ describe PageRepository do
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", post_headers, {}, 200
+          mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}/up", post_headers, {}, 200
         end
       end
 
       describe "api" do
-        it "sends the new page position to the API" do
+        it "calls the move endpoint through ActiveResource" do
+          move_request = ActiveResource::Request.new(:put, "/api/v1/forms/#{form_id}/pages/#{page.id}/up", {}, post_headers)
           described_class.move_page(page, :up)
-          expect(JSON.parse(ActiveResource::HttpMock.requests.last.body)).to include("position" => 1)
+          expect(ActiveResource::HttpMock.requests).to include move_request
         end
       end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/dGcFbmNo/2412-test-usedatabaseastruth-for-forms-admin-in-dev <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The forms-api endpoint to update pages does not accept `position` as a valid parameter, so this method was not moving pages in the API database, causing database drift and errors. This commit fixes things by calling the `PageResource#move_page` method instead of trying to set `position` directly.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?