### PR TITLE
Remove use_database_as_truth setting

### DIFF
--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -39,7 +39,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def edit
-    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    condition = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
 
     condition_input = Pages::ConditionsInput.new(form: current_form, page:, record: condition, answer_value: condition.answer_value, goto_page_id: condition.goto_page_id, skip_to_end: condition.skip_to_end).assign_condition_values
 
@@ -49,7 +49,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def update
-    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    condition = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
 
     form_params = condition_input_params.merge(record: condition)
 
@@ -72,7 +72,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def delete
-    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    condition = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
 
     delete_condition_input = Pages::DeleteConditionInput.new(form: current_form, page:, record: condition)
 
@@ -80,7 +80,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def destroy
-    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    condition = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
 
     form_params = delete_condition_input_params.merge(record: condition)
 
@@ -98,7 +98,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def confirm_delete_exit_page
-    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    condition = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
     delete_exit_page_input = Pages::DeleteExitPageInput.new
 
     render template: "pages/conditions/confirm_delete_exit_page", locals: {
@@ -110,7 +110,7 @@ class Pages::ConditionsController < PagesController
   end
 
   def update_change_exit_page
-    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    condition = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
 
     return redirect_to form_pages_path(current_form.id) unless condition.exit_page?
 

--- a/app/controllers/pages/exit_page_controller.rb
+++ b/app/controllers/pages/exit_page_controller.rb
@@ -20,7 +20,7 @@ class Pages::ExitPageController < PagesController
   end
 
   def edit
-    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    condition = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
 
     update_exit_page_input = Pages::UpdateExitPageInput.new(form: current_form, page:, record: condition).assign_condition_values
 
@@ -28,7 +28,7 @@ class Pages::ExitPageController < PagesController
   end
 
   def update
-    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    condition = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
 
     form_params = update_exit_page_input_params.merge(record: condition)
 
@@ -42,12 +42,12 @@ class Pages::ExitPageController < PagesController
   end
 
   def delete
-    @exit_page = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    @exit_page = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
     @delete_exit_page_input = Pages::DeleteExitPageInput.new
   end
 
   def destroy
-    condition = ConditionRepository.find(condition_id: params[:condition_id], form_id: current_form.id, page_id: page.id)
+    condition = ConditionRepository.find(condition_id: params[:condition_id], page_id: page.id)
 
     # if this isn't an exit page, maybe because of a multiple tabs, redirect to the form pages page
     return redirect_to form_pages_path(current_form.id) unless condition.exit_page?

--- a/app/services/condition_repository.rb
+++ b/app/services/condition_repository.rb
@@ -9,59 +9,31 @@ class ConditionRepository
                 skip_to_end:,
                 exit_page_heading: nil,
                 exit_page_markdown: nil)
-      if Settings.use_database_as_truth
-        condition = Condition.new(
-          check_page_id:,
-          routing_page_id:,
-          answer_value:,
-          goto_page_id:,
-          skip_to_end:,
-          exit_page_heading:,
-          exit_page_markdown:,
-        )
-        condition.save_and_update_form
-        Api::V1::ConditionResource.create!(condition.attributes.merge(form_id:, page_id:))
-        condition
-      else
-        condition = Api::V1::ConditionResource.create!(
-          form_id:,
-          page_id:,
-          check_page_id:,
-          routing_page_id:,
-          answer_value:,
-          goto_page_id:,
-          skip_to_end:,
-          exit_page_heading:,
-          exit_page_markdown:,
-        )
-        update_and_save_to_database!(condition)
-      end
+      condition = Condition.new(
+        check_page_id:,
+        routing_page_id:,
+        answer_value:,
+        goto_page_id:,
+        skip_to_end:,
+        exit_page_heading:,
+        exit_page_markdown:,
+      )
+      condition.save_and_update_form
+      Api::V1::ConditionResource.create!(condition.attributes.merge(form_id:, page_id:))
+      condition
     end
 
-    def find(condition_id:, form_id:, page_id:)
-      if Settings.use_database_as_truth
-        Condition.find_by!(id: condition_id, routing_page_id: page_id)
-      else
-        condition = Api::V1::ConditionResource.find(condition_id, params: { form_id:, page_id: })
-        save_to_database!(condition)
-      end
+    def find(condition_id:, page_id:)
+      Condition.find_by!(id: condition_id, routing_page_id: page_id)
     end
 
     def save!(record)
-      if Settings.use_database_as_truth
-        record.save_and_update_form
-        condition = Api::V1::ConditionResource.new(record.attributes, true)
-        condition.prefix_options[:form_id] = record.form.id
-        condition.prefix_options[:page_id] = record.routing_page_id
-        condition.save!
-        record
-      else
-        condition = Api::V1::ConditionResource.new(record.attributes, true)
-        condition.prefix_options[:form_id] = record.form.id
-        condition.prefix_options[:page_id] = record.routing_page_id
-        condition.save!
-        update_and_save_to_database!(condition)
-      end
+      record.save_and_update_form
+      condition = Api::V1::ConditionResource.new(record.attributes, true)
+      condition.prefix_options[:form_id] = record.form.id
+      condition.prefix_options[:page_id] = record.routing_page_id
+      condition.save!
+      record
     end
 
     def destroy(record)
@@ -83,20 +55,6 @@ class ConditionRepository
       end
 
       record
-    end
-
-  private
-
-    def save_to_database!(record)
-      Condition.upsert(record.database_attributes)
-      Condition.find(record.id)
-    end
-
-    def update_and_save_to_database!(record)
-      condition = Condition.find_or_initialize_by(id: record.id)
-      condition.assign_attributes(record.database_attributes)
-      condition.save_and_update_form
-      condition
     end
   end
 end

--- a/app/services/form_repository.rb
+++ b/app/services/form_repository.rb
@@ -1,23 +1,13 @@
 class FormRepository
   class << self
     def create!(creator_id:, name:)
-      if Settings.use_database_as_truth
-        form = Form.create!(creator_id:, name:)
-        Api::V1::FormResource.create!(form.attributes)
-        form
-      else
-        form = Api::V1::FormResource.create!(creator_id:, name:)
-        save_to_database!(form)
-      end
+      form = Form.create!(creator_id:, name:)
+      Api::V1::FormResource.create!(form.attributes)
+      form
     end
 
     def find(form_id:)
-      if Settings.use_database_as_truth
-        Form.find(form_id)
-      else
-        form = Api::V1::FormResource.find(form_id)
-        save_to_database!(form)
-      end
+      Form.find(form_id)
     end
 
     def find_live(form_id:)
@@ -29,46 +19,21 @@ class FormRepository
     end
 
     def where(creator_id:)
-      if Settings.use_database_as_truth
-        Form.where(creator_id:)
-      else
-        Api::V1::FormResource.where(creator_id:)
-      end
+      Form.where(creator_id:)
     end
 
     def save!(record)
-      if Settings.use_database_as_truth
-        record.save!
-        record.create_draft_from_live_form! if record.live?
-        record.create_draft_from_archived_form! if record.archived?
-        Api::V1::FormResource.new(record.attributes, true).save!
-        record
-      else
-        form = Api::V1::FormResource.new(record.attributes, true)
-        form.save!
-        db_form = save_to_database!(form)
-        db_form.create_draft_from_live_form! if db_form.live?
-        db_form.create_draft_from_archived_form! if db_form.archived?
-        db_form
-      end
+      record.save!
+      record.create_draft_from_live_form! if record.live?
+      record.create_draft_from_archived_form! if record.archived?
+      Api::V1::FormResource.new(record.attributes, true).save!
+      record
     end
 
     def make_live!(record)
-      if Settings.use_database_as_truth
-        record.make_live!
-        Api::V1::FormResource.new(record.attributes, true).make_live!
-        record
-      else
-        form = Api::V1::FormResource.new(record.attributes, true)
-
-        save_pages_to_database!(form, form.pages) if Form.find(record.id).pages.empty?
-
-        form.make_live!
-
-        db_form = Form.find(record.id)
-        db_form.make_live!
-        db_form
-      end
+      record.make_live!
+      Api::V1::FormResource.new(record.attributes, true).make_live!
+      record
     end
 
     def archive!(record)
@@ -97,49 +62,7 @@ class FormRepository
     end
 
     def pages(record)
-      unless Settings.use_database_as_truth
-        if Rails.env.test? && record.attributes.key?("pages")
-          raise "Form response should not include pages, check the spec factories and mocks, or stub .pages instead"
-        end
-
-        form = Api::V1::FormResource.new(record.attributes, true)
-
-        pages = form.pages
-        save_pages_to_database!(record, pages)
-      end
-
       Form.find(record.id).pages
-    end
-
-  private
-
-    def save_to_database!(record)
-      Form.upsert(record.database_attributes)
-      Form.find(record.id)
-    end
-
-    def save_pages_to_database!(form_record, page_records)
-      pages_attributes = page_records.map(&:database_attributes)
-
-      Page.upsert_all(pages_attributes)
-
-      # delete any pages that may have previously been associated with this form
-      form = Form.find(form_record.id)
-      form.update!(page_ids: pages_attributes.pluck("id"))
-
-      page_records.map { |page| save_routing_conditions_to_database!(page) }
-    end
-
-    def save_routing_conditions_to_database!(page_record)
-      return if page_record.attributes["routing_conditions"].blank?
-
-      routing_conditions = page_record.routing_conditions.map(&:database_attributes)
-
-      Condition.upsert_all(routing_conditions)
-
-      # delete any routing conditions that may have previously been associated with this page
-      page = Page.find(page_record.id)
-      page.update!(routing_condition_ids: routing_conditions.pluck("id"))
     end
   end
 end

--- a/app/services/page_repository.rb
+++ b/app/services/page_repository.rb
@@ -1,12 +1,7 @@
 class PageRepository
   class << self
     def find(page_id:, form_id:)
-      if Settings.use_database_as_truth
-        Page.find_by!(id: page_id, form_id:)
-      else
-        page = Api::V1::PageResource.find(page_id, params: { form_id: })
-        save_to_database!(page)
-      end
+      Page.find_by!(id: page_id, form_id:)
     end
 
     def create!(form_id:,
@@ -18,50 +13,28 @@ class PageRepository
                 page_heading:,
                 guidance_markdown:,
                 answer_type:)
-      if Settings.use_database_as_truth
-        page = Page.new(
-          form_id:,
-          question_text:,
-          hint_text:,
-          is_optional:,
-          is_repeatable:,
-          answer_settings:,
-          page_heading:,
-          guidance_markdown:,
-          answer_type:,
-        )
-        page.save_and_update_form
-        Api::V1::PageResource.create!(page.attributes)
-        page
-      else
-        page_resource = Api::V1::PageResource.create!(
-          form_id:,
-          question_text:,
-          hint_text:,
-          is_optional:,
-          is_repeatable:,
-          answer_settings:,
-          page_heading:,
-          guidance_markdown:,
-          answer_type:,
-        )
-        update_and_save_to_database!(page_resource)
-      end
+      page = Page.new(
+        form_id:,
+        question_text:,
+        hint_text:,
+        is_optional:,
+        is_repeatable:,
+        answer_settings:,
+        page_heading:,
+        guidance_markdown:,
+        answer_type:,
+      )
+      page.save_and_update_form
+      Api::V1::PageResource.create!(page.attributes)
+      page
     end
 
     def save!(record)
-      if Settings.use_database_as_truth
-        record.save_and_update_form
-        page = Api::V1::PageResource.new(record.attributes, true)
-        page.prefix_options[:form_id] = record.form.id
-        page.save!
-        record
-      else
-        page = Api::V1::PageResource.new(record.attributes, true)
-        page.prefix_options[:form_id] = record.form.id
-        page.save!
-        update_and_save_to_database!(page)
-      end
+      record.save_and_update_form
+      page = Api::V1::PageResource.new(record.attributes, true)
+      page.prefix_options[:form_id] = record.form.id
+      page.save!
+      record
     end
 
     def destroy(record)
