### PR TITLE
Remove repeated group and organisation lookups

### DIFF
--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -73,7 +73,7 @@ private
   def report_forms_table_row(form)
     [
       form_link(form),
-      form.dig("group", "organisation", "name") || "",
+      form["organisation_name"],
     ]
   end
 

--- a/app/services/reports/feature_report_service.rb
+++ b/app/services/reports/feature_report_service.rb
@@ -81,48 +81,29 @@ class Reports::FeatureReportService
   def forms_with_payments
     form_documents
       .select { |form| Reports::FormDocumentsService.has_payments?(form) }
-      .map { |form| form_details(form) }
   end
 
   def forms_with_exit_pages
     form_documents
       .select { |form| Reports::FormDocumentsService.has_exit_pages?(form) }
-      .map { |form| form_details(form) }
   end
 
   def forms_with_csv_submission_enabled
     form_documents
       .select { |form| Reports::FormDocumentsService.has_csv_submission_enabled?(form) }
-      .map { |form| form_details(form) }
   end
 
 private
 
   def questions_details(form, step)
-    form = form_details(form)
     step.dup.merge("form" => form)
   end
 
   def form_with_routes_details(form)
-    form = form_details(form)
     form["metadata"] = {
       "number_of_routes" => form["content"]["steps"].count { |step| step["routing_conditions"].present? },
       "number_of_branch_routes" => Reports::FormDocumentsService.count_secondary_skip_routes(form),
     }
     form
-  end
-
-  def form_details(form)
-    form = form.dup
-    form["group"] = {
-      "organisation" => {
-        "name" => organisation_name(form["form_id"]),
-      },
-    }
-    form
-  end
-
-  def organisation_name(form_id)
-    GroupForm.find_by_form_id(form_id)&.group&.organisation&.name
   end
 end

--- a/app/services/reports/forms_csv_report_service.rb
+++ b/app/services/reports/forms_csv_report_service.rb
@@ -47,16 +47,15 @@ private
 
   def form_row(form)
     form_id = form["form_id"]
