### PR TITLE
Tweaked for house style - mainly adding single quotes and bold 

### DIFF
--- a/app/views/forms/payment_link/new.html.erb
+++ b/app/views/forms/payment_link/new.html.erb
@@ -26,7 +26,7 @@
         <%= t('payment_link_input.creating_your_payment_link.heading') %>
       </h2>
 
-      <p><%= t('payment_link_input.creating_your_payment_link.body') %></p>
+      <p><%= t('payment_link_input.creating_your_payment_link.body_html') %></p>
 
       <h3 class="govuk-heading-s"><%= t('payment_link_input.set_up_your_payment_link.heading') %></h3>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1306,7 +1306,7 @@ en:
 
       <p>Once it’s set up, you can copy and paste the payment link URL into the box below. This will add a payment page to the end of your form.</p>
     creating_your_payment_link:
-      body: Once you have a GOV.UK Pay account you can “add a new service” and start creating your payment link.
+      body: Once you have a GOV.UK Pay account you can start creating your payment link by selecting **Add a new service**.
       heading: Creating your payment link in GOV.UK Pay
     heading: Add a link to a payment page on GOV.UK Pay
     how_this_will_help_processors:
@@ -1322,10 +1322,10 @@ en:
         <p>Once someone’s submitted their form they’ll see a confirmation page showing:</p>
 
         <ul class="govuk-list govuk-list--bullet">
-          <li>a blue banner saying “You still need to pay”</li>
+          <li>a blue banner saying ‘You still need to pay’</li>
           <li>their form’s unique reference number</li>
           <li>the ‘what happens next’ information you’ve added</li>
-          <li>a green “Continue to pay” button - this will take them to GOV.UK Pay to make their payment</li>
+          <li>a green ‘Continue to pay’ button - this will take them to GOV.UK Pay to make their payment</li>
         </ul>
 
         <p>The reference number, payment link and ‘what happens next’ information will also be included in a confirmation email for form fillers - if they choose to receive this.</p>
@@ -1334,13 +1334,13 @@ en:
       body_html: |
         <p>GOV.UK Forms adds a unique 8-character reference to each form submission.</p>
 
-        <p>When creating a payment link in GOV.UK Pay, you’ll be asked “Do your users already have a payment reference?”</p>
+        <p>When creating a payment link in GOV.UK Pay, you’ll be asked ‘Do your users already have a payment reference?’</p>
 
-        <p>Select “Yes”.</p>
+        <p>Select **Yes**.</p>
 
         <p>This means the form reference number will automatically be sent through to GOV.UK Pay when someone makes a payment.</p>
 
-        <p>When asked to fill in the “Name of payment reference” field, enter “Form reference number”.</p>
+        <p>When asked to fill in the **Name of payment reference** field, enter ‘Form reference number’.</p>
       heading: Set up your payment link to use a form’s unique reference number
     setting_up_govuk_pay:
       body_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1306,7 +1306,7 @@ en:
 
       <p>Once it’s set up, you can copy and paste the payment link URL into the box below. This will add a payment page to the end of your form.</p>
     creating_your_payment_link:
-      body: Once you have a GOV.UK Pay account you can start creating your payment link by selecting <strong>Add a new service</strong>.
+      body_html: Once you have a GOV.UK Pay account you can start creating your payment link by selecting <strong>Add a new service</strong>.
       heading: Creating your payment link in GOV.UK Pay
     heading: Add a link to a payment page on GOV.UK Pay
     how_this_will_help_processors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1306,7 +1306,7 @@ en:
 
       <p>Once it’s set up, you can copy and paste the payment link URL into the box below. This will add a payment page to the end of your form.</p>
     creating_your_payment_link:
-      body: Once you have a GOV.UK Pay account you can start creating your payment link by selecting **Add a new service**.
+      body: Once you have a GOV.UK Pay account you can start creating your payment link by selecting <strong>Add a new service</strong>.
       heading: Creating your payment link in GOV.UK Pay
     heading: Add a link to a payment page on GOV.UK Pay
     how_this_will_help_processors:
@@ -1336,11 +1336,11 @@ en:
 
         <p>When creating a payment link in GOV.UK Pay, you’ll be asked ‘Do your users already have a payment reference?’</p>
 
-        <p>Select **Yes**.</p>
+        <p>Select <strong>Yes</strong>.</p>
 
         <p>This means the form reference number will automatically be sent through to GOV.UK Pay when someone makes a payment.</p>
 
-        <p>When asked to fill in the **Name of payment reference** field, enter ‘Form reference number’.</p>
+        <p>When asked to fill in the <strong>Name of payment reference</strong> field, enter ‘Form reference number’.</p>
       heading: Set up your payment link to use a form’s unique reference number
     setting_up_govuk_pay:
       body_html: |

--- a/spec/views/forms/payment_link/new.html.erb_spec.rb
+++ b/spec/views/forms/payment_link/new.html.erb_spec.rb
@@ -25,7 +25,7 @@ describe "forms/payment_link/new.html.erb" do
 
   it "contains information about creating your payment link" do
     expect(rendered).to have_css("h2", text: I18n.t("payment_link_input.creating_your_payment_link.heading"))
-    expect(rendered).to have_text(I18n.t("payment_link_input.creating_your_payment_link.body"))
+    expect(rendered).to include(I18n.t("payment_link_input.creating_your_payment_link.body_html"))
   end
 
   it "contains information about setting up your payment link with a reference number" do


### PR DESCRIPTION
Updating the 'Add a payment link on GOV.UK Pay' page content to match GOV.UK house style so that:

- bold is used to indicate UI elements that explicitly tell users what to do - like “Select **Yes**” (with 'Yes' in bold')
- we've replaced double quotes with single quotes when referring to interface elements in non-instructional contexts

I also tweaked the wording of one sentence to make it a bit clearer:

"Once you have a GOV.UK Pay account you can start creating your payment link by selecting **Add a new service**." 

### What problem does this pull request solve?

Trello card: <https://trello.com/c/P2f1eCnv/2482-re-format-instructional-ui-text-on-add-a-link-to-a-payment-page>

It was pointed out to us by a tech writer on GOV.UK Pay that we weren't using bold for instructional UI elements, so this is an effort to right that. (Though what qualifies as explicit UI instructional text versus a reference to UI elements is sometimes a bit unclear.) 

We've also clarified that we should use single quotes in almost all instances, so this address that too.

### Things to consider when reviewing

- Please can you make sure I've edited this in the right file?! (I was confused by why the content isn't in the order it displays on the actual page. I found this a bit disorienting and it made me question whether I was editing the right content!)
- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