@@ -85,81 +58,12 @@ class PageRepository
     end
 
     def move_page(record, direction)
+      record.move_page(direction)
+
       page = Api::V1::PageResource.new(record.attributes, true)
       page.prefix_options[:form_id] = record.form.id
-
-      if Settings.use_database_as_truth
-        record.move_page(direction)
-        page.move_page(direction)
-        record
-      else
-        page.move_page(direction)
-        update_and_save_to_database!(page)
-      end
-    end
-
-  private
-
-    def find_form_and_save_to_database!(page_record)
-      form_id = page_record.prefix_options[:form_id]
-      FormRepository.find(form_id:)
-    end
-
-    def save_routing_conditions_to_database!(page_record)
-      return if page_record.attributes["routing_conditions"].blank?
-
-      routing_conditions = page_record.routing_conditions.map(&:database_attributes)
-
-      Condition.upsert_all(routing_conditions)
-
-      # delete any routing conditions that may have previously been associated with this page
-      page = Page.find(page_record.id)
-      page.update!(routing_condition_ids: routing_conditions.pluck("id"))
-    end
-
-    def save_to_database!(record)
-      attributes = record.database_attributes
-
-      begin
-        # transaction is required to be able to retry after catching exception
-        ActiveRecord::Base.transaction do
-          Page.upsert(attributes)
-        end
-      # we get an exception if the form does not already exist in the database
-      rescue ActiveRecord::InvalidForeignKey => e
-        raise unless e.message.include? 'table "forms"'
-
-        find_form_and_save_to_database!(record)
-
-        retry
-      end
-
-      save_routing_conditions_to_database!(record)
-      Page.find(record.id)
-    end
-
-    def update_and_save_to_database!(record)
-      attributes = record.database_attributes
-
-      page_record = begin
-        # transaction is required to be able to retry after catching exception
-        ActiveRecord::Base.transaction do
-          page = Page.find_or_initialize_by(id: record.id)
-          page.assign_attributes(**attributes)
-          page.save_and_update_form
-          page
-        end
-      # we get an exception if the form does not already exist in the database
-      rescue ActiveRecord::RecordInvalid => e
-        raise unless e.message.include? "Form must exist"
-
-        find_form_and_save_to_database!(record)
-
-        retry
-      end
-
-      save_routing_conditions_to_database!(record)
-      page_record
+      page.move_page(direction)
+      record
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,9 +5,6 @@ features:
   welsh:
     enabled_by_group: true
 
-# Migrating data from Forms API to Forms Admin's database - this flag determines whether we read from Forms API or from Forms Admin's database
-use_database_as_truth: true
-
 forms_api:
   # Authentication key to authenticate with forms-api
   auth_key: development_key

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -25,10 +25,6 @@ describe "Settings" do
     include_examples expected_value_test, :welsh, features, { "enabled_by_group" => true }
   end
 
-  describe ".use_database_as_truth" do
-    include_examples expected_value_test, :use_database_as_truth, settings, true
-  end
-
   describe "forms_api" do
     forms_api = settings[:forms_api]
 

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "forms.rake" do
           expect {
             task.invoke(*invalid_args)
           }.to raise_error(SystemExit)
-           .and output(/usage: rake forms:move/).to_stderr
+                 .and output(/usage: rake forms:move/).to_stderr
         end
       end
 
@@ -122,36 +122,12 @@ RSpec.describe "forms.rake" do
       end
 
       context "with invalid form_id" do
-        context "when use_database_as_truth if false" do
-          let(:invalid_args) { ["99", group.external_id] }
+        let(:invalid_args) { ["99", group.external_id] }
 
-          before do
-            allow(Settings).to receive(:use_database_as_truth).and_return(false)
-
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.get "/api/v1/forms/99", headers, nil, 404
-            end
-          end
-
-          it "raises an error" do
-            expect {
-              task.invoke(*invalid_args)
-            }.to raise_error(ActiveResource::ResourceNotFound)
-          end
-        end
-
-        context "when use_database_as_truth if true" do
-          let(:invalid_args) { ["99", group.external_id] }
-
-          before do
-            allow(Settings).to receive(:use_database_as_truth).and_return(true)
-          end
-
-          it "raises an error" do
-            expect {
-              task.invoke(*invalid_args)
-            }.to raise_error(ActiveRecord::RecordNotFound)
-          end
+        it "raises an error" do
+          expect {
+            task.invoke(*invalid_args)
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end
@@ -224,7 +200,7 @@ RSpec.describe "forms.rake" do
           expect {
             task.invoke(*invalid_args)
           }.to raise_error(SystemExit)
-           .and output(/usage: rake forms:submission_email:update/).to_stderr
+                 .and output(/usage: rake forms:submission_email:update/).to_stderr
         end
       end
 
@@ -241,36 +217,12 @@ RSpec.describe "forms.rake" do
       end
 
       context "with invalid form_id" do
-        context "when use_database_as_truth is false" do
-          let(:invalid_args) { ["99", "test@example.com"] }
+        let(:invalid_args) { ["99", "test@example.com"] }
 
-          before do
-            allow(Settings).to receive(:use_database_as_truth).and_return(false)
-
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.get "/api/v1/forms/99", headers, nil, 404
-            end
-          end
-
-          it "raises an error" do
-            expect {
-              task.invoke(*invalid_args)
-            }.to raise_error(ActiveResource::ResourceNotFound)
-          end
-        end
-
-        context "when use_database_as_truth is true" do
-          let(:invalid_args) { ["99", "test@example.com"] }
-
-          before do
-            allow(Settings).to receive(:use_database_as_truth).and_return(true)
-          end
-
-          it "raises an error" do
-            expect {
-              task.invoke(*invalid_args)
-            }.to raise_error(ActiveRecord::RecordNotFound)
-          end
+        it "raises an error" do
+          expect {
+            task.invoke(*invalid_args)
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -64,46 +64,16 @@ RSpec.describe FormsController, type: :request do
   end
 
   describe "no form found" do
-    context "when use_database_as_truth is false" do
-      let(:no_data_found_response) do
-        {
-          "error": "not_found",
-        }
-      end
-
-      before do
-        allow(Settings).to receive(:use_database_as_truth).and_return(false)
-
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/999", headers, no_data_found_response, 404
-        end
-
-        get form_path(999)
-      end
-
-      it "Render the not found page" do
-        expect(response.body).to include(I18n.t("not_found.title"))
-      end
-
-      it "returns 404" do
-        expect(response.status).to eq(404)
-      end
+    before do
+      get form_path(999)
     end
 
-    context "when use_database_as_truth is true" do
-      before do
-        allow(Settings).to receive(:use_database_as_truth).and_return(true)
+    it "Render the not found page" do
+      expect(response.body).to include(I18n.t("not_found.title"))
+    end
 
-        get form_path(999)
-      end
-
-      it "Render the not found page" do
-        expect(response.body).to include(I18n.t("not_found.title"))
-      end
-
-      it "returns 404" do
-        expect(response.status).to eq(404)
-      end
+    it "returns 404" do
+      expect(response.status).to eq(404)
     end
   end
 

--- a/spec/services/condition_repository_spec.rb
+++ b/spec/services/condition_repository_spec.rb
@@ -5,432 +5,201 @@ describe ConditionRepository do
   let(:routing_page) { create(:page_record, form:) }
   let(:goto_page) { create(:page_record, form:) }
 
-  context "when use_database_as_truth is false" do
+  describe "#create!" do
+    let(:condition_params) do
+      { form_id: form.id,
+        page_id: routing_page.id,
+        check_page_id: routing_page.id,
+        routing_page_id: routing_page.id,
+        answer_value: "Yes",
+        goto_page_id: goto_page.id,
+        skip_to_end: false,
+        exit_page_heading: nil,
+        exit_page_markdown: nil }
+    end
+    let(:ignored_api_condition_id) { 999_999 }
+
     before do
-      allow(Settings).to receive(:use_database_as_truth).and_return(false)
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions", post_headers, { id: ignored_api_condition_id }.to_json, 200
+      end
     end
 
-    describe "#create!" do
-      let(:created_condition_id) { 4 }
-      let(:condition_params) do
-        { form_id: form.id,
-          page_id: routing_page.id,
-          check_page_id: routing_page.id,
-          routing_page_id: routing_page.id,
-          answer_value: "Yes",
-          goto_page_id: goto_page.id,
-          skip_to_end: false,
-          exit_page_heading: nil,
-          exit_page_markdown: nil }
+    describe "api" do
+      it "creates a condition through ActiveResource" do
+        condition = described_class.create!(**condition_params)
+        expect(Api::V1::ConditionResource.new(condition.attributes.merge(form_id: form.id, page_id: routing_page.id))).to have_been_created
       end
+    end
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions", post_headers, { id: created_condition_id }.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "creates a condition through ActiveResource" do
+    describe "database" do
+      it "saves the condition to the database" do
+        expect {
           described_class.create!(**condition_params)
-          expect(Api::V1::ConditionResource.new(**condition_params)).to have_been_created
-        end
+        }.to change(Condition, :count).by(1)
       end
 
-      describe "database" do
-        it "saves the condition to the database" do
+      it "returns a condition record" do
+        expect(described_class.create!(**condition_params)).to be_a(Condition)
+      end
+
+      it "doesn't use the API response to create the condition" do
+        expect(described_class.create!(**condition_params).id).not_to eq(ignored_api_condition_id)
+      end
+
+      context "when the form question section is complete" do
+        let(:form) { create(:form_record, question_section_completed: true) }
+
+        it "updates the form to mark the question section as incomplete" do
           expect {
             described_class.create!(**condition_params)
-          }.to change(Condition, :count).by(1)
-        end
-
-        it "returns a condition record" do
-          expect(described_class.create!(**condition_params)).to be_a(Condition)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.create!(**condition_params)
-            }.to change { Form.find(form.id).question_section_completed }.to(false)
-          end
-        end
-
-        it "associates the condition with pages" do
-          described_class.create!(**condition_params)
-          expect(Condition.last).to have_attributes(routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id)
+          }.to change { Form.find(form.id).question_section_completed }.to(false)
         end
       end
 
-      it "has the same ID in the database and for the API" do
+      it "associates the condition with pages" do
         described_class.create!(**condition_params)
-        expect(Condition.last.id).to eq created_condition_id
+        expect(Condition.last).to have_attributes(routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id)
       end
     end
 
-    describe "#find" do
-      let(:condition) { build(:condition_resource, id: 4, routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id) }
+    it "has the same ID in the database and for the API" do
+      described_class.create!(**condition_params)
+      expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("id" => Condition.last.id)
+    end
+  end
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", headers, condition.to_json, 200
-        end
-      end
+  describe "#find" do
+    let(:condition) { create(:condition_record, routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id) }
 
-      describe "api" do
-        it "finds the condition through ActiveResource" do
-          described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)
-          expect(Api::V1::ConditionResource.new(id: condition.id, form_id: form.id, page_id: routing_page.id)).to have_been_read
-        end
-      end
-
-      describe "database" do
-        it "saves the condition to the database" do
-          expect {
-            described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)
-          }.to change(Condition, :count).by(1)
-        end
-
-        it "returns a condition record" do
-          expect(described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)).to be_a(Condition)
-        end
-
-        it "associates the condition with pages" do
-          described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)
-          expect(Condition.last).to have_attributes(routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id)
-        end
-
-        context "when the condition already exists in the database" do
-          let!(:existing_condition) { create(:condition_record, id: condition.id, routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id) }
-
-          it "does not create a new condition" do
-            expect {
-              described_class.find(condition_id: existing_condition.id, form_id: form.id, page_id: routing_page.id)
-            }.not_to change(Condition, :count)
-          end
-
-          it "returns the existing condition" do
-            expect(described_class.find(condition_id: existing_condition.id, form_id: form.id, page_id: routing_page.id)).to eq(existing_condition)
-          end
-        end
-      end
+    it "does not call the API" do
+      described_class.find(condition_id: condition.id, page_id: routing_page.id)
+      expect(Api::V1::ConditionResource.new(id: condition.id, form_id: form.id, page_id: routing_page.id)).not_to have_been_read
     end
 
