### PR TITLE
Display correct content for date of birth answer type

### DIFF
--- a/app/services/page_options_service.rb
+++ b/app/services/page_options_service.rb
@@ -118,13 +118,7 @@ private
   end
 
   def date_options
-    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: date_answer_type_text } }]
-  end
-
-  def date_answer_type_text
-    return I18n.t("helpers.label.page.date_settings_options.input_types.#{@page.answer_settings.input_type}") if @page.answer_settings.input_type.to_sym == :date_of_birth
-
-    I18n.t("page_options_service.date")
+    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: I18n.t("page_options_service.date_type.#{@page.answer_settings.input_type}") } }]
   end
 
   def address_options

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1095,7 +1095,9 @@ en:
     skip_condition_route_page_text: "%{route_page_question_number}, “%{route_page_question_text}”"
   page_options_service:
     answer_type: Answer type
-    date: Date
+    date_type:
+      date_of_birth: Date of birth
+      other_date: Date
     guidance_markdown: Guidance
     hint_text: Hint text
     name_type:

--- a/spec/services/page_options_service_spec.rb
+++ b/spec/services/page_options_service_spec.rb
@@ -60,7 +60,7 @@ describe PageOptionsService do
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
-            value: { text: I18n.t("helpers.label.page.date_settings_options.input_types.date_of_birth") } },
+            value: { text: "Date of birth" } },
         ])
       end
     end
@@ -71,7 +71,7 @@ describe PageOptionsService do
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
-            value: { text: I18n.t("helpers.label.page.answer_type_options.names.date") } },
+            value: { text: "Date" } },
         ])
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/xjtv1mqG/2450-answer-type-is-yes-for-date-of-birth-question-on-live-form-questions-page

Previously, on the live questions page, we were displaying the answer type as "Yes" for date questions where “Are you asking for someone’s date of birth?” was answered as true when creating the question.

Fix this so that we display the answer type as "Date of birth". Continue displaying the answer type as "Date" for date questions that aren't asking for a date of birth.

Before:

<img width="640" height="139" alt="Screenshot 2025-08-18 at 12 47 39" src="https://github.com/user-attachments/assets/ee3c2805-30fb-41f7-a51a-2fc0e0079fd3" />

After:

<img width="680" height="318" alt="Screenshot 2025-08-18 at 15 04 15" src="https://github.com/user-attachments/assets/1b60ddde-2fb4-443c-90e7-a0aa727b41a8" />


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
