### PR TITLE
Remove remaining used of FormRepository find_live and find_archived

### DIFF
--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -64,7 +64,7 @@ module Forms
     end
 
     def current_live_form
-      @current_live_form ||= FormRepository.find_live(form_id: params[:form_id])
+      @current_live_form ||= FormDocument::Content.from_form_document(current_form.live_form_document)
     end
   end
 end

--- a/app/services/form_repository.rb
+++ b/app/services/form_repository.rb
@@ -10,14 +10,6 @@ class FormRepository
       Form.find(form_id)
     end
 
-    def find_live(form_id:)
-      Api::V1::FormResource.find_live(form_id)
-    end
-
-    def find_archived(form_id:)
-      Api::V1::FormResource.find_archived(form_id)
-    end
-
     def where(creator_id:)
       Form.where(creator_id:)
     end

--- a/spec/requests/forms/unarchive_controller_spec.rb
+++ b/spec/requests/forms/unarchive_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Forms::UnarchiveController, type: :request do
 
   describe "#new" do
     before do
-      allow(FormRepository).to receive_messages(find: form, save!: updated_form)
+      allow(FormRepository).to receive_messages(save!: updated_form)
 
       Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user, role: :group_admin)
       GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -30,10 +30,6 @@ RSpec.describe Forms::UnarchiveController, type: :request do
       login_as user
 
       get unarchive_path(form_id: form.id)
-    end
-
-    it "reads the form" do
-      expect(FormRepository).to have_received(:find)
     end
 
     it "returns 200" do
@@ -55,7 +51,7 @@ RSpec.describe Forms::UnarchiveController, type: :request do
 
   describe "#create" do
     before do
-      allow(FormRepository).to receive_messages(find: form, make_live!: form, find_live: made_live_form)
+      allow(FormRepository).to receive_messages(make_live!: form)
 
       Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user, role: :group_admin)
       GroupForm.create!(form_id: form.id, group_id: group.id)
@@ -67,10 +63,6 @@ RSpec.describe Forms::UnarchiveController, type: :request do
 
     context "when making a form live again" do
       let(:form_params) { { forms_make_live_input: { confirm: :yes, form: } } }
-
-      it "reads the form" do
-        expect(FormRepository).to have_received(:find)
-      end
 
       it "makes form live" do
         expect(FormRepository).to have_received(:make_live!)
@@ -87,10 +79,6 @@ RSpec.describe Forms::UnarchiveController, type: :request do
 
     context "when deciding not to make a form live again" do
       let(:form_params) { { forms_make_live_input: { confirm: :no } } }
-
-      it "reads the form" do
-        expect(FormRepository).to have_received(:find)
-      end
 
       it "does not make the form live" do
         expect(FormRepository).not_to have_received(:make_live!)

--- a/spec/services/form_repository_spec.rb
+++ b/spec/services/form_repository_spec.rb
@@ -64,58 +64,6 @@ describe FormRepository do
     end
   end
 
-  describe "#find_live" do
-    let(:form) { build(:made_live_form, id: 2) }
-
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{form.id}/live", headers, form.to_json, 200
-      end
-    end
-
-    describe "api" do
-      it "calls the find_live endpoint through ActiveResource" do
-        find_live_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/live", form, headers)
-        described_class.find_live(form_id: form.id)
-        expect(ActiveResource::HttpMock.requests).to include find_live_request
-      end
-    end
-
-    describe "database" do
-      it "does not save anything to the database" do
-        expect {
-          described_class.find_live(form_id: form.id)
-        }.not_to change(Form, :count)
-      end
-    end
-  end
-
-  describe "#find_archived" do
-    let(:form) { build(:made_live_form, id: 2) }
-
-    before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/#{form.id}/archived", headers, form.to_json, 200
-      end
-    end
-
-    describe "api" do
-      it "calls the find_archived endpoint through ActiveResource" do
-        find_archived_request = ActiveResource::Request.new(:get, "/api/v1/forms/#{form.id}/archived", form, headers)
-        described_class.find_archived(form_id: form.id)
-        expect(ActiveResource::HttpMock.requests).to include find_archived_request
-      end
-    end
-
-    describe "database" do
-      it "does not save anything to the database" do
-        expect {
-          described_class.find_archived(form_id: form.id)
-        }.not_to change(Form, :count)
-      end
-    end
-  end
-
   describe "#where" do
     let(:form) { create(:form_record, creator_id: 3) }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/9nB9yBQT/

Update SubmissionEmailController to use the live FormDocument for comparing the submission email between the live and draft forms instead of getting the live form from forms-api.

Remove find_live and find_archived methods from FormRepository.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