-    group = GroupForm.find_by_form_id(form_id)&.group
     [
       form_id,
       form["tag"],
       form["content"]["name"],
       form["content"]["form_slug"],
-      group&.organisation&.name,
-      group&.organisation&.id,
-      group&.name,
-      group&.external_id,
+      form["organisation_name"],
+      form["organisation_id"],
+      form["group_name"],
+      form["group_external_id"],
       form["content"]["created_at"],
       form["content"]["updated_at"],
       form["content"]["steps"].length,

--- a/app/services/reports/questions_csv_report_service.rb
+++ b/app/services/reports/questions_csv_report_service.rb
@@ -50,16 +50,16 @@ private
   def question_row(step)
     form = step["form"]
     form_id = form["form_id"]
-    group = GroupForm.find_by_form_id(form_id)&.group
+    GroupForm.find_by_form_id(form_id)&.group
 
     [
       form_id,
       form["tag"],
       form["content"]["name"],
-      group&.organisation&.name,
-      group&.organisation&.id,
-      group&.name,
-      group&.external_id,
+      form["organisation_name"],
+      form["organisation_id"],
+      form["group_name"],
+      form["group_external_id"],
       step["position"],
       step["data"]["question_text"],
       step["data"]["answer_type"],

--- a/spec/helpers/report_helpers_spec.rb
+++ b/spec/helpers/report_helpers_spec.rb
@@ -3,23 +3,23 @@ require "rails_helper"
 RSpec.describe ReportHelper, type: :helper do
   let(:forms) do
     [
-      { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
-      { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Ministry of Tests" } } },
-      { "form_id" => 4, "tag" => "live", "content" => { "name" => "Skip route form" }, "group" => { "organisation" => { "name" => "Department for Testing" } } },
+      { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" },
+      { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "organisation_name" => "Ministry of Tests" },
+      { "form_id" => 4, "tag" => "live", "content" => { "name" => "Skip route form" }, "organisation_name" => "Department for Testing" },
     ]
   end
 
   let(:forms_with_routes) do
     [
-      { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Ministry of Tests" } }, "metadata" => { "number_of_routes" => 2, "number_of_branch_routes" => 1 } },
-      { "form_id" => 4, "tag" => "live", "content" => { "name" => "Skip route form" }, "group" => { "organisation" => { "name" => "Department for Testing" } }, "metadata" => { "number_of_routes" => 1, "number_of_branch_routes" => 0 } },
+      { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "organisation_name" => "Ministry of Tests", "metadata" => { "number_of_routes" => 2, "number_of_branch_routes" => 1 } },
+      { "form_id" => 4, "tag" => "live", "content" => { "name" => "Skip route form" }, "organisation_name" => "Department for Testing", "metadata" => { "number_of_routes" => 1, "number_of_branch_routes" => 0 } },
     ]
   end
 
   let(:questions) do
     [
-      { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
-      { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Ministry of Tests" } } } },
+      { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" } },
+      { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "organisation_name" => "Ministry of Tests" } },
     ]
   end
 
@@ -154,20 +154,6 @@ RSpec.describe ReportHelper, type: :helper do
         "Department for Testing",
       ]
     end
-
-    context "when form is not in a group" do
-      let(:forms) do
-        [
-          { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => nil },
-        ]
-      end
-
-      it "returns the empty string for the organisation name" do
-        expect(helper.report_forms_table_rows(forms).map(&:second)).to eq [
-          "",
-        ]
-      end
-    end
   end
 
   describe "#report_forms_with_routes_table_head" do
@@ -228,20 +214,6 @@ RSpec.describe ReportHelper, type: :helper do
         0
       ]
     end
-
-    context "when form is not in a group" do
-      let(:forms) do
-        [
-          { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => nil },
-        ]
-      end
-
-      it "returns the empty string for the organisation name" do
-        expect(helper.report_forms_table_rows(forms).map(&:second)).to eq [
-          "",
-        ]
-      end
-    end
   end
 
   describe "#report_questions_table_head" do
@@ -281,20 +253,6 @@ RSpec.describe ReportHelper, type: :helper do
         "Email address",
         "What’s your email address?",
       ]
-    end
-
-    context "when form is not in a group" do
-      let(:questions) do
-        [
-          { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "group" => nil } },
-        ]
-      end
-
-      it "returns the empty string for the organisation name" do
-        expect(helper.report_questions_table_rows(questions).map(&:second)).to eq [
-          "",
-        ]
-      end
     end
   end
 end

--- a/spec/services/reports/feature_report_service_spec.rb
+++ b/spec/services/reports/feature_report_service_spec.rb
@@ -190,11 +190,6 @@ RSpec.describe Reports::FeatureReportService do
             "content" => a_hash_including(
               "name" => form_with_all_answer_types.name,
             ),
-            "group" => a_hash_including(
-              "organisation" => a_hash_including(
-                "name" => group.organisation.name,
-              ),
-            ),
           ),
           "data" => a_hash_including(
             "question_text" => form_with_all_answer_types.pages[0].question_text,
@@ -205,11 +200,6 @@ RSpec.describe Reports::FeatureReportService do
             "form_id" => form_with_all_answer_types.id,
             "content" => a_hash_including(
               "name" => form_with_all_answer_types.name,
-            ),
-            "group" => a_hash_including(
-              "organisation" => a_hash_including(
-                "name" => group.organisation.name,
-              ),
             ),
           ),
           "data" => a_hash_including(
@@ -241,96 +231,6 @@ RSpec.describe Reports::FeatureReportService do
         ),
       )
     end
-
-    it "includes a reference to the organisation record" do
-      questions = described_class.new(form_documents).questions_with_answer_type("text")
-      expect(questions).to all include(
-        "form" => a_hash_including(
-          "group" => a_hash_including(
-            "organisation" => a_hash_including(
-              "name",
-            ),
-          ),
-        ),
-      )
-    end
-  end
-
-  describe "#forms_with_routes" do
-    it "returns details needed to render report" do
-      forms = described_class.new(form_documents).forms_with_routes
-      expect(forms).to match [
-        a_hash_including(
-          "form_id" => branch_route_form.id,
-          "content" => a_hash_including(
-            "name" => branch_route_form.name,
-          ),
-          "group" => a_hash_including(
-            "organisation" => a_hash_including(
-              "name" => group.organisation.name,
-            ),
-          ),
-          "metadata" => {
-            "number_of_routes" => 3,
-            "number_of_branch_routes" => 1,
-          },
-        ),
-        a_hash_including(
-          "form_id" => basic_route_form.id,
-          "content" => a_hash_including(
-            "name" => basic_route_form.name,
-          ),
-          "group" => a_hash_including(
-            "organisation" => a_hash_including(
-              "name" => group.organisation.name,
-            ),
-          ),
-          "metadata" => {
-            "number_of_routes" => 1,
-            "number_of_branch_routes" => 0,
-          },
-        ),
-      ]
-    end
-
-    it "returns forms with routes" do
-      forms = described_class.new(form_documents).forms_with_routes
-      expect(forms).to match [
-        a_hash_including(
-          "form_id" => branch_route_form.id,
-          "content" => a_hash_including(
-            "name" => branch_route_form.name,
-          ),
-        ),
-        a_hash_including(
-          "form_id" => basic_route_form.id,
-          "content" => a_hash_including(
-            "name" =>  basic_route_form.name,
-          ),
-        ),
-      ]
-    end
-
-    it "includes counts of routes" do
-      forms = described_class.new(form_documents).forms_with_routes
-      expect(forms).to all include(
-        "metadata" => a_hash_including(
-          "number_of_routes" => an_instance_of(Integer),
-          "number_of_branch_routes" => an_instance_of(Integer),
-        ),
-      )
-    end
-
-    it "includes a reference to the organisation record" do
-      forms = described_class.new(form_documents).forms_with_routes
-      expect(forms).to all include(
-        "group" => a_hash_including(
-          "organisation" => a_hash_including(
-            "name",
-          ),
-        ),
-      )
-    end
   end
 
   describe "#forms_with_branch_routes" do
@@ -341,11 +241,6 @@ RSpec.describe Reports::FeatureReportService do
           "form_id" => branch_route_form.id,
           "content" => a_hash_including(
             "name" => branch_route_form.name,
-          ),
-          "group" => a_hash_including(
-            "organisation" => a_hash_including(
-              "name" => group.organisation.name,
-            ),
           ),
           "metadata" => {
             "number_of_routes" => 3,
@@ -376,17 +271,6 @@ RSpec.describe Reports::FeatureReportService do
         ),
       )
     end
-
-    it "includes a reference to the organisation record" do
-      forms = described_class.new(form_documents).forms_with_branch_routes
-      expect(forms).to all include(
-        "group" => a_hash_including(
-          "organisation" => a_hash_including(
-            "name",
-          ),
-        ),
-      )
-    end
   end
 
   describe "#forms_with_payments" do
@@ -400,17 +284,6 @@ RSpec.describe Reports::FeatureReportService do
           ),
         ),
       ]
