### PR TITLE
Add link to move forms from group pages

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,7 +23,7 @@ class GroupsController < WebController
     authorize @group
 
     forms = @group.forms
-    @form_list_presenter = FormListPresenter.call(forms:, group: @group, can_admin: @current_user.can_admin_org?(@group.organisation)) unless forms.empty?
+    @form_list_presenter = FormListPresenter.call(forms:, group: @group, can_admin: @current_user.can_administer_org?(@group.organisation)) unless forms.empty?
   end
 
   # GET /groups/new

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -21,8 +21,9 @@ class GroupsController < WebController
   # GET /groups/1
   def show
     authorize @group
+
     forms = @group.forms
-    @form_list_presenter = FormListPresenter.call(forms:, group: @group) unless forms.empty?
+    @form_list_presenter = FormListPresenter.call(forms:, group: @group, can_admin: @current_user.can_admin_org?(@group.organisation)) unless forms.empty?
   end
 
   # GET /groups/new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,10 @@ class User < ApplicationRecord
     mou_signatures.find_by(organisation:)
   end
 
+  def can_admin_org?(org)
+    is_organisations_admin?(org) || super_admin?
+  end
+
   def is_organisations_admin?(org)
     organisation_admin? && organisation == org
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,7 +89,7 @@ class User < ApplicationRecord
     mou_signatures.find_by(organisation:)
   end
 
-  def can_admin_org?(org)
+  def can_administer_org?(org)
     is_organisations_admin?(org) || super_admin?
   end
 

--- a/app/presenters/form_list_presenter.rb
+++ b/app/presenters/form_list_presenter.rb
@@ -11,9 +11,10 @@ class FormListPresenter
     end
   end
 
-  def initialize(forms:, group:)
+  def initialize(forms:, group:, can_admin: false)
     @forms = forms
     @group = group
+    @can_admin = can_admin
     @list_of_creator_id = forms.map(&:creator_id).uniq
     @list_of_creators = User.where(id: @list_of_creator_id)
                              .select(:id, :name)
@@ -35,19 +36,29 @@ private
   end
 
   def head
-    [
+    head = [
       I18n.t("home.form_name_heading"),
       { text: I18n.t("home.created_by") },
       { text: I18n.t("home.form_status_heading"), numeric: true },
-    ].compact
+    ]
+
+    head << { text: I18n.t("home.actions"), numeric: true } if @can_admin
+
+    head.compact
   end
 
   def rows
-    forms.sort_by { |form| [form.name.downcase, form.created_at] }.map do |form|
-      [{ text: form_name_link(form) },
-       { text: find_creator_name(form) },
-       { text: form_status_tags(form), numeric: true }].compact
+    rows = forms.sort_by { |form| [form.name.downcase, form.created_at] }.map do |form|
+      row = [{ text: form_name_link(form) },
+             { text: find_creator_name(form) },
+             { text: form_status_tags(form), numeric: true }]
+
+      row << { text: govuk_link_to(I18n.t("home.move_form"), edit_group_form_path(group, id: form.id)), numeric: true } if @can_admin
+
+      row
     end
+
+    rows.compact
   end
 
   def form_name_link(form)

--- a/app/presenters/form_list_presenter.rb
+++ b/app/presenters/form_list_presenter.rb
@@ -1,7 +1,8 @@
 class FormListPresenter
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
-  include GovukRailsCompatibleLinkHelper
+  include GovukLinkHelper
+  include GovukVisuallyHiddenHelper
 
   attr_accessor :forms, :group
 
@@ -53,7 +54,7 @@ private
              { text: find_creator_name(form) },
              { text: form_status_tags(form), numeric: true }]
 
-      row << { text: govuk_link_to(I18n.t("home.move_form"), edit_group_form_path(group, id: form.id)), numeric: true } if @can_admin
+      row << { text: change_group_link(form), numeric: true } if @can_admin
 
       row
     end
@@ -63,6 +64,14 @@ private
 
   def form_name_link(form)
     govuk_link_to(form.name, FormService.new(form).path_for_state)
