### PR TITLE
Add type="module" to analytics script

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -62,7 +62,7 @@
     <%= vite_javascript_tag 'application' %>
 
     <% if AnalyticsService.analytics_events.present? && @current_user&.collect_analytics? %>
-      <script data-analytics-events>
+      <script data-analytics-events type="module">
         window.dataLayer = window.dataLayer || [];
 
         <% AnalyticsService.analytics_events.each do |event| %>


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/b6jmnphx/2288-waiting-on-anne-to-recheck-track-branching-validation-errors

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We were getting a 'Config command out of order' warning in Google Tag Manager because our analytics script was sending events before the GTM config script ran.

This might be a cause of the behaviour we're seeing with branching validation errors not being properly populated in Google Analytics.

This was happening because the main application.js file, where the GTM tag is configured, has `type="module"` but the analytics script is a plain inline script. The execution of module scripts is deferred until after the HTML is parsed, but inline scripts are executed immediately (here's a [good explainer on how different script attributes affect execution order](https://gist.github.com/jakub-g/385ee6b41085303a53ad92c7c8afd7a6)). 

This commit adds `type="module"` to the inline script so that it will be deferred until after the HTML has been parsed and the application.js file has executed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
