### PR TITLE
Use localhost for test database connections

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -58,6 +58,9 @@ development:
 test:
   <<: *default
   database: forms_admin_test
+  username: postgres
+  password: postgres
+  host: localhost
   gssencmode: disable # needed to stop spring from segfaulting
 
 # As with config/credentials.yml, you never want to store sensitive information,


### PR DESCRIPTION
This fixes an issue if using psql container in docker and running the tests on the host machine. By specifying "localhost" this ensures the connection is done via TCP rather than sockets, which is needed to connect to the container.

Follows https://github.com/alphagov/forms-runner/pull/1588

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