-    end
-
-    it "includes a reference to the organisation record" do
-      forms = described_class.new(form_documents).forms_with_routes
-      expect(forms).to all include(
-        "group" => a_hash_including(
-          "organisation" => a_hash_including(
-            "name",
-          ),
-        ),
-      )
     end
   end
 
@@ -426,17 +299,6 @@ RSpec.describe Reports::FeatureReportService do
         ),
       ]
     end
-
-    it "includes a reference to the organisation record" do
-      forms = described_class.new(form_documents).forms_with_exit_pages
-      expect(forms).to all include(
-        "group" => a_hash_including(
-          "organisation" => a_hash_including(
-            "name",
-          ),
-        ),
-      )
-    end
   end
 
   describe "#forms_with_csv_submission_enabled" do
@@ -450,17 +312,6 @@ RSpec.describe Reports::FeatureReportService do
           ),
         ),
       ]
-    end
-
-    it "includes a reference to the organisation record" do
-      forms = described_class.new(form_documents).forms_with_routes
-      expect(forms).to all include(
-        "group" => a_hash_including(
-          "organisation" => a_hash_including(
-            "name",
-          ),
-        ),
-      )
     end
   end
 end

--- a/spec/services/reports/form_documents_service_spec.rb
+++ b/spec/services/reports/form_documents_service_spec.rb
@@ -63,9 +63,19 @@ RSpec.describe Reports::FormDocumentsService do
       end
 
       it "only includes draft form documents from external organisations" do
-        form_documents = described_class.form_documents(tag:).to_a
+        form_documents = described_class.form_documents(tag:)
         expect(form_documents.map { |form_document| form_document["form_id"] })
           .to contain_exactly(draft_form.id, live_with_draft_form.id, archived_with_draft_form.id)
+      end
+
+      it "includes the group and organisation details" do
+        form_document = described_class.form_documents(tag:).first
+        expect(form_document).to include(
+          "organisation_name" => group.organisation.name,
+          "organisation_id" => group.organisation.id,
+          "group_name" => group.name,
+          "group_external_id" => group.external_id,
+        )
       end
     end
 
@@ -79,7 +89,7 @@ RSpec.describe Reports::FormDocumentsService do
       end
 
       it "only includes live form documents from external organisations" do
-        form_documents = described_class.form_documents(tag:).to_a
+        form_documents = described_class.form_documents(tag:)
         expect(form_documents.map { |form_document| form_document["form_id"] })
           .to contain_exactly(
             form_with_no_routes.id,
@@ -88,6 +98,16 @@ RSpec.describe Reports::FormDocumentsService do
             basic_route_form.id,
             form_with_2_branch_routes.id,
           )
