### PR TITLE
Fix translations for summary list on delete condition page

### DIFF
--- a/app/views/pages/conditions/delete.html.erb
+++ b/app/views/pages/conditions/delete.html.erb
@@ -23,15 +23,15 @@
 
       <%= govuk_summary_list(actions: false) do |summary_list|
         summary_list.with_row do |row|
-          row.with_key { t("new_condition.routing_page_text") }
+          row.with_key(text: t("new_condition.routing_page_text"))
           row.with_value { delete_condition_input.page.question_text }
         end;
         summary_list.with_row do |row|
-          row.with_key { t(".answered_as_key") }
+          row.with_key(text: t(".answered_as_key"))
           row.with_value { delete_condition_input.answer_value }
         end;
         summary_list.with_row do |row|
-          row.with_key { t(".skip_to_key") }
+          row.with_key(text: t(".skip_to_key"))
           row.with_value { delete_condition_input.record.exit_page? ? delete_condition_input.record.exit_page_heading : delete_condition_input.goto_page_question_text }
         end;
 

--- a/spec/views/pages/conditions/delete.html.erb_spec.rb
+++ b/spec/views/pages/conditions/delete.html.erb_spec.rb
@@ -25,8 +25,11 @@ describe "pages/conditions/delete.html.erb" do
   end
 
   it "contains the condition details" do
+    expect(rendered).to have_css(".govuk-summary-list__key", text: "If the question")
     expect(rendered).to have_css(".govuk-summary-list__value", text: delete_condition_input.page.question_text)
+    expect(rendered).to have_css(".govuk-summary-list__key", text: "is answered as")
     expect(rendered).to have_css(".govuk-summary-list__value", text: delete_condition_input.answer_value)
+    expect(rendered).to have_css(".govuk-summary-list__key", text: "skip the person to")
     expect(rendered).to have_css(".govuk-summary-list__value", text: delete_condition_input.goto_page_question_text)
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

A block passed to `GovukComponent::SummaryListComponent::RowComponent#with_key` is evaluated in the context of that class, rather than the context of the view; so for a translation key starting with `.` the scope will be `govuk_component.summary_list_component` rather than the scope for the view as expected.

Testing locally it seems the behaviour changed in govuk-components v5.11.2; this was the release that bumped view_component from v2 to v4, so I think the breakage was probably introduced by that gem.

It's not clear whether the new behaviour is intended or not, but we can workaround easily enough by passing the desired string as an argument to `with_key` rather than using a block.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?