### PR TITLE
Add form documents table to forms admin

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -4,6 +4,7 @@ class Form < ApplicationRecord
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
   has_one :form_submission_email, dependent: :destroy
   has_one :group_form, dependent: :destroy
+  has_many :form_documents, dependent: :destroy
 
   enum :submission_type, {
     email: "email",

--- a/app/models/form_document.rb
+++ b/app/models/form_document.rb
@@ -1,0 +1,5 @@
+class FormDocument < ApplicationRecord
+  belongs_to :form
+
+  validates :tag, presence: true
+end

--- a/app/services/api_form_document_service.rb
+++ b/app/services/api_form_document_service.rb
@@ -1,0 +1,19 @@
+class ApiFormDocumentService
+  class << self
+    REQUEST_HEADERS = {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }.freeze
+    FORM_DOCUMENTS_URL = "#{Settings.forms_api.base_url}/api/v2/forms".freeze
+
+    def form_document(form_id:, tag:)
+      uri = URI(FORM_DOCUMENTS_URL + "/#{form_id}/#{tag}")
+
+      response = Net::HTTP.get_response(uri, REQUEST_HEADERS)
+
+      return JSON.parse(response.body) if response.is_a? Net::HTTPSuccess
+
+      raise StandardError, "Forms API responded with a non-success HTTP code when retrieving form document: status #{response.code}"
+    end
+  end
+end

--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -1,0 +1,30 @@
+class FormDocumentSyncService
+  class << self
+    def synchronize_form(form)
+      case form.state
+      when "live"
+        sync_live_form(form)
+      when "archived"
+        sync_archived_form(form)
+      end
+    end
+
+  private
+
+    def sync_live_form(form)
+      live_form_document = FormDocument.find_or_initialize_by(form: form)
+      live_form_document.tag = "live"
+      live_form_document.content = form.as_form_document
+      live_form_document.save!
+    end
+
+    def sync_archived_form(form)
+      form_document = FormDocument.find_or_initialize_by(form:)
+      unless form_document.persisted?
+        form_document.content = ApiFormDocumentService.form_document(form_id: form.id, tag: "live")
+      end
+      form_document.tag = "archived"
+      form_document.save!
+    end
+  end
+end

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -30,6 +30,7 @@ module FormStateMachine
         after do
           live_at ||= Time.zone.now
           touch(time: live_at)
+          FormDocumentSyncService.synchronize_form(self)
         end
 
         transitions from: %i[draft live_with_draft archived archived_with_draft], to: :live, guard: proc { ready_for_live }
@@ -52,6 +53,10 @@ module FormStateMachine
       end
 
       event :archive_live_form do
+        after do
+          FormDocumentSyncService.synchronize_form(self)
+        end
+
         transitions from: :live, to: :archived
         transitions from: :live_with_draft, to: :archived_with_draft
       end

--- a/db/migrate/20250820140606_create_form_documents.rb
+++ b/db/migrate/20250820140606_create_form_documents.rb
@@ -1,0 +1,13 @@
+class CreateFormDocuments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :form_documents do |t|
+      t.references :form, foreign_key: true, comment: "The form this document belongs to"
+      t.text :tag, null: false,  comment: "The tag for the form, for example: 'live' or 'draft'"
+      t.jsonb :content, comment: "The JSON which describes the form"
+
+      t.timestamps
+
+      t.index %i[form_id tag], unique: true, name: "index_form_documents_on_form_id_and_tag"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_15_135356) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_20_140606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -58,6 +58,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_15_135356) do
     t.boolean "is_repeatable"
     t.index ["form_id"], name: "index_draft_questions_on_form_id"
     t.index ["user_id"], name: "index_draft_questions_on_user_id"
+  end
+
+  create_table "form_documents", force: :cascade do |t|
+    t.bigint "form_id", comment: "The form this document belongs to"
+    t.text "tag", null: false, comment: "The tag for the form, for example: 'live' or 'draft'"
+    t.jsonb "content", comment: "The JSON which describes the form"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["form_id", "tag"], name: "index_form_documents_on_form_id_and_tag", unique: true
+    t.index ["form_id"], name: "index_form_documents_on_form_id"
   end
 
   create_table "form_submission_emails", force: :cascade do |t|
@@ -217,6 +227,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_15_135356) do
   add_foreign_key "create_form_events", "groups", on_delete: :cascade
   add_foreign_key "create_form_events", "users", on_delete: :cascade
   add_foreign_key "draft_questions", "users"
+  add_foreign_key "form_documents", "forms"
   add_foreign_key "groups", "users", column: "creator_id"
   add_foreign_key "groups", "users", column: "upgrade_requester_id"
   add_foreign_key "memberships", "groups"

--- a/spec/factories/models/form_documents.rb
+++ b/spec/factories/models/form_documents.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :form_document do
+    form { association :form }
+    tag { :draft }
+  end
+end

--- a/spec/factories/models/form_documents.rb
+++ b/spec/factories/models/form_documents.rb
@@ -1,6 +1,14 @@
 FactoryBot.define do
   factory :form_document do
     form { association :form }
-    tag { :draft }
+    tag { "draft" }
+
+    trait :live do
+      tag { "live" }
+    end
+
+    trait :archived do
+      tag { "archived" }
+    end
   end
 end