+      end
+
+      it "includes the group and organisation details" do
+        form_document = described_class.form_documents(tag:).first
+        expect(form_document).to include(
+          "organisation_name" => group.organisation.name,
+          "organisation_id" => group.organisation.id,
+          "group_name" => group.name,
+          "group_external_id" => group.external_id,
+        )
       end
     end
 

--- a/spec/services/reports/forms_csv_report_service_spec.rb
+++ b/spec/services/reports/forms_csv_report_service_spec.rb
@@ -5,7 +5,22 @@ RSpec.describe Reports::FormsCsvReportService do
     described_class.new(form_documents)
   end
 
-  let(:form_documents) { forms.map { |form| form.live_form_document.as_json } }
+  let(:organisation_name) { Faker::Company.name }
+  let(:organisation_id) { Faker::Number.number }
+  let(:group_name) { Faker::Lorem.sentence }
+  let(:group_external_id) { Faker::Alphanumeric.alphanumeric(number: 8) }
+  let(:form_documents) do
+    forms.map do |form|
+      # FormDocumentsService adds in the organisation and group details as part of the database query
+      form.live_form_document.as_json
+          .merge({
+            "organisation_name" => organisation_name,
+            "organisation_id" => organisation_id,
+            "group_name" => group_name,
+            "group_external_id" => group_external_id,
+          })
+    end
+  end
   let(:form) do
     create(:form, :live, :with_support, submission_type: "email_with_csv", payment_url: "https://www.gov.uk/payments/organisation/service", pages: [
       create(:page, :with_address_settings, is_repeatable: true),
@@ -20,14 +35,6 @@ RSpec.describe Reports::FormsCsvReportService do
     ])
   end
   let(:forms) { [form, create(:form, :live)] }
-
-  let(:group) { create(:group) }
-
-  before do
-    forms.each do |form|
-      GroupForm.create!(form: form, group: group)
-    end
-  end
 
   describe "#csv" do
     it "returns a CSV with a header row and a row for each form" do
@@ -44,10 +51,10 @@ RSpec.describe Reports::FormsCsvReportService do
         "live",
         form.name,
         form.form_slug,
-        group.organisation.name,
-        group.organisation.id.to_s,
-        group.name,
-        group.external_id,
+        organisation_name,
+        organisation_id.to_s,
+        group_name,
+        group_external_id,
         form.created_at.iso8601(6),
         form.updated_at.iso8601(6),
         "9",

--- a/spec/services/reports/questions_csv_report_service_spec.rb
+++ b/spec/services/reports/questions_csv_report_service_spec.rb
@@ -5,8 +5,24 @@ RSpec.describe Reports::QuestionsCsvReportService do
     described_class.new(question_page_documents)
   end
 
+  let(:organisation_name) { Faker::Company.name }
+  let(:organisation_id) { Faker::Number.number }
+  let(:group_name) { Faker::Lorem.sentence }
+  let(:group_external_id) { Faker::Alphanumeric.alphanumeric(number: 8) }
+
   let(:question_page_documents) { Reports::FeatureReportService.new(form_documents).questions }
