### PR TITLE
Add custom error for missing draft question

### DIFF
--- a/app/controllers/pages/questions_controller.rb
+++ b/app/controllers/pages/questions_controller.rb
@@ -1,7 +1,5 @@
 class Pages::QuestionsController < PagesController
-  before_action do
-    raise "No answer type set for draft question" if draft_question.answer_type.blank?
-  end
+  before_action :check_draft_question, only: %i[new create]
 
   def new
     @question_input = Pages::QuestionInput.new(answer_type: draft_question.answer_type,
@@ -70,5 +68,9 @@ private
                       page_heading: draft_question.page_heading,
                       guidance_markdown: draft_question.guidance_markdown,
                       answer_type: draft_question.answer_type)
+  end
+
+  def check_draft_question
+    render "errors/missing_draft_question", status: :unprocessable_content, formats: :html if draft_question.answer_type.blank?
   end
 end

--- a/app/views/errors/missing_draft_question.html.erb
+++ b/app/views/errors/missing_draft_question.html.erb
@@ -1,0 +1,9 @@
+<% set_page_title(t("page_titles.missing_draft_question")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t("page_titles.missing_draft_question") %></h1>
+    <p><%= t(".expired_data") %></p>
+    <p><%= t(".possible_causes") %></p>
+    <p><%= t(".next_steps_html", add_question_link: start_new_question_path(@current_form.id), questions_link: form_pages_path(@current_form.id)) %></p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,6 +306,10 @@ en:
   errors:
     messages:
       non_government_email: Enter a government email address
+    missing_draft_question:
+      expired_data: This page cannot be loaded because it’s trying to use expired data.
+      next_steps_html: <a href="%{add_question_link}">Add a question</a> or <a href="%{questions_link}">go to your list of questions</a> to continue building your form.
+      possible_causes: This can happen if you use the back button or multiple tabs on your browser.
     page_conditions:
       answer_value_doesnt_exist: The answer that question %{question_number}’s route %{route_number} is based on no longer exists - edit or delete this route
       any_other_answer_route:
@@ -1179,6 +1183,7 @@ en:
     make_archived_draft_live: Make your form live again
     make_changes_live: Make your changes live
     make_live: Make your form live
+    missing_draft_question: There’s a problem with this page
     mou_signature_confirmation: You’ve agreed to the MOU
     mou_signature_new: GOV.UK Forms Memorandum of Understanding
     mou_signatures: Memorandum of Understanding agreements

--- a/spec/requests/pages/questions_controller_spec.rb
+++ b/spec/requests/pages/questions_controller_spec.rb
@@ -56,27 +56,39 @@ RSpec.describe Pages::QuestionsController, type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    context "when the draft question is not present" do
+      let(:draft_question) { nil }
+
+      it "renders the index page" do
+        expect(response).to render_template("errors/missing_draft_question")
+      end
+
+      it "returns a 422 error code" do
+        expect(response.status).to eq(422)
+      end
+    end
+
     include_examples "logging"
   end
 
   describe "#create" do
+    let(:params) do
+      { pages_question_input: {
+        question_text: "What is your home address?",
+        hint_text: "This should be the location stated in your contract.",
+        is_optional: false,
+        is_repeatable: false,
+      } }
+    end
+
+    before do
+      # Setup a draft_question so that create question action doesn't need to create a completely new records
+      draft_question
+
+      post create_question_path(form.id), params:
+    end
+
     describe "Given a valid page" do
-      let(:params) do
-        { pages_question_input: {
-          question_text: "What is your home address?",
-          hint_text: "This should be the location stated in your contract.",
-          is_optional: false,
-          is_repeatable: false,
-        } }
-      end
-
-      before do
-        # Setup a draft_question so that create question action doesn't need to create a completely new records
-        draft_question
-
-        post create_question_path(form.id), params:
-      end
-
       it "Redirects you to edit page for new question" do
         expect(response).to redirect_to(edit_question_path(form_id: form.id, page_id: page.id))
       end
@@ -94,11 +106,8 @@ RSpec.describe Pages::QuestionsController, type: :request do
     end
 
     context "when question_input has invalid data" do
-      before do
-        # Setup a draft_question so that create question action doesn't need to create a completely new records
-        draft_question
-
-        post create_question_path(form.id), params: { pages_question_input: {
+      let(:params) do
+        { pages_question_input: {
           hint_text: "This should be the location stated in your contract.",
           is_optional: false,
         } }
@@ -114,6 +123,18 @@ RSpec.describe Pages::QuestionsController, type: :request do
 
       it "outputs error message" do
         expect(response.body).to include("Enter a question")
+      end
+    end
+
+    context "when the draft question is not present" do
+      let(:draft_question) { nil }
+
+      it "renders the index page" do
+        expect(response).to render_template("errors/missing_draft_question")
+      end
+
+      it "returns a 422 error code" do
+        expect(response.status).to eq(422)
       end
     end
   end

--- a/spec/views/errors/missing_draft_question.html.erb_spec.rb
+++ b/spec/views/errors/missing_draft_question.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "errors/missing_draft_question.html.erb" do
+  let(:form) { create :form }
+
+  before do
+    assign(:current_form, form)
+
+    render
+  end
+
+  it "has a page title" do
+    expect(view.content_for(:title)).to include I18n.t("page_titles.missing_draft_question")
+  end
+
+  it "has a heading" do
+    expect(rendered).to have_css "h1", text: I18n.t("page_titles.missing_draft_question")
+  end
+
+  it "informs the user about the expired data" do
+    expect(rendered).to have_css "p", text: I18n.t("errors.missing_draft_question.expired_data")
+  end
+
+  it "suggests possible causes of the error" do
+    expect(rendered).to have_css "p", text: I18n.t("errors.missing_draft_question.possible_causes")
+  end
+
+  it "has information about next steps" do
+    expect(rendered).to include I18n.t("errors.missing_draft_question.next_steps_html", add_question_link: start_new_question_path(form.id), questions_link: form_pages_path(form.id))
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/Cv7Df8ho/2452-navigating-to-the-new-page-view-causes-an-error-if-the-answer-type-and-answer-settings-arent-valid

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds a new custom error page for when a user attempts to use the new or create question actions without having a draft question. Currently we just display a generic 500 error in this case.

### Testing instructions

The easiest way to see the new page is to go straight to the 'new question' page without setting up a draft question first: https://pr-2193.admin.review.forms.service.gov.uk/forms/1/pages/new/question

Screenshots:
Before:
<img width="1026" height="664" alt="A GOV.UK Forms error page with heading 'Sorry, there is a problem with the service' and a single line 'Please try again later' underneath" src="https://github.com/user-attachments/assets/699ad97e-cf84-4484-b7c8-f0c340250e40" />


After:
<img width="1029" height="775" alt="A GOV.UK Forms error page with heading 'There’s a problem with this page' and three lines reading 'This page cannot be loaded because it’s trying to use expired data. This can happen if you use the back button or multiple tabs on your browser. Add a question or go to your list of questions to continue building your form.' underneath" src="https://github.com/user-attachments/assets/ca381317-65b9-4575-8f62-388647d72ea0" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