--- a/spec/models/form_document_spec.rb
+++ b/spec/models/form_document_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe FormDocument, type: :model do
+  it "is valid with valid attributes" do
+    form_document = build(:form_document)
+    expect(form_document).to be_valid
+  end
+
+  it "is invalid without a form" do
+    form_document = build(:form_document, form: nil)
+    expect(form_document).not_to be_valid
+  end
+
+  it "is invalid without a tag" do
+    form_document = build(:form_document, tag: nil)
+    expect(form_document).not_to be_valid
+  end
+
+  it "has a default created_at and updated_at" do
+    travel_to Time.zone.local(2023, 10, 1, 10, 0, 0) do
+      form_document = create(:form_document)
+
+      expect(form_document.created_at).to eq(Time.zone.now)
+      expect(form_document.updated_at).to eq(Time.zone.now)
+    end
+  end
+
+  it "belongs to a Form" do
+    form_document = build(:form_document)
+
+    expect(form_document.form).to be_a(Form)
+  end
+
+  it "tags must be unique for a given form" do
+    form_document = create(:form_document, tag: "live")
+    expect { create(:form_document, form: form_document.form, tag: "live") }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+end

--- a/spec/services/form_document_sync_service_spec.rb
+++ b/spec/services/form_document_sync_service_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe FormDocumentSyncService do
+  let(:service) { described_class }
+  let(:form) { create(:form) }
+
+  describe "#synchronize_form" do
+    context "when form state is live" do
+      let(:form) { create(:form, :live) }
+
+      context "when there is no existing form document" do
+        it "creates a live form document" do
+          expect {
+            service.synchronize_form(form)
+          }.to change(FormDocument, :count).by(1)
+
+          expect(FormDocument.last).to have_attributes(form:, tag: "live", content: form.as_form_document)
+        end
+      end
+
+      context "when there is an existing live form document" do
+        let!(:form_document) { create :form_document, :live, form: }
+
+        it "updates the live form document" do
+          expect {
+            service.synchronize_form(form)
+          }.to change { form_document.reload.content }.to(form.as_form_document)
+        end
+      end
+
+      context "when there is an existing archived form document" do
+        before do
+          create :form_document, :archived, form:
+        end
+
+        it "destroys the archived form document" do
+          expect {
+            service.synchronize_form(form)
+          }.to(change { FormDocument.exists?(form:, tag: "archived") })
+        end
+
+        it "creates the live form document" do
+          expect {
+            service.synchronize_form(form)
+          }.to(change { FormDocument.exists?(form:, tag: "live", content: form.as_form_document) })
+        end
+      end
+    end
+
+    context "when form state is archived" do
+      let(:form) { create(:form, :archived) }
+
+      context "when there is no existing form document" do
+        it "creates an archived form document" do
+          allow(ApiFormDocumentService).to receive(:form_document).with(form_id: form.id, tag: "live").and_return(form.as_form_document)
+
+          expect {
+            service.synchronize_form(form)
+          }.to change(FormDocument, :count).by(1)
+
+          expect(FormDocument.last).to have_attributes(form:, tag: "archived", content: form.as_form_document)
+        end
+      end
+
+      context "when there is an existing live form document" do
+        let!(:live_form_document) { create :form_document, :live, form:, content: "content" }
+
+        it "destroys the live form document" do
+          expect {
+            service.synchronize_form(form)
+          }.to(change { FormDocument.exists?(form:, tag: "live") })
+        end
+
+        it "creates the archived form document" do
+          expect {
+            service.synchronize_form(form)
+          }.to(change { FormDocument.exists?(form:, tag: "archived", content: live_form_document.content) })
+        end
+      end
+    end
+  end
+end

--- a/spec/services/form_repository_spec.rb
+++ b/spec/services/form_repository_spec.rb
@@ -243,6 +243,8 @@ describe FormRepository do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.post "/api/v1/forms/#{form.id}/archive", post_headers, archived_form_resource.to_json, 200
       end
+
+      create(:form_document, :live, form:)
     end
 
     describe "api" do

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -125,8 +125,17 @@ RSpec.describe FormStateMachine do
     context "when the form is live" do
       let(:form) { FakeForm.new(state: :live) }
 
+      before do
+        allow(FormDocumentSyncService).to receive(:synchronize_form)
+      end
+
       it "transitions to archived" do
         expect(form).to transition_from(:live).to(:archived).on_event(:archive_live_form)
+      end
+
+      it "calls the FormDocumentSyncService" do
+        form.archive_live_form
+        expect(FormDocumentSyncService).to have_received(:synchronize_form).with(form)
       end
     end
 

--- a/spec/support/shared_examples/state_machine.rb
+++ b/spec/support/shared_examples/state_machine.rb
@@ -6,8 +6,10 @@ RSpec.shared_examples "transition to live state" do |form_object, form_state|
   end
 
   it "transitions to live state" do
+    allow(FormDocumentSyncService).to receive(:synchronize_form)
     allow(form).to receive(:touch)
 
     expect(form).to transition_from(form_state).to(:live).on_event(:make_live)
+    expect(FormDocumentSyncService).to have_received(:synchronize_form).with(form)
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/sSOKmA23/2463-add-form-documents-table-to-forms-admin

Adds the form documents table, and starts to populate it with live and archived form documents. Whenever a form changes state to live or to archived, a form document is added to the db with a snapshot of the form in its live state. 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