-  let(:form_documents) { forms.map { |form| form.live_form_document.as_json } }
+  let(:form_documents) do
+    forms.map do |form|
+      # FormDocumentsService adds in the organisation and group details as part of the database query
+      form.live_form_document.as_json
+          .merge({
+            "organisation_name" => organisation_name,
+            "organisation_id" => organisation_id,
+            "group_name" => group_name,
+            "group_external_id" => group_external_id,
+          })
+    end
+  end
   let(:form_with_all_answer_types) do
     create(:form, :live, :with_support, submission_type: "email_with_csv", payment_url: "https://www.gov.uk/payments/organisation/service", pages: [
       create(:page, :with_address_settings, is_repeatable: true),
@@ -36,14 +52,6 @@ RSpec.describe Reports::QuestionsCsvReportService do
   end
   let(:forms) { [form_with_all_answer_types, branch_route_form, basic_route_form] }
 
-  let(:group) { create(:group) }
-
-  before do
-    forms.each do |form|
-      GroupForm.create!(form: form, group: group)
-    end
-  end
-
   describe "#csv" do
     it "returns a CSV with a header row and a rows for each question" do
       csv = csv_reports_service.csv
@@ -59,10 +67,10 @@ RSpec.describe Reports::QuestionsCsvReportService do
         form_with_all_answer_types.id.to_s,
         "live",
         form_with_all_answer_types.name,
-        group.organisation.name,
-        group.organisation.id.to_s,
-        group.name,
-        group.external_id,
+        organisation_name,
+        organisation_id.to_s,
+        group_name,
+        group_external_id,
         form_with_all_answer_types.pages.last.position.to_s,
         form_with_all_answer_types.pages.last.question_text,
         "text",
@@ -89,10 +97,10 @@ RSpec.describe Reports::QuestionsCsvReportService do
         form_with_all_answer_types.id.to_s,
         "live",
         form_with_all_answer_types.name,
-        group.organisation.name,
-        group.organisation.id.to_s,
-        group.name,
-        group.external_id,
+        organisation_name,
+        organisation_id.to_s,
+        group_name,
+        group_external_id,
         form_with_all_answer_types.pages[7].position.to_s,
         form_with_all_answer_types.pages[7].question_text,
         "selection",
@@ -119,10 +127,10 @@ RSpec.describe Reports::QuestionsCsvReportService do
         form_with_all_answer_types.id.to_s,
         "live",
         form_with_all_answer_types.name,
-        group.organisation.name,
-        group.organisation.id.to_s,
-        group.name,
-        group.external_id,
+        organisation_name,
+        organisation_id.to_s,
+        group_name,
+        group_external_id,
         form_with_all_answer_types.pages[3].position.to_s,
         form_with_all_answer_types.pages[3].question_text,
         "name",
@@ -149,10 +157,10 @@ RSpec.describe Reports::QuestionsCsvReportService do
         basic_route_form.id.to_s,
         "live",
         basic_route_form.name,
-        group.organisation.name,
-        group.organisation.id.to_s,
-        group.name,
-        group.external_id,
+        organisation_name,
+        organisation_id.to_s,
+        group_name,
+        group_external_id,
         basic_route_form.pages.first.position.to_s,
         basic_route_form.pages.first.question_text,
         "selection",
@@ -179,10 +187,10 @@ RSpec.describe Reports::QuestionsCsvReportService do
         branch_route_form.id.to_s,
         "live",
         branch_route_form.name.to_s,
-        group.organisation.name,
-        group.organisation.id.to_s,
-        group.name,
-        group.external_id,
+        organisation_name,
+        organisation_id.to_s,
+        group_name,
+        group_external_id,
         branch_route_form.pages[1].position.to_s,
         branch_route_form.pages[1].question_text,
         "selection",

--- a/spec/views/reports/feature_report.html.erb_spec.rb
+++ b/spec/views/reports/feature_report.html.erb_spec.rb
@@ -16,8 +16,8 @@ describe "reports/feature_report" do
     let(:report) { "forms_with_csv_submission_enabled" }
     let(:records) do
       [
-        { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
-        { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
+        { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" },
+        { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "organisation_name" => "Government Digital Service" },
       ]
     end
 
@@ -72,8 +72,8 @@ describe "reports/feature_report" do
     let(:report) { "forms_with_payments" }
     let(:records) do
       [
-        { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
-        { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } },
+        { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" },
+        { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "organisation_name" => "Government Digital Service" },
       ]
     end
 
@@ -128,8 +128,8 @@ describe "reports/feature_report" do
     let(:report) { "forms_with_routes" }
     let(:records) do
       [
-        { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } }, "metadata" => { "number_of_routes" => 1 } },
-        { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } }, "metadata" => { "number_of_routes" => 2 } },
+        { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service", "metadata" => { "number_of_routes" => 1 } },
+        { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "organisation_name" => "Government Digital Service", "metadata" => { "number_of_routes" => 2 } },
       ]
     end
 
@@ -184,8 +184,8 @@ describe "reports/feature_report" do
     let(:report) { "questions_with_add_another_answer" }
     let(:records) do
       [
-        { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
-        { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
+        { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" } },
+        { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "organisation_name" => "Government Digital Service" } },
       ]
     end
 

--- a/spec/views/reports/questions_with_answer_type.html.erb_spec.rb
+++ b/spec/views/reports/questions_with_answer_type.html.erb_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "reports/questions_with_answer_type" do
   let(:questions) do
     [
-      { "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
-      { "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "group" => { "organisation" => { "name" => "Government Digital Service" } } } },
+      { "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" } },
+      { "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "organisation_name" => "Government Digital Service" } },
     ]
   end
   let(:tag) { "live" }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/KIdXtAro/

The reports were joining on the group and organisation for the form when doing the initial query to get the form data in order to filter out forms from internal organisations. They were then later looking up the group and organisation per form in order to construct the data for either the table of forms/questions to display or the CSV to download. Remove the lookup of group/organisation per form by selecting the group and organisation details in the initial query and using this when rendering.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
