### PR TITLE
Use FormDocuments locally for displaying live and archived form information

### DIFF
--- a/app/controllers/forms/archived_controller.rb
+++ b/app/controllers/forms/archived_controller.rb
@@ -13,7 +13,7 @@ module Forms
     end
 
     def current_archived_form
-      @current_archived_form ||= FormRepository.find_archived(form_id: params[:form_id])
+      @current_archived_form ||= FormDocument::Content.new(**current_form.archived_form_document.content)
     end
   end
 end

--- a/app/controllers/forms/archived_controller.rb
+++ b/app/controllers/forms/archived_controller.rb
@@ -13,7 +13,7 @@ module Forms
     end
 
     def current_archived_form
-      @current_archived_form ||= FormDocument::Content.new(**current_form.archived_form_document.content)
+      @current_archived_form ||= FormDocument::Content.from_form_document(current_form.archived_form_document)
     end
   end
 end

--- a/app/controllers/forms/archived_controller.rb
+++ b/app/controllers/forms/archived_controller.rb
@@ -4,12 +4,12 @@ module Forms
 
     def show_form
       authorize current_form, :can_view_form?
-      render :show_form, locals: { form_metadata: current_form, form: current_archived_form }
+      render :show_form, locals: { form_metadata: current_form, form_document: current_archived_form }
     end
 
     def show_pages
       authorize current_form, :can_view_form?
-      render :show_pages, locals: { form: current_archived_form }
+      render :show_pages, locals: { form_document: current_archived_form }
     end
 
     def current_archived_form

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -4,12 +4,12 @@ module Forms
 
     def show_form
       authorize current_form, :can_view_form?
-      render :show_form, locals: { form_metadata: current_form, form: current_live_form }
+      render :show_form, locals: { form_metadata: current_form, form_document: current_live_form }
     end
 
     def show_pages
       authorize current_form, :can_view_form?
-      render :show_pages, locals: { form: current_live_form }
+      render :show_pages, locals: { form_document: current_live_form }
     end
 
   private

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -15,7 +15,7 @@ module Forms
   private
 
     def current_live_form
-      @current_live_form ||= FormRepository.find_live(form_id: params[:form_id])
+      @current_live_form ||= FormDocument::Content.new(**current_form.live_form_document.content)
     end
   end
 end

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -15,7 +15,7 @@ module Forms
   private
 
     def current_live_form
-      @current_live_form ||= FormDocument::Content.new(**current_form.live_form_document.content)
+      @current_live_form ||= FormDocument::Content.from_form_document(current_form.live_form_document)
     end
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -5,6 +5,8 @@ class Form < ApplicationRecord
   has_one :form_submission_email, dependent: :destroy
   has_one :group_form, dependent: :destroy
   has_many :form_documents, dependent: :destroy
+  has_one :live_form_document, -> { where tag: "live" }, class_name: "FormDocument"
+  has_one :archived_form_document, -> { where tag: "archived" }, class_name: "FormDocument"
 
   enum :submission_type, {
     email: "email",

--- a/app/models/form_document/content.rb
+++ b/app/models/form_document/content.rb
@@ -38,4 +38,8 @@ class FormDocument::Content
   def made_live_date
     live_at.to_date if live_at.present?
   end
+
+  def self.from_form_document(form_document)
+    new(**form_document.content)
+  end
 end

--- a/app/services/make_form_live_service.rb
+++ b/app/services/make_form_live_service.rb
@@ -9,7 +9,7 @@ class MakeFormLiveService
     @current_form = current_form
     @current_form_was_live = current_form.is_live?
     @current_form_was_archived = current_form.is_archived?
-    @current_live_form = FormRepository.find_live(form_id: current_form.id) if current_form.is_live?
+    @current_live_form = FormDocument::Content.new(**current_form.live_form_document.content) if current_form.is_live?
     @current_user = current_user
   end
 

--- a/app/services/make_form_live_service.rb
+++ b/app/services/make_form_live_service.rb
@@ -9,7 +9,7 @@ class MakeFormLiveService
     @current_form = current_form
     @current_form_was_live = current_form.is_live?
     @current_form_was_archived = current_form.is_archived?
-    @current_live_form = FormDocument::Content.new(**current_form.live_form_document.content) if current_form.is_live?
+    @current_live_form = FormDocument::Content.from_form_document(current_form.live_form_document) if current_form.is_live?
     @current_user = current_user
   end
 

--- a/app/services/page_options_service.rb
+++ b/app/services/page_options_service.rb
@@ -27,7 +27,7 @@ class PageOptionsService
     options.concat(question_text_options) if @page.answer_type == "file" && @page.page_heading.present?
 
     # Other answer types
-    options.concat(hint_options) if @page.hint_text?.present?
+    options.concat(hint_options) if @page.hint_text.present?
     options.concat(generic_options) if @read_only && %w[address date text selection name].exclude?(@page.answer_type)
 
     options.concat(selection_options) if @page.answer_type == "selection"
@@ -98,7 +98,7 @@ private
   def selection_list
     return @page.show_selection_options unless @page.answer_settings.selection_options.length >= 1
 
-    options = @page.answer_settings.selection_options.map { |option| option.attributes[:name] }
+    options = @page.answer_settings.selection_options.map(&:name)
     options << I18n.t("page_options_service.selection_type.none_of_the_above") if @page.is_optional?
     formatted_list = html_unordered_list(options)
 

--- a/app/services/step_summary_card_presenter.rb
+++ b/app/services/step_summary_card_presenter.rb
@@ -1,4 +1,4 @@
-class PageSummaryCardDataService
+class StepSummaryCardPresenter
   class << self
     def call(**args)
       new(**args)

--- a/app/services/step_summary_card_presenter.rb
+++ b/app/services/step_summary_card_presenter.rb
@@ -5,9 +5,9 @@ class StepSummaryCardPresenter
     end
   end
 
-  def initialize(page:, pages:)
-    @page = page
-    @pages = pages
+  def initialize(step:, steps:)
+    @step = step
+    @steps = steps
   end
 
   def build_data
@@ -16,7 +16,7 @@ class StepSummaryCardPresenter
         title: build_title,
         classes: "app-summary-card",
       },
-      rows: StepSummaryCardService.call(page: @page, pages: @pages).all_options_for_answer_type,
+      rows: StepSummaryCardService.call(step: @step, steps: @steps).all_options_for_answer_type,
 
     }
   end
@@ -24,23 +24,23 @@ class StepSummaryCardPresenter
 private
 
   def build_title
-    page_number = page_number(@page)
-    heading = @page.page_heading
-    question = @page.question_text
+    page_number = page_number(@step)
+    heading = @step.page_heading
+    question = @step.question_text
 
     # Use the actual heading instead of the question text for the title on file upload type
-    title = if @page.answer_type == "file" && heading.present?
+    title = if @step.answer_type == "file" && heading.present?
               "#{page_number}. #{heading}"
             else
               "#{page_number}. #{question}"
             end
 
-    title += " (optional)" if @page.is_optional? && @page.answer_type != "selection"
+    title += " (optional)" if @step.is_optional? && @step.answer_type != "selection"
 
     title
   end
 
-  def page_number(page)
-    @pages.find_index(page) + 1
+  def page_number(step)
+    @steps.find_index(step) + 1
   end
 end

--- a/app/services/step_summary_card_presenter.rb
+++ b/app/services/step_summary_card_presenter.rb
@@ -16,7 +16,7 @@ class StepSummaryCardPresenter
         title: build_title,
         classes: "app-summary-card",
       },
-      rows: PageOptionsService.call(page: @page, pages: @pages).all_options_for_answer_type,
+      rows: StepSummaryCardService.call(page: @page, pages: @pages).all_options_for_answer_type,
 
     }
   end

--- a/app/services/step_summary_card_service.rb
+++ b/app/services/step_summary_card_service.rb
@@ -7,35 +7,35 @@ class StepSummaryCardService
     end
   end
 
-  def initialize(page:, pages:, read_only: true)
+  def initialize(step:, steps:, read_only: true)
     @read_only = read_only
-    @page = page
-    @pages = pages
+    @step = step
+    @steps = steps
   end
 
   def all_options_for_answer_type
     options = []
 
     # Prioritize guidance markdown for file uploads
-    options.concat(guidance_markdown_options) if @page.respond_to?(:guidance_markdown) && @page.guidance_markdown.present?
+    options.concat(guidance_markdown_options) if @step.respond_to?(:guidance_markdown) && @step.guidance_markdown.present?
 
     # Page heading for non-file types
-    options.concat(page_heading_options) if @page.respond_to?(:page_heading) && @page.page_heading.present? && @page.answer_type != "file"
+    options.concat(page_heading_options) if @step.respond_to?(:page_heading) && @step.page_heading.present? && @step.answer_type != "file"
 
     # File upload: If a page heading/guidance is present, show the question text in the body of the summary card
     # as we're using the heading in the title rather than the question text.
-    options.concat(question_text_options) if @page.answer_type == "file" && @page.page_heading.present?
+    options.concat(question_text_options) if @step.answer_type == "file" && @step.page_heading.present?
 
     # Other answer types
-    options.concat(hint_options) if @page.hint_text.present?
-    options.concat(generic_options) if @read_only && %w[address date text selection name].exclude?(@page.answer_type)
+    options.concat(hint_options) if @step.hint_text.present?
+    options.concat(generic_options) if @read_only && %w[address date text selection name].exclude?(@step.answer_type)
 
-    options.concat(selection_options) if @page.answer_type == "selection"
-    options.concat(text_options) if @page.answer_type == "text"
-    options.concat(date_options) if @page.answer_type == "date"
-    options.concat(address_options) if @page.answer_type == "address"
-    options.concat(name_options) if @page.answer_type == "name"
-    options.concat(route_options) if @page.respond_to?(:routing_conditions) && @page.routing_conditions.present?
+    options.concat(selection_options) if @step.answer_type == "selection"
+    options.concat(text_options) if @step.answer_type == "text"
+    options.concat(date_options) if @step.answer_type == "date"
+    options.concat(address_options) if @step.answer_type == "address"
+    options.concat(name_options) if @step.answer_type == "name"
+    options.concat(route_options) if @step.respond_to?(:routing_conditions) && @step.routing_conditions.present?
     options
   end
 
@@ -44,19 +44,19 @@ private
   def page_heading_options
     [{
       key: { text: I18n.t("step_summary_card.page_heading") },
-      value: { text: @page.page_heading },
+      value: { text: @step.page_heading },
     }]
   end
 
   def question_text_options
     [{
       key: { text: I18n.t("reports.form_or_questions_list_table.headings.question_text") },
-      value: { text: @page.question_text },
+      value: { text: @step.question_text },
     }]
   end
 
   def markdown_content
-    safe_join(['<pre class="app-markdown-editor__markdown-example-block">'.html_safe, @page.guidance_markdown, "</pre>".html_safe])
+    safe_join(['<pre class="app-markdown-editor__markdown-example-block">'.html_safe, @step.guidance_markdown, "</pre>".html_safe])
   end
 
   def guidance_markdown_options
@@ -69,7 +69,7 @@ private
   def hint_options
     [{
       key: { text: I18n.t("step_summary_card.hint_text") },
-      value: { text: @page.hint_text },
+      value: { text: @step.hint_text },
     }]
   end
 
@@ -77,7 +77,7 @@ private
     [].tap do |options|
       options << {
         key: { text: I18n.t("step_summary_card.answer_type") },
-        value: { text: I18n.t("helpers.label.page.answer_type_options.names.#{@page.answer_type}") },
+        value: { text: I18n.t("helpers.label.page.answer_type_options.names.#{@step.answer_type}") },
       }
     end
   end
@@ -90,16 +90,16 @@ private
   end
 
   def selection_answer_type
-    return I18n.t("step_summary_card.selection_type.default") unless @page.answer_settings.only_one_option == "true"
+    return I18n.t("step_summary_card.selection_type.default") unless @step.answer_settings.only_one_option == "true"
 
     I18n.t("step_summary_card.selection_type.only_one_option")
   end
 
   def selection_list
-    return @page.show_selection_options unless @page.answer_settings.selection_options.length >= 1
+    return @step.show_selection_options unless @step.answer_settings.selection_options.length >= 1
 
-    options = @page.answer_settings.selection_options.map(&:name)
-    options << I18n.t("step_summary_card.selection_type.none_of_the_above") if @page.is_optional?
+    options = @step.answer_settings.selection_options.map(&:name)
+    options << I18n.t("step_summary_card.selection_type.none_of_the_above") if @step.is_optional?
     formatted_list = html_unordered_list(options)
 
     if options.length > 10
@@ -114,11 +114,11 @@ private
   end
 
   def text_options
