### PR TITLE
Prepend empty line to markdown block elements

### DIFF
--- a/app/frontend/javascript/markdown-editor-toolbar/index.test.js
+++ b/app/frontend/javascript/markdown-editor-toolbar/index.test.js
@@ -3,6 +3,7 @@
  */
 import markdownEditorToolbar from '.'
 import { getByText } from '@testing-library/dom'
+import { describe, beforeEach, test, expect } from 'vitest'
 
 const selectText = (textArea, text) => {
   textArea.setSelectionRange(
@@ -13,8 +14,25 @@ const selectText = (textArea, text) => {
 
 let toolbar
 let textArea
-
-const prefixes = ['## ', '### ', '* ', '- ', '1. ']
+const blockElements = [
+  {
+    buttonText: 'Add a second-level heading',
+    prefixes: ['## ']
+  },
+  {
+    buttonText: 'Add a third-level heading',
+    prefixes: ['### ']
+  },
+  {
+    buttonText: 'Add a bulleted list',
+    prefixes: ['* ', '- ']
+  },
+  {
+    buttonText: 'Add a numbered list',
+    prefixes: ['1. ']
+  }
+]
+const prefixes = blockElements.flatMap(element => element.prefixes)
 
 describe('Markdown toolbar', () => {
   beforeEach(() => {
@@ -344,6 +362,67 @@ describe('Markdown toolbar', () => {
         ).toBe(
           `${prefix}[This is an item with an existing markdown block style](https://www.gov.uk/link-text-url)`
         )
+      })
+    })
+  })
+
+  describe('Block element line break insertion', () => {
+    blockElements.forEach(element => {
+      describe('when the selection has no empty line before it', () => {
+        beforeEach(() => {
+          textArea.value = `Some other text
+            * This is an item with an existing markdown block style`
+          selectText(
+            textArea,
+            'This is an item with an existing markdown block style'
+          )
+        })
+
+        test('prepends an empty line', () => {
+          getByText(toolbar, element.buttonText).click()
+
+          expect(textArea.value).toBe(`Some other text
+
+${element.prefixes[0]}This is an item with an existing markdown block style`)
+        })
+
+        describe('when the selection already has an empty line before it', () => {
+          beforeEach(() => {
+            textArea.value = `Some other text
+
+        * This is an item with an existing markdown block style`
+            selectText(
+              textArea,
+              'This is an item with an existing markdown block style'
+            )
+          })
+          test('does not prepend an empty line', () => {
+            getByText(toolbar, element.buttonText).click()
+
+            expect(textArea.value).toBe(`Some other text
+
+${element.prefixes[0]}This is an item with an existing markdown block style`)
+          })
+        })
+
+        describe('when the selection has nothing before it', () => {
+          beforeEach(() => {
+            textArea.value =
+              '* This is an item with an existing markdown block style'
+            selectText(
+              textArea,
+              'This is an item with an existing markdown block style'
+            )
+          })
+
+          test('does not prepend an empty line', () => {
+            getByText(toolbar, element.buttonText).click()
+
+            expect(textArea.value).toBe(
+              `${element.prefixes[0]}This is an item with an existing markdown block style`
+            )
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/b/9cKfKKdR/govuk-forms-sprint-board

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Markdown block elements (in our case, headings and list items) should have an empty line between them and any previous content.

If this empty line isn't present, it's possible the markdown will not be rendered as the user intended.

This PR adds logic so that if the user adds a block element using the markdown toolbar, they'll automatically have an empty line added if there isn't already one present.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
