### PR TITLE
Add code to create form document from form model to forms admin

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -97,6 +97,12 @@ class Condition < ApplicationRecord
     end
   end
 
+  def as_json(options = {})
+    super(options.reverse_merge(
+      methods: %i[validation_errors has_routing_errors],
+    ))
+  end
+
 private
 
   def has_precondition?

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -134,6 +134,13 @@ class Form < ApplicationRecord
     group_form&.destroy
   end
 
+  def as_form_document
+    as_json(
+      except: %i[state external_id pages question_section_completed declaration_section_completed share_preview_completed],
+      methods: %i[start_page steps],
+    )
+  end
+
 private
 
   def set_external_id
@@ -154,5 +161,13 @@ private
 
   def email_task_status_service
     @email_task_status_service ||= EmailTaskStatusService.new(form: self)
+  end
+
+  def steps
+    pages.map(&:as_form_document_step)
+  end
+
+  def start_page
+    pages&.first&.id
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -83,6 +83,17 @@ class Page < ApplicationRecord
     is_optional? && answer_type != "selection"
   end
 
+  def as_form_document_step
+    {
+      "id" => id,
+      "position" => position,
+      "next_step_id" => next_page,
+      "type" => "question_page",
+      "data" => slice(*%w[question_text hint_text answer_type is_optional answer_settings page_heading guidance_markdown is_repeatable]),
+      "routing_conditions" => routing_conditions.map(&:as_json),
+    }
+  end
+
 private
 
   def update_form

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -495,4 +495,31 @@ RSpec.describe Condition, type: :model do
       end
     end
   end
+
+  describe "#as_json" do
+    let(:form) { create :form_record }
+    let(:check_page) { create :page_record, :with_selection_settings, form: }
+    let(:goto_page) { create :page_record, form: }
+    let(:condition) { create :condition_record, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, skip_to_end: false }
+
+    it "returns a json object" do
+      expect(condition.as_json).to match({
+        "id" => condition.id,
+        "check_page_id" => check_page.id,
+        "routing_page_id" => check_page.id,
+        "goto_page_id" => goto_page.id,
+        "answer_value" => nil,
+        "created_at" => a_kind_of(String),
+        "updated_at" => a_kind_of(String),
+        "skip_to_end" => false,
+        "exit_page_markdown" => nil,
+        "exit_page_heading" => nil,
+        "validation_errors" => [
+          { "name" => "answer_value_doesnt_exist" },
+          { "name" => "cannot_route_to_next_page" },
+        ],
+        "has_routing_errors" => true,
+      })
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -646,4 +646,22 @@ RSpec.describe Form, type: :model do
       expect(form.file_upload_question_count).to eq(4)
     end
   end
+
+  describe "#as_form_document" do
+    let(:form) { create :form, :ready_for_live }
+
+    it "includes all attributes for the form" do
+      form_attributes = described_class.attribute_names - %w[state external_id pages question_section_completed declaration_section_completed share_preview_completed]
+      expect(form.as_form_document).to match a_hash_including(*form_attributes)
+    end
+
+    it "includes start page" do
+      expect(form.as_form_document).to match a_hash_including("start_page" => form.pages.first.id)
+    end
+
+    it "includes steps" do
+      expect(form.as_form_document["steps"].count).to eq(form.pages.count)
+      expect(form.as_form_document["steps"].first).to match a_hash_including("type" => "question_page")
+    end
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -611,4 +611,34 @@ RSpec.describe Page, type: :model do
       end
     end
   end
+
+  describe "#as_form_document_step" do
+    let!(:page) { create :page, form: }
+    let!(:second_page) { create :page, form: }
+
+    it "has an id" do
+      expect(page.as_form_document_step).to match a_hash_including("id" => page.id)
+    end
+
+    it "has a position" do
+      expect(page.as_form_document_step).to match a_hash_including("position" => page.position)
+    end
+
+    it "has a next_step_id" do
+      expect(page.as_form_document_step).to match a_hash_including("next_step_id" => second_page.id)
+    end
+
+    it "includes all attributes for the page as a step" do
+      page_attributes = described_class.attribute_names - %w[id form_id next_page position created_at updated_at]
+      expect(page.as_form_document_step["data"]).to match a_hash_including(*page_attributes)
+    end
+
+    context "when there are conditions associated with the page" do
+      let!(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id }
+
+      it "includes the routing conditions" do
+        expect(page.reload.as_form_document_step["routing_conditions"]).to include(condition.as_json)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/T44nnWv3/2461-add-code-to-create-form-document-from-form-model-to-forms-admin

Adds a method to the form model, `#as_form_document`, which recreates the `content` part of the form documents in forms api. This is a json blob which has all the important form, page and condition bits. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