-    describe "#save!" do
-      let(:condition) { create(:condition_record, skip_to_end: false, routing_page_id: routing_page.id, answer_value: "database answer value") }
-      let(:updated_condition_resource) { build(:condition_resource, id: condition.id, routing_page_id: routing_page.id, skip_to_end: true, answer_value: "API answer value") }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", post_headers, updated_condition_resource.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "updates the condition through ActiveResource" do
-          condition.skip_to_end = true
-          described_class.save!(condition)
-          expect(Api::V1::ConditionResource.new(id: condition.id, skip_to_end: true, form_id: form.id, page_id: routing_page.id)).to have_been_updated
-          expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("skip_to_end" => true)
-        end
-
-        it "returns a condition constructed from the API response" do
-          expect(described_class.save!(condition)).to have_attributes(answer_value: "API answer value")
-        end
-      end
-
-      describe "database" do
-        it "saves the condition to the repository" do
-          condition.skip_to_end = true
-
-          expect {
-            described_class.save!(condition)
-          }.to change { Condition.find(condition.id).skip_to_end }.to(true)
-        end
-
-        it "returns a condition record" do
-          expect(described_class.save!(condition)).to be_a(Condition)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.save!(condition)
-            }.to change { Form.find(form.id).question_section_completed }.to(false)
-          end
-        end
-      end
+    it "returns the condition" do
+      expect(described_class.find(condition_id: condition.id, page_id: routing_page.id)).to eq(condition)
     end
 
-    describe "#destroy" do
-      let(:condition) { create(:condition_record, routing_page_id: routing_page.id) }
+    context "when given a page_id that the condition doesn't belong to" do
+      let(:page_id) { "non-existent-id" }
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.delete "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", delete_headers, nil, 204
-        end
-      end
-
-      describe "api" do
-        it "destroys the condition through ActiveResource" do
-          described_class.destroy(condition)
-          expect(Api::V1::ConditionResource.new(id: condition.id, form_id: form.id, page_id: routing_page.id)).to have_been_deleted
-        end
-
-        context "when the condition has already been deleted" do
-          before do
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.delete "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", delete_headers, nil, 404
-            end
-          end
-
-          it "does not raise an error" do
-            expect {
-              described_class.destroy(condition)
-            }.not_to raise_error
-          end
-
-          it "still deletes the condition from the database" do
-            expect {
-              described_class.destroy(condition)
-            }.to change(Condition, :count).by(-1)
-          end
-        end
-      end
-
-      describe "database" do
-        it "removes the condition from the database" do
-          expect {
-            described_class.destroy(condition)
-          }.to change(Condition, :count).by(-1)
-        end
-
-        it "returns a condition record" do
-          expect(described_class.destroy(condition)).to be_a(Condition)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.destroy(condition)
-            }.to change { Form.find(form.id).question_section_completed }.to(false)
-          end
-        end
-      end
-
-      it "returns the deleted condition" do
-        expect(described_class.destroy(condition)).to eq condition
+      it "raises a RecordNotFound error" do
+        expect {
+          described_class.find(condition_id: condition.id, page_id: page_id)
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
 
-  context "when use_database_as_truth is true" do
+  describe "#save!" do
+    let(:condition) { create(:condition_record, skip_to_end: false, routing_page_id: routing_page.id, answer_value: "database condition") }
+    let(:updated_condition_resource) { build(:condition_resource, id: condition.id, routing_page_id: routing_page.id, skip_to_end: true, answer_value: "API condition") }
+
     before do
-      allow(Settings).to receive(:use_database_as_truth).and_return(true)
-    end
-
-    describe "#create!" do
-      let(:condition_params) do
-        { form_id: form.id,
-          page_id: routing_page.id,
-          check_page_id: routing_page.id,
-          routing_page_id: routing_page.id,
-          answer_value: "Yes",
-          goto_page_id: goto_page.id,
-          skip_to_end: false,
-          exit_page_heading: nil,
-          exit_page_markdown: nil }
-      end
-      let(:ignored_api_condition_id) { 999_999 }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions", post_headers, { id: ignored_api_condition_id }.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "creates a condition through ActiveResource" do
-          condition = described_class.create!(**condition_params)
-          expect(Api::V1::ConditionResource.new(condition.attributes.merge(form_id: form.id, page_id: routing_page.id))).to have_been_created
-        end
-      end
-
-      describe "database" do
-        it "saves the condition to the database" do
-          expect {
-            described_class.create!(**condition_params)
-          }.to change(Condition, :count).by(1)
-        end
-
-        it "returns a condition record" do
-          expect(described_class.create!(**condition_params)).to be_a(Condition)
-        end
-
-        it "doesn't use the API response to create the condition" do
-          expect(described_class.create!(**condition_params).id).not_to eq(ignored_api_condition_id)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.create!(**condition_params)
-            }.to change { Form.find(form.id).question_section_completed }.to(false)
-          end
-        end
-
-        it "associates the condition with pages" do
-          described_class.create!(**condition_params)
-          expect(Condition.last).to have_attributes(routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id)
-        end
-      end
-
-      it "has the same ID in the database and for the API" do
-        described_class.create!(**condition_params)
-        expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("id" => Condition.last.id)
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.put "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", post_headers, updated_condition_resource.to_json, 200
       end
     end
 
-    describe "#find" do
-      let(:condition) { create(:condition_record, routing_page_id: routing_page.id, check_page_id: routing_page.id, goto_page_id: goto_page.id) }
-
-      it "does not call the API" do
-        described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)
-        expect(Api::V1::ConditionResource.new(id: condition.id, form_id: form.id, page_id: routing_page.id)).not_to have_been_read
-      end
-
-      it "returns the condition" do
-        expect(described_class.find(condition_id: condition.id, form_id: form.id, page_id: routing_page.id)).to eq(condition)
-      end
-
-      context "when given a page_id that the condition doesn't belong to" do
-        let(:page_id) { "non-existent-id" }
-
-        it "raises a RecordNotFound error" do
-          expect {
-            described_class.find(condition_id: condition.id, form_id: form.id, page_id: page_id)
-          }.to raise_error(ActiveRecord::RecordNotFound)
-        end
+    describe "api" do
+      it "updates the condition through ActiveResource" do
+        condition.skip_to_end = true
+        described_class.save!(condition)
+        expect(Api::V1::ConditionResource.new(id: condition.id, skip_to_end: true, form_id: form.id, page_id: routing_page.id)).to have_been_updated
+        expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("skip_to_end" => true)
       end
     end
 
-    describe "#save!" do
-      let(:condition) { create(:condition_record, skip_to_end: false, routing_page_id: routing_page.id, answer_value: "database condition") }
-      let(:updated_condition_resource) { build(:condition_resource, id: condition.id, routing_page_id: routing_page.id, skip_to_end: true, answer_value: "API condition") }
+    describe "database" do
+      it "saves the condition to the database" do
+        condition.skip_to_end = true
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", post_headers, updated_condition_resource.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "updates the condition through ActiveResource" do
-          condition.skip_to_end = true
+        expect {
           described_class.save!(condition)
-          expect(Api::V1::ConditionResource.new(id: condition.id, skip_to_end: true, form_id: form.id, page_id: routing_page.id)).to have_been_updated
-          expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("skip_to_end" => true)
-        end
+        }.to change { Condition.find(condition.id).skip_to_end }.to(true)
       end
 
-      describe "database" do
-        it "saves the condition to the database" do
-          condition.skip_to_end = true
+      it "returns the database condition" do
+        expect(described_class.save!(condition)).to eq(condition)
+      end
 
+      it "doesn't use the API response to update the condition" do
+        expect(described_class.save!(condition).answer_value).to eq("database condition")
+      end
+
+      context "when the form question section is complete" do
+        let(:form) { create(:form_record, question_section_completed: true) }
+
+        it "updates the form to mark the question section as incomplete" do
           expect {
             described_class.save!(condition)
-          }.to change { Condition.find(condition.id).skip_to_end }.to(true)
-        end
-
-        it "returns the database condition" do
-          expect(described_class.save!(condition)).to eq(condition)
-        end
-
-        it "doesn't use the API response to update the condition" do
-          expect(described_class.save!(condition).answer_value).to eq("database condition")
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.save!(condition)
-            }.to change { Form.find(form.id).question_section_completed }.to(false)
-          end
+          }.to change { Form.find(form.id).question_section_completed }.to(false)
         end
       end
     end
+  end
 
-    describe "#destroy" do
-      let(:condition) { create(:condition_record, routing_page_id: routing_page.id) }
+  describe "#destroy" do
+    let(:condition) { create(:condition_record, routing_page_id: routing_page.id) }
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.delete "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", delete_headers, nil, 204
-        end
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.delete "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", delete_headers, nil, 204
+      end
+    end
+
+    describe "api" do
+      it "destroys the condition through ActiveResource" do
+        described_class.destroy(condition)
+        expect(Api::V1::ConditionResource.new(id: condition.id, form_id: form.id, page_id: routing_page.id)).to have_been_deleted
       end
 
-      describe "api" do
-        it "destroys the condition through ActiveResource" do
-          described_class.destroy(condition)
-          expect(Api::V1::ConditionResource.new(id: condition.id, form_id: form.id, page_id: routing_page.id)).to have_been_deleted
-        end
-
-        context "when the condition has already been deleted" do
-          before do
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.delete "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", delete_headers, nil, 404
-            end
-          end
-
-          it "does not raise an error" do
-            expect {
-              described_class.destroy(condition)
-            }.not_to raise_error
-          end
-
-          it "still deletes the condition from the database" do
-            expect {
-              described_class.destroy(condition)
-            }.to change(Condition, :count).by(-1)
+      context "when the condition has already been deleted" do
+        before do
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.delete "/api/v1/forms/#{form.id}/pages/#{routing_page.id}/conditions/#{condition.id}", delete_headers, nil, 404
           end
         end
-      end
 
-      describe "database" do
-        it "removes the condition from the database" do
+        it "does not raise an error" do
+          expect {
+            described_class.destroy(condition)
+          }.not_to raise_error
+        end
+
+        it "still deletes the condition from the database" do
           expect {
             described_class.destroy(condition)
           }.to change(Condition, :count).by(-1)
         end
+      end
+    end
 
-        it "returns a condition record" do
-          expect(described_class.destroy(condition)).to be_a(Condition)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.destroy(condition)
-            }.to change { Form.find(form.id).question_section_completed }.to(false)
-          end
-        end
+    describe "database" do
+      it "removes the condition from the database" do
+        expect {
+          described_class.destroy(condition)
+        }.to change(Condition, :count).by(-1)
       end
 
-      it "returns the deleted condition" do
-        expect(described_class.destroy(condition)).to eq condition
+      it "returns a condition record" do
+        expect(described_class.destroy(condition)).to be_a(Condition)
       end
+
+      context "when the form question section is complete" do
+        let(:form) { create(:form_record, question_section_completed: true) }
+
+        it "updates the form to mark the question section as incomplete" do
+          expect {
+            described_class.destroy(condition)
+          }.to change { Form.find(form.id).question_section_completed }.to(false)
+        end
+      end
+    end
+
+    it "returns the deleted condition" do
+      expect(described_class.destroy(condition)).to eq condition
     end
   end
 end

--- a/spec/services/form_repository_spec.rb
+++ b/spec/services/form_repository_spec.rb
@@ -1,873 +1,353 @@
 require "rails_helper"
 
 describe FormRepository do
-  context "when use_database_as_truth is false" do
+  describe "#create!" do
+    let(:form_params) { { creator_id: 1, name: "asdf" } }
+    let(:ignored_api_form_id) { 999_999 }
+
     before do
-      allow(Settings).to receive(:use_database_as_truth).and_return(false)
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms", post_headers, { id: ignored_api_form_id }.to_json, 200
+      end
     end
 
