### PR TITLE
Add form_id attribute to form_document serialization

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -141,6 +141,7 @@ class Form < ApplicationRecord
       except: %i[state external_id pages question_section_completed declaration_section_completed share_preview_completed],
       methods: %i[start_page steps],
     )
+    content["form_id"] = content.delete("id").to_s
     content["live_at"] = live_at if live_at.present?
     content
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -647,8 +647,14 @@ RSpec.describe Form, type: :model do
     let(:form) { create :form, :ready_for_live }
 
     it "includes all attributes for the form" do
-      form_attributes = described_class.attribute_names - %w[state external_id pages question_section_completed declaration_section_completed share_preview_completed]
+      form_attributes = described_class.attribute_names - %w[id state external_id pages question_section_completed declaration_section_completed share_preview_completed]
       expect(form.as_form_document).to match a_hash_including(*form_attributes)
+    end
+
+    it "includes the form ID" do
+      form_document = form.as_form_document
+      expect(form_document).to include "form_id" => form.id.to_s
+      expect(form_document).not_to include "id"
     end
 
     it "includes start page" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/sSOKmA23/2463-add-form-documents-table-to-forms-admin <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Form documents should have a form_id that has the ID of the form that created the form document (rather than its own ID). This commit makes the `Form#as_form_document` method match this behaviour, same as what is in forms-api.

We can fix any form documents that were created in the forms-admin database without the form_id attribute by running the `form_documents:sync` task.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?