-    [{ key: { text: I18n.t("step_summary_card.answer_type") }, value: { text: I18n.t("helpers.label.page.text_settings_options.names.#{@page.answer_settings.input_type}") } }]
+    [{ key: { text: I18n.t("step_summary_card.answer_type") }, value: { text: I18n.t("helpers.label.page.text_settings_options.names.#{@step.answer_settings.input_type}") } }]
   end
 
   def date_options
-    [{ key: { text: I18n.t("step_summary_card.answer_type") }, value: { text: I18n.t("step_summary_card.date_type.#{@page.answer_settings.input_type}") } }]
+    [{ key: { text: I18n.t("step_summary_card.answer_type") }, value: { text: I18n.t("step_summary_card.date_type.#{@step.answer_settings.input_type}") } }]
   end
 
   def address_options
@@ -130,14 +130,14 @@ private
   end
 
   def name_answer_type
-    title_needed = if @page.answer_settings.title_needed == "true"
+    title_needed = if @step.answer_settings.title_needed == "true"
                      I18n.t("step_summary_card.name_type.title_selected")
                    else
                      I18n.t("step_summary_card.name_type.title_not_selected")
                    end
 
-    settings = [I18n.t("helpers.label.page.answer_type_options.names.#{@page.answer_type}"),
-                I18n.t("helpers.label.page.name_settings_options.names.#{@page.answer_settings.input_type}")]
+    settings = [I18n.t("helpers.label.page.answer_type_options.names.#{@step.answer_type}"),
+                I18n.t("helpers.label.page.name_settings_options.names.#{@step.answer_settings.input_type}")]
     settings << title_needed
 
     formatted_list = html_list_item(settings)
@@ -146,7 +146,7 @@ private
   end
 
   def address_input_type_to_string
-    input_type = @page.answer_settings.input_type
+    input_type = @step.answer_settings.input_type
     if input_type.uk_address == "true" && input_type.international_address == "true"
       "uk_and_international_addresses"
     elsif input_type.uk_address == "true"
@@ -161,10 +161,10 @@ private
   end
 
   def route_value
-    if @page.routing_conditions.length == 1
-      print_route(@page.routing_conditions.first)
+    if @step.routing_conditions.length == 1
+      print_route(@step.routing_conditions.first)
     else
-      html_ordered_list(@page.routing_conditions.map { |condition| print_route(condition) })
+      html_ordered_list(@step.routing_conditions.map { |condition| print_route(condition) })
     end
   end
 
@@ -174,17 +174,17 @@ private
     if condition.skip_to_end
       I18n.t("page_conditions.condition_compact_html_end_of_form", answer_value:).html_safe
     elsif condition.secondary_skip?
-      goto_question = @pages.find { |page| page.id == condition.goto_page_id }
+      goto_question = @steps.find { |page| page.id == condition.goto_page_id }
       goto_page_question_text = ActionController::Base.helpers.sanitize(goto_question.question_text)
-      goto_page_question_number = @pages.find_index(goto_question) + 1
+      goto_page_question_number = @steps.find_index(goto_question) + 1
 
       I18n.t("page_conditions.condition_compact_html_secondary_skip", goto_page_question_number:, goto_page_question_text:).html_safe
     elsif condition.exit_page?
       I18n.t("page_conditions.condition_compact_html_exit_page", answer_value:, exit_page_heading: condition.exit_page_heading).html_safe
     else
-      goto_question = @pages.find { |page| page.id == condition.goto_page_id }
+      goto_question = @steps.find { |page| page.id == condition.goto_page_id }
       goto_page_question_text = ActionController::Base.helpers.sanitize(goto_question.question_text)
-      goto_page_question_number = @pages.find_index(goto_question) + 1
+      goto_page_question_number = @steps.find_index(goto_question) + 1
 
       I18n.t("page_conditions.condition_compact_html", answer_value:, goto_page_question_number:, goto_page_question_text:).html_safe
     end

--- a/app/services/step_summary_card_service.rb
+++ b/app/services/step_summary_card_service.rb
@@ -1,4 +1,4 @@
-class PageOptionsService
+class StepSummaryCardService
   include ActionView::Helpers::TagHelper
 
   class << self
@@ -43,7 +43,7 @@ private
 
   def page_heading_options
     [{
-      key: { text: I18n.t("page_options_service.page_heading") },
+      key: { text: I18n.t("step_summary_card.page_heading") },
       value: { text: @page.page_heading },
     }]
   end
@@ -61,14 +61,14 @@ private
 
   def guidance_markdown_options
     [{
-      key: { text: I18n.t("page_options_service.guidance_markdown") },
+      key: { text: I18n.t("step_summary_card.guidance_markdown") },
       value: { text: markdown_content },
     }]
   end
 
   def hint_options
     [{
-      key: { text: I18n.t("page_options_service.hint_text") },
+      key: { text: I18n.t("step_summary_card.hint_text") },
       value: { text: @page.hint_text },
     }]
   end
@@ -76,7 +76,7 @@ private
   def generic_options
     [].tap do |options|
       options << {
-        key: { text: I18n.t("page_options_service.answer_type") },
+        key: { text: I18n.t("step_summary_card.answer_type") },
         value: { text: I18n.t("helpers.label.page.answer_type_options.names.#{@page.answer_type}") },
       }
     end
@@ -84,22 +84,22 @@ private
 
   def selection_options
     [
-      { key: { text: I18n.t("page_options_service.answer_type") }, value: { text: selection_answer_type } },
-      { key: { text: I18n.t("page_options_service.options_title") }, value: { text: selection_list } },
+      { key: { text: I18n.t("step_summary_card.answer_type") }, value: { text: selection_answer_type } },
+      { key: { text: I18n.t("step_summary_card.options_title") }, value: { text: selection_list } },
     ]
   end
 
   def selection_answer_type
-    return I18n.t("page_options_service.selection_type.default") unless @page.answer_settings.only_one_option == "true"
+    return I18n.t("step_summary_card.selection_type.default") unless @page.answer_settings.only_one_option == "true"
 
-    I18n.t("page_options_service.selection_type.only_one_option")
+    I18n.t("step_summary_card.selection_type.only_one_option")
   end
 
   def selection_list
     return @page.show_selection_options unless @page.answer_settings.selection_options.length >= 1
 
     options = @page.answer_settings.selection_options.map(&:name)
-    options << I18n.t("page_options_service.selection_type.none_of_the_above") if @page.is_optional?
+    options << I18n.t("step_summary_card.selection_type.none_of_the_above") if @page.is_optional?
     formatted_list = html_unordered_list(options)
 
     if options.length > 10
@@ -114,26 +114,26 @@ private
   end
 
   def text_options
-    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: I18n.t("helpers.label.page.text_settings_options.names.#{@page.answer_settings.input_type}") } }]
+    [{ key: { text: I18n.t("step_summary_card.answer_type") }, value: { text: I18n.t("helpers.label.page.text_settings_options.names.#{@page.answer_settings.input_type}") } }]
   end
 
   def date_options
-    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: I18n.t("page_options_service.date_type.#{@page.answer_settings.input_type}") } }]
+    [{ key: { text: I18n.t("step_summary_card.answer_type") }, value: { text: I18n.t("step_summary_card.date_type.#{@page.answer_settings.input_type}") } }]
   end
 
   def address_options
-    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: I18n.t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}") } }]
+    [{ key: { text: I18n.t("step_summary_card.answer_type") }, value: { text: I18n.t("helpers.label.page.address_settings_options.names.#{address_input_type_to_string}") } }]
   end
 
   def name_options
-    [{ key: { text: I18n.t("page_options_service.answer_type") }, value: { text: name_answer_type } }]
+    [{ key: { text: I18n.t("step_summary_card.answer_type") }, value: { text: name_answer_type } }]
   end
 
   def name_answer_type
     title_needed = if @page.answer_settings.title_needed == "true"
-                     I18n.t("page_options_service.name_type.title_selected")
+                     I18n.t("step_summary_card.name_type.title_selected")
                    else
-                     I18n.t("page_options_service.name_type.title_not_selected")
+                     I18n.t("step_summary_card.name_type.title_not_selected")
                    end
 
     settings = [I18n.t("helpers.label.page.answer_type_options.names.#{@page.answer_type}"),

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -1,7 +1,7 @@
 <% set_page_title(form_document.name) %>
 
-<% if form_document.group.present? %>
-  <% content_for :back_link, govuk_back_link_to(group_path(form_document.group), t("back_link.group", group_name: form_document.group.name)) %>
+<% if form_metadata.group.present? %>
+  <% content_for :back_link, govuk_back_link_to(group_path(form_metadata.group), t("back_link.group", group_name: form_metadata.group.name)) %>
 <% else %>
   <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>
 <% end %>
@@ -19,7 +19,7 @@
     <h2 class="govuk-heading-l">Your form</h2>
 
     <p>
-      <%= render PreviewLinkComponent::View.new(form_document.pages, link_to_runner(Settings.forms_runner.url, form_document.id, form_document.form_slug, mode: preview_mode)) %>
+      <%= render PreviewLinkComponent::View.new(form_document.steps, link_to_runner(Settings.forms_runner.url, form_document.id, form_document.form_slug, mode: preview_mode)) %>
     </p>
 
     <% if status == :live %>
@@ -32,7 +32,7 @@
     <% end %>
 
     <h3 class="govuk-heading-m"><%= t('made_live_form.questions') %></h3>
-    <p><%= govuk_link_to t('made_live_form.questions_link', count: form_document.pages.count), questions_path %></p>
+    <p><%= govuk_link_to t('made_live_form.questions_link', count: form_document.steps.count), questions_path %></p>
 
     <% if form_document.declaration_text.present? %>
       <h3 class="govuk-heading-m"><%= t('made_live_form.declaration') %></h3>

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -1,7 +1,7 @@
-<% set_page_title(form.name) %>
+<% set_page_title(form_document.name) %>
 
-<% if form.group.present? %>
-  <% content_for :back_link, govuk_back_link_to(group_path(form.group), t("back_link.group", group_name: form.group.name)) %>
+<% if form_document.group.present? %>
+  <% content_for :back_link, govuk_back_link_to(group_path(form_document.group), t("back_link.group", group_name: form_document.group.name)) %>
 <% else %>
   <% content_for :back_link, govuk_back_link_to(root_path, t("back_link.forms")) %>
 <% end %>
@@ -9,84 +9,84 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-      <%= form.name %>
+      <%= form_document.name %>
     </h1>
     <%= render FormStatusTagDescriptionComponent::View.new(status: status) %>
 
-    <% metrics_data = CloudWatchService.new(form.id, form.made_live_date).metrics_data %>
-    <%= render MetricsSummaryComponent::View.new(form.made_live_date, metrics_data) %>
+    <% metrics_data = CloudWatchService.new(form_document.id, form_document.made_live_date).metrics_data %>
+    <%= render MetricsSummaryComponent::View.new(form_document.made_live_date, metrics_data) %>
 
     <h2 class="govuk-heading-l">Your form</h2>
 
     <p>
-      <%= render PreviewLinkComponent::View.new(form.pages, link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: preview_mode)) %>
+      <%= render PreviewLinkComponent::View.new(form_document.pages, link_to_runner(Settings.forms_runner.url, form_document.id, form_document.form_slug, mode: preview_mode)) %>
     </p>
 
     <% if status == :live %>
-      <%= render FormUrlComponent::View.new(runner_link: link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: :live))%>
+      <%= render FormUrlComponent::View.new(runner_link: link_to_runner(Settings.forms_runner.url, form_document.id, form_document.form_slug, mode: :live))%>
     <% else %>
       <h3 class="govuk-heading-m"><%= t('made_live_form.previous_form_url') %></h3>
       <p>
-        <%= link_to_runner(Settings.forms_runner.url, form.id, form.form_slug, mode: :live) %>
+        <%= link_to_runner(Settings.forms_runner.url, form_document.id, form_document.form_slug, mode: :live) %>
       </p>
     <% end %>
 
     <h3 class="govuk-heading-m"><%= t('made_live_form.questions') %></h3>
-    <p><%= govuk_link_to t('made_live_form.questions_link', count: form.pages.count), questions_path %></p>
+    <p><%= govuk_link_to t('made_live_form.questions_link', count: form_document.pages.count), questions_path %></p>
 
-    <% if form.declaration_text.present? %>
+    <% if form_document.declaration_text.present? %>
       <h3 class="govuk-heading-m"><%= t('made_live_form.declaration') %></h3>
-      <p><%= form.declaration_text %></p>
+      <p><%= form_document.declaration_text %></p>
       <%= govuk_details(summary_text: t('made_live_form.what_is_declaration'), text: t('made_live_form.declaration_description')) %>
     <% end %>
 
     <h3 class="govuk-heading-m"><%= t('made_live_form.what_happens_next') %></h3>
     <div class="app-preview-area">