-    describe "#create!" do
-      let(:form_params) { { creator_id: 1, name: "asdf" } }
-      let(:created_form_id) { 4 }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms", post_headers, build(:form_resource, form_params.merge(id: created_form_id)).to_json, 200
-        end
+    describe "api" do
+      it "creates a form through ActiveResource" do
+        form = described_class.create!(**form_params)
+        expect(Api::V1::FormResource.new(form.attributes)).to have_been_created
       end
+    end
 
-      describe "api" do
-        it "creates a form through ActiveResource" do
+    describe "database" do
+      it "saves the form to the the database" do
+        expect {
           described_class.create!(**form_params)
-          expect(Api::V1::FormResource.new(form_params)).to have_been_created
-        end
+        }.to change(Form, :count).by(1)
       end
 
-      describe "database" do
-        it "saves the form to the the database" do
-          expect {
-            described_class.create!(**form_params)
-          }.to change(Form, :count).by(1)
-        end
-
-        it "returns a form record" do
-          expect(described_class.create!(**form_params)).to be_a(Form)
-        end
-
-        it "sets the external ID" do
-          described_class.create!(**form_params)
-          expect(Form.find(created_form_id)).to have_attributes id: created_form_id, external_id: created_form_id.to_s
-        end
+      it "returns a form record" do
+        expect(described_class.create!(**form_params)).to be_a(Form)
       end
 
-      it "has the same ID in the database and for the API" do
-        described_class.create!(**form_params)
-        expect(Form.last.id).to eq created_form_id
+      it "doesn't use the API response to create the form" do
+        expect(described_class.create!(**form_params).id).not_to eq(ignored_api_form_id)
+      end
+
+      it "sets the external ID" do
+        form = described_class.create!(**form_params)
+        expect(form).to have_attributes external_id: form.id.to_s
       end
     end
 
-    describe "#find" do
-      let(:form) { build(:form_resource, id: 2) }
+    it "has the same ID in the database and for the API" do
+      described_class.create!(**form_params)
+      expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("id" => Form.last.id)
+    end
+  end
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{form.id}", headers, form.to_json, 200
-        end
-      end
+  describe "#find" do
+    let(:form) { create(:form_record) }
 
-      describe "api" do
-        it "finds the form through ActiveResource" do
-          described_class.find(form_id: form.id)
-          expect(Api::V1::FormResource.new(id: form.id)).to have_been_read
-        end
-      end
-
-      describe "database" do
-        it "saves the form to the the database" do
-          expect {
-            described_class.find(form_id: form.id)
-          }.to change(Form, :count).by(1)
-        end
-
-        it "returns a form record" do
-          expect(described_class.find(form_id: form.id)).to be_a(Form)
-        end
-
-        it "has the same ID in the database and for the API" do
-          described_class.find(form_id: form.id)
-          expect(Form.last.id).to eq form.id
-        end
-
-        it "has the same external ID in the database as the API ID" do
-          described_class.find(form_id: form.id)
-          expect(Form.find(form.id).external_id).to eq form.id.to_s
-        end
-
-        context "when the form already exists in the database" do
-          let!(:form_record) { create(:form_record, id: form.id) }
-
-          it "does not create a new form" do
-            expect {
-              described_class.find(form_id: form_record.id)
-            }.not_to change(Form, :count)
-          end
-
-          it "returns the existing form" do
-            expect(described_class.find(form_id: form_record.id)).to eq(form_record)
-          end
-        end
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/#{form.id}", headers, form.to_json, 200
       end
     end
 
