### PR TITLE
Spike: Only clear draft when starting a new question

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -19,7 +19,6 @@ class Pages::QuestionsController < PagesController
 
     if @question_input.valid?
       @page = @question_input.submit
-      clear_draft_questions_data
       redirect_to edit_question_path(current_form.id, @page.id), success: "Your changes have been saved"
     else
       render :new, locals: { current_form:, draft_question: }, status: :unprocessable_content
@@ -42,7 +41,6 @@ class Pages::QuestionsController < PagesController
     @question_input = Pages::QuestionInput.new(page_params_for_form_object)
 
     if @question_input.update_page(@page)
-      clear_draft_questions_data
       redirect_to edit_question_path(current_form.id, @page.id), success: "Your changes have been saved"
     else
       render :edit, locals: { current_form:, draft_question: }, status: :unprocessable_content

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,5 @@
 class PagesController < ApplicationController
   before_action :check_user_has_permission
-  before_action :clear_draft_questions_data, only: %i[index move_page]
   after_action :verify_authorized
   after_action :set_answer_type_logging_attribute
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/Cv7Df8ho/2452-navigating-to-the-new-page-view-causes-an-error-if-the-answer-type-and-answer-settings-arent-valid

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Resolves/reduces the likelihood of the draft question error by being less aggressive about clearing draft questions. Here we only clear the draft question for a form on the `start-new-question` route. This means that if the user navigates back to `/pages/new/question` with the back button, their draft question will still exist, so if they submit from this page the answers will be saved instead of throwing an error.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