+  end
+
+  def change_group_link(form)
+    govuk_link_to(
+      I18n.t("home.move_form"),
+      edit_group_form_path(group, id: form.id),
+      visually_hidden_suffix: I18n.t("home.for", form_name: form.name),
+    )
   end
 
   def form_status_tags(form)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -876,6 +876,7 @@ en:
     change_filter: Change
     create_a_form: Create a form
     created_by: Created by
+    for: for %{form_name}
     form_name_heading: Form name
     form_status_heading: Status
     move_form: Change group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -872,11 +872,13 @@ en:
       pages_selection_options_input:
         include_none_of_the_above: Should the list include an option for ‘None of the above’?
   home:
+    actions: Actions
     change_filter: Change
     create_a_form: Create a form
     created_by: Created by
     form_name_heading: Form name
     form_status_heading: Status
+    move_form: Change group
     preview: Preview this form
   internal_server_error:
     body: Please try again later.

--- a/spec/features/group_form/move_form_spec.rb
+++ b/spec/features/group_form/move_form_spec.rb
@@ -70,14 +70,12 @@ feature "Move a form", type: :feature do
   end
 
   def and_i_click_move_form
-    # TODO: Implement the actual link to move the form, and delete the visit line below
-    # expect(page).to have_content("Change group")
-    # click_link "Change group"
-    visit edit_group_form_path(group, id: form.id)
+    expect(page).to have_content("Change group")
+    click_link "Change group"
   end
 
   def but_i_do_not_see_the_move_link
-    expect(page).not_to have_link("Change group") # This passes anyway as we don't have that link in the UI, but a useful check once we do add it
+    expect(page).not_to have_link("Change group")
   end
 
   def and_i_cannot_visit_the_move_form_page

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -234,6 +234,32 @@ describe User, type: :model do
     end
   end
 
+  describe "#can_admin_org?" do
+    context "when the user is a super admin" do
+      it "returns true" do
+        user = create(:super_admin_user)
+
+        expect(user.can_admin_org?(organisation)).to be(true)
+      end
+    end
+
+    context "when the user is an organisation admin" do
+      it "returns true" do
+        user = create(:organisation_admin_user)
+
+        expect(user.can_admin_org?(organisation)).to be(true)
+      end
+    end
+
+    context "when the user is a standard user" do
+      it "returns false" do
+        user = create(:user)
+
+        expect(user.can_admin_org?(organisation)).to be(false)
+      end
+    end
+  end
+
   describe "#is_organisations_admin?" do
     context "when the user does not have the organisation admin role" do
       it "returns false" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -234,12 +234,12 @@ describe User, type: :model do
     end
   end
 
-  describe "#can_admin_org?" do
+  describe "#can_administer_org?" do
     context "when the user is a super admin" do
       it "returns true" do
         user = create(:super_admin_user)
 
-        expect(user.can_admin_org?(organisation)).to be(true)
+        expect(user.can_administer_org?(organisation)).to be(true)
       end
     end
 
@@ -247,7 +247,7 @@ describe User, type: :model do
       it "returns true" do
         user = create(:organisation_admin_user)
 
-        expect(user.can_admin_org?(organisation)).to be(true)
+        expect(user.can_administer_org?(organisation)).to be(true)
       end
     end
 
@@ -255,7 +255,7 @@ describe User, type: :model do
       it "returns false" do
         user = create(:user)
 
-        expect(user.can_admin_org?(organisation)).to be(false)
+        expect(user.can_administer_org?(organisation)).to be(false)
       end
     end
   end

--- a/spec/presenters/form_list_presenter_spec.rb
+++ b/spec/presenters/form_list_presenter_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 describe FormListPresenter do
-  let(:presenter) { described_class.call(forms:, group:) }
+  let(:presenter) { described_class.call(forms:, group:, can_admin:) }
 
   let(:creator) { create :user }
   let(:forms) { build_list :form, 5, :with_id, creator_id: creator.id, created_at: "2024-10-08T07:31:15.762Z" }
