### PR TITLE
Add a form documents sync rake task

### DIFF
--- a/lib/tasks/form_documents.rake
+++ b/lib/tasks/form_documents.rake
@@ -1,0 +1,58 @@
+namespace :form_documents do
+  desc "retrieve all live and archived form documents from Forms API"
+  task sync: :environment do
+    puts "Started with #{FormDocument.count} formdocs"
+
+    ActiveRecord::Base.transaction do
+      sync_live_forms
+
+      sync_archived_forms
+    end
+
+    puts "Finished with #{FormDocument.count} formdocs"
+  end
+
+  desc "dry run retrieve all live and archived form documents from Forms API"
+  task sync_dry_run: :environment do
+    puts "Started with #{FormDocument.count} formdocs"
+
+    ActiveRecord::Base.transaction do
+      sync_live_forms
+
+      sync_archived_forms
+      puts "Finished with #{FormDocument.count} formdocs"
+
+      raise ActiveRecord::Rollback
+    end
+  end
+end
+
+def sync_live_forms
+  live_forms = Form.where(state: "live").or(Form.where(state: "live_with_draft"))
+
+  count = 0
+
+  live_forms.each do |form|
+    form_doc = FormDocument.find_or_initialize_by(form_id: form.id, tag: "live")
+    form_doc.content = ApiFormDocumentService.form_document(form_id: form.id, tag: "live")
+    form_doc.save!
+    count += 1
+  end
+
+  puts "Created or updated #{count} live formdocs"
+end
+
+def sync_archived_forms
+  archived_forms = Form.where(state: "archived").or(Form.where(state: "archived_with_draft"))
+
+  count = 0
+
+  archived_forms.each do |form|
+    form_doc = FormDocument.find_or_initialize_by(form_id: form.id, tag: "archived")
+    form_doc.content = ApiFormDocumentService.form_document(form_id: form.id, tag: "archived")
+    form_doc.save!
+    count += 1
+  end
+
+  puts "Created or updated #{count} archived formdocs"
+end