-    describe "#find_live" do
-      let(:form) { build(:made_live_form, id: 2) }
+    it "does not call the API" do
+      described_class.find(form_id: form.id)
+      expect(Api::V1::FormResource.new(id: form.id)).not_to have_been_read
+    end
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{form.id}/live", headers, form.to_json, 200
-        end
+    it "returns the form" do
+      expect(described_class.find(form_id: form.id)).to eq(form)
+    end
+  end
+
+  describe "#find_live" do
+    let(:form) { build(:made_live_form, id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/#{form.id}/live", headers, form.to_json, 200
       end
+    end
 
-      describe "api" do
-        it "calls the find_live endpoint through ActiveResource" do
-          find_live_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/live", form, headers)
+    describe "api" do
+      it "calls the find_live endpoint through ActiveResource" do
+        find_live_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/live", form, headers)
+        described_class.find_live(form_id: form.id)
+        expect(ActiveResource::HttpMock.requests).to include find_live_request
+      end
+    end
+
+    describe "database" do
+      it "does not save anything to the database" do
+        expect {
           described_class.find_live(form_id: form.id)
-          expect(ActiveResource::HttpMock.requests).to include find_live_request
-        end
+        }.not_to change(Form, :count)
       end
+    end
+  end
 
-      describe "database" do
-        it "does not save anything to the database" do
-          expect {
-            described_class.find_live(form_id: form.id)
-          }.not_to change(Form, :count)
-        end
+  describe "#find_archived" do
+    let(:form) { build(:made_live_form, id: 2) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/#{form.id}/archived", headers, form.to_json, 200
       end
     end
 
-    describe "#find_archived" do
-      let(:form) { build(:made_live_form, id: 2) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{form.id}/archived", headers, form.to_json, 200
-        end
+    describe "api" do
+      it "calls the find_archived endpoint through ActiveResource" do
+        find_archived_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/archived", form, headers)
+        described_class.find_archived(form_id: form.id)
+        expect(ActiveResource::HttpMock.requests).to include find_archived_request
       end
+    end
 
-      describe "api" do
-        it "calls the find_archived endpoint through ActiveResource" do
-          find_archived_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/archived", form, headers)
+    describe "database" do
+      it "does not save anything to the database" do
+        expect {
           described_class.find_archived(form_id: form.id)
-          expect(ActiveResource::HttpMock.requests).to include find_archived_request
-        end
+        }.not_to change(Form, :count)
       end
+    end
+  end
 
-      describe "database" do
-        it "does not save anything to the database" do
-          expect {
-            described_class.find_archived(form_id: form.id)
-          }.not_to change(Form, :count)
-        end
+  describe "#where" do
+    let(:form) { create(:form_record, creator_id: 3) }
+
+    it "does not call the where endpoint through ActiveResource" do
+      where_request = ActiveResource::Request.new(:get, "/api/v1/forms?creator_id=#{form.creator_id}", [form], headers)
+      described_class.where(creator_id: form.creator_id)
+      expect(ActiveResource::HttpMock.requests).not_to include where_request
+    end
+
+    it "returns forms with a matching creator id" do
+      expect(described_class.where(creator_id: form.creator_id)).to eq([form])
+    end
+  end
+
+  describe "#save!" do
+    let(:form) { create(:form_record, name: "database name", creator_id: 3) }
+    let(:updated_form_resource) { build(:form_resource, id: form.id, name: "API name", creator_id: 5) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.put "/api/v1/forms/#{form.id}", post_headers, updated_form_resource.to_json, 200
       end
     end
 
-    describe "#where" do
-      let(:form) { build(:form_resource, id: 2, creator_id: 3) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms?creator_id=#{form.creator_id}", headers, [form].to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "calls the where endpoint through ActiveResource" do
-          where_request = ActiveResource::Request.new(:get, "/api/v1/forms?creator_id=#{form.creator_id}", [form], headers)
-          described_class.where(creator_id: form.creator_id)
-          expect(ActiveResource::HttpMock.requests).to include where_request
-        end
-      end
-
-      describe "database" do
-        it "does not save anything to the database" do
-          expect {
-            described_class.where(creator_id: form.creator_id)
-          }.not_to change(Form, :count)
-        end
+    describe "api" do
+      it "updates the form through ActiveResource" do
+        form.name = "new name"
+        described_class.save!(form)
+        expect(Api::V1::FormResource.new(id: form.id, name: "new name")).to have_been_updated
+        expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("name" => "new name")
       end
     end
 
-    describe "#save!" do
-      let(:form) { create(:form_record, name: "original name", creator_id: 3) }
-      let(:updated_form_resource) { build(:form_resource, id: form.id, name: "new name", creator_id: 5) }
+    describe "database" do
+      it "saves the form to the the database" do
+        form.name = "new name"
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form.id}", post_headers, updated_form_resource.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "updates the form through ActiveResource" do
-          form.name = "new name"
+        expect {
           described_class.save!(form)
-          expect(Api::V1::FormResource.new(id: form.id, name: "new name")).to have_been_updated
-          expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("name" => "new name")
-        end
-
-        it "returns a form constructed from the API response" do
-          expect(described_class.save!(form)).to have_attributes(creator_id: 5)
-        end
+        }.to change { Form.find(form.id).name }.to("new name")
       end
 
-      describe "database" do
-        it "saves the form to the the database" do
-          form.name = "new name"
+      it "returns a form record" do
+        expect(described_class.save!(form)).to be_a(Form)
+      end
 
+      it "doesn't use the API response to update the form" do
+        expect(described_class.save!(form).creator_id).to eq(3)
+      end
+
+      context "when the form is live" do
+        let(:form) { create(:form, :live) }
+        let(:updated_form_resource) { build(:form_resource, :live, id: form.id) }
+
+        it "changes the form's state to live_with_draft" do
           expect {
             described_class.save!(form)
-          }.to change { Form.find(form.id).name }.to("new name")
-        end
-
-        it "returns a form record" do
-          expect(described_class.save!(form)).to be_a(Form)
-        end
-
-        context "when the form is live" do
-          let(:form) { create(:form, :live) }
-          let(:updated_form_resource) { build(:form_resource, :live, id: form.id) }
-
-          it "changes the form's state to live_with_draft" do
-            expect {
-              described_class.save!(form)
-            }.to change { Form.find(form.id).state }.to("live_with_draft")
-          end
-        end
-
-        context "when the form is archived" do
-          let(:form) { create(:form, :archived) }
-          let(:updated_form_resource) { build(:form_resource, :archived, id: form.id) }
-
-          it "changes the form's state to archived_with_draft" do
-            expect {
-              described_class.save!(form)
-            }.to change { Form.find(form.id).state }.to("archived_with_draft")
-          end
-        end
-      end
-    end
-
-    describe "#make_live!" do
-      let(:form) { create(:form_record, :live_with_draft) }
-      let(:live_form_resource) { build(:form_resource, :live, id: form.id) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/#{form.id}/make-live", post_headers, live_form_resource.to_json, 200
+          }.to change { Form.find(form.id).state }.to("live_with_draft")
         end
       end
 
-      describe "api" do
-        it "calls the make-live endpoint through ActiveResource" do
-          make_live_request = ActiveResource::Request.new(:post, "/api/v1/forms/#{form.id}/make-live", {}, post_headers)
-          described_class.make_live!(form)
-          expect(ActiveResource::HttpMock.requests).to include make_live_request
-        end
-      end
+      context "when the form is archived" do
+        let(:form) { create(:form, :archived) }
+        let(:updated_form_resource) { build(:form_resource, :archived, id: form.id) }
 
-      describe "database" do
-        it "saves the form to the database" do
+        it "changes the form's state to archived_with_draft" do
           expect {
-            described_class.make_live!(form)
-          }.to change { Form.find(form.id).state }.to("live")
-        end
-
-        it "returns a form record" do
-          expect(described_class.make_live!(form)).to be_a(Form)
-        end
-
-        context "when there are no pages for the form in the database" do
-          let(:form) { create(:form_record, :live_with_draft, pages_count: 0) }
-
-          before do
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.post "/api/v1/forms/#{form.id}/make-live", post_headers, live_form_resource.to_json, 200
-              mock.get "/api/v1/forms/#{form.id}/pages", headers, live_form_resource.pages.to_json, 200
-            end
-          end
-
-          it "save the form pages to the database" do
-            expect {
-              described_class.make_live!(form)
-            }.to(change { form.reload.pages.length })
-          end
-        end
-
-        context "when the form has a draft" do
-          let(:form) { create(:form, :live_with_draft) }
-
-          it "touches the form" do
-            expect {
-              described_class.make_live!(form)
-            }.to(change { Form.find(form.id).updated_at })
-          end
-        end
-      end
-    end
-
-    describe "#archive!" do
-      let(:form) { create(:form_record, :live) }
-      let(:archived_form_resource) { build(:form_resource, :archived, id: form.id) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/#{form.id}/archive", post_headers, archived_form_resource.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "calls the archive endpoint through ActiveResource" do
-          archive_request = ActiveResource::Request.new(:post, "/api/v1/forms/#{form.id}/archive", {}, post_headers)
-          described_class.archive!(form)
-          expect(ActiveResource::HttpMock.requests).to include archive_request
-        end
-      end
-
-      describe "database" do
-        it "archives the form in the database" do
-          expect {
-            described_class.archive!(form)
-          }.to change { Form.find(form.id).state }.to("archived")
-        end
-
-        it "returns a form record" do
-          expect(described_class.archive!(form)).to be_a(Form)
-        end
-      end
-    end
-
-    describe "#destroy" do
-      let(:form) { create(:form_record) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.delete "/api/v1/forms/#{form.id}", delete_headers, {}, 204
-        end
-      end
-
-      describe "api" do
-        it "destroys the form through ActiveResource" do
-          described_class.destroy(form)
-          expect(Api::V1::FormResource.new(id: form.id)).to have_been_deleted
-        end
-      end
-
-      describe "database" do
-        it "removes the form from the database" do
-          expect {
-            described_class.destroy(form)
-          }.to change(Form, :count).by(-1)
-        end
-
-        it "returns a form record" do
-          expect(described_class.destroy(form)).to be_a(Form)
-        end
-
-        context "when the form is not already in the database" do
-          it "does not raise an error" do
-            expect {
-              described_class.destroy(form)
-            }.not_to raise_error
-          end
-        end
-      end
-
-      it "returns the deleted form" do
-        expect(described_class.destroy(form)).to eq form
-      end
-
-      context "when the form has already been deleted" do
-        it "does not raise an error" do
-          described_class.destroy(form)
-
-          ActiveResource::HttpMock.respond_to do |mock|
-            mock.delete "/api/v1/forms/#{form.id}", delete_headers, nil, 404
-          end
-
-          expect {
-            described_class.destroy(form)
-          }.not_to raise_error
-        end
-
-        it "still deletes the form from the database" do
-          expect {
-            described_class.destroy(form)
-          }.to change(Form, :count).by(-1)
-        end
-
-        it "returns the deleted form" do
-          described_class.destroy(form)
-
-          ActiveResource::HttpMock.respond_to do |mock|
-            mock.delete "/api/v1/forms/#{form.id}", delete_headers, nil, 404
-          end
-
-          expect(described_class.destroy(form)).to eq form
-        end
-      end
-    end
-
-    describe "#pages" do
-      let(:form) { create(:form_record) }
-      let(:resource_pages) { form_resource.pages }
-      let(:form_resource) { build(:form_resource, :with_pages, id: form.id) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{form.id}/pages", headers, resource_pages.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "gets a form's pages through ActiveResource" do
-          pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/pages", {}, headers)
-          described_class.pages(form)
-          expect(ActiveResource::HttpMock.requests).to include pages_request
-        end
-      end
-
-      describe "database" do
-        it "saves the pages to the database" do
-          expect {
-            described_class.pages(form)
-          }.to change(Page, :count).by(5)
-        end
-
-        it "returns page records" do
-          expect(described_class.pages(form).first).to be_a(Page)
-        end
-
-        context "when the form in the database has pages which were deleted in the api" do
-          it "deletes pages from the database" do
-            # ensure that pages exist in the db with the same IDs as the API pages
-            described_class.pages(form)
-
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.get "/api/v1/forms/#{form.id}/pages", headers, resource_pages.drop(1).to_json, 200
-            end
-
-            expect {
-              described_class.pages(form)
-            }.to change(Page, :count).by(-1)
-          end
-
-          context "and page had routing_conditions" do
-            let(:form_resource) { build(:form_resource, pages: resource_pages, id: form.id) }
-            let(:resource_pages) do
-              [
-                build(:page_resource, id: 1),
-                build(:page_resource, id: 2, routing_conditions:),
-                *build_list(:page_resource, 5),
-              ]
-            end
-
-            let(:routing_conditions) do
-              [
-                build(:condition_resource, id: 1, routing_page_id: 2, check_page_id: 2, goto_page_id: nil, skip_to_end: true, answer_value: "Red"),
-                build(:condition_resource, id: 2, routing_page_id: 2, check_page_id: 2, goto_page_id: nil, skip_to_end: true, answer_value: "Green"),
-              ]
-            end
-
-            it "deletes conditions from the database" do
-              described_class.pages(form)
-
-              ActiveResource::HttpMock.respond_to do |mock|
-                mock.get "/api/v1/forms/#{form.id}/pages", headers, resource_pages.drop(2).to_json, 200
-              end
-
-              expect {
-                described_class.pages(form)
-              }.to change(Page, :count).by(-2)
-                .and change(Condition, :count).by(-2)
-            end
-          end
-        end
-
-        context "when the pages have routing conditions" do
-          let(:form_resource) { build(:form_resource, pages: resource_pages, id: form.id) }
-          let(:resource_pages) do
-            [
-              build(:page_resource, id: 1),
-              build(:page_resource, id: 2, routing_conditions:),
-              *build_list(:page_resource, 5),
-            ]
-          end
-
-          let(:routing_conditions) do
-            [
-              build(:condition_resource, id: 1, routing_page_id: 2, check_page_id: 2, goto_page_id: nil, skip_to_end: true, answer_value: "Red"),
-              build(:condition_resource, id: 2, routing_page_id: 2, check_page_id: 2, goto_page_id: nil, skip_to_end: true, answer_value: "Green"),
-            ]
-          end
-
-          it "saves the routing conditions to the database" do
-            expect {
-              described_class.pages(form)
-            }.to change(Condition, :count).by(2)
-          end
-
-          context "when the page in the database has conditions which were deleted in the api" do
-            it "deletes conditions from the database" do
-              described_class.pages(form)
-
-              resource_pages.second.routing_conditions = routing_conditions.drop(1)
-              ActiveResource::HttpMock.respond_to do |mock|
-                mock.get "/api/v1/forms/#{form.id}/pages", headers, resource_pages.to_json, 200
-              end
-
-              expect {
-                described_class.pages(form)
-              }.to change(Condition, :count).by(-1)
-            end
-          end
+            described_class.save!(form)
+          }.to change { Form.find(form.id).state }.to("archived_with_draft")
         end
       end
     end
   end
 
-  context "when use_database_as_truth is true" do
+  describe "#make_live!" do
+    let(:form) { create(:form_record, :live_with_draft, name: "database form name") }
+    let(:live_form_resource) { build(:form_resource, :live, id: form.id, name: "API form name") }
+
     before do
-      allow(Settings).to receive(:use_database_as_truth).and_return(true)
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms/#{form.id}/make-live", post_headers, live_form_resource.to_json, 200
+      end
     end
 
-    describe "#create!" do
-      let(:form_params) { { creator_id: 1, name: "asdf" } }
-      let(:ignored_api_form_id) { 999_999 }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms", post_headers, { id: ignored_api_form_id }.to_json, 200
-        end
+    describe "api" do
+      it "calls the make-live endpoint through ActiveResource" do
+        make_live_request = ActiveResource::Request.new(:post, "/api/v1/forms/#{form.id}/make-live", {}, post_headers)
+        described_class.make_live!(form)
+        expect(ActiveResource::HttpMock.requests).to include make_live_request
       end
+    end
 
-      describe "api" do
-        it "creates a form through ActiveResource" do
-          form = described_class.create!(**form_params)
-          expect(Api::V1::FormResource.new(form.attributes)).to have_been_created
-        end
-      end
+    describe "database" do
+      context "when there are a different number of pages for the form in the database and the form in the API" do
+        let(:form) { create(:form_record, :live_with_draft, pages_count: 1) }
 
-      describe "database" do
-        it "saves the form to the the database" do
+        it "does not save pages from the API to the database" do
           expect {
-            described_class.create!(**form_params)
-          }.to change(Form, :count).by(1)
-        end
-
-        it "returns a form record" do
-          expect(described_class.create!(**form_params)).to be_a(Form)
-        end
-
-        it "doesn't use the API response to create the form" do
-          expect(described_class.create!(**form_params).id).not_to eq(ignored_api_form_id)
-        end
-
-        it "sets the external ID" do
-          form = described_class.create!(**form_params)
-          expect(form).to have_attributes external_id: form.id.to_s
+            described_class.make_live!(form)
+          }.not_to(change { form.reload.pages.length })
         end
       end
 
-      it "has the same ID in the database and for the API" do
-        described_class.create!(**form_params)
-        expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("id" => Form.last.id)
-      end
-    end
-
-    describe "#find" do
-      let(:form) { create(:form_record) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{form.id}", headers, form.to_json, 200
-        end
+      it "returns a form record" do
+        expect(described_class.make_live!(form)).to be_a(Form)
       end
 
-      it "does not call the API" do
-        described_class.find(form_id: form.id)
-        expect(Api::V1::FormResource.new(id: form.id)).not_to have_been_read
-      end
+      context "when the form has a draft" do
+        let(:form) { create(:form, :live_with_draft) }
 
-      it "returns the form" do
-        expect(described_class.find(form_id: form.id)).to eq(form)
-      end
-    end
-
-    describe "#find_live" do
-      let(:form) { build(:made_live_form, id: 2) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{form.id}/live", headers, form.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "calls the find_live endpoint through ActiveResource" do
-          find_live_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/live", form, headers)
-          described_class.find_live(form_id: form.id)
-          expect(ActiveResource::HttpMock.requests).to include find_live_request
-        end
-      end
-
-      describe "database" do
-        it "does not save anything to the database" do
+        it "touches the form" do
           expect {
-            described_class.find_live(form_id: form.id)
-          }.not_to change(Form, :count)
+            described_class.make_live!(form)
+          }.to(change { Form.find(form.id).updated_at })
         end
       end
     end
+  end
 
-    describe "#find_archived" do
-      let(:form) { build(:made_live_form, id: 2) }
+  describe "#archive!" do
+    let(:form) { create(:form_record, :live) }
+    let(:archived_form_resource) { build(:form_resource, :archived, id: form.id) }
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{form.id}/archived", headers, form.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "calls the find_archived endpoint through ActiveResource" do
-          find_archived_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/archived", form, headers)
-          described_class.find_archived(form_id: form.id)
-          expect(ActiveResource::HttpMock.requests).to include find_archived_request
-        end
-      end
-
-      describe "database" do
-        it "does not save anything to the database" do
-          expect {
-            described_class.find_archived(form_id: form.id)
-          }.not_to change(Form, :count)
-        end
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms/#{form.id}/archive", post_headers, archived_form_resource.to_json, 200
       end
     end
 
-    describe "#where" do
-      let(:form) { create(:form_record, creator_id: 3) }
-
-      it "does not call the where endpoint through ActiveResource" do
-        where_request = ActiveResource::Request.new(:get, "/api/v1/forms?creator_id=#{form.creator_id}", [form], headers)
-        described_class.where(creator_id: form.creator_id)
-        expect(ActiveResource::HttpMock.requests).not_to include where_request
-      end
-
-      it "returns forms with a matching creator id" do
-        expect(described_class.where(creator_id: form.creator_id)).to eq([form])
+    describe "api" do
+      it "calls the archive endpoint through ActiveResource" do
+        archive_request = ActiveResource::Request.new(:post, "/api/v1/forms/#{form.id}/archive", {}, post_headers)
+        described_class.archive!(form)
+        expect(ActiveResource::HttpMock.requests).to include archive_request
       end
     end
 
-    describe "#save!" do
-      let(:form) { create(:form_record, name: "database name", creator_id: 3) }
-      let(:updated_form_resource) { build(:form_resource, id: form.id, name: "API name", creator_id: 5) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form.id}", post_headers, updated_form_resource.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "updates the form through ActiveResource" do
-          form.name = "new name"
-          described_class.save!(form)
-          expect(Api::V1::FormResource.new(id: form.id, name: "new name")).to have_been_updated
-          expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("name" => "new name")
-        end
-      end
-
-      describe "database" do
-        it "saves the form to the the database" do
-          form.name = "new name"
-
-          expect {
-            described_class.save!(form)
-          }.to change { Form.find(form.id).name }.to("new name")
-        end
-
-        it "returns a form record" do
-          expect(described_class.save!(form)).to be_a(Form)
-        end
-
-        it "doesn't use the API response to update the form" do
-          expect(described_class.save!(form).creator_id).to eq(3)
-        end
-
-        context "when the form is live" do
-          let(:form) { create(:form, :live) }
-          let(:updated_form_resource) { build(:form_resource, :live, id: form.id) }
-
-          it "changes the form's state to live_with_draft" do
-            expect {
-              described_class.save!(form)
-            }.to change { Form.find(form.id).state }.to("live_with_draft")
-          end
-        end
-
-        context "when the form is archived" do
-          let(:form) { create(:form, :archived) }
-          let(:updated_form_resource) { build(:form_resource, :archived, id: form.id) }
-
-          it "changes the form's state to archived_with_draft" do
-            expect {
-              described_class.save!(form)
-            }.to change { Form.find(form.id).state }.to("archived_with_draft")
-          end
-        end
-      end
-    end
-
-    describe "#make_live!" do
-      let(:form) { create(:form_record, :live_with_draft, name: "database form name") }
-      let(:live_form_resource) { build(:form_resource, :live, id: form.id, name: "API form name") }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/#{form.id}/make-live", post_headers, live_form_resource.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "calls the make-live endpoint through ActiveResource" do
-          make_live_request = ActiveResource::Request.new(:post, "/api/v1/forms/#{form.id}/make-live", {}, post_headers)
-          described_class.make_live!(form)
-          expect(ActiveResource::HttpMock.requests).to include make_live_request
-        end
-      end
-
-      describe "database" do
-        context "when there are a different number of pages for the form in the database and the form in the API" do
-          let(:form) { create(:form_record, :live_with_draft, pages_count: 1) }
-
-          it "does not save pages from the API to the database" do
-            expect {
-              described_class.make_live!(form)
-            }.not_to(change { form.reload.pages.length })
-          end
-        end
-
-        it "returns a form record" do
-          expect(described_class.make_live!(form)).to be_a(Form)
-        end
-
-        context "when the form has a draft" do
-          let(:form) { create(:form, :live_with_draft) }
-
-          it "touches the form" do
-            expect {
-              described_class.make_live!(form)
-            }.to(change { Form.find(form.id).updated_at })
-          end
-        end
-      end
-    end
-
-    describe "#archive!" do
-      let(:form) { create(:form_record, :live) }
-      let(:archived_form_resource) { build(:form_resource, :archived, id: form.id) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/#{form.id}/archive", post_headers, archived_form_resource.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "calls the archive endpoint through ActiveResource" do
-          archive_request = ActiveResource::Request.new(:post, "/api/v1/forms/#{form.id}/archive", {}, post_headers)
+    describe "database" do
+      it "archives the form to the database" do
+        expect {
           described_class.archive!(form)
-          expect(ActiveResource::HttpMock.requests).to include archive_request
-        end
+        }.to change { Form.find(form.id).state }.to("archived")
       end
 
-      describe "database" do
-        it "archives the form to the database" do
-          expect {
-            described_class.archive!(form)
-          }.to change { Form.find(form.id).state }.to("archived")
-        end
+      it "returns a Form object" do
+        expect(described_class.archive!(form)).to be_a(Form)
+      end
+    end
+  end
 
-        it "returns a Form object" do
-          expect(described_class.archive!(form)).to be_a(Form)
-        end
+  describe "#destroy" do
+    let(:form) { create(:form_record) }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.delete "/api/v1/forms/#{form.id}", delete_headers, {}, 204
       end
     end
 
-    describe "#destroy" do
-      let(:form) { create(:form_record) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.delete "/api/v1/forms/#{form.id}", delete_headers, {}, 204
-        end
+    describe "api" do
+      it "destroys the form through ActiveResource" do
+        described_class.destroy(form)
+        expect(Api::V1::FormResource.new(id: form.id)).to have_been_deleted
       end
+    end
 
-      describe "api" do
-        it "destroys the form through ActiveResource" do
+    describe "database" do
+      it "removes the form from the database" do
+        expect {
           described_class.destroy(form)
-          expect(Api::V1::FormResource.new(id: form.id)).to have_been_deleted
-        end
+        }.to change(Form, :count).by(-1)
       end
 
-      describe "database" do
-        it "removes the form from the database" do
-          expect {
-            described_class.destroy(form)
-          }.to change(Form, :count).by(-1)
-        end
-
-        it "returns a Form object" do
-          expect(described_class.destroy(form)).to be_a(Form)
-        end
-
-        context "when the form is not already in the database" do
-          it "does not raise an error" do
-            expect {
-              described_class.destroy(form)
-            }.not_to raise_error
-          end
-        end
+      it "returns a Form object" do
+        expect(described_class.destroy(form)).to be_a(Form)
       end
 
-      it "returns the deleted form" do
-        expect(described_class.destroy(form)).to eq form
-      end
-
-      context "when the form has already been deleted" do
+      context "when the form is not already in the database" do
         it "does not raise an error" do
-          described_class.destroy(form)
-
-          ActiveResource::HttpMock.respond_to do |mock|
-            mock.delete "/api/v1/forms/#{form.id}", delete_headers, nil, 404
-          end
-
           expect {
             described_class.destroy(form)
           }.not_to raise_error
         end
-
-        it "still deletes the form from the database" do
-          expect {
-            described_class.destroy(form)
-          }.to change(Form, :count).by(-1)
-        end
-
-        it "returns the deleted form" do
-          described_class.destroy(form)
-
-          ActiveResource::HttpMock.respond_to do |mock|
-            mock.delete "/api/v1/forms/#{form.id}", delete_headers, nil, 404
-          end
-
-          expect(described_class.destroy(form)).to eq form
-        end
       end
     end
 
-    describe "#pages" do
-      let(:form) { create(:form_record, :with_pages) }
+    it "returns the deleted form" do
+      expect(described_class.destroy(form)).to eq form
+    end
 
-      it "does not request a form's pages through ActiveResource" do
-        pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/pages", {}, headers)
-        described_class.pages(form)
-        expect(ActiveResource::HttpMock.requests).not_to include pages_request
+    context "when the form has already been deleted" do
+      it "does not raise an error" do
+        described_class.destroy(form)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.delete "/api/v1/forms/#{form.id}", delete_headers, nil, 404
+        end
+
+        expect {
+          described_class.destroy(form)
+        }.not_to raise_error
       end
 
-      it "returns page records" do
-        expect(described_class.pages(form).first).to be_a(Page)
+      it "still deletes the form from the database" do
+        expect {
+          described_class.destroy(form)
+        }.to change(Form, :count).by(-1)
       end
+
+      it "returns the deleted form" do
+        described_class.destroy(form)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.delete "/api/v1/forms/#{form.id}", delete_headers, nil, 404
+        end
+
+        expect(described_class.destroy(form)).to eq form
+      end
+    end
+  end
+
+  describe "#pages" do
+    let(:form) { create(:form_record, :with_pages) }
+
+    it "does not request a form's pages through ActiveResource" do
+      pages_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/pages", {}, headers)
+      described_class.pages(form)
+      expect(ActiveResource::HttpMock.requests).not_to include pages_request
+    end
+
+    it "returns page records" do
+      expect(described_class.pages(form).first).to be_a(Page)
     end
   end
 end

--- a/spec/services/page_repository_spec.rb
+++ b/spec/services/page_repository_spec.rb
@@ -4,747 +4,312 @@ describe PageRepository do
   let(:form_id) { form.id }
   let(:form) { create(:form_record) }
 
-  context "when use_database_as_truth is false" do
+  describe "#find" do
+    let(:page) { create(:page_record, form:) }
+
+    it "does not call the API" do
+      described_class.find(page_id: page.id, form_id:)
+      expect(Api::V1::PageResource.new(id: page.id, form_id:)).not_to have_been_read
+    end
+
+    it "returns the page" do
+      expect(described_class.find(page_id: page.id, form_id:)).to eq(page)
+    end
+
+    context "when given a form_id that the page doesn't belong to" do
+      let(:form_id) { "non-existent-id" }
+
+      it "raises a RecordNotFound error" do
+        expect {
+          described_class.find(page_id: page.id, form_id:)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe "#create!" do
+    let(:page_params) do
+      { question_text: "asdf",
+        hint_text: "",
+        is_optional: false,
+        is_repeatable: false,
+        form_id:,
+        answer_settings:,
+        page_heading: nil,
+        guidance_markdown: nil,
+        answer_type: }
+    end
+    let(:answer_type) { "organisation_name" }
+    let(:answer_settings) { {} }
+    let(:ignored_api_page_id) { 999_999 }
+
     before do
-      allow(Settings).to receive(:use_database_as_truth).and_return(false)
-    end
-
-    describe "#find" do
-      let(:page) { build(:page_resource, id: 4, form_id:, answer_type:, answer_settings:) }
-      let(:answer_type) { "text" }
-      let(:answer_settings) { {} }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/#{form_id}/pages/#{page.id}", headers, page.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "finds the page through ActiveResource" do
-          described_class.find(page_id: page.id, form_id:)
-          expect(Api::V1::PageResource.new(id: page.id, form_id:)).to have_been_read
-        end
-      end
-
-      describe "database" do
-        it "saves the page to the database" do
-          expect {
-            described_class.find(page_id: page.id, form_id:)
-          }.to change(Page, :count).by(1)
-        end
-
-        it "returns a page record" do
-          expect(described_class.find(page_id: page.id, form_id:)).to be_a(Page)
-        end
-
-        it "associates the page with a form" do
-          described_class.find(page_id: page.id, form_id:)
-          expect(Page.last).to have_attributes(form_id:)
-        end
-
-        context "when the form does not exist in the database" do
-          let(:form_id) { 1 }
-          let(:form) { build(:form_resource, id: form_id) }
-
-          it "gets the form from the api and saves it to the database" do
-            ActiveResource::HttpMock.respond_to(false) do |mock|
-              mock.get "/api/v1/forms/1", headers, form.to_json, 200
-            end
-
-            expect {
-              described_class.find(page_id: page.id, form_id:)
-            }.to change(Form, :count).by(1)
-          end
-        end
-
-        context "when the page has routing conditions" do
-          let(:routing_conditions) do
-            [
-              build(:condition_resource, id: 1, routing_page_id: 2, check_page_id: 2, goto_page_id: nil, skip_to_end: true, answer_value: "Red"),
-              build(:condition_resource, id: 2, routing_page_id: 2, check_page_id: 2, goto_page_id: nil, skip_to_end: true, answer_value: "Green"),
-            ]
-          end
-
-          let(:page) { build(:page_resource, id: 2, form_id:, routing_conditions:) }
-
-          it "saves the conditions to the database" do
-            expect {
-              described_class.find(page_id: page.id, form_id:)
-            }.to change(Condition, :count).by(2)
-          end
-
-          context "when the page in the database has conditions which were deleted in the api" do
-            it "deletes conditions from the database" do
-              described_class.find(page_id: page.id, form_id:)
-
-              page.routing_conditions = routing_conditions.drop(1)
-              ActiveResource::HttpMock.respond_to do |mock|
-                mock.get "/api/v1/forms/#{form_id}/pages/2", headers, page.to_json, 200
-              end
-
-              expect {
-                described_class.find(page_id: page.id, form_id:)
-              }.to change(Condition, :count).by(-1)
-            end
-          end
-        end
-
-        context "when the page has answer settings" do
-          let(:answer_type) { "selection" }
-          let(:answer_settings) { { only_one_option: "true", selection_options: [{ name: "Option 1" }] } }
-
-          it "saves the answer settings to the database" do
-            described_class.find(page_id: page.id, form_id:)
-            expect(Page.find(page.id)).to have_attributes(
-              "answer_settings" => DataStruct.new({
-                "only_one_option" => "true",
-                "selection_options" => [DataStruct.new({ name: "Option 1" })],
-              }),
-            )
-          end
-        end
-
-        context "when the page is already in the database" do
-          let!(:existing_page) { create(:page_record, id: page.id, form_id:) }
-
-          it "does not create a new page" do
-            expect {
-              described_class.find(page_id: existing_page.id, form_id:)
-            }.not_to change(Page, :count)
-          end
-
-          it "returns the existing page" do
-            expect(described_class.find(page_id: existing_page.id, form_id:)).to eq(existing_page)
-          end
-        end
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.post "/api/v1/forms/#{form_id}/pages", post_headers, build(:page_resource, page_params.merge(id: ignored_api_page_id)).to_json, 200
       end
     end
 
-    describe "#create!" do
-      let(:page_params) do
-        { question_text: "asdf",
-          hint_text: "",
-          is_optional: false,
-          is_repeatable: false,
-          form_id:,
-          answer_settings:,
-          page_heading: nil,
-          guidance_markdown: nil,
-          answer_type: }
+    describe "api" do
+      it "creates a page through ActiveResource" do
+        page = described_class.create!(**page_params)
+        expect(Api::V1::PageResource.new(page.attributes)).to have_been_created
       end
-      let(:answer_type) { "organisation_name" }
-      let(:created_page_id) { 4 }
-      let(:answer_settings) { {} }
+    end
 
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/#{form_id}/pages", post_headers, build(:page_resource, page_params.merge(id: created_page_id)).to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "creates a page through ActiveResource" do
+    describe "database" do
+      it "saves the new page to the database" do
+        expect {
           described_class.create!(**page_params)
-          expect(Api::V1::PageResource.new(page_params)).to have_been_created
-        end
+        }.to change(Page, :count).by(1)
       end
 
-      describe "database" do
-        it "saves the new page to the database" do
-          expect {
-            described_class.create!(**page_params)
-          }.to change(Page, :count).by(1)
-        end
-
-        it "returns a page record" do
-          expect(described_class.create!(**page_params)).to be_a(Page)
-        end
-
-        it "associates the page with a form" do
-          described_class.create!(**page_params)
-          expect(Page.last).to have_attributes(form_id:)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.create!(**page_params)
-            }.to change { Form.find(form_id).question_section_completed }.to(false)
-          end
-        end
-
-        context "when the page has answer settings" do
-          let(:answer_type) { "selection" }
-          let(:answer_settings) { { only_one_option: "true", selection_options: [] } }
-
-          it "saves the answer settings to the database" do
-            described_class.create!(**page_params)
-            expect(Page.find(created_page_id)).to have_attributes(
-              "answer_settings" => DataStruct.new({
-                "only_one_option" => "true",
-                "selection_options" => [],
-              }),
-            )
-          end
-        end
+      it "returns a page record" do
+        expect(described_class.create!(**page_params)).to be_a(Page)
       end
 
-      it "has the same ID in the database and for the API" do
+      it "doesn't use the API response to create the page" do
+        expect(described_class.create!(**page_params).id).not_to eq(ignored_api_page_id)
+      end
+
+      it "associates the page with a form" do
         described_class.create!(**page_params)
-        expect(Page.last.id).to eq created_page_id
+        expect(Page.last).to have_attributes(form_id:)
+      end
+
+      context "when the form question section is complete" do
+        let(:form) { create(:form_record, question_section_completed: true) }
+
+        it "updates the form to mark the question section as incomplete" do
+          expect {
+            described_class.create!(**page_params)
+          }.to change { Form.find(form_id).question_section_completed }.to(false)
+        end
+      end
+
+      context "when the page has answer settings" do
+        let(:answer_type) { "selection" }
+        let(:answer_settings) { { only_one_option: "true", selection_options: [] } }
+
+        it "saves the answer settings to the database" do
+          described_class.create!(**page_params)
+          expect(Page.last).to have_attributes(
+            "answer_settings" => DataStruct.new({
+              "only_one_option" => "true",
+              "selection_options" => [],
+            }),
+          )
+        end
       end
     end
 
-    describe "#save!" do
-      let(:page) { create(:page_record, form:, is_optional: false, question_text: "database page") }
-      let(:updated_page_resource) { build(:page_resource, id: page.id, form_id:, is_optional: true, question_text: "API page") }
+    it "has the same ID in the database and for the API" do
+      described_class.create!(**page_params)
+      expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("id" => Page.last.id)
+    end
+  end
 
-      before do
+  describe "#save!" do
+    let(:page) { create(:page_record, form:, is_optional: false, question_text: "database page") }
+    let(:updated_page_resource) { build(:page_resource, id: page.id, form_id:, is_optional: true, question_text: "API page") }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", post_headers, updated_page_resource.to_json, 200
+      end
+    end
+
+    describe "api" do
+      it "updates the page through ActiveResource" do
+        page.is_optional = true
+        described_class.save!(page)
+        expect(Api::V1::PageResource.new(id: page.id, form_id:, is_optional: true)).to have_been_updated
+        expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("is_optional" => true)
+      end
+    end
+
+    describe "database" do
+      it "saves the page to the database" do
+        page.is_optional = true
+
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", post_headers, updated_page_resource.to_json, 200
+          mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", put_headers, page.to_json
         end
+
+        expect {
+          described_class.save!(page)
+        }.to change { Page.find(page.id).is_optional }.to(true)
       end
 
-      describe "api" do
-        it "updates the page through ActiveResource" do
-          page.is_optional = true
-          described_class.save!(page)
-          expect(Api::V1::PageResource.new(id: page.id, form_id:, is_optional: true)).to have_been_updated
-          expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("is_optional" => true)
-        end
-
-        it "returns a page constructed from the API response" do
-          described_class.save!(page)
-          expect(described_class.save!(page)).to have_attributes(question_text: "API page")
-        end
+      it "returns the database page" do
+        expect(described_class.save!(page)).to eq(page)
       end
 
-      describe "database" do
-        it "saves the page to the database" do
-          page.is_optional = true
+      it "doesn't use the API response to udpate the page" do
+        expect(described_class.save!(page).question_text).to eq("database page")
+      end
 
+      context "when there are no changes to save" do
+        let(:form) { create(:form_record, question_section_completed: true) }
+        let(:page) { create(:page_record, form: form, answer_type: "number", answer_settings: { foo: "bar" }) }
+        let(:updated_page_resource) do
+          build(:page_resource,
+                id: page.id,
+                form_id:,
+                question_text: page.question_text,
+                answer_type: page.answer_type,
+                answer_settings: page.answer_settings,
+                position: page.position)
+        end
+
+        it "does not update the form" do
           ActiveResource::HttpMock.respond_to do |mock|
-            mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", put_headers, page.to_json
+            mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", put_headers, updated_page_resource.to_json
           end
 
           expect {
             described_class.save!(page)
-          }.to change { Page.find(page.id).is_optional }.to(true)
-        end
-
-        it "returns a page record" do
-          expect(described_class.save!(page)).to be_a(Page)
-        end
-
-        context "when there are no changes to save" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-          let(:page) { create(:page_record, form: form, answer_type: "number", answer_settings: { foo: "bar" }) }
-          let(:updated_page_resource) do
-            build(:page_resource,
-                  id: page.id,
-                  form_id:,
-                  question_text: page.question_text,
-                  answer_type: page.answer_type,
-                  answer_settings: page.answer_settings,
-                  position: page.position)
-          end
-
-          it "does not update the form" do
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", put_headers, updated_page_resource.to_json
-            end
-
-            expect {
-              described_class.save!(page)
-            }.not_to(change { Form.find(form_id).question_section_completed })
-          end
-        end
-
-        context "when there are changes to save" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form" do
-            page.is_optional = true
-
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", put_headers, updated_page_resource.to_json
-            end
-
-            expect {
-              described_class.save!(page)
-            }.to change { Form.find(form_id).question_section_completed }.to(false)
-          end
-        end
-      end
-    end
-
-    describe "#destroy" do
-      let(:page) { create(:page_record, form_id:) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 204
+          }.not_to(change { Form.find(form_id).question_section_completed })
         end
       end
 
-      describe "api" do
-        it "destroys the page through ActiveResource" do
-          described_class.destroy(page)
-          expect(Api::V1::PageResource.new(id: page.id, form_id:)).to have_been_deleted
-        end
+      context "when there are changes to save" do
+        let(:form) { create(:form_record, question_section_completed: true) }
 
-        context "when the page has already been deleted" do
-          it "does not raise an error" do
-            described_class.destroy(page)
-
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 404
-            end
-
-            expect {
-              described_class.destroy(page)
-            }.not_to raise_error
-          end
-
-          it "still deletes the page from the database" do
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 404
-            end
-
-            expect {
-              described_class.destroy(page)
-            }.to change(Page, :count).by(-1)
-          end
-        end
-      end
-
-      describe "database" do
-        it "removes the page from the database" do
-          expect {
-            described_class.destroy(page)
-          }.to change(Page, :count).by(-1)
-        end
-
-        it "returns a page record" do
-          expect(described_class.destroy(page)).to be_a(Page)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.destroy(page)
-            }.to change { Form.find(form_id).question_section_completed }.to(false)
-          end
-        end
-
-        context "when the page has routing conditions" do
-          before do
-            create(:condition_record, routing_page_id: page.id, check_page_id: page.id, goto_page_id: nil, skip_to_end: true, answer_value: "Red")
-            create(:condition_record, routing_page_id: page.id, check_page_id: page.id, goto_page_id: nil, skip_to_end: true, answer_value: "Green")
-            page.reload
-          end
-
-          it "deletes the conditions" do
-            expect {
-              described_class.destroy(page)
-            }.to change(Condition, :count).by(-2)
-          end
-        end
-      end
-
-      it "returns the deleted page" do
-        expect(described_class.destroy(page)).to eq page
-      end
-
-      context "when the page has already been deleted" do
-        it "returns the deleted page" do
-          described_class.destroy(page)
+        it "updates the form" do
+          page.is_optional = true
 
           ActiveResource::HttpMock.respond_to do |mock|
-            mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 404
+            mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", put_headers, updated_page_resource.to_json
           end
 
-          expect(described_class.destroy(page)).to eq page
-        end
-      end
-    end
-
-    describe "#move_page" do
-      let(:page) { create(:page_record, form_id:, position: 2) }
-      let(:moved_page_resource) { build(:page_resource, id: page.id, form_id:, position: 1) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}/up", post_headers, moved_page_resource.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "calls the move endpoint through ActiveResource" do
-          move_request = ActiveResource::Request.new(:put, "/api/v1/forms/#{form_id}/pages/#{page.id}/up", {}, post_headers)
-          described_class.move_page(page, :up)
-          expect(ActiveResource::HttpMock.requests).to include move_request
-        end
-      end
-
-      describe "database" do
-        it "updates the page in the database" do
           expect {
-            described_class.move_page(page, :up)
-          }.to change { Page.find(page.id).position }.from(2).to(1)
-        end
-
-        it "returns a page record" do
-          expect(described_class.move_page(page, :up)).to be_a(Page)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.move_page(page, :up)
-            }.to change { Form.find(form_id).question_section_completed }.to(false)
-          end
-        end
-
-        context "when the page has routing conditions" do
-          before do
-            create(:condition_record, routing_page_id: page.id, check_page_id: page.id, goto_page_id: nil, skip_to_end: true, answer_value: "Red")
-            create(:condition_record, routing_page_id: page.id, check_page_id: page.id, goto_page_id: nil, skip_to_end: true, answer_value: "Green")
-            page.reload
-          end
-
-          let(:page) { create(:page_record, form_id:, position: 2) }
-          let(:moved_page_resource) { build(:page_resource, id: page.id, form_id:, position: 1) }
-
-          it "does not raise an error" do
-            expect {
-              described_class.move_page(page, :up)
-            }.not_to raise_error
-          end
+            described_class.save!(page)
+          }.to change { Form.find(form_id).question_section_completed }.to(false)
         end
       end
     end
   end
 
-  context "when use_database_as_truth is true" do
+  describe "#destroy" do
+    let(:page) { create(:page_record, form_id:) }
+
     before do
-      allow(Settings).to receive(:use_database_as_truth).and_return(true)
-    end
-
-    describe "#find" do
-      let(:page) { create(:page_record, form:) }
-
-      it "does not call the API" do
-        described_class.find(page_id: page.id, form_id:)
-        expect(Api::V1::PageResource.new(id: page.id, form_id:)).not_to have_been_read
-      end
-
-      it "returns the page" do
-        expect(described_class.find(page_id: page.id, form_id:)).to eq(page)
-      end
-
-      context "when given a form_id that the page doesn't belong to" do
-        let(:form_id) { "non-existent-id" }
-
-        it "raises a RecordNotFound error" do
-          expect {
-            described_class.find(page_id: page.id, form_id:)
-          }.to raise_error(ActiveRecord::RecordNotFound)
-        end
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 204
       end
     end
 
-    describe "#create!" do
-      let(:page_params) do
-        { question_text: "asdf",
-          hint_text: "",
-          is_optional: false,
-          is_repeatable: false,
-          form_id:,
-          answer_settings:,
-          page_heading: nil,
-          guidance_markdown: nil,
-          answer_type: }
-      end
-      let(:answer_type) { "organisation_name" }
-      let(:answer_settings) { {} }
-      let(:ignored_api_page_id) { 999_999 }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.post "/api/v1/forms/#{form_id}/pages", post_headers, build(:page_resource, page_params.merge(id: ignored_api_page_id)).to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "creates a page through ActiveResource" do
-          page = described_class.create!(**page_params)
-          expect(Api::V1::PageResource.new(page.attributes)).to have_been_created
-        end
-      end
-
-      describe "database" do
-        it "saves the new page to the database" do
-          expect {
-            described_class.create!(**page_params)
-          }.to change(Page, :count).by(1)
-        end
-
-        it "returns a page record" do
-          expect(described_class.create!(**page_params)).to be_a(Page)
-        end
-
-        it "doesn't use the API response to create the page" do
-          expect(described_class.create!(**page_params).id).not_to eq(ignored_api_page_id)
-        end
-
-        it "associates the page with a form" do
-          described_class.create!(**page_params)
-          expect(Page.last).to have_attributes(form_id:)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.create!(**page_params)
-            }.to change { Form.find(form_id).question_section_completed }.to(false)
-          end
-        end
-
-        context "when the page has answer settings" do
-          let(:answer_type) { "selection" }
-          let(:answer_settings) { { only_one_option: "true", selection_options: [] } }
-
-          it "saves the answer settings to the database" do
-            described_class.create!(**page_params)
-            expect(Page.last).to have_attributes(
-              "answer_settings" => DataStruct.new({
-                "only_one_option" => "true",
-                "selection_options" => [],
-              }),
-            )
-          end
-        end
-      end
-
-      it "has the same ID in the database and for the API" do
-        described_class.create!(**page_params)
-        expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("id" => Page.last.id)
-      end
-    end
-
-    describe "#save!" do
-      let(:page) { create(:page_record, form:, is_optional: false, question_text: "database page") }
-      let(:updated_page_resource) { build(:page_resource, id: page.id, form_id:, is_optional: true, question_text: "API page") }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", post_headers, updated_page_resource.to_json, 200
-        end
-      end
-
-      describe "api" do
-        it "updates the page through ActiveResource" do
-          page.is_optional = true
-          described_class.save!(page)
-          expect(Api::V1::PageResource.new(id: page.id, form_id:, is_optional: true)).to have_been_updated
-          expect(JSON.parse(ActiveResource::HttpMock.requests.first.body)).to include("is_optional" => true)
-        end
-      end
-
-      describe "database" do
-        it "saves the page to the database" do
-          page.is_optional = true
-
-          ActiveResource::HttpMock.respond_to do |mock|
-            mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", put_headers, page.to_json
-          end
-
-          expect {
-            described_class.save!(page)
-          }.to change { Page.find(page.id).is_optional }.to(true)
-        end
-
-        it "returns the database page" do
-          expect(described_class.save!(page)).to eq(page)
-        end
-
-        it "doesn't use the API response to udpate the page" do
-          expect(described_class.save!(page).question_text).to eq("database page")
-        end
-
-        context "when there are no changes to save" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-          let(:page) { create(:page_record, form: form, answer_type: "number", answer_settings: { foo: "bar" }) }
-          let(:updated_page_resource) do
-            build(:page_resource,
-                  id: page.id,
-                  form_id:,
-                  question_text: page.question_text,
-                  answer_type: page.answer_type,
-                  answer_settings: page.answer_settings,
-                  position: page.position)
-          end
-
-          it "does not update the form" do
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", put_headers, updated_page_resource.to_json
-            end
-
-            expect {
-              described_class.save!(page)
-            }.not_to(change { Form.find(form_id).question_section_completed })
-          end
-        end
-
-        context "when there are changes to save" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form" do
-            page.is_optional = true
-
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}", put_headers, updated_page_resource.to_json
-            end
-
-            expect {
-              described_class.save!(page)
-            }.to change { Form.find(form_id).question_section_completed }.to(false)
-          end
-        end
-      end
-    end
-
-    describe "#destroy" do
-      let(:page) { create(:page_record, form_id:) }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 204
-        end
-      end
-
-      describe "api" do
-        it "destroys the page through ActiveResource" do
-          described_class.destroy(page)
-          expect(Api::V1::PageResource.new(id: page.id, form_id:)).to have_been_deleted
-        end
-
-        context "when the page has already been deleted" do
-          it "does not raise an error" do
-            described_class.destroy(page)
-
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 404
-            end
-
-            expect {
-              described_class.destroy(page)
-            }.not_to raise_error
-          end
-
-          it "still deletes the page from the database" do
-            ActiveResource::HttpMock.respond_to do |mock|
-              mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 404
-            end
-
-            expect {
-              described_class.destroy(page)
-            }.to change(Page, :count).by(-1)
-          end
-        end
-      end
-
-      describe "database" do
-        it "removes the page from the database" do
-          expect {
-            described_class.destroy(page)
-          }.to change(Page, :count).by(-1)
-        end
-
-        it "returns a page record" do
-          expect(described_class.destroy(page)).to be_a(Page)
-        end
-
-        context "when the form question section is complete" do
-          let(:form) { create(:form_record, question_section_completed: true) }
-
-          it "updates the form to mark the question section as incomplete" do
-            expect {
-              described_class.destroy(page)
-            }.to change { Form.find(form_id).question_section_completed }.to(false)
-          end
-        end
-
-        context "when the page has routing conditions" do
-          before do
-            create(:condition_record, routing_page_id: page.id, check_page_id: page.id, goto_page_id: nil, skip_to_end: true, answer_value: "Red")
-            create(:condition_record, routing_page_id: page.id, check_page_id: page.id, goto_page_id: nil, skip_to_end: true, answer_value: "Green")
-            page.reload
-          end
-
-          it "deletes the conditions" do
-            expect {
-              described_class.destroy(page)
-            }.to change(Condition, :count).by(-2)
-          end
-        end
-      end
-
-      it "returns the deleted page" do
-        expect(described_class.destroy(page)).to eq page
+    describe "api" do
+      it "destroys the page through ActiveResource" do
+        described_class.destroy(page)
+        expect(Api::V1::PageResource.new(id: page.id, form_id:)).to have_been_deleted
       end
 
       context "when the page has already been deleted" do
-        it "returns the deleted page" do
+        it "does not raise an error" do
           described_class.destroy(page)
 
           ActiveResource::HttpMock.respond_to do |mock|
             mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 404
           end
 
-          expect(described_class.destroy(page)).to eq page
+          expect {
+            described_class.destroy(page)
+          }.not_to raise_error
+        end
+
+        it "still deletes the page from the database" do
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 404
+          end
+
+          expect {
+            described_class.destroy(page)
+          }.to change(Page, :count).by(-1)
         end
       end
     end
 
-    describe "#move_page" do
-      let(:form) { create(:form_record, :with_pages) }
-      let(:page) { form.pages.second }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}/up", post_headers, {}, 200
-        end
+    describe "database" do
+      it "removes the page from the database" do
+        expect {
+          described_class.destroy(page)
+        }.to change(Page, :count).by(-1)
       end
 
-      describe "api" do
-        it "calls the move endpoint through ActiveResource" do
-          move_request = ActiveResource::Request.new(:put, "/api/v1/forms/#{form_id}/pages/#{page.id}/up", {}, post_headers)
-          described_class.move_page(page, :up)
-          expect(ActiveResource::HttpMock.requests).to include move_request
-        end
+      it "returns a page record" do
+        expect(described_class.destroy(page)).to be_a(Page)
       end
 
-      describe "database" do
-        it "updates the page in the database" do
+      context "when the form question section is complete" do
+        let(:form) { create(:form_record, question_section_completed: true) }
+
+        it "updates the form to mark the question section as incomplete" do
           expect {
-            described_class.move_page(page, :up)
-          }.to change { Page.find(page.id).position }.from(2).to(1)
+            described_class.destroy(page)
+          }.to change { Form.find(form_id).question_section_completed }.to(false)
+        end
+      end
+
+      context "when the page has routing conditions" do
+        before do
+          create(:condition_record, routing_page_id: page.id, check_page_id: page.id, goto_page_id: nil, skip_to_end: true, answer_value: "Red")
+          create(:condition_record, routing_page_id: page.id, check_page_id: page.id, goto_page_id: nil, skip_to_end: true, answer_value: "Green")
+          page.reload
         end
 
-        it "returns a page record" do
-          expect(described_class.move_page(page, :up)).to be_a(Page)
+        it "deletes the conditions" do
+          expect {
+            described_class.destroy(page)
+          }.to change(Condition, :count).by(-2)
         end
+      end
+    end
+
+    it "returns the deleted page" do
+      expect(described_class.destroy(page)).to eq page
+    end
+
+    context "when the page has already been deleted" do
+      it "returns the deleted page" do
+        described_class.destroy(page)
+
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.delete "/api/v1/forms/#{form_id}/pages/#{page.id}", delete_headers, nil, 404
+        end
+
+        expect(described_class.destroy(page)).to eq page
+      end
+    end
+  end
+
+  describe "#move_page" do
+    let(:form) { create(:form_record, :with_pages) }
+    let(:page) { form.pages.second }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.put "/api/v1/forms/#{form_id}/pages/#{page.id}/up", post_headers, {}, 200
+      end
+    end
+
+    describe "api" do
+      it "calls the move endpoint through ActiveResource" do
+        move_request = ActiveResource::Request.new(:put, "/api/v1/forms/#{form_id}/pages/#{page.id}/up", {}, post_headers)
+        described_class.move_page(page, :up)
+        expect(ActiveResource::HttpMock.requests).to include move_request
+      end
+    end
+
+    describe "database" do
+      it "updates the page in the database" do
+        expect {
+          described_class.move_page(page, :up)
+        }.to change { Page.find(page.id).position }.from(2).to(1)
+      end
+
+      it "returns a page record" do
+        expect(described_class.move_page(page, :up)).to be_a(Page)
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ipJBFWpv/2462-remove-usedatabaseastruth-configuration-flag-from-forms-admin

The `use_database_as_truth` setting has now been enabled on all environments and we don't want to switch back. This PR removes this setting and the old code for when it is set to false.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
