### PR TITLE
Use group form association to get forms for show group action

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -21,7 +21,7 @@ class GroupsController < ApplicationController
   # GET /groups/1
   def show
     authorize @group
-    forms = @group.group_forms.map(&:form)
+    forms = @group.forms
     @form_list_presenter = FormListPresenter.call(forms:, group: @group) unless forms.empty?
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Now that we have an association through group_forms connecting groups and forms, we can use the database to collate the forms for a group rather than looping through each group_form in turn.

This should make the view to list the forms for a group quicker for groups with lots of forms.

This was missed from PR #2159.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?