### PR TITLE
Remove has_routing_errors from form document conditions

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -104,7 +104,7 @@ class Condition < ApplicationRecord
   end
 
   def as_form_document_condition
-    as_json
+    as_json(methods: %i[validation_errors])
   end
 
 private

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -103,6 +103,10 @@ class Condition < ApplicationRecord
     ))
   end
 
+  def as_form_document_condition
+    as_json
+  end
+
 private
 
   def has_precondition?

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -90,7 +90,7 @@ class Page < ApplicationRecord
       "next_step_id" => next_page,
       "type" => "question_page",
       "data" => slice(*%w[question_text hint_text answer_type is_optional answer_settings page_heading guidance_markdown is_repeatable]),
-      "routing_conditions" => routing_conditions.map(&:as_json),
+      "routing_conditions" => routing_conditions.map(&:as_form_document_condition),
     }
   end
 

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -522,4 +522,31 @@ RSpec.describe Condition, type: :model do
       })
     end
   end
+
+  describe "#as_form_document_condition" do
+    let(:form) { create :form_record }
+    let(:check_page) { create :page_record, :with_selection_settings, form: }
+    let(:goto_page) { create :page_record, form: }
+    let(:condition) { create :condition_record, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, skip_to_end: false }
+
+    it "returns a json object" do
+      expect(condition.as_form_document_condition).to match({
+        "id" => condition.id,
+        "check_page_id" => check_page.id,
+        "routing_page_id" => check_page.id,
+        "goto_page_id" => goto_page.id,
+        "answer_value" => nil,
+        "created_at" => a_kind_of(String),
+        "updated_at" => a_kind_of(String),
+        "skip_to_end" => false,
+        "exit_page_markdown" => nil,
+        "exit_page_heading" => nil,
+        "validation_errors" => [
+          { "name" => "answer_value_doesnt_exist" },
+          { "name" => "cannot_route_to_next_page" },
+        ],
+        "has_routing_errors" => true,
+      })
+    end
+  end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -545,7 +545,6 @@ RSpec.describe Condition, type: :model do
           { "name" => "answer_value_doesnt_exist" },
           { "name" => "cannot_route_to_next_page" },
         ],
-        "has_routing_errors" => true,
       })
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -637,7 +637,7 @@ RSpec.describe Page, type: :model do
       let!(:condition) { create :condition, routing_page_id: page.id, check_page_id: page.id }
 
       it "includes the routing conditions" do
-        expect(page.reload.as_form_document_step["routing_conditions"]).to include(condition.as_json)
+        expect(page.reload.as_form_document_step["routing_conditions"]).to include(condition.as_form_document_condition)
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/sSOKmA23/2463-add-form-documents-table-to-forms-admin <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When forms-api creates a form document it doesn't include the `has_routing_errors` method, so we shouldn't include it in the form documents generated in forms-admin.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?