### PR TITLE
Remove transaction from rake task

### DIFF
--- a/lib/tasks/form_documents.rake
+++ b/lib/tasks/form_documents.rake
@@ -30,10 +30,8 @@ namespace :form_documents do
   task sync_draft_form_documents: :environment do
     Rails.logger.info "Started with #{FormDocument.where(tag: 'draft').count} draft FormDocuments"
 
-    ActiveRecord::Base.transaction do
-      Form.find_each do |form|
-        FormDocumentSyncService.update_draft_form_document(form)
-      end
+    Form.find_each do |form|
+      FormDocumentSyncService.update_draft_form_document(form)
     end
 
     Rails.logger.info "Finished with #{FormDocument.where(tag: 'draft').count} draft FormDocuments"


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/KIdXtAro/2470-change-feature-reports-to-use-form-documents-in-forms-admin-database

Remove the transaction from the rake task to synchronise draft forms. The task was timing out when running on production. Running in a single transaction was possibly slowing down the database operations, and there are no negative consequences of committing the changes even if the task fails midway.
