### PR TITLE
Handle "archived_with_draft" state in FormDocumentSyncService

### DIFF
--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -4,7 +4,7 @@ class FormDocumentSyncService
       case form.state
       when "live"
         sync_live_form(form)
-      when "archived"
+      when "archived", "archived_with_draft"
         sync_archived_form(form)
       end
     end

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -142,8 +142,17 @@ RSpec.describe FormStateMachine do
     context "when form is live_with_draft" do
       let(:form) { FakeForm.new(state: :live_with_draft) }
 
+      before do
+        allow(FormDocumentSyncService).to receive(:synchronize_form)
+      end
+
       it "transitions to archived_with_draft" do
         expect(form).to transition_from(:live_with_draft).to(:archived_with_draft).on_event(:archive_live_form)
+      end
+
+      it "calls the FormDocumentSyncService" do
+        form.archive_live_form
+        expect(FormDocumentSyncService).to have_received(:synchronize_form).with(form)
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

We weren't handling the case where the form status is updated to the "archived_with_draft" state, which is the state we transition to when archiving a form in the "live_with_draft" state. This should be handled the same way as the "archived" state, creating a FormDocument with the "archived" tag and deleting the live FormDocument.

> [!NOTE]
> Hiding whitespace changes in the diff will make reviewing easier as I've moved around some contexts in the spec.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
