### PR TITLE
Fix move page flash message position

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -79,15 +79,9 @@ class PagesController < ApplicationController
   def move_page
     page_to_move = PageRepository.find(page_id: move_params[:page_id], form_id: move_params[:form_id])
 
-    PageRepository.move_page(page_to_move, move_params[:direction])
+    moved_page = PageRepository.move_page(page_to_move, move_params[:direction])
 
-    position = if move_params[:direction] == :up
-                 page_to_move.position - 1
-               else
-                 page_to_move.position + 1
-               end
-
-    redirect_to form_pages_path, success: t("banner.success.form.page_moved", question_text: page_to_move.question_text, direction: move_params[:direction], question_number: position)
+    redirect_to form_pages_path, success: t("banner.success.form.page_moved", question_text: page_to_move.question_text, direction: move_params[:direction], question_number: moved_page.position)
   end
 
 private


### PR DESCRIPTION
When a page is moved, we show a success message to indicate the new position of the page. As part of change to the way the Page Repository moved pages around, we were unecessarily recalculating the new page position in the controller.

This change makes use of the new Page Repository move_page behaviour to get the new page position directly from the updated db page.

### What problem does this pull request solve?

Trello card: https://trello.com/c/dGcFbmNo/2412-test-usedatabaseastruth-for-forms-admin-in-dev

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
