### PR TITLE
Update requirements on submission email page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1581,8 +1581,17 @@ en:
     new:
       body_html: |
         <p>
-          You need to provide an email address for completed forms to be sent to for processing. It should be a shared government email inbox.
+          You need to provide an email address for completed forms to be sent to for processing.
         </p>
+
+        <p>
+          The email address:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>should be a shared government email inbox</li>
+          <li>must not send automatic replies</li>
+        </ul>
 
         <p>
           To make sure the email address you provide is correct, we’ll send an email to it with a confirmation code and your email address.


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/tUx4WhB9/2483-create-guidance-to-not-use-an-auto-reply-on-the-submission-mailbox

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Updates the submission email guidance to include a requirement that the inbox should not have an autoresponse set up.

### Screenshots

#### Before
<img width="667" height="315" alt="image" src="https://github.com/user-attachments/assets/56ca07c8-feea-4eed-b37f-b8a6a94bbe09" />

#### After
<img width="647" height="366" alt="image" src="https://github.com/user-attachments/assets/328acaac-6d22-46d4-b12d-d112b37b5916" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
