### PR TITLE
Allow requests addressed to internal host name

### DIFF
--- a/lib/host_patterns.rb
+++ b/lib/host_patterns.rb
@@ -2,6 +2,7 @@ module HostPatterns
   ALLOWED_HOST_PATTERNS = [
     /admin\.forms\.service\.gov\.uk/,
     /admin\.[^.]*\.forms\.service\.gov\.uk/,
+    /admin\.internal.[^.]*\.forms\.service\.gov\.uk/,
     /pr-[^.]*\.admin\.review\.forms\.service\.gov\.uk/,
     /pr-[^.]*-admin\.submit\.review\.forms\.service\.gov\.uk/,
   ].freeze


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WE2USq8v/2474-change-infrastructure-to-allow-apps-to-talk-to-each-other-directly <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We're adding a VPC internal route to our infrastructure, so that requests between apps don't need to go via the public internet. These routes will be assigned names in the internal.(dev|staging|prod|user-research).forms.service.gov.uk domain, so we need to allow admin to receive requests at this address.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?