-      <%= GovukFormsMarkdown.render(form.what_happens_next_markdown).html_safe %>
+      <%= GovukFormsMarkdown.render(form_document.what_happens_next_markdown).html_safe %>
     </div>
     <%= govuk_details(summary_text: t('made_live_form.what_is_what_happens_next'), text: t('made_live_form.what_happens_next_description')) %>
 
-    <% if form.respond_to?(:payment_url) && form.payment_url.present? %>
+    <% if form_document.respond_to?(:payment_url) && form_document.payment_url.present? %>
       <h3 class="govuk-heading-m"><%= t("made_live_form.payment_link") %></h3>
-      <p><%= govuk_link_to(form.payment_url, form.payment_url) %></p>
+      <p><%= govuk_link_to(form_document.payment_url, form_document.payment_url) %></p>
     <% end %>
 
     <h3 class="govuk-heading-m"><%= t("made_live_form.how_you_get_completed_forms") %></h3>
 
     <h4 class="govuk-heading-s"><%= t('made_live_form.submission_email') %></h4>
-    <p class="govuk-!-text-break-word"><%= form.submission_email %></p>
+    <p class="govuk-!-text-break-word"><%= form_document.submission_email %></p>
 
     <h4 class="govuk-heading-s"><%= t("made_live_form.csv") %></h4>
-    <p><%= t("made_live_form.submission_type.#{form.submission_type}") %></p>
+    <p><%= t("made_live_form.submission_type.#{form_document.submission_type}") %></p>
 
     <h3 class="govuk-heading-m"><%= t('made_live_form.privacy_policy_link') %></h3>
-    <p><%= govuk_link_to(form.privacy_policy_url, form.privacy_policy_url) %></p>
+    <p><%= govuk_link_to(form_document.privacy_policy_url, form_document.privacy_policy_url) %></p>
 
     <h3 class="govuk-heading-m"><%= t('made_live_form.contact_details') %></h3>
 
-    <% if form.support_email %>
+    <% if form_document.support_email %>
       <h4 class="govuk-heading-s"><%= t('made_live_form.support_email') %></h4>
-      <p class="govuk-!-text-break-word"><%= form.support_email %></p>
+      <p class="govuk-!-text-break-word"><%= form_document.support_email %></p>
     <% end %>
 
-    <% if form.support_phone %>
+    <% if form_document.support_phone %>
       <h4 class="govuk-heading-s"><%= t('made_live_form.support_phone') %></h4>
-      <p><%= form.support_phone %></p>
+      <p><%= form_document.support_phone %></p>
     <% end %>
 
-    <% if form.support_url %>
+    <% if form_document.support_url %>
       <h4 class="govuk-heading-s"><%= t('made_live_form.support_url') %></h4>
-      <p><%= govuk_link_to form.support_url_text, form.support_url %></p>
+      <p><%= govuk_link_to form_document.support_url_text, form_document.support_url %></p>
     <% end %>
 
     <div class="govuk-button-group">
       <%# i18n-tasks-use t('made_live_form.draft_create') %>
       <%# i18n-tasks-use t('made_live_form.draft_edit') %>
-      <%= govuk_button_link_to t("made_live_form.draft_#{ form_metadata.has_draft_version ? 'edit': 'create'}"), form_path(form.id) %>
+      <%= govuk_button_link_to t("made_live_form.draft_#{ form_metadata.has_draft_version ? 'edit': 'create'}"), form_path(form_document.id) %>
       <% if status == :live %>
-        <%= govuk_button_link_to t("made_live_form.archive_this_form"), archive_form_path(form.id), warning: true %>
+        <%= govuk_button_link_to t("made_live_form.archive_this_form"), archive_form_path(form_document.id), warning: true %>
       <% elsif status == :archived %>
-        <%= govuk_button_link_to t("made_live_form.make_this_form_live"), unarchive_path(form.id), secondary: true %>
+        <%= govuk_button_link_to t("made_live_form.make_this_form_live"), unarchive_path(form_document.id), secondary: true %>
       <% end %>
     </div>
   </div>

--- a/app/views/forms/_made_live_form_pages.html.erb
+++ b/app/views/forms/_made_live_form_pages.html.erb
@@ -11,8 +11,8 @@
 
     <%= render FormStatusTagDescriptionComponent::View.new(status: status) %>
 
-    <% form_document.pages.each_with_index do |page, index| %>
-      <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: form_document.pages).build_data)%>
+    <% form_document.steps.each_with_index do |page, index| %>
+      <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: form_document.steps).build_data)%>
     <% end %>
 
     <p>

--- a/app/views/forms/_made_live_form_pages.html.erb
+++ b/app/views/forms/_made_live_form_pages.html.erb
@@ -11,8 +11,8 @@
 
     <%= render FormStatusTagDescriptionComponent::View.new(status: status) %>
 
-    <% form_document.steps.each_with_index do |page, index| %>
-      <%= govuk_summary_list(**StepSummaryCardPresenter.call(page:, pages: form_document.steps).build_data)%>
+    <% form_document.steps.each_with_index do |step, index| %>
+      <%= govuk_summary_list(**StepSummaryCardPresenter.call(step:, steps: form_document.steps).build_data)%>
     <% end %>
 
     <p>

--- a/app/views/forms/_made_live_form_pages.html.erb
+++ b/app/views/forms/_made_live_form_pages.html.erb
@@ -12,7 +12,7 @@
     <%= render FormStatusTagDescriptionComponent::View.new(status: status) %>
 
     <% form_document.steps.each_with_index do |page, index| %>
-      <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: form_document.steps).build_data)%>
+      <%= govuk_summary_list(**StepSummaryCardPresenter.call(page:, pages: form_document.steps).build_data)%>
     <% end %>
 
     <p>

--- a/app/views/forms/_made_live_form_pages.html.erb
+++ b/app/views/forms/_made_live_form_pages.html.erb
@@ -1,18 +1,18 @@
-<% set_page_title(form.name) %>
+<% set_page_title(form_document.name) %>
 
 <% content_for :back_link, govuk_back_link_to(show_form_path, t("back_link.form_view")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-      <span class="govuk-caption-l"><%= form.name %></span><span class="govuk-visually-hidden"> - </span>
+      <span class="govuk-caption-l"><%= form_document.name %></span><span class="govuk-visually-hidden"> - </span>
       <%= t("forms.form_overview.your_questions") %>
     </h1>
 
     <%= render FormStatusTagDescriptionComponent::View.new(status: status) %>
 
-    <% form.pages.each_with_index do |page, index| %>
-      <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: form.pages).build_data)%>
+    <% form_document.pages.each_with_index do |page, index| %>
+      <%= govuk_summary_list(**PageSummaryCardDataService.call(page:, pages: form_document.pages).build_data)%>
     <% end %>
 
     <p>

