### PR TITLE
Retrieve FormDocuments from database for reports

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -116,7 +116,7 @@ class ReportsController < WebController
   def csv_downloads; end
 
   def live_forms_csv
-    forms = Reports::FormDocumentsService.live_form_documents
+    forms = Reports::FormDocumentsService.form_documents(tag: "live")
 
     send_data Reports::FormsCsvReportService.new(forms).csv,
               type: "text/csv; charset=iso-8859-1",
@@ -124,7 +124,7 @@ class ReportsController < WebController
   end
 
   def live_questions_csv
-    forms = Reports::FormDocumentsService.live_form_documents
+    forms = Reports::FormDocumentsService.form_documents(tag: "live")
     questions = Reports::FeatureReportService.new(forms).questions
 
     send_data Reports::QuestionsCsvReportService.new(questions).csv,

--- a/app/services/reports/form_documents_service.rb
+++ b/app/services/reports/form_documents_service.rb
@@ -1,32 +1,13 @@
 class Reports::FormDocumentsService
   class << self
-    REQUEST_HEADERS = {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }.freeze
-    FORM_DOCUMENTS_URL = "#{Settings.forms_api.base_url}/api/v2/form-documents".freeze
-
-    FormDocumentsResponse = Data.define(:forms, :has_more_results?)
-
-    def draft_form_documents
-      form_documents(tag: "draft")
-    end
-
-    def live_form_documents
-      form_documents(tag: "live")
-    end
-
     def form_documents(tag:)
-      Enumerator.new do |yielder|
-        page = 1
-        loop do
-          form_documents_response = form_documents_page(tag:, page:)
-          form_documents_response.forms.each { |f| yielder << f unless is_in_internal_organisation?(f) }
-
-          break unless form_documents_response.has_more_results?
-
-          page += 1
-        end
+      case tag
+      when "draft"
+        draft_form_documents
+      when "live"
+        live_form_documents
+      else
+        raise StandardError "Unsupported tag"
       end
     end
 
@@ -66,36 +47,16 @@ class Reports::FormDocumentsService
 
   private
 
-    def form_documents_page(tag:, page:)
-      uri = URI(FORM_DOCUMENTS_URL)
-      params = { tag:, page:, per_page: Settings.reports.forms_api_forms_per_request_page }
-      uri.query = URI.encode_www_form(params)
+    def draft_form_documents
+      draft_forms = Form.joins(group_form: { group: :organisation })
+        .where(state: %w[draft live_with_draft archived_with_draft])
+          .where.not(organisation: { "internal": true })
 
-      response = Net::HTTP.get_response(uri, REQUEST_HEADERS)
-
-      return parse_response(response) if response.is_a? Net::HTTPSuccess
-
-      raise StandardError, "Forms API responded with a non-success HTTP code when retrieving form documents: status #{response.code}"
+      draft_forms.map { |form| FormDocument.new(form:, tag: "draft", content: form.as_form_document).as_json }
     end
 
-    def parse_response(response)
-      FormDocumentsResponse.new(forms: JSON.parse(response.body), has_more_results?: has_more_results?(response))
-    end
-
-    def has_more_results?(response)
-      total = response["pagination-total"].to_i
-      offset = response["pagination-offset"].to_i
-      limit = response["pagination-limit"].to_i
-
-      total > offset + limit
-    end
-
-    def is_in_internal_organisation?(form)
-      group_form = GroupForm.find_by_form_id(form["form_id"])
-
-      return false if group_form.blank?
-
-      group_form.group.organisation.internal?
+    def live_form_documents
+      FormDocument.joins(form: { group_form: { group: :organisation } }).where(tag: "live").where.not(organisation: { "internal": true }).map(&:as_json)
     end
 
     def secondary_skip_conditions(form_document)

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -2,21 +2,11 @@ require "rails_helper"
 
 RSpec.describe ReportsController, type: :request do
   let(:question_text) { "Question text" }
-  let(:form_documents_url) { "#{Settings.forms_api.base_url}/api/v2/form-documents".freeze }
   let(:forms) { create_list(:form, 4, :live) }
-  let(:form_documents) { forms.map(&:live_form_document) }
-  let(:response_headers) do
-    {
-      "pagination-total" => "3",
-      "pagination-offset" => "0",
-      "pagination-limit" => "3",
-    }
-  end
 
   before do
