### PR TITLE
Set live_at when creating a live FormDocument

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -136,11 +136,13 @@ class Form < ApplicationRecord
     group_form&.destroy
   end
 
-  def as_form_document
-    as_json(
+  def as_form_document(live_at: nil)
+    content = as_json(
       except: %i[state external_id pages question_section_completed declaration_section_completed share_preview_completed],
       methods: %i[start_page steps],
     )
+    content["live_at"] = live_at if live_at.present?
+    content
   end
 
 private

--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -14,7 +14,7 @@ class FormDocumentSyncService
     def sync_live_form(form)
       live_form_document = FormDocument.find_or_initialize_by(form: form)
       live_form_document.tag = "live"
-      live_form_document.content = form.as_form_document
+      live_form_document.content = form.as_form_document(live_at: form.updated_at)
       live_form_document.save!
     end
 

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -28,8 +28,6 @@ module FormStateMachine
 
       event :make_live do
         after do
-          live_at ||= Time.zone.now
-          touch(time: live_at)
           FormDocumentSyncService.synchronize_form(self)
         end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -659,5 +659,16 @@ RSpec.describe Form, type: :model do
       expect(form.as_form_document["steps"].count).to eq(form.pages.count)
       expect(form.as_form_document["steps"].first).to match a_hash_including("type" => "question_page")
     end
+
+    it "does not include a live_at date" do
+      expect(form.as_form_document).not_to have_key("live_at")
+    end
+
+    context "when a live_at date is provided" do
+      it "includes the live_at date" do
+        live_at = Time.zone.local(2023, 10, 16, 13, 24)
+        expect(form.as_form_document(live_at:)["live_at"]).to eq("2023-10-16 13:24:00.000000")
+      end
+    end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/sSOKmA23/2463-add-form-documents-table-to-forms-admin

When a Form Document is made as part of the #make_live! form action, we want to assign a live_at timestamp to keep track of when the form went live.
<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
