### PR TITLE
Add form name to validation analytics

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -144,7 +144,7 @@ private
       page.routing_conditions.each do |condition|
         condition.validation_errors.each do |error|
           error_type = condition.secondary_skip? ? "any_other_answer_route.#{error.name}" : error.name
-          AnalyticsService.track_validation_errors(input_object_name: "PageList", field: :condition, error_type:)
+          AnalyticsService.track_validation_errors(input_object_name: "PageList", field: :condition, error_type:, form_name: current_form.name)
         end
       end
     end

--- a/app/input_objects/base_input.rb
+++ b/app/input_objects/base_input.rb
@@ -8,8 +8,10 @@ private
 
   def set_validation_error_logging_attributes
     CurrentLoggingAttributes.validation_errors = errors.map { |error| "#{error.attribute}: #{error.type}" } if errors.any?
+    form_name = form.name if defined?(form) && form.present?
+
     errors.each do |error|
-      AnalyticsService.track_validation_errors(input_object_name: self.class.name, field: error.attribute, error_type: error.type)
+      AnalyticsService.track_validation_errors(input_object_name: self.class.name, field: error.attribute, error_type: error.type, form_name:)
     end
   end
 end

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,9 +1,10 @@
 class AnalyticsService
   class << self
-    def track_validation_errors(input_object_name:, field:, error_type:)
+    def track_validation_errors(input_object_name:, field:, error_type:, form_name:)
       add_event("validation_error", {
         event_name: "validation_error",
-        form_name: input_object_name,
+        input_object_name: input_object_name,
+        form_name:,
         error_field: field,
         error_type: error_type,
       })

--- a/spec/input_objects/forms/declaration_input_spec.rb
+++ b/spec/input_objects/forms/declaration_input_spec.rb
@@ -56,8 +56,9 @@ RSpec.describe Forms::DeclarationInput, type: :model do
     end
 
     it "returns false if the data is invalid" do
-      form = described_class.new(declaration_text: ("abc" * 2001), form: { declaration_text: "" })
-      expect(form.submit).to be false
+      form = OpenStruct.new(declaration_text: "", name: "Apply for a juggling licence")
+      declaration_input = described_class.new(declaration_text: ("abc" * 2001), form:)
+      expect(declaration_input.submit).to be false
     end
 
     it "sets the form's attribute values" do

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe AnalyticsService do
   describe ".track_validation_errors" do
     it "adds a validation_error event with correct parameters" do
       input_object_name = "user_form"
+      form_name = "Apply for a juggling licence"
       field = "email"
       error_type = "invalid_format"
       expected_event_name = "validation_error"
       expected_properties = {
-        form_name: input_object_name,
+        input_object_name: input_object_name,
+        form_name:,
         event_name: "validation_error",
         error_field: field,
         error_type: error_type,
@@ -21,6 +23,7 @@ RSpec.describe AnalyticsService do
 
       described_class.track_validation_errors(
         input_object_name: input_object_name,
+        form_name:,
         field: field,
         error_type: error_type,
       )


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/b6jmnphx/2288-track-branching-validation-errors

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Previously we were passing the name of the input object (e.g. `Pages::SecondarySkipInput`) as the `form_name` value for the validation error events in Google Analytics.

While this is useful for tracking the specific input object that is tripping users up, it would also be useful to the engagement team to see which forms (e.g. `Apply for a juggling licence`) validation errors occur on.

This PR:

- uses the `form_name` to pass the form name instead of the input object name
- passes the input object name with a new key  `input_object_name`

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