-    stub_request(:get, form_documents_url)
-      .with(query: { page: "1", per_page: "3", tag: "live" })
-      .to_return(body: form_documents.to_json, headers: response_headers)
+    group = create :group
+    forms.each { |form| group.group_forms.create!(form:) }
   end
 
   shared_examples "unauthorized user is forbidden" do

--- a/spec/services/reports/form_documents_service_spec.rb
+++ b/spec/services/reports/form_documents_service_spec.rb
@@ -1,17 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Reports::FormDocumentsService do
-  let(:forms) do
-    [
-      form_with_no_routes,
-      branch_route_form,
-      basic_route_form,
-      form_with_2_branch_routes,
-    ]
-  end
-  let(:form_documents) { forms.map(&:live_form_document) }
-
   let(:form_with_no_routes) { create(:form, :live) }
+  let(:draft_form) { create(:form) }
+  let(:archived_form) { create(:form, :archived) }
+  let(:live_with_draft_form) { create(:form, :live_with_draft) }
+  let(:archived_with_draft_form) { create(:form, :archived_with_draft) }
+  let(:draft_internal_organisation_form) { create :form }
+  let(:live_internal_organisation_form) { create :form }
   let(:branch_route_form) do
     form = create(:form, :live, :ready_for_routing)
     create(:condition, :with_exit_page, routing_page_id: form.pages[0].id, check_page_id: form.pages[0].id, answer_value: "Option 1")
@@ -38,52 +34,27 @@ RSpec.describe Reports::FormDocumentsService do
     form
   end
 
-  describe ".form_documents" do
-    let(:form_documents_url) { "#{Settings.forms_api.base_url}/api/v2/form-documents".freeze }
-    let(:tag) { "live" }
+  let(:organisation) { create :organisation, internal: false, slug: "hm-revenue-customs" }
+  let(:internal_organisation) { create :organisation, internal: true, slug: "internal-org" }
+  let(:group) { create :group, organisation: }
+  let(:internal_group) { create :group, organisation: internal_organisation }
 
-    before do
-      allow(Settings.reports).to receive(:forms_api_forms_per_request_page).and_return 4
+  before do
+    group.group_forms.create!(form: form_with_no_routes)
+    group.group_forms.create!(form: draft_form)
+    group.group_forms.create!(form: archived_form)
+    group.group_forms.create!(form: live_with_draft_form)
+    group.group_forms.create!(form: archived_with_draft_form)
+    group.group_forms.create!(form: branch_route_form)
+    group.group_forms.create!(form: basic_route_form)
+    group.group_forms.create!(form: form_with_2_branch_routes)
+    internal_group.group_forms.create!(form: draft_internal_organisation_form)
+    internal_group.group_forms.create!(form: live_internal_organisation_form)
+  end
 
-      stub_request(:get, form_documents_url)
-        .with(query: { page: "1", per_page: "4", tag: })
-        .to_return(body: form_documents.to_json, headers: response_headers(12, 0, 4))
-      stub_request(:get, form_documents_url)
-        .with(query: { page: "2", per_page: "4", tag: })
-        .to_return(body: form_documents.to_json, headers: response_headers(12, 4, 4))
-      stub_request(:get, form_documents_url)
-        .with(query: { page: "3", per_page: "4", tag: })
-        .to_return(body: form_documents.to_json, headers: response_headers(12, 8, 4))
-    end
-
-    context "with draft tag" do
+  describe "#form_documents" do
+    context "when the tag is draft" do
       let(:tag) { "draft" }
-
-      it "makes request to forms-api for each page of results" do
-        form_documents = described_class.form_documents(tag:).to_a
-        expect(form_documents.size).to eq(12)
-        assert_requested(:get, form_documents_url, query: { page: "1", per_page: "4", tag: "draft" }, headers:, times: 1)
-        assert_requested(:get, form_documents_url, query: { page: "2", per_page: "4", tag: "draft" }, headers:, times: 1)
-        assert_requested(:get, form_documents_url, query: { page: "3", per_page: "4", tag: "draft" }, headers:, times: 1)
-      end
-
-      it "returns form documents" do
-        form_document = described_class.form_documents(tag:).first
-        expect(form_document).to be_a(Hash)
-        expect(form_document).to have_key("form_id")
-      end
-    end
-
-    context "with live tag" do
-      let(:tag) { :live }
-
-      it "makes request to forms-api for each page of results" do
-        form_documents = described_class.form_documents(tag:).to_a
-        expect(form_documents.size).to eq(12)
-        assert_requested(:get, form_documents_url, query: { page: "1", per_page: "4", tag: "live" }, headers:, times: 1)
-        assert_requested(:get, form_documents_url, query: { page: "2", per_page: "4", tag: "live" }, headers:, times: 1)
-        assert_requested(:get, form_documents_url, query: { page: "3", per_page: "4", tag: "live" }, headers:, times: 1)
-      end
 
       it "returns form documents" do
         form_document = described_class.form_documents(tag:).first