--- a/spec/lib/tasks/form_documents.rake_spec.rb
+++ b/spec/lib/tasks/form_documents.rake_spec.rb
@@ -1,0 +1,179 @@
+require "rake"
+require "rails_helper"
+
+RSpec.describe "form_documents.rake" do
+  before do
+    Rake.application.rake_require "tasks/form_documents"
+    Rake::Task.define_task(:environment)
+    allow($stdout).to receive(:puts) # to prevent logs printing during tests
+  end
+
+  describe "form_documents:sync" do
+    subject(:task) do
+      Rake::Task["form_documents:sync"]
+        .tap(&:reenable)
+    end
+
+    context "when there is a draft form locally" do
+      before do
+        create :form, :draft
+      end
+
+      it "does not add a FormDocument" do
+        expect {
+          task.invoke
+        }.not_to(change(FormDocument, :count))
+      end
+    end
+
+    context "when there is a live form locally" do
+      let(:live_form) { create :form, :live }
+
+      before do
+        allow(ApiFormDocumentService).to receive(:form_document).with(form_id: live_form.id, tag: "live").and_return("content")
+      end
+
+      it "calls the ApiFormDocumentService" do
+        task.invoke
+        expect(ApiFormDocumentService).to have_received(:form_document)
+      end
+
+      it "creates a FormDocument for the form" do
+        expect {
+          task.invoke
+        }.to(change { FormDocument.exists?(form_id: live_form.id, tag: "live") })
+      end
+
+      context "when there is already a live FormDocument for the form" do
+        before do
+          create :form_document, :live, form: live_form
+        end
+
+        it "does not affect the existing FormDocument" do
+          expect {
+            task.invoke
+          }.not_to(change { FormDocument.exists?(form_id: live_form.id, tag: "live") })
+        end
+      end
+    end
+
+    context "when there is a live_with_draft form locally" do
+      let(:live_form) { create :form, :live_with_draft }
+
+      before do
+        allow(ApiFormDocumentService).to receive(:form_document).with(form_id: live_form.id, tag: "live").and_return("content")
+      end
+
+      it "calls the ApiFormDocumentService" do
+        task.invoke
+        expect(ApiFormDocumentService).to have_received(:form_document)
+      end
+
+      it "creates a FormDocument for the form" do
+        expect {
+          task.invoke
+        }.to(change { FormDocument.exists?(form_id: live_form.id, tag: "live") })
+      end
+
+      context "when there is already a live FormDocument for the form" do
+        before do
+          create :form_document, :live, form: live_form
+        end
+
+        it "does not affect the existing FormDocument" do
+          expect {
+            task.invoke
+          }.not_to(change { FormDocument.exists?(form_id: live_form.id, tag: "live") })
+        end
+      end
+    end
+
+    context "when there is an archived form locally" do
+      let(:archived_form) { create :form, :archived }
+
+      before do
+        allow(ApiFormDocumentService).to receive(:form_document).with(form_id: archived_form.id, tag: "archived").and_return("content")
+      end
+
+      it "calls the ApiFormDocumentService" do
+        task.invoke
+        expect(ApiFormDocumentService).to have_received(:form_document)
+      end
+
+      it "creates a FormDocument for the form" do
+        expect {
+          task.invoke
+        }.to(change { FormDocument.exists?(form_id: archived_form.id, tag: "archived") })
+      end
+
+      context "when there is already a live FormDocument for the form" do
+        before do
+          create :form_document, :archived, form: archived_form
+        end
+
+        it "does not affect the existing FormDocument" do
+          expect {
+            task.invoke
+          }.not_to(change { FormDocument.exists?(form_id: archived_form.id, tag: "archived") })
+        end
+      end
+    end
+
+    context "when there is an archived_with_draft form locally" do
+      let(:archived_form) { create :form, :archived_with_draft }
+
+      before do
+        allow(ApiFormDocumentService).to receive(:form_document).with(form_id: archived_form.id, tag: "archived").and_return("content")
+      end
+
+      it "calls the ApiFormDocumentService" do
+        task.invoke
+        expect(ApiFormDocumentService).to have_received(:form_document)
+      end
+
+      it "creates a FormDocument for the form" do
+        expect {
+          task.invoke
+        }.to(change { FormDocument.exists?(form_id: archived_form.id, tag: "archived") })
+      end
+
+      context "when there is already a live FormDocument for the form" do
+        before do
+          create :form_document, :archived, form: archived_form
+        end
+
+        it "does not affect the existing FormDocument" do
+          expect {
+            task.invoke
+          }.not_to(change { FormDocument.exists?(form_id: archived_form.id, tag: "archived") })
+        end
+      end
+    end
+  end
+
+  describe "form_documents:sync_dry_run" do
+    subject(:task) do
+      Rake::Task["form_documents:sync_dry_run"]
+        .tap(&:reenable)
+    end
+
+    context "when there is a live form locally" do
+      let(:form) { create :form, :live }
+
+      before do
+        allow(ApiFormDocumentService).to receive(:form_document).with(form_id: form.id, tag: "live").and_return("content")
+      end
+
+      it "calls the ApiFormDocumentService" do
+        task.invoke
+        expect(ApiFormDocumentService).to have_received(:form_document)
+      end
+
+      it "does not add a FormDocument" do
+        expect {
+          task.invoke
+        }.not_to(change(FormDocument, :count))
+      end
+    end
+  end
+end


### PR DESCRIPTION
The task finds all the live and archived forms, and checks if we have a corresponding form document for them locally. If we don't, it sets one up, then asks the API for the content for that formdoc, and saves the formdoc with that content.

The intention here is to make sure that all the local formdocs have content which matches their live or archived version, rather than what the current form looks like in draft.

### What problem does this pull request solve?

Trello card: https://trello.com/c/evpgt16h/2464-copy-existing-forms-into-forms-admin-form-documents-table

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
