### PR TITLE
Enable use_database_as_truth everywhere

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,7 +6,7 @@ features:
     enabled_by_group: true
 
 # Migrating data from Forms API to Forms Admin's database - this flag determines whether we read from Forms API or from Forms Admin's database
-use_database_as_truth: false
+use_database_as_truth: true
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -26,7 +26,7 @@ describe "Settings" do
   end
 
   describe ".use_database_as_truth" do
-    include_examples expected_value_test, :use_database_as_truth, settings, false
+    include_examples expected_value_test, :use_database_as_truth, settings, true
   end
 
   describe "forms_api" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/VEhRvpO8/2413-enable-usedatabaseastruth-for-forms-admin-in-production <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This configuration flag has been enabled in all AWS environments, let's
set it to true here so it's true by default.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?