@@ -91,72 +62,43 @@ RSpec.describe Reports::FormDocumentsService do
         expect(form_document).to have_key("form_id")
       end
 
-      context "when there are forms from internal organisations" do
-        let(:organisation) { create :organisation, internal: false, slug: "hm-revenue-customs" }
-        let(:internal_organisation) { create :organisation, internal: true, slug: "internal-org" }
-        let(:group) { create :group, organisation: }
-        let(:internal_group) { create :group, organisation: internal_organisation }
-
-        before do
-          group.group_forms.create!(form: forms[0])
-          group.group_forms.create!(form: forms[1])
-          group.group_forms.create!(form: forms[2])
-          internal_group.group_forms.create!(form: forms[3])
-        end
-
-        it "does not include these forms in the live_form_documents output" do
-          form_documents = described_class.live_form_documents.to_a
-          expect(form_documents.size).to eq(9)
-
-          form_documents_with_internal_id = form_documents.filter { it["id"] == forms[3].id }
-          expect(form_documents_with_internal_id).to be_empty
-        end
-      end
-    end
-
-    context "when forms-api responds with a non-success status code" do
-      before do
-        stub_request(:get, form_documents_url)
-          .with(query: { page: "1", per_page: "4", tag: "live" })
-          .to_return(body: "There was an error", status: 400)
-      end
-
-      it "raises a StandardError" do
-        expect { described_class.form_documents(tag: "live").first }.to raise_error(
-          StandardError, "Forms API responded with a non-success HTTP code when retrieving form documents: status 400"
-        )
-      end
-    end
-
-    context "when there are forms from internal organisations" do
-      let(:organisation) { create :organisation, internal: false, slug: "hm-revenue-customs" }
-      let(:internal_organisation) { create :organisation, internal: true, slug: "internal-org" }
-      let(:group) { create :group, organisation: }
-      let(:internal_group) { create :group, organisation: internal_organisation }
-      let(:tag) { "draft" }
-
-      before do
-        group.group_forms.create!(form: forms[0])
-        group.group_forms.create!(form: forms[1])
-        group.group_forms.create!(form: forms[2])
-        internal_group.group_forms.create!(form: forms[3])
-      end
-
-      it "does not include these forms in the draft_form_documents output" do
+      it "only includes draft form documents from external organisations" do
         form_documents = described_class.form_documents(tag:).to_a
-        expect(form_documents.size).to eq(9)
-
-        form_documents_with_internal_id = form_documents.filter { it["id"] == forms[3].id }
-        expect(form_documents_with_internal_id).to be_empty
+        expect(form_documents.map { |form_document| form_document["form_id"] })
+          .to contain_exactly(draft_form.id, live_with_draft_form.id, archived_with_draft_form.id)
       end
     end
 
-    def response_headers(total, offset, limit)
-      {
-        "pagination-total" => total.to_s,
-        "pagination-offset" => offset.to_s,
-        "pagination-limit" => limit.to_s,
-      }
+    context "when the tag is live" do
+      let(:tag) { "live" }
+
+      it "returns form documents" do
+        form_document = described_class.form_documents(tag:).first
+        expect(form_document).to be_a(Hash)
+        expect(form_document).to have_key("form_id")
+      end
+
+      it "only includes live form documents from external organisations" do
+        form_documents = described_class.form_documents(tag:).to_a
+        expect(form_documents.map { |form_document| form_document["form_id"] })
+          .to contain_exactly(
+            form_with_no_routes.id,
+            live_with_draft_form.id,
+            branch_route_form.id,
+            basic_route_form.id,
+            form_with_2_branch_routes.id,
+          )
+      end
+    end
+
+    context "when the tag is unsupported" do
+      let(:tag) { "tag not supported" }
+
+      it "raises an error" do
+        expect {
+          described_class.form_documents(tag:)
+        }.to raise_error(StandardError)
+      end
     end
   end
 


### PR DESCRIPTION
The FormDocumentsService gets FormDocuments from the local db rather than the API.

### What problem does this pull request solve?

Trello card: https://trello.com/c/KIdXtAro/2470-change-feature-reports-to-use-form-documents-in-forms-admin-database

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