-  let(:group) { build :group }
+  let(:group) { create :group }
+  let(:can_admin) { false }
 
   describe "#data" do
     describe "caption" do
@@ -19,6 +20,17 @@ describe FormListPresenter do
         expect(presenter.data[:head]).to eq([I18n.t("home.form_name_heading"),
                                              { text: I18n.t("home.created_by") },
                                              { text: I18n.t("home.form_status_heading"), numeric: true }])
+      end
+
+      context "when user is org admin" do
+        let(:can_admin) { true }
+
+        it "contains an additional 'Actions' column heading" do
+          expect(presenter.data[:head]).to eq([I18n.t("home.form_name_heading"),
+                                               { text: I18n.t("home.created_by") },
+                                               { text: I18n.t("home.form_status_heading"), numeric: true },
+                                               { text: I18n.t("home.actions"), numeric: true }])
+        end
       end
     end
 
@@ -41,6 +53,28 @@ describe FormListPresenter do
         end
       end
 
+      context "when user is org admin" do
+        let(:can_admin) { true }
+
+        it "has an additional actions column with links" do
+          presenter.data[:rows].each_with_index do |row, index|
+            form = forms[index]
+            expect(row).to eq([
+              { text: "<a class=\"govuk-link\" href=\"/forms/#{form.id}\">#{form.name}</a>" },
+              { text: creator.name.to_s },
+              {
+                numeric: true,
+                text: "<div class='app-form-states'><strong class=\"govuk-tag govuk-tag--yellow\">Draft</strong>\n</div>",
+              },
+              {
+                numeric: true,
+                text: "<a class=\"govuk-link\" href=\"/groups/#{group.external_id}/forms/#{form.id}/edit\">Change group</a>",
+              },
+            ])
+          end
+        end
+      end
+
       context "when forms with names are random" do
         let(:forms) do
           [
@@ -50,7 +84,7 @@ describe FormListPresenter do
             build(:form, id: 4, name: "C", created_at: "2024-10-08T07:31:15.762Z"),
           ]
         end
-        let(:presenter) { described_class.call(forms:, group:) }
+        let(:presenter) { described_class.call(forms:, group:, can_admin:) }
 
         it "sorts alphabetically" do
           rows = presenter.data[:rows]
@@ -70,7 +104,7 @@ describe FormListPresenter do
             build(:form, id: 4, name: "a", created_at: "2024-10-08T09:31:15.762Z"),
           ]
         end
-        let(:presenter) { described_class.call(forms:, group:) }
+        let(:presenter) { described_class.call(forms:, group:, can_admin:) }
 
         it "sorts alphabetically first, then by created_at time" do
           rows = presenter.data[:rows]

--- a/spec/presenters/form_list_presenter_spec.rb
+++ b/spec/presenters/form_list_presenter_spec.rb
@@ -68,7 +68,7 @@ describe FormListPresenter do
               },
               {
                 numeric: true,
-                text: "<a class=\"govuk-link\" href=\"/groups/#{group.external_id}/forms/#{form.id}/edit\">Change group</a>",
+                text: "<a class=\"govuk-link\" href=\"/groups/#{group.external_id}/forms/#{form.id}/edit\">Change group<span class=\"govuk-visually-hidden\"> for #{form.name}</span></a>",
               },
             ])
           end

--- a/spec/views/group_forms/edit.html.erb_spec.rb
+++ b/spec/views/group_forms/edit.html.erb_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe "group_forms/edit.html.erb", type: :view do
 
   it "renders the page title" do
     render
-    expect(rendered).to have_css("h1", text: /Move this form/)
+    expect(rendered).to have_css("h1", text: /Move this form to a different group/)
   end
 
   it "renders the page title with error prefix when form has errors" do
-    skip "not sure we need this at the moment"
+    group_select.errors.add :group, :blank
 
     render
-    expect(view.content_for(:page_title)).to eq("Error: Move Form")
+    expect(view.content_for(:title)).to eq("Error: Move this form to a different group")
   end
 
   it "sets the back link to the group" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/6ZzEQzWx/2457-add-a-change-group-link-to-the-move-forms-screen

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
