### PR TITLE
Fix parallel rspec link and gem environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ npm run test
 
 ### Running the RSpec tests in parallel
 
-You can run the RSpec tests in parallel with the following setup: you will first need to create multiple test databases:
+You can run the RSpec tests in parallel with [parallel_rspec] You will first need to create multiple test databases:
 
 ```bash
-bundle exec rake db:parallel:create db:parallel:prepare
+RAILS_ENV=test bundle exec rake db:parallel:create db:parallel:prepare
 ```
 
 You can then run the tests in parallel:


### PR DESCRIPTION
### What problem does this pull request solve?

We have to do this so that the gem's rake task can be run using the command line without needing to specify the environment
   
<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
