### PR TITLE
Update db seed to create local form records

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -128,8 +128,219 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
 
   Membership.create! user: default_user, group: end_to_end_group, added_by: default_user, role: :group_admin
 
-  # add forms to groups (assumes database seed is being used for forms-api)
-  GroupForm.create! group: end_to_end_group, form_id: 1 # All question types form
-  GroupForm.create! group: end_to_end_group, form_id: 2 # s3 submission test form
-  GroupForm.create! group: test_group, form_id: 3 # Branch routing form
+  submission_email = ENV["EMAIL"] || `git config --get user.email`.strip
+
+  all_question_types_form = Form.create!(
+    name: "All question types form",
+    pages: [
+      Page.create(
+        question_text: "Single line of text",
+        answer_type: "text",
+        answer_settings: {
+          input_type: "single_line",
+        },
+        is_optional: false,
+      ),
+      Page.create(
+        question_text: "Number",
+        answer_type: "number",
+        is_optional: false,
+      ),
+      Page.create(
+        question_text: "Address",
+        answer_type: "address",
+        answer_settings: {
+          input_type: {
+            international_address: false,
+            uk_address: true,
+          },
+        },
+        is_optional: false,
+      ),
+      Page.create(
+        question_text: "Email address",
+        answer_type: "email",
+        is_optional: false,
+      ),
+      Page.create(
+        question_text: "Todays Date",
+        answer_type: "date",
+        answer_settings: {
+          input_type: "other_date",
+        },
+        is_optional: false,
+      ),
+      Page.create(
+        question_text: "National Insurance number",
+        answer_type: "national_insurance_number",
+        is_optional: false,
+      ),
+      Page.create(
+        question_text: "Phone number",
+        answer_type: "phone_number",
+        is_optional: false,
+      ),
+      Page.create(
+        question_text: "Selection from a list of options",
+        answer_type: "selection",
+        answer_settings: {
+          "only_one_option": "0", # TODO: investigate why we set this to "0"
+          "selection_options": [
+            { "name": "Option 1" },
+            { "name": "Option 2" },
+            { "name": "Option 3" },
+          ],
+        },
+        is_optional: true, # Include an option for 'None of the above'
+      ),
+      Page.create(
+        question_text: "Multiple lines of text",
+        answer_type: "text",
+        answer_settings: {
+          input_type: "long_text",
+        },
+        is_optional: true,
+      ),
+    ],
+    question_section_completed: true,
+    declaration_text: "",
+    declaration_section_completed: true,
+    privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
+    submission_email:,
+    support_email: "your.email+fakedata84701@gmail.com.gov.uk",
+    support_phone: "08000800",
+    what_happens_next_markdown: "Test",
+    share_preview_completed: true,
+  )
+  all_question_types_form.make_live!
+
+  e2e_s3_forms = Form.create!(
+    name: "s3 submission test form",
+    pages: [
+      Page.create(
+        question_text: "Single line of text",
+        answer_type: "text",
+        answer_settings: {
+          input_type: "single_line",
+        },
+        is_optional: false,
+      ),
+    ],
+    question_section_completed: true,
+    declaration_text: "",
+    declaration_section_completed: true,
+    privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
+    submission_email:,
+    support_email: "your.email+fakedata84701@gmail.com.gov.uk",
+    support_phone: "08000800",
+    what_happens_next_markdown: "Test",
+    share_preview_completed: true,
+    submission_type: "s3",
+    s3_bucket_region: "eu-west-2",
+  )
+  e2e_s3_forms.make_live!
+
+  branch_route_form = Form.create!(
+    name: "Branch route form",
+    pages: [
+      Page.create(
+        question_text: "Are you eligible to submit this form?",
+        answer_type: "selection",
+        answer_settings: {
+          only_one_option: "true",
+          selection_options: [
+            { "name": "Yes" },
+            { "name": "No" },
+          ],
+        },
+        is_optional: false,
+      ),
+      Page.create(
+        question_text: "How many times have you filled out this form?",
+        answer_type: "selection",
+        answer_settings: {
+          only_one_option: "true",
+          selection_options: [
+            { "name": "Once" },
+            { "name": "More than once" },
+          ],
+        },
+        is_optional: false,
+      ),
+      Page.create(
+        question_text: "What’s your name?",
+        answer_type: "name",
+        answer_settings: {
+          input_type: "full_name",
+          title_needed: false,
+        },
+        is_optional: false,
+        is_repeatable: false,
+      ),
+      Page.create(
+        question_text: "What’s your email address?",
+        answer_type: "email",
+        is_optional: false,
+        is_repeatable: false,
+      ),
+      Page.create(
+        question_text: "What was the reference of your previous submission?",
+        answer_type: "text",
+        answer_settings: {
+          input_type: "single_line",
+        },
+        is_optional: false,
+        is_repeatable: false,
+      ),
+      Page.create(
+        question_text: "What’s your answer?",
+        answer_type: "text",
+        answer_settings: {
+          input_type: "single_line",
+        },
+        is_optional: false,
+        is_repeatable: false,
+      ),
+    ],
+    question_section_completed: true,
+    declaration_text: "",
+    declaration_section_completed: true,
+    privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
+    submission_email:,
+    support_email: "your.email+fakedata84701@gmail.com.gov.uk",
+    support_phone: "08000800",
+    what_happens_next_markdown: "Test",
+    share_preview_completed: true,
+  )
+  Condition.create!(
+    check_page: branch_route_form.pages.second,
+    routing_page: branch_route_form.pages.second,
+    goto_page: branch_route_form.pages.fifth,
+    answer_value: "More than once",
+  )
+  Condition.create!(
+    check_page: branch_route_form.pages.second,
+    routing_page: branch_route_form.pages.fourth,
+    goto_page: branch_route_form.pages.last,
+    answer_value: nil,
+  )
+  Condition.create!(
+    check_page: branch_route_form.pages.first,
+    routing_page: branch_route_form.pages.first,
+    goto_page: nil,
+    answer_value: "No",
+    exit_page_heading: "You are not eligible to submit this form",
+    exit_page_markdown: <<~MARKDOWN,
+      To complete this form you must:
+
+        - Be over 16
+        - Confirmed that you are eligible to submit this form
+    MARKDOWN
+  )
+  branch_route_form.reload.make_live!
+
+  # add forms to groups
+  GroupForm.create! group: end_to_end_group, form_id: all_question_types_form.id # All question types form
+  GroupForm.create! group: end_to_end_group, form_id: e2e_s3_forms.id # s3 submission test form
+  GroupForm.create! group: test_group, form_id: branch_route_form.id # Branch routing form
 end


### PR DESCRIPTION
Now that we're using the local database as the source of truth, we need our database seed to recreate forms that used to be drawn from the Forms API

If you want to reseed your database, you can run `bundle exec rails db:reset` which will remove all existing data and replant the seeds. 

### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