--- a/app/views/forms/archived/show_form.html.erb
+++ b/app/views/forms/archived/show_form.html.erb
@@ -1,6 +1,6 @@
-<%= render partial: 'forms/made_live_form', locals: { form:,
+<%= render partial: 'forms/made_live_form', locals: { form_document:,
                                              form_metadata:,
                                              status: :archived,
                                              preview_mode: :preview_archived,
-                                             questions_path: archived_form_pages_path(form.id),
+                                             questions_path: archived_form_pages_path(form_document.id),
 } %>

--- a/app/views/forms/archived/show_pages.html.erb
+++ b/app/views/forms/archived/show_pages.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'forms/made_live_form_pages', locals: { form:,
+<%= render partial: 'forms/made_live_form_pages', locals: { form_document:,
                                                             status: :archived,
-                                                            show_form_path: archived_form_path(form.id),
+                                                            show_form_path: archived_form_path(form_document.id),
 } %>

--- a/app/views/forms/live/show_form.html.erb
+++ b/app/views/forms/live/show_form.html.erb
@@ -1,6 +1,6 @@
-<%= render partial: 'forms/made_live_form', locals: { form:,
+<%= render partial: 'forms/made_live_form', locals: { form_document:,
                                              form_metadata:,
                                              status: :live,
                                              preview_mode: :preview_live,
-                                             questions_path: live_form_pages_path(form.id),
+                                             questions_path: live_form_pages_path(form_document.id),
 } %>

--- a/app/views/forms/live/show_pages.html.erb
+++ b/app/views/forms/live/show_pages.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'forms/made_live_form_pages', locals: { form:,
+<%= render partial: 'forms/made_live_form_pages', locals: { form_document:,
                                                             status: :live,
-                                                            show_form_path: live_form_path(form.id),
+                                                            show_form_path: live_form_path(form_document.id),
 } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1093,22 +1093,6 @@ en:
     route: Route
     secondary_skip_description: After %{check_page_question_text} go to %{goto_page_question_text}
     skip_condition_route_page_text: "%{route_page_question_number}, “%{route_page_question_text}”"
-  page_options_service:
-    answer_type: Answer type
-    date_type:
-      date_of_birth: Date of birth
-      other_date: Date
-    guidance_markdown: Guidance
-    hint_text: Hint text
-    name_type:
-      title_not_selected: Title not needed
-      title_selected: Title needed
-    options_title: Options
-    page_heading: Page heading
-    selection_type:
-      default: Selection from a list
-      none_of_the_above: None of the above
-      only_one_option: Selection from a list, one option only
   page_route_card:
     any_other_answer: Route for any other answer
     check_your_answers: Check your answers before submitting
@@ -1612,6 +1596,22 @@ en:
   skip_to_main_content: Skip to main content
   status_tag_description_component:
     status: Status
+  step_summary_card:
+    answer_type: Answer type
+    date_type:
+      date_of_birth: Date of birth
+      other_date: Date
+    guidance_markdown: Guidance
+    hint_text: Hint text
+    name_type:
+      title_not_selected: Title not needed
+      title_selected: Title needed
+    options_title: Options
+    page_heading: Page heading
+    selection_type:
+      default: Selection from a list
+      none_of_the_above: None of the above
+      only_one_option: Selection from a list, one option only
   task_statuses:
     cannot_start: Cannot start yet
     completed: Completed

--- a/spec/factories/models/form_document/form_document_steps.rb
+++ b/spec/factories/models/form_document/form_document_steps.rb
@@ -1,0 +1,46 @@
+FactoryBot.define do
+  factory :form_document_step, class: "FormDocument::Step" do
+    id { |n| n }
+    type { "question_page" }
+    position { |n| n }
+    next_step_id { nil }
+    data do
+      DataStruct.new({
+        is_optional:,
+        page_heading:,
+        question_text:,
+        answer_type:,
+        answer_settings:,
+        guidance_markdown:,
+      })
+    end
+
+    transient do
+      is_optional { false }
+      page_heading { nil }
+      question_text { Faker::Lorem.question.truncate(250) }
+      answer_type { Page::ANSWER_TYPES_WITHOUT_SETTINGS.sample }
+      answer_settings { nil }
+      guidance_markdown { nil }
+    end
+
+    trait :with_selection_settings do
+      transient do
+        only_one_option { "true" }
+        selection_options { [{ name: "Option 1" }, { name: "Option 2" }] }
+      end
+
+      answer_type { "selection" }
+      answer_settings { DataStruct.new(only_one_option:, selection_options:) }
+    end
+
+    trait :with_guidance do
+      page_heading { Faker::Quote.yoda.truncate(250) }
+      guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
+    end
+
+    trait :with_file_upload_answer_type do
+      answer_type { "file" }
+    end
+  end
+end

--- a/spec/factories/models/form_record.rb
+++ b/spec/factories/models/form_record.rb
@@ -70,6 +70,9 @@ FactoryBot.define do
     trait :live do
       ready_for_live
       state { :live }
+      after(:create) do |form|
+        FormDocument.create(form:, tag: "live", content: form.as_form_document(live_at: form.updated_at))
+      end
     end
 
     trait :live_with_draft do
@@ -78,12 +81,15 @@ FactoryBot.define do
     end
 
     trait :archived do
-      live
+      ready_for_live
       state { :archived }
+      after(:create) do |form|
+        FormDocument.create(form:, tag: "archived", content: form.as_form_document(live_at: form.updated_at))
+      end
     end
 
     trait :archived_with_draft do
-      live
+      archived
       state { :archived_with_draft }
     end
 

--- a/spec/features/form/archive_a_form_spec.rb
+++ b/spec/features/form/archive_a_form_spec.rb
@@ -3,13 +3,14 @@ require "rails_helper"
 feature "Archive a form", type: :feature do
   let(:form) { create(:form, :live) }
   let(:group) { create(:group, organisation: standard_user.organisation) }
-  let(:made_live_form) { build(:made_live_form, id: form.id, name: form.name) }
 
   before do
-    allow(FormRepository).to receive_messages(find: form, pages: form.pages, find_live: made_live_form, find_archived: made_live_form, archive!: {})
-
     GroupForm.create! group:, form_id: form.id
     create(:membership, group:, user: standard_user, added_by: standard_user)
+
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.post "/api/v1/forms/#{form.id}/archive", post_headers, {}, 200
+    end
 
     login_as standard_user
   end

--- a/spec/lib/tasks/form_documents.rake_spec.rb
+++ b/spec/lib/tasks/form_documents.rake_spec.rb
@@ -38,17 +38,19 @@ RSpec.describe "form_documents.rake" do
         expect(ApiFormDocumentService).to have_received(:form_document)
       end
 
-      it "creates a FormDocument for the form" do
-        expect {
-          task.invoke
-        }.to(change { FormDocument.exists?(form_id: live_form.id, tag: "live") })
+      context "when there is no FormDocument for the form" do
+        before do
+          live_form.live_form_document.destroy!
+        end
+
+        it "creates a FormDocument for the form" do
+          expect {
+            task.invoke
+          }.to(change { FormDocument.exists?(form_id: live_form.id, tag: "live") })
+        end
       end
 
       context "when there is already a live FormDocument for the form" do
-        before do
-          create :form_document, :live, form: live_form
-        end
-
         it "does not affect the existing FormDocument" do
           expect {
             task.invoke
@@ -69,17 +71,19 @@ RSpec.describe "form_documents.rake" do
         expect(ApiFormDocumentService).to have_received(:form_document)
       end
 
-      it "creates a FormDocument for the form" do
-        expect {
-          task.invoke
-        }.to(change { FormDocument.exists?(form_id: live_form.id, tag: "live") })
+      context "when there is no FormDocument for the form" do
+        before do
+          live_form.live_form_document.destroy!
+        end
+
+        it "creates a FormDocument for the form" do
+          expect {
+            task.invoke
+          }.to(change { FormDocument.exists?(form_id: live_form.id, tag: "live") })
+        end
       end
 
       context "when there is already a live FormDocument for the form" do
-        before do
-          create :form_document, :live, form: live_form
-        end
-
         it "does not affect the existing FormDocument" do
           expect {
             task.invoke
@@ -100,17 +104,19 @@ RSpec.describe "form_documents.rake" do
         expect(ApiFormDocumentService).to have_received(:form_document)
       end
 
-      it "creates a FormDocument for the form" do
-        expect {
-          task.invoke
-        }.to(change { FormDocument.exists?(form_id: archived_form.id, tag: "archived") })
-      end
-
-      context "when there is already a live FormDocument for the form" do
+      context "when there is no FormDocument for the form" do
         before do
-          create :form_document, :archived, form: archived_form
+          archived_form.archived_form_document.destroy!
         end
 
+        it "creates a FormDocument for the form" do
+          expect {
+            task.invoke
+          }.to(change { FormDocument.exists?(form_id: archived_form.id, tag: "archived") })
+        end
+      end
+
+      context "when there is already a archived FormDocument for the form" do
         it "does not affect the existing FormDocument" do
           expect {
             task.invoke
@@ -131,17 +137,19 @@ RSpec.describe "form_documents.rake" do
         expect(ApiFormDocumentService).to have_received(:form_document)
       end
 
-      it "creates a FormDocument for the form" do
-        expect {
-          task.invoke
-        }.to(change { FormDocument.exists?(form_id: archived_form.id, tag: "archived") })
-      end
-
-      context "when there is already a live FormDocument for the form" do
+      context "when there is no FormDocument for the form" do
         before do
-          create :form_document, :archived, form: archived_form
+          archived_form.archived_form_document.destroy!
         end
 
+        it "creates a FormDocument for the form" do
+          expect {
+            task.invoke
+          }.to(change { FormDocument.exists?(form_id: archived_form.id, tag: "archived") })
+        end
+      end
+
+      context "when there is already a archived FormDocument for the form" do
         it "does not affect the existing FormDocument" do
           expect {
             task.invoke

--- a/spec/models/form_document/content_spec.rb
+++ b/spec/models/form_document/content_spec.rb
@@ -50,4 +50,13 @@ RSpec.describe FormDocument::Content, type: :model do
       end
     end
   end
+
+  describe ".from_form_document" do
+    let(:form) { create :form, :live }
+    let(:form_document) { form.live_form_document }
+
+    it "creates a FormDocument::Content" do
+      expect(described_class.from_form_document(form_document)).to be_a(described_class)
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -160,6 +160,54 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "live_form_document" do
+    context "when there is no live form document" do
+      it "returns nil" do
+        expect(form.live_form_document).to be_nil
+      end
+    end
+
+    context "when there is a live form document" do
+      subject(:form) { create :form, :live }
+
+      it "returns the live form document" do
+        expect(form.live_form_document).to be_a(FormDocument)
+      end
+    end
+
+    context "when there only an archived form document" do
+      subject(:form) { create :form, :archived }
+
+      it "returns nil" do
+        expect(form.live_form_document).to be_nil
+      end
+    end
+  end
+
+  describe "archived_form_document" do
+    context "when there is no archived form document" do
+      it "returns nil" do
+        expect(form.archived_form_document).to be_nil
+      end
+    end
+
+    context "when there is an archived form document" do
+      subject(:form) { create :form, :archived }
+
+      it "returns nil" do
+        expect(form.archived_form_document).to be_a(FormDocument)
+      end
+    end
+
+    context "when there is only a live form document" do
+      subject(:form) { create :form, :live }
+
+      it "returns nil" do
+        expect(form.archived_form_document).to be_nil
+      end
+    end
+  end
+
   describe "FormStateMachine" do
     describe "#create_draft_from_live_form!" do
       let(:form) { create :form_record, :live }

--- a/spec/requests/forms/archived_controller_spec.rb
+++ b/spec/requests/forms/archived_controller_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::ArchivedController, type: :request do
-  let(:form) { create(:form, :live) }
-  let(:archived_form) { build(:made_live_form, id:) }
+  let(:form) { create(:form, :archived) }
   let(:id) { form.id }
 
   let(:group) { create(:group, organisation: standard_user.organisation) }
@@ -11,17 +10,11 @@ RSpec.describe Forms::ArchivedController, type: :request do
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
     GroupForm.create!(form_id: form.id, group_id: group.id)
     login_as_standard_user
-
-    allow(FormRepository).to receive_messages(find: form, find_archived: archived_form)
   end
 
   describe "#show_form" do
     before do
       get archived_form_path(id)
-    end
-
-    it "Reads the form" do
-      expect(FormRepository).to have_received(:find)
     end
 
     it "renders the show archived form template" do

--- a/spec/services/form_document_sync_service_spec.rb
+++ b/spec/services/form_document_sync_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FormDocumentSyncService do
 
   describe "#synchronize_form" do
     context "when form state is live" do
-      let(:form) { create(:form, :live) }
+      let(:form) { create(:form, state: "live") }
       let(:expected_live_at) { form.reload.updated_at.strftime("%Y-%m-%dT%H:%M:%S.%6NZ") }
 
       context "when there is no existing form document" do
@@ -56,7 +56,7 @@ RSpec.describe FormDocumentSyncService do
     end
 
     context "when form state is archived" do
-      let(:form) { create(:form, :archived) }
+      let(:form) { create(:form, state: "archived") }
 
       context "when there is no existing form document" do
         it "creates an archived form document" do

--- a/spec/services/form_repository_spec.rb
+++ b/spec/services/form_repository_spec.rb
@@ -243,8 +243,6 @@ describe FormRepository do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.post "/api/v1/forms/#{form.id}/archive", post_headers, archived_form_resource.to_json, 200
       end
-
-      create(:form_document, :live, form:)
     end
 
     describe "api" do

--- a/spec/services/page_options_service_spec.rb
+++ b/spec/services/page_options_service_spec.rb
@@ -5,7 +5,7 @@ describe PageOptionsService do
     described_class.new(page: form_document_step, pages: form_document_steps)
   end
 
-  let(:form_document_content) { FormDocument::Content.new(form.live_form_document.content) }
+  let(:form_document_content) { FormDocument::Content.from_form_document(form.live_form_document) }
   let(:form_document_steps) { form_document_content.steps }
   let(:form_document_step) { FormDocument::Step.new(page.as_form_document_step) }
 

--- a/spec/services/page_options_service_spec.rb
+++ b/spec/services/page_options_service_spec.rb
@@ -2,16 +2,20 @@ require "rails_helper"
 
 describe PageOptionsService do
   subject(:page_options_service) do
-    described_class.new(page:, pages:)
+    described_class.new(page: form_document_step, pages: form_document_steps)
   end
 
-  let(:pages) do
-    [page, (build :made_live_page, id: 2), (build :made_live_page, id: 3), (build :made_live_page, id: 4)]
-  end
+  let(:form_document_content) { FormDocument::Content.new(form.live_form_document.content) }
+  let(:form_document_steps) { form_document_content.steps }
+  let(:form_document_step) { FormDocument::Step.new(page.as_form_document_step) }
+
+  let(:form) { create :form, :live }
+
+  let(:pages) { form.pages }
 
   describe "#all_options_for_answer_type" do
     context "with uk and international address" do
-      let(:page) { build :made_live_page, :with_address_settings, uk_address: "true", international_address: "true", routing_conditions: [] }
+      let(:page) { create :page, :with_address_settings, form:, uk_address: "true", international_address: "true" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq(
@@ -22,7 +26,7 @@ describe PageOptionsService do
     end
 
     context "with international address only" do
-      let(:page) { build :made_live_page, :with_address_settings, uk_address: "false", international_address: "true" }
+      let(:page) { create :page, :with_address_settings, form:, uk_address: "false", international_address: "true" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq(
@@ -33,7 +37,7 @@ describe PageOptionsService do
     end
 
     context "with uk address" do
-      let(:page) { build :made_live_page, :with_address_settings, international_address: "false" }
+      let(:page) { create :page, :with_address_settings, form:, international_address: "false" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq(
@@ -44,7 +48,7 @@ describe PageOptionsService do
     end
 
     context "with address and not international or UK" do
-      let(:page) { build :made_live_page, :with_address_settings, uk_address: "false", international_address: "false" }
+      let(:page) { create :page, :with_address_settings, form:, uk_address: "false", international_address: "false" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq(
@@ -55,7 +59,7 @@ describe PageOptionsService do
     end
 
     context "with date of birth" do
-      let(:page) { build :made_live_page, :with_date_settings, input_type: "date_of_birth" }
+      let(:page) { create :page, :with_date_settings, form:, input_type: "date_of_birth" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
@@ -66,7 +70,7 @@ describe PageOptionsService do
     end
 
     context "with date other_date" do
-      let(:page) { build :made_live_page, :with_date_settings, input_type: "other_date" }
+      let(:page) { create :page, :with_date_settings, form:, input_type: "other_date" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
@@ -77,7 +81,7 @@ describe PageOptionsService do
     end
 
     context "with short text" do
-      let(:page) { build :made_live_page, :with_text_settings, input_type: "single_line" }
+      let(:page) { create :page, :with_text_settings, form:, input_type: "single_line" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
@@ -88,7 +92,7 @@ describe PageOptionsService do
     end
 
     context "with long text" do
-      let(:page) { build :made_live_page, :with_text_settings, input_type: "long_text" }
+      let(:page) { create :page, :with_text_settings, form:, input_type: "long_text" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
@@ -100,12 +104,13 @@ describe PageOptionsService do
 
     context "with selection" do
       let(:page) do
-        build :made_live_page,
-              is_optional: "false",
-              answer_type: "selection",
-              answer_settings: OpenStruct.new(only_one_option: "true",
-                                              selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
-                                                                  OpenStruct.new(attributes: { name: "Option 2" })])
+        create :page,
+               form:,
+               is_optional: "false",
+               answer_type: "selection",
+               answer_settings: DataStruct.new(only_one_option: "true",
+                                               selection_options: [DataStruct.new({ name: "Option 1" }),
+                                                                   DataStruct.new({ name: "Option 2" })])
       end
 
       it "returns the correct options" do
@@ -118,12 +123,13 @@ describe PageOptionsService do
 
     context "with selection not only_one_option" do
       let(:page) do
-        build :made_live_page,
-              is_optional: "false",
-              answer_type: "selection",
-              answer_settings: OpenStruct.new(only_one_option: "false",
-                                              selection_options: [OpenStruct.new(attributes: { name: "Option 1" }),
-                                                                  OpenStruct.new(attributes: { name: "Option 2" })])
+        create :page,
+               form:,
+               is_optional: "false",
+               answer_type: "selection",
+               answer_settings: DataStruct.new(only_one_option: "false",
+                                               selection_options: [DataStruct.new({ name: "Option 1" }),
+                                                                   DataStruct.new({ name: "Option 2" })])
       end
 
       it "returns the correct options" do
@@ -136,12 +142,13 @@ describe PageOptionsService do
 
     context "with selection with more than ten options" do
       let(:option_names) { Array.new(11).each_with_index.map { |_element, index| "Option #{index}" } }
-      let(:selection_options) { option_names.map { |option| OpenStruct.new(attributes: { name: option }) } }
+      let(:selection_options) { option_names.map { |option| DataStruct.new({ name: option }) } }
       let(:page) do
-        build :made_live_page,
-              is_optional: "false",
-              answer_type: "selection",
-              answer_settings: OpenStruct.new(only_one_option: "false", selection_options:)
+        create :page,
+               form:,
+               is_optional: "false",
+               answer_type: "selection",
+               answer_settings: DataStruct.new(only_one_option: "false", selection_options:)
       end
 
       it "returns the options in a details component" do
@@ -161,7 +168,7 @@ describe PageOptionsService do
     end
 
     context "with full name, no title needed" do
-      let(:page) { build :made_live_page, :with_name_settings, input_type: "full_name", title_needed: "false" }
+      let(:page) { create :page, :with_name_settings, form:, input_type: "full_name", title_needed: "false" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
@@ -172,7 +179,7 @@ describe PageOptionsService do
     end
 
     context "with first_and_last_name, title needed" do
-      let(:page) { build :made_live_page, :with_name_settings, input_type: "first_and_last_name", title_needed: "true" }
+      let(:page) { create :page, :with_name_settings, form:, input_type: "first_and_last_name", title_needed: "true" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
@@ -183,7 +190,7 @@ describe PageOptionsService do
     end
 
     context "with first_middle_and_last_name, title no needed" do
-      let(:page) { build :made_live_page, :with_name_settings, input_type: "first_middle_and_last_name", title_needed: "false" }
+      let(:page) { create :page, :with_name_settings, form:, input_type: "first_middle_and_last_name", title_needed: "false" }
 
       it "returns the correct options" do
         expect(page_options_service.all_options_for_answer_type).to eq([
@@ -195,7 +202,7 @@ describe PageOptionsService do
 
     Page::ANSWER_TYPES_WITHOUT_SETTINGS.each do |answer_type|
       context "with #{answer_type}" do
-        let(:page) { build :made_live_page, answer_type: }
+        let(:page) { create :page, form:, answer_type: }
 
         it "returns the correct options" do
           expect(page_options_service.all_options_for_answer_type).to eq([
@@ -205,101 +212,117 @@ describe PageOptionsService do
       end
     end
 
+    context "with no condition" do
+      let(:page) { create :page, form:, answer_type: "email" }
+
+      it "does not include a route" do
+        expect(page_options_service.all_options_for_answer_type).not_to include(
+          { key: { text: I18n.t("page_conditions.route") } },
+        )
+      end
+    end
+
     context "with conditions" do
-      let(:page) { build :made_live_page, id: 1, answer_type: "email", routing_conditions: }
-      let(:condition_pointing_to_page_3) { build :made_live_condition, routing_page_id: 1, check_page_id: 1, answer_value: "Wales", goto_page_id: 3 } # rubocop:disable RSpec/IndexedLet
-      let(:condition_pointing_to_page_4) { build :made_live_condition, routing_page_id: 1, check_page_id: 1, answer_value: "England", goto_page_id: 4 } # rubocop:disable RSpec/IndexedLet
-      let(:routing_conditions) { nil }
-
-      context "with a legacy page that doesn't have routing conditions method" do
-        subject(:page_options_service) do
-          page_without_routing_conditions_method = page.dup.tap { |p| p.routing_conditions = nil }
-          described_class.new(page: page_without_routing_conditions_method, pages:)
-        end
-
-        it "returns the correct options" do
-          expect(page_options_service.all_options_for_answer_type).to include(
-            { key: { text: "Answer type" }, value: { text: "Email address" } },
-          )
-        end
-      end
-
-      context "with no condition" do
-        let(:routing_conditions) { [] }
-
-        it "returns the correct options" do
-          expect(page_options_service.all_options_for_answer_type).to include(
-            { key: { text: "Answer type" }, value: { text: "Email address" } },
-          )
-        end
-      end
+      let(:form) { create :form, :ready_for_live, :ready_for_routing }
+      let(:page) { form.pages.first }
 
       context "with a single condition" do
-        let(:routing_conditions) { [condition_pointing_to_page_3] }
+        let(:goto_page) { form.pages.third }
+
+        before do
+          create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: goto_page.id, answer_value: "Option 1"
+
+          page.reload
+          form.reload.make_live!
+        end
 
         it "returns the correct options" do
           expect(page_options_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
-              value: { text: I18n.t("page_conditions.condition_compact_html", answer_value: condition_pointing_to_page_3.answer_value, goto_page_question_number: 3, goto_page_question_text: pages[2].question_text) },
+              value: { text: I18n.t("page_conditions.condition_compact_html", answer_value: "Option 1", goto_page_question_number: goto_page.position, goto_page_question_text: goto_page.question_text) },
             },
           )
         end
       end
 
       context "with multiple conditions" do
-        let(:routing_conditions) { [condition_pointing_to_page_3, condition_pointing_to_page_4] }
+        let(:first_goto_page) { form.pages.third }
+        let(:second_goto_page) { form.pages.fourth }
+
+        before do
+          create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: first_goto_page.id, answer_value: "Option 1"
+          create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: second_goto_page.id, answer_value: "Option 2"
+
+          page.reload
+          form.reload.make_live!
+        end
 
         it "returns the correct options" do
+          first_condition_text = I18n.t("page_conditions.condition_compact_html", answer_value: "Option 1", goto_page_question_number: first_goto_page.position, goto_page_question_text: first_goto_page.question_text)
+          second_condition_text = I18n.t("page_conditions.condition_compact_html", answer_value: "Option 2", goto_page_question_number: second_goto_page.position, goto_page_question_text: second_goto_page.question_text)
+
           expect(page_options_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
-              value: { text: "<ol class=\"govuk-list govuk-list--number\"><li>#{I18n.t('page_conditions.condition_compact_html', answer_value: condition_pointing_to_page_3.answer_value, goto_page_question_number: 3, goto_page_question_text: pages[2].question_text)}</li><li>#{I18n.t('page_conditions.condition_compact_html', answer_value: condition_pointing_to_page_4.answer_value, goto_page_question_number: 4, goto_page_question_text: pages[3].question_text)}</li></ol>" },
+              value: { text: "<ol class=\"govuk-list govuk-list--number\"><li>#{first_condition_text}</li><li>#{second_condition_text}</li></ol>" },
             },
           )
         end
       end
 
       context "with a condition that points to the end of the form" do
-        let(:routing_conditions) { [condition] }
-        let(:answer_value) { "Wales" }
-        let(:condition) { build :made_live_condition, answer_value:, goto_page_id: nil, skip_to_end: true }
+        before do
+          create :condition, routing_page_id: page.id, check_page_id: page.id, skip_to_end: true, answer_value: "Option 1"
+
+          page.reload
+          form.reload.make_live!
+        end
 
         it "returns the correct options" do
           expect(page_options_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
-              value: { text: I18n.t("page_conditions.condition_compact_html_end_of_form", answer_value:) },
+              value: { text: I18n.t("page_conditions.condition_compact_html_end_of_form", answer_value: "Option 1") },
             },
           )
         end
       end
 
       context "with a secondary skip" do
-        let(:page) { build :made_live_page, routing_conditions: }
-        let(:skip_condition) { build :made_live_condition, routing_page_id: pages.third.id, goto_page_id: pages.fourth.id, check_page_id: page.id, skip_to_end: false }
+        let(:page) { form.pages.second }
+
+        before do
+          create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, goto_page_id: pages.third.id, answer_value: "Option 1"
+          create :condition, routing_page_id: page.id, check_page_id: pages.first.id, goto_page_id: pages.fourth.id
+
+          page.reload
+          form.reload.make_live!
+        end
 
         it "returns the correct options" do
-          page.routing_conditions = [skip_condition]
           expect(page_options_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
-              value: { text: I18n.t("page_conditions.condition_compact_html_secondary_skip", goto_page_question_number: 4, goto_page_question_text: pages.fourth.question_text) },
+              value: { text: I18n.t("page_conditions.condition_compact_html_secondary_skip", goto_page_question_number: pages.fourth.position, goto_page_question_text: pages.fourth.question_text) },
             },
           )
         end
       end
 
       context "with an exit page" do
-        let(:page) { build :made_live_page, routing_conditions: }
-        let(:exit_page_condition) { build :made_live_condition, routing_page_id: page.id, answer_value: "yes", goto_page_id: nil, check_page_id: page.id, exit_page_markdown: "Exit!", exit_page_heading: "You are not eligible" }
+        let!(:condition) { create :condition, :with_exit_page, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1" }
+
+        before do
+          page.reload
+          form.reload.make_live!
+        end
 
         it "returns the correct options" do
-          page.routing_conditions = [exit_page_condition]
           expect(page_options_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
-              value: { text: I18n.t("page_conditions.condition_compact_html_exit_page", answer_value: "yes", exit_page_heading: "You are not eligible") },
+              value: { text: I18n.t("page_conditions.condition_compact_html_exit_page", answer_value: condition.answer_value, exit_page_heading: condition.exit_page_heading) },
             },
           )
         end
@@ -307,7 +330,7 @@ describe PageOptionsService do
     end
 
     context "with guidance" do
-      let(:page) { build :made_live_page, :with_guidance }
+      let(:page) { create :page, :with_guidance, form: }
 
       it "returns the correct page heading" do
         expect(page_options_service.all_options_for_answer_type).to include(
@@ -324,11 +347,9 @@ describe PageOptionsService do
       end
 
       context "when page doesn't have a page_heading or guidance_markdown method defined" do
-        let(:page) do
-          build(:page).tap do |p|
-            p.attributes.delete(:page_heading)
-            p.attributes.delete(:guidance_markdown)
-          end
+        before do
+          form_document_step.data.delete_field(:page_heading)
+          form_document_step.data.delete_field(:guidance_markdown)
         end
 
         it "does not raise an error" do
@@ -351,7 +372,7 @@ describe PageOptionsService do
 
     context "with answer type of file" do
       context "when file upload question does not have a page heading" do
-        let(:page) { build :made_live_page, :with_file_upload_answer_type }
+        let(:page) { create :page, :with_file_upload_answer_type, form: }
 
         it "does not include the question text" do
           expect(page_options_service.all_options_for_answer_type).not_to include(
@@ -362,7 +383,7 @@ describe PageOptionsService do
       end
 
       context "when file upload question contains guidance text" do
-        let(:page) { build :made_live_page, :with_guidance, :with_file_upload_answer_type }
+        let(:page) { create :page, :with_guidance, :with_file_upload_answer_type, form: }
 
         it "returns question text" do
           expect(page_options_service.all_options_for_answer_type).to include(

--- a/spec/services/page_summary_card_data_service_spec.rb
+++ b/spec/services/page_summary_card_data_service_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 describe PageSummaryCardDataService do
-  let(:page) { build :made_live_page, is_optional: }
+  let(:page) { build :form_document_step, is_optional: }
   let(:is_optional) { false }
   let(:pages) do
-    [page, *build_list(:made_live_page, 5)]
+    [page, *build_list(:form_document_step, 5)]
   end
   let(:service) { described_class.call(page:, pages:) }
 
@@ -22,7 +22,7 @@ describe PageSummaryCardDataService do
     end
 
     context "when the page is a selection question" do
-      let(:page) { build :made_live_page, :with_selection_settings, is_optional: }
+      let(:page) { build :form_document_step, :with_selection_settings, is_optional: }
 
       it "includes a title without (optional) added to it" do
         expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
@@ -37,7 +37,7 @@ describe PageSummaryCardDataService do
       end
 
       context "when the page is a selection question" do
-        let(:page) { build :made_live_page, :with_selection_settings, is_optional: }
+        let(:page) { build :form_document_step, :with_selection_settings, is_optional: }
 
         it "includes a title without (optional) added to it" do
           expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
@@ -53,7 +53,7 @@ describe PageSummaryCardDataService do
       end
 
       context "when the page is a selection question" do
-        let(:page) { build :made_live_page, :with_selection_settings, is_optional: }
+        let(:page) { build :form_document_step, :with_selection_settings, is_optional: }
 
         it "includes a title without (optional) added to it" do
           expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
@@ -62,7 +62,7 @@ describe PageSummaryCardDataService do
     end
 
     context "when file upload question contains guidance text" do
-      let(:page) { build :made_live_page, :with_guidance, :with_file_upload_answer_type, is_optional: }
+      let(:page) { build :form_document_step, :with_guidance, :with_file_upload_answer_type, is_optional: }
 
       it "includes the guidance text page heading as title" do
         expect(service.build_data[:card][:title]).to eq "1. #{page.page_heading}"

--- a/spec/services/step_summary_card_presenter_spec.rb
+++ b/spec/services/step_summary_card_presenter_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
-describe PageSummaryCardDataService do
+describe StepSummaryCardPresenter do
   let(:page) { build :form_document_step, is_optional: }
   let(:is_optional) { false }
   let(:pages) do
     [page, *build_list(:form_document_step, 5)]
   end
-  let(:service) { described_class.call(page:, pages:) }
+  let(:presenter) { described_class.call(page:, pages:) }
 
   describe "#build_data" do
     before do
@@ -14,18 +14,18 @@ describe PageSummaryCardDataService do
     end
 
     it "includes a title" do
-      expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
+      expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
     end
 
     it "includes an array of rows" do
-      expect(service.build_data[:rows]).to eq [1, 2]
+      expect(presenter.build_data[:rows]).to eq [1, 2]
     end
 
     context "when the page is a selection question" do
       let(:page) { build :form_document_step, :with_selection_settings, is_optional: }
 
       it "includes a title without (optional) added to it" do
-        expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
+        expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
       end
     end
 
@@ -33,14 +33,14 @@ describe PageSummaryCardDataService do
       let(:is_optional) { "true" }
 
       it "includes a title with (optional) added to it" do
-        expect(service.build_data[:card][:title]).to eq "1. #{page.question_text} (optional)"
+        expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text} (optional)"
       end
 
       context "when the page is a selection question" do
         let(:page) { build :form_document_step, :with_selection_settings, is_optional: }
 
         it "includes a title without (optional) added to it" do
-          expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
+          expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
         end
       end
     end
@@ -49,14 +49,14 @@ describe PageSummaryCardDataService do
       let(:is_optional) { nil }
 
       it "includes a title" do
-        expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
+        expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
       end
 
       context "when the page is a selection question" do
         let(:page) { build :form_document_step, :with_selection_settings, is_optional: }
 
         it "includes a title without (optional) added to it" do
-          expect(service.build_data[:card][:title]).to eq "1. #{page.question_text}"
+          expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
         end
       end
     end
@@ -65,14 +65,14 @@ describe PageSummaryCardDataService do
       let(:page) { build :form_document_step, :with_guidance, :with_file_upload_answer_type, is_optional: }
 
       it "includes the guidance text page heading as title" do
-        expect(service.build_data[:card][:title]).to eq "1. #{page.page_heading}"
+        expect(presenter.build_data[:card][:title]).to eq "1. #{page.page_heading}"
       end
 
       context "when the question is optional" do
         let(:is_optional) { "true" }
 
         it "includes a title with (optional) added to it" do
-          expect(service.build_data[:card][:title]).to eq "1. #{page.page_heading} (optional)"
+          expect(presenter.build_data[:card][:title]).to eq "1. #{page.page_heading} (optional)"
         end
       end
     end

--- a/spec/services/step_summary_card_presenter_spec.rb
+++ b/spec/services/step_summary_card_presenter_spec.rb
@@ -10,7 +10,7 @@ describe StepSummaryCardPresenter do
 
   describe "#build_data" do
     before do
-      allow(PageOptionsService).to receive(:call).and_return(OpenStruct.new(all_options_for_answer_type: [1, 2]))
+      allow(StepSummaryCardService).to receive(:call).and_return(OpenStruct.new(all_options_for_answer_type: [1, 2]))
     end
 
     it "includes a title" do

--- a/spec/services/step_summary_card_presenter_spec.rb
+++ b/spec/services/step_summary_card_presenter_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 describe StepSummaryCardPresenter do
-  let(:page) { build :form_document_step, is_optional: }
+  let(:step) { build :form_document_step, is_optional: }
   let(:is_optional) { false }
-  let(:pages) do
-    [page, *build_list(:form_document_step, 5)]
+  let(:steps) do
+    [step, *build_list(:form_document_step, 5)]
   end
-  let(:presenter) { described_class.call(page:, pages:) }
+  let(:presenter) { described_class.call(step:, steps:) }
 
   describe "#build_data" do
     before do
@@ -14,18 +14,18 @@ describe StepSummaryCardPresenter do
     end
 
     it "includes a title" do
-      expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
+      expect(presenter.build_data[:card][:title]).to eq "1. #{step.question_text}"
     end
 
     it "includes an array of rows" do
       expect(presenter.build_data[:rows]).to eq [1, 2]
     end
 
-    context "when the page is a selection question" do
-      let(:page) { build :form_document_step, :with_selection_settings, is_optional: }
+    context "when the step is a selection question" do
+      let(:step) { build :form_document_step, :with_selection_settings, is_optional: }
 
       it "includes a title without (optional) added to it" do
-        expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
+        expect(presenter.build_data[:card][:title]).to eq "1. #{step.question_text}"
       end
     end
 
@@ -33,14 +33,14 @@ describe StepSummaryCardPresenter do
       let(:is_optional) { "true" }
 
       it "includes a title with (optional) added to it" do
-        expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text} (optional)"
+        expect(presenter.build_data[:card][:title]).to eq "1. #{step.question_text} (optional)"
       end
 
-      context "when the page is a selection question" do
-        let(:page) { build :form_document_step, :with_selection_settings, is_optional: }
+      context "when the step is a selection question" do
+        let(:step) { build :form_document_step, :with_selection_settings, is_optional: }
 
         it "includes a title without (optional) added to it" do
-          expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
+          expect(presenter.build_data[:card][:title]).to eq "1. #{step.question_text}"
         end
       end
     end
@@ -49,30 +49,30 @@ describe StepSummaryCardPresenter do
       let(:is_optional) { nil }
 
       it "includes a title" do
-        expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
+        expect(presenter.build_data[:card][:title]).to eq "1. #{step.question_text}"
       end
 
-      context "when the page is a selection question" do
-        let(:page) { build :form_document_step, :with_selection_settings, is_optional: }
+      context "when the step is a selection question" do
+        let(:step) { build :form_document_step, :with_selection_settings, is_optional: }
 
         it "includes a title without (optional) added to it" do
-          expect(presenter.build_data[:card][:title]).to eq "1. #{page.question_text}"
+          expect(presenter.build_data[:card][:title]).to eq "1. #{step.question_text}"
         end
       end
     end
 
     context "when file upload question contains guidance text" do
-      let(:page) { build :form_document_step, :with_guidance, :with_file_upload_answer_type, is_optional: }
+      let(:step) { build :form_document_step, :with_guidance, :with_file_upload_answer_type, is_optional: }
 
       it "includes the guidance text page heading as title" do
-        expect(presenter.build_data[:card][:title]).to eq "1. #{page.page_heading}"
+        expect(presenter.build_data[:card][:title]).to eq "1. #{step.page_heading}"
       end
 
       context "when the question is optional" do
         let(:is_optional) { "true" }
 
         it "includes a title with (optional) added to it" do
-          expect(presenter.build_data[:card][:title]).to eq "1. #{page.page_heading} (optional)"
+          expect(presenter.build_data[:card][:title]).to eq "1. #{step.page_heading} (optional)"
         end
       end
     end

--- a/spec/services/step_summary_card_service_spec.rb
+++ b/spec/services/step_summary_card_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe StepSummaryCardService do
   subject(:step_summary_card_service) do
-    described_class.new(page: form_document_step, pages: form_document_steps)
+    described_class.new(step: form_document_step, steps: form_document_steps)
   end
 
   let(:form_document_content) { FormDocument::Content.from_form_document(form.live_form_document) }

--- a/spec/services/step_summary_card_service_spec.rb
+++ b/spec/services/step_summary_card_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-describe PageOptionsService do
-  subject(:page_options_service) do
+describe StepSummaryCardService do
+  subject(:step_summary_card_service) do
     described_class.new(page: form_document_step, pages: form_document_steps)
   end
 
@@ -18,7 +18,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_address_settings, form:, uk_address: "true", international_address: "true" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq(
+        expect(step_summary_card_service.all_options_for_answer_type).to eq(
           [{ key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
              value: { text: I18n.t("helpers.label.page.address_settings_options.names.uk_and_international_addresses") } }],
         )
@@ -29,7 +29,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_address_settings, form:, uk_address: "false", international_address: "true" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq(
+        expect(step_summary_card_service.all_options_for_answer_type).to eq(
           [{ key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
              value: { text: I18n.t("helpers.label.page.address_settings_options.names.international_addresses") } }],
         )
@@ -40,7 +40,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_address_settings, form:, international_address: "false" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq(
+        expect(step_summary_card_service.all_options_for_answer_type).to eq(
           [{ key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
              value: { text: I18n.t("helpers.label.page.address_settings_options.names.uk_addresses") } }],
         )
@@ -51,7 +51,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_address_settings, form:, uk_address: "false", international_address: "false" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq(
+        expect(step_summary_card_service.all_options_for_answer_type).to eq(
           [{ key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
              value: { text: I18n.t("helpers.label.page.address_settings_options.names.international_addresses") } }],
         )
@@ -62,7 +62,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_date_settings, form:, input_type: "date_of_birth" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
             value: { text: "Date of birth" } },
         ])
@@ -73,7 +73,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_date_settings, form:, input_type: "other_date" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
             value: { text: "Date" } },
         ])
@@ -84,7 +84,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_text_settings, form:, input_type: "single_line" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
             value: { text: I18n.t("helpers.label.page.text_settings_options.names.single_line") } },
         ])
@@ -95,7 +95,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_text_settings, form:, input_type: "long_text" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
             value: { text: I18n.t("helpers.label.page.text_settings_options.names.long_text") } },
         ])
@@ -114,9 +114,9 @@ describe PageOptionsService do
       end
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list, one option only" } },
-          { key: { text: I18n.t("page_options_service.options_title") }, value: { text: "<p class=\"govuk-body-s\">2 options:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Option 1</li><li>Option 2</li></ul>" } },
+          { key: { text: I18n.t("step_summary_card.options_title") }, value: { text: "<p class=\"govuk-body-s\">2 options:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Option 1</li><li>Option 2</li></ul>" } },
         ])
       end
     end
@@ -133,7 +133,7 @@ describe PageOptionsService do
       end
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list" } },
           { key: { text: "Options" }, value: { text: "<p class=\"govuk-body-s\">2 options:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Option 1</li><li>Option 2</li></ul>" } },
         ])
@@ -160,7 +160,7 @@ describe PageOptionsService do
           "#{expected_list_items}" \
           "</ul></div></details>"
 
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: "Selection from a list" } },
           { key: { text: "Options" }, value: { text: expected_options_html } },
         ])
@@ -171,7 +171,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_name_settings, form:, input_type: "full_name", title_needed: "false" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
             value: { text: "<ul class=\"govuk-list\"><li>Person’s name</li><li>Full name in a single box</li><li>Title not needed</li></ul>" } },
         ])
@@ -182,7 +182,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_name_settings, form:, input_type: "first_and_last_name", title_needed: "true" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
             value: { text: "<ul class=\"govuk-list\"><li>Person’s name</li><li>First and last names in separate boxes</li><li>Title needed</li></ul>" } },
         ])
