### PR TITLE
Fix use of translation in Summary List Component

### DIFF
--- a/app/views/group_forms/edit.html.erb
+++ b/app/views/group_forms/edit.html.erb
@@ -15,11 +15,11 @@
 
     <%= govuk_summary_list(classes: "govuk-summary-list--no-border") do |summary_list|
       summary_list.with_row do |row|
-        row.with_key { t('group_forms.edit.form_name_label') }
+        row.with_key(text: t('.form_name_label'))
         row.with_value { @group_select.form.name }
       end;
       summary_list.with_row do |row|
-        row.with_key { t('group_forms.edit.group_name_label') }
+        row.with_key(text: t('.group_name_label'))
         row.with_value { @group.name }
       end;
     end %>


### PR DESCRIPTION
The shorthand for using i18n.t wasn't working because the context is for the class it's being used [1]

[1]: https://github.com/alphagov/forms-admin/pull/2219

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