@@ -193,7 +193,7 @@ describe PageOptionsService do
       let(:page) { create :page, :with_name_settings, form:, input_type: "first_middle_and_last_name", title_needed: "false" }
 
       it "returns the correct options" do
-        expect(page_options_service.all_options_for_answer_type).to eq([
+        expect(step_summary_card_service.all_options_for_answer_type).to eq([
           { key: { text: I18n.t("helpers.label.page.answer_type_options.title") },
             value: { text: "<ul class=\"govuk-list\"><li>Person’s name</li><li>First, middle and last names in separate boxes</li><li>Title not needed</li></ul>" } },
         ])
@@ -205,7 +205,7 @@ describe PageOptionsService do
         let(:page) { create :page, form:, answer_type: }
 
         it "returns the correct options" do
-          expect(page_options_service.all_options_for_answer_type).to eq([
+          expect(step_summary_card_service.all_options_for_answer_type).to eq([
             { key: { text: I18n.t("helpers.label.page.answer_type_options.title") }, value: { text: I18n.t("helpers.label.page.answer_type_options.names.#{answer_type}") } },
           ])
         end
@@ -216,7 +216,7 @@ describe PageOptionsService do
       let(:page) { create :page, form:, answer_type: "email" }
 
       it "does not include a route" do
-        expect(page_options_service.all_options_for_answer_type).not_to include(
+        expect(step_summary_card_service.all_options_for_answer_type).not_to include(
           { key: { text: I18n.t("page_conditions.route") } },
         )
       end
@@ -237,7 +237,7 @@ describe PageOptionsService do
         end
 
         it "returns the correct options" do
-          expect(page_options_service.all_options_for_answer_type).to include(
+          expect(step_summary_card_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
               value: { text: I18n.t("page_conditions.condition_compact_html", answer_value: "Option 1", goto_page_question_number: goto_page.position, goto_page_question_text: goto_page.question_text) },
@@ -262,7 +262,7 @@ describe PageOptionsService do
           first_condition_text = I18n.t("page_conditions.condition_compact_html", answer_value: "Option 1", goto_page_question_number: first_goto_page.position, goto_page_question_text: first_goto_page.question_text)
           second_condition_text = I18n.t("page_conditions.condition_compact_html", answer_value: "Option 2", goto_page_question_number: second_goto_page.position, goto_page_question_text: second_goto_page.question_text)
 
-          expect(page_options_service.all_options_for_answer_type).to include(
+          expect(step_summary_card_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
               value: { text: "<ol class=\"govuk-list govuk-list--number\"><li>#{first_condition_text}</li><li>#{second_condition_text}</li></ol>" },
@@ -280,7 +280,7 @@ describe PageOptionsService do
         end
 
         it "returns the correct options" do
-          expect(page_options_service.all_options_for_answer_type).to include(
+          expect(step_summary_card_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
               value: { text: I18n.t("page_conditions.condition_compact_html_end_of_form", answer_value: "Option 1") },
@@ -301,7 +301,7 @@ describe PageOptionsService do
         end
 
         it "returns the correct options" do
-          expect(page_options_service.all_options_for_answer_type).to include(
+          expect(step_summary_card_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
               value: { text: I18n.t("page_conditions.condition_compact_html_secondary_skip", goto_page_question_number: pages.fourth.position, goto_page_question_text: pages.fourth.question_text) },
@@ -319,7 +319,7 @@ describe PageOptionsService do
         end
 
         it "returns the correct options" do
-          expect(page_options_service.all_options_for_answer_type).to include(
+          expect(step_summary_card_service.all_options_for_answer_type).to include(
             {
               key: { text: I18n.t("page_conditions.route") },
               value: { text: I18n.t("page_conditions.condition_compact_html_exit_page", answer_value: condition.answer_value, exit_page_heading: condition.exit_page_heading) },
@@ -333,15 +333,15 @@ describe PageOptionsService do
       let(:page) { create :page, :with_guidance, form: }
 
       it "returns the correct page heading" do
-        expect(page_options_service.all_options_for_answer_type).to include(
-          { key: { text: I18n.t("page_options_service.page_heading") },
+        expect(step_summary_card_service.all_options_for_answer_type).to include(
+          { key: { text: I18n.t("step_summary_card.page_heading") },
             value: { text: page.page_heading } },
         )
       end
 
       it "returns the correct guidance markdown" do
-        expect(page_options_service.all_options_for_answer_type).to include(
-          { key: { text: I18n.t("page_options_service.guidance_markdown") },
+        expect(step_summary_card_service.all_options_for_answer_type).to include(
+          { key: { text: I18n.t("step_summary_card.guidance_markdown") },
             value: { text: "<pre class=\"app-markdown-editor__markdown-example-block\">#{page.guidance_markdown}</pre>" } },
         )
       end
@@ -353,18 +353,18 @@ describe PageOptionsService do
         end
 
         it "does not raise an error" do
-          expect { page_options_service.all_options_for_answer_type }.not_to raise_error
+          expect { step_summary_card_service.all_options_for_answer_type }.not_to raise_error
         end
 
         it "does not return a page heading key" do
-          expect(page_options_service.all_options_for_answer_type).not_to include(
-            { key: { text: I18n.t("page_options_service.page_heading") } },
+          expect(step_summary_card_service.all_options_for_answer_type).not_to include(
+            { key: { text: I18n.t("step_summary_card.page_heading") } },
           )
         end
 
         it "does not return a guidance markdown key" do
-          expect(page_options_service.all_options_for_answer_type).not_to include(
-            { key: { text: I18n.t("page_options_service.guidance_markdown") } },
+          expect(step_summary_card_service.all_options_for_answer_type).not_to include(
+            { key: { text: I18n.t("step_summary_card.guidance_markdown") } },
           )
         end
       end
@@ -375,7 +375,7 @@ describe PageOptionsService do
         let(:page) { create :page, :with_file_upload_answer_type, form: }
 
         it "does not include the question text" do
-          expect(page_options_service.all_options_for_answer_type).not_to include(
+          expect(step_summary_card_service.all_options_for_answer_type).not_to include(
             { key: { text: I18n.t("reports.form_or_questions_list_table.headings.question_text") },
               value: { text: page.question_text } },
           )
@@ -386,15 +386,15 @@ describe PageOptionsService do
         let(:page) { create :page, :with_guidance, :with_file_upload_answer_type, form: }
 
         it "returns question text" do
-          expect(page_options_service.all_options_for_answer_type).to include(
+          expect(step_summary_card_service.all_options_for_answer_type).to include(
             { key: { text: I18n.t("reports.form_or_questions_list_table.headings.question_text") },
               value: { text: page.question_text } },
           )
         end
 
         it "does not return page heading" do
-          expect(page_options_service.all_options_for_answer_type).not_to include(
-            { key: { text: I18n.t("page_options_service.page_heading") } },
+          expect(step_summary_card_service.all_options_for_answer_type).not_to include(
+            { key: { text: I18n.t("step_summary_card.page_heading") } },
           )
         end
       end

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -1,11 +1,15 @@
 require "rails_helper"
 
 describe "forms/_made_live_form.html.erb" do
-  let(:declaration) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
+  let(:declaration_text) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:metrics_data) { { weekly_submissions: 125, weekly_starts: 256 } }
-  let(:what_happens_next) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
-  let(:form_metadata) { create :form, :live }
-  let(:form) { build(:made_live_form, id: form_metadata.id, declaration_text: declaration, what_happens_next_markdown: what_happens_next, live_at: 1.week.ago, submission_type:) }
+  let(:what_happens_next_markdown) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
+  let(:form_metadata) { create :form, :live, declaration_text:, what_happens_next_markdown:, submission_type: }
+  let(:form_document) do
+    form_document_content = FormDocument::Content.new(form_metadata.live_form_document.content)
+    form_document_content.live_at = 1.week.ago
+    form_document_content
+  end
   let(:group) { create(:group, name: "Group 1") }
   let(:status) { :live }
   let(:preview_mode) { :preview_live }
@@ -17,12 +21,12 @@ describe "forms/_made_live_form.html.erb" do
     allow(CloudWatchService).to receive(:new).and_return(cloudwatch_service)
 
     if group.present?
-      GroupForm.create!(form_id: form.id, group_id: group.id)
+      GroupForm.create!(form_id: form_document.id, group_id: group.id)
     end
 
     render(partial: "forms/made_live_form", locals: {
       form_metadata:,
-      form_document: form,
+      form_document:,
       status:,
       preview_mode:,
       questions_path:,
@@ -30,7 +34,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   it "has the correct title" do
-    expect(view.content_for(:title)).to have_content(form.name.to_s)
+    expect(view.content_for(:title)).to have_content(form_document.name.to_s)
   end
 
   it "back link is set to group page" do
@@ -38,7 +42,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   it "contains page heading" do
-    expect(rendered).to have_css("h1.govuk-heading-xl", text: form.name)
+    expect(rendered).to have_css("h1.govuk-heading-xl", text: form_document.name)
   end
 
   describe "form status tag" do
@@ -60,7 +64,7 @@ describe "forms/_made_live_form.html.erb" do
   describe "the link to the preview form" do
     context "when the form is live" do
       it "contains a link to preview the form" do
-        expect(rendered).to have_link(t("home.preview"), href: "runner-host/preview-live/#{form.id}/#{form.form_slug}", visible: :all)
+        expect(rendered).to have_link(t("home.preview"), href: "runner-host/preview-live/#{form_document.id}/#{form_document.form_slug}", visible: :all)
       end
     end
 
@@ -68,7 +72,7 @@ describe "forms/_made_live_form.html.erb" do
       let(:preview_mode) { :preview_archived }
 
       it "contains a link to preview the archived form" do
-        expect(rendered).to have_link(t("home.preview"), href: "runner-host/preview-archived/#{form.id}/#{form.form_slug}", visible: :all)
+        expect(rendered).to have_link(t("home.preview"), href: "runner-host/preview-archived/#{form_document.id}/#{form_document.form_slug}", visible: :all)
       end
     end
   end
@@ -80,7 +84,7 @@ describe "forms/_made_live_form.html.erb" do
       end
 
       it "contains a link to the form in the runner" do
-        expect(rendered).to have_content("runner-host/form/#{form.id}/#{form.form_slug}")
+        expect(rendered).to have_content("runner-host/form/#{form_document.id}/#{form_document.form_slug}")
       end
     end
 
@@ -92,17 +96,17 @@ describe "forms/_made_live_form.html.erb" do
       end
 
       it "contains a link to the form in the runner" do
-        expect(rendered).to have_content("runner-host/form/#{form.id}/#{form.form_slug}")
+        expect(rendered).to have_content("runner-host/form/#{form_document.id}/#{form_document.form_slug}")
       end
     end
   end
 
   it "contains a link to view questions" do
-    expect(rendered).to have_link("#{form.pages.count} questions", href: questions_path)
+    expect(rendered).to have_link("#{form_document.steps.count} questions", href: questions_path)
   end
 
   context "with only a single question" do
-    let(:form) { build(:made_live_form, :with_one_page, id: form_metadata.id) }
+    let(:form_metadata) { create :form, :live, pages_count: 1 }
 
     it "contains a link to view questions with correct pluralization" do
       expect(rendered).to have_link("1 question", href: questions_path)
@@ -111,11 +115,11 @@ describe "forms/_made_live_form.html.erb" do
 
   it "contains declaration" do
     expect(rendered).to have_css("h3", text: "Declaration")
-    expect(rendered).to have_content(form.declaration_text)
+    expect(rendered).to have_content(declaration_text)
   end
 
   context "with no declaration set" do
-    let(:declaration) { nil }
+    let(:declaration_text) { nil }
 
     it "does not include declaration" do
       expect(rendered).not_to have_css("h3", text: "Declaration")
@@ -123,13 +127,13 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   it "contains what happens next text" do
-    expect(rendered).to have_content(form.what_happens_next_markdown)
+    expect(rendered).to have_content(what_happens_next_markdown)
   end
 
   it "contains information about how you get completed forms" do
     expect(rendered).to have_css("h3", text: I18n.t("made_live_form.how_you_get_completed_forms"))
     expect(rendered).to have_xpath("//h3[text()='#{I18n.t('made_live_form.how_you_get_completed_forms')}']/following-sibling::h4", text: "Email")
-    expect(rendered).to have_text(form.submission_email)
+    expect(rendered).to have_text(form_document.submission_email)
   end
 
   context "when CSV submission is enabled" do
@@ -153,11 +157,11 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   it "contains link to privacy policy" do
-    expect(rendered).to have_link(form.privacy_policy_url, href: form.privacy_policy_url)
+    expect(rendered).to have_link(form_document.privacy_policy_url, href: form_document.privacy_policy_url)
   end
 
   context "with a support email address" do
-    let(:form) { build(:made_live_form, id: form_metadata.id, support_email: "support@example.gov.uk") }
+    let(:form_metadata) { create :form, :live, support_email: "support@example.gov.uk" }
 
     it "shows the support email address" do
       expect(rendered).to have_xpath("//h3[text()='#{I18n.t('made_live_form.contact_details')}']/following-sibling::h4", text: "Email")
@@ -166,7 +170,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "with a support phone" do
-    let(:form) { build(:made_live_form, id: form_metadata.id, support_phone: "phone details") }
+    let(:form_metadata) { create :form, :live, support_phone: "phone details" }
 
     it "shows the support phone number" do
       expect(rendered).to have_css("h4", text: "Phone")
@@ -175,16 +179,23 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "with a support online" do
-    let(:form) { build(:made_live_form, id: form_metadata.id, support_url_text: "website", support_url: "www.example.gov.uk") }
+    let(:form_metadata) { create :form, :live, support_url_text: "website", support_url: "www.example.gov.uk" }
 
     it "shows the support contact online" do
       expect(rendered).to have_css("h4", text: "Support contact online")
-      expect(rendered).to have_link(form.support_url_text, href: form.support_url)
+      expect(rendered).to have_link(form_document.support_url_text, href: form_document.support_url)
     end
   end
 
   context "with no support information set" do
-    let(:form) { build(:made_live_form, id: form_metadata.id, support_email: nil, support_phone: nil, support_url_text: nil, support_url: nil) }
+    let(:form_document) do
+      form_document_content = FormDocument::Content.new(form_metadata.live_form_document.content)
+      form_document_content.support_email = nil
+      form_document_content.support_url_text = nil
+      form_document_content.support_url = nil
+      form_document_content.support_phone = nil
+      form_document_content
+    end
 
     it "does not include support details if they are not set" do
       expect(rendered).not_to have_xpath("//h3[text()='#{I18n.t('made_live_form.contact_details')}']/following-sibling::h4", text: "Email")
@@ -194,14 +205,14 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   it "contains a link to create a new draft" do
-    expect(rendered).to have_link("Create a draft to edit", href: form_path(form.id))
+    expect(rendered).to have_link("Create a draft to edit", href: form_path(form_document.id))
   end
 
   context "when form has a draft version already" do
     let(:form_metadata) { create :form, :live_with_draft }
 
     it "contains a link to edit the draft" do
-      expect(rendered).to have_link("Edit the draft of this form", href: form_path(form.id))
+      expect(rendered).to have_link("Edit the draft of this form", href: form_path(form_document.id))
     end
   end
 
@@ -235,7 +246,7 @@ describe "forms/_made_live_form.html.erb" do
 
   context "when the form has a payment link" do
     let(:payment_url) { "https://www.gov.uk/payments/your-payment-link" }
-    let(:form) { build(:made_live_form, id: form_metadata.id, payment_url:) }
+    let(:form_metadata) { create :form, :live, payment_url: }
 
     it "contains a link to the payment url" do
       expect(rendered).to have_css("h3", text: "GOV.UK Pay payment link")

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -22,7 +22,7 @@ describe "forms/_made_live_form.html.erb" do
 
     render(partial: "forms/made_live_form", locals: {
       form_metadata:,
-      form:,
+      form_document: form,
       status:,
       preview_mode:,
       questions_path:,

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe "forms/_made_live_form.html.erb" do
   let(:what_happens_next_markdown) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:form_metadata) { create :form, :live, declaration_text:, what_happens_next_markdown:, submission_type: }
   let(:form_document) do
-    form_document_content = FormDocument::Content.new(form_metadata.live_form_document.content)
+    form_document_content = FormDocument::Content.from_form_document(form_metadata.live_form_document)
     form_document_content.live_at = 1.week.ago
     form_document_content
   end
@@ -189,7 +189,7 @@ describe "forms/_made_live_form.html.erb" do
 
   context "with no support information set" do
     let(:form_document) do
-      form_document_content = FormDocument::Content.new(form_metadata.live_form_document.content)
+      form_document_content = FormDocument::Content.from_form_document(form_metadata.live_form_document)
       form_document_content.support_email = nil
       form_document_content.support_url_text = nil
       form_document_content.support_url = nil

--- a/spec/views/forms/archived/show_form.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_form.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "archived/show_form.html.erb" do
   let(:form_metadata) { create :form, :archived }
-  let(:form_document) { FormDocument::Content.new(form_metadata.archived_form_document.content) }
+  let(:form_document) { FormDocument::Content.from_form_document(form_metadata.archived_form_document) }
 
   before do
     render(template: "forms/archived/show_form", locals: { form_document:, form_metadata: })

--- a/spec/views/forms/archived/show_form.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_form.html.erb_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 describe "archived/show_form.html.erb" do
-  let(:form_metadata) { OpenStruct.new(has_draft_version: false) }
-  let(:form) { build(:made_live_form, id: 1) }
+  let(:form_metadata) { create :form, :archived }
+  let(:form_document) { FormDocument::Content.new(form_metadata.archived_form_document.content) }
 
   before do
-    render(template: "forms/archived/show_form", locals: { form_document: form, form_metadata: })
+    render(template: "forms/archived/show_form", locals: { form_document:, form_metadata: })
   end
 
   it "renders the archived tag" do
@@ -13,7 +13,7 @@ describe "archived/show_form.html.erb" do
   end
 
   it "contains a link to preview the archived form" do
-    expect(rendered).to have_link(t("home.preview"), href: "runner-host/preview-archived/#{form.id}/#{form.form_slug}", visible: :all)
+    expect(rendered).to have_link(t("home.preview"), href: "runner-host/preview-archived/#{form_document.id}/#{form_document.form_slug}", visible: :all)
   end
 
   it "contains the title 'Previous form URL'" do
@@ -21,10 +21,10 @@ describe "archived/show_form.html.erb" do
   end
 
   it "contains a link to view questions" do
-    expect(rendered).to have_link("#{form.pages.count} questions", href: "/forms/#{form.id}/archived/pages")
+    expect(rendered).to have_link("#{form_document.steps.count} questions", href: "/forms/#{form_document.id}/archived/pages")
   end
 
   it "contains a link to make the form live again" do
-    expect(rendered).to have_link("Make this form live", href: "/forms/#{form.id}/unarchive")
+    expect(rendered).to have_link("Make this form live", href: "/forms/#{form_document.id}/unarchive")
   end
 end

--- a/spec/views/forms/archived/show_form.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_form.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe "archived/show_form.html.erb" do
   let(:form) { build(:made_live_form, id: 1) }
 
   before do
-    render(template: "forms/archived/show_form", locals: { form:, form_metadata: })
+    render(template: "forms/archived/show_form", locals: { form_document: form, form_metadata: })
   end
 
   it "renders the archived tag" do

--- a/spec/views/forms/archived/show_pages.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_pages.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe "forms/archived/show_pages.html.erb" do
   let(:form) { build :made_live_form, id: 1 }
 
   before do
-    render(template: "forms/archived/show_pages", locals: { form: })
+    render(template: "forms/archived/show_pages", locals: { form_document: form })
   end
 
   it "form name is in the page title" do

--- a/spec/views/forms/archived/show_pages.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_pages.html.erb_spec.rb
@@ -1,22 +1,23 @@
 require "rails_helper"
 
 describe "forms/archived/show_pages.html.erb" do
-  let(:form) { build :made_live_form, id: 1 }
+  let(:form_metadata) { create :form, :archived }
+  let(:form_document) { FormDocument::Content.new(form_metadata.archived_form_document.content) }
 
   before do
-    render(template: "forms/archived/show_pages", locals: { form_document: form })
+    render(template: "forms/archived/show_pages", locals: { form_document: })
   end
 
   it "form name is in the page title" do
-    expect(view.content_for(:title)).to have_content(form.name)
+    expect(view.content_for(:title)).to have_content(form_document.name)
   end
 
   it "back link is set to path to show an archived form" do
-    expect(rendered).to have_link("Back to your form", href: "/forms/#{form.id}/archived")
+    expect(rendered).to have_link("Back to your form", href: "/forms/#{form_document.id}/archived")
   end
 
   it "has correct page heading" do
-    expect(rendered).to have_css("h1", text: "#{form.name} - Your questions", exact_text: true, normalize_ws: true)
+    expect(rendered).to have_css("h1", text: "#{form_document.name} - Your questions", exact_text: true, normalize_ws: true)
   end
 
   it "rendered archived tag" do

--- a/spec/views/forms/archived/show_pages.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_pages.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "forms/archived/show_pages.html.erb" do
   let(:form_metadata) { create :form, :archived }
-  let(:form_document) { FormDocument::Content.new(form_metadata.archived_form_document.content) }
+  let(:form_document) { FormDocument::Content.from_form_document(form_metadata.archived_form_document) }
 
   before do
     render(template: "forms/archived/show_pages", locals: { form_document: })

--- a/spec/views/forms/live/show_form.html.erb_spec.rb
+++ b/spec/views/forms/live/show_form.html.erb_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 describe "forms/live/show_form.html.erb" do
-  let(:form_metadata) { OpenStruct.new(has_draft_version: false) }
-  let(:form) { build(:made_live_form, id: 1) }
+  let(:form_metadata) { create :form, :live }
+  let(:form_document) { FormDocument::Content.new(form_metadata.live_form_document.content) }
 
   before do
-    render(template: "forms/live/show_form", locals: { form_document: form, form_metadata: })
+    render(template: "forms/live/show_form", locals: { form_document:, form_metadata: })
   end
 
   it "renders the live tag" do
@@ -13,7 +13,7 @@ describe "forms/live/show_form.html.erb" do
   end
 
   it "contains a link to preview the live form" do
-    expect(rendered).to have_link(t("home.preview"), href: "runner-host/preview-live/#{form.id}/#{form.form_slug}", visible: :all)
+    expect(rendered).to have_link(t("home.preview"), href: "runner-host/preview-live/#{form_document.id}/#{form_document.form_slug}", visible: :all)
   end
 
   it "contains the title 'Form URL'" do
@@ -21,6 +21,6 @@ describe "forms/live/show_form.html.erb" do
   end
 
   it "contains a link to view questions" do
-    expect(rendered).to have_link("#{form.pages.count} questions", href: "/forms/#{form.id}/live/pages")
+    expect(rendered).to have_link("#{form_document.steps.count} questions", href: "/forms/#{form_document.id}/live/pages")
   end
 end

--- a/spec/views/forms/live/show_form.html.erb_spec.rb
+++ b/spec/views/forms/live/show_form.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "forms/live/show_form.html.erb" do
   let(:form_metadata) { create :form, :live }
-  let(:form_document) { FormDocument::Content.new(form_metadata.live_form_document.content) }
+  let(:form_document) { FormDocument::Content.from_form_document(form_metadata.live_form_document) }
 
   before do
     render(template: "forms/live/show_form", locals: { form_document:, form_metadata: })

--- a/spec/views/forms/live/show_form.html.erb_spec.rb
+++ b/spec/views/forms/live/show_form.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe "forms/live/show_form.html.erb" do
   let(:form) { build(:made_live_form, id: 1) }
 
   before do
-    render(template: "forms/live/show_form", locals: { form:, form_metadata: })
+    render(template: "forms/live/show_form", locals: { form_document: form, form_metadata: })
   end
 
   it "renders the live tag" do

--- a/spec/views/forms/live/show_pages.html.erb_spec.rb
+++ b/spec/views/forms/live/show_pages.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe "forms/live/show_pages.html.erb" do
   let(:form) { build :made_live_form, id: 1 }
 
   before do
-    render(template: "forms/live/show_pages", locals: { form: })
+    render(template: "forms/live/show_pages", locals: { form_document: form })
   end
 
   it "form name is in the page title" do

--- a/spec/views/forms/live/show_pages.html.erb_spec.rb
+++ b/spec/views/forms/live/show_pages.html.erb_spec.rb
@@ -1,22 +1,23 @@
 require "rails_helper"
 
 describe "forms/live/show_pages.html.erb" do
-  let(:form) { build :made_live_form, id: 1 }
+  let(:form) { create :form, :live }
+  let(:form_document) { FormDocument::Content.new(form.live_form_document.content) }
 
   before do
-    render(template: "forms/live/show_pages", locals: { form_document: form })
+    render(template: "forms/live/show_pages", locals: { form_document: form_document })
   end
 
   it "form name is in the page title" do
-    expect(view.content_for(:title)).to have_content(form.name)
+    expect(view.content_for(:title)).to have_content(form_document.name)
   end
 
   it "back link is set to the path to show a live form" do
-    expect(rendered).to have_link("Back to your form", href: "/forms/#{form.id}/live")
+    expect(rendered).to have_link("Back to your form", href: "/forms/#{form_document.id}/live")
   end
 
   it "has correct page heading" do
-    expect(rendered).to have_css("h1", text: "#{form.name} - Your questions", exact_text: true, normalize_ws: true)
+    expect(rendered).to have_css("h1", text: "#{form_document.name} - Your questions", exact_text: true, normalize_ws: true)
   end
 
   it "rendered live tag" do

--- a/spec/views/forms/live/show_pages.html.erb_spec.rb
+++ b/spec/views/forms/live/show_pages.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "forms/live/show_pages.html.erb" do
   let(:form) { create :form, :live }
-  let(:form_document) { FormDocument::Content.new(form.live_form_document.content) }
+  let(:form_document) { FormDocument::Content.from_form_document(form.live_form_document) }
 
   before do
     render(template: "forms/live/show_pages", locals: { form_document: form_document })


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/9nB9yBQT/2468-change-forms-admin-made-live-forms-views-to-use-form-documents-instead-of-v1-api <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Instead of using forms-api to get the live/archived form data, use the records in the form documents table for pages which are about live/archived forms.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
