### PR TITLE
Add filters and pagination to users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,9 @@ gem "aasm", "~> 5.5"
 # Used by AASM to autocommit state changes when even method is used with bang eg. make_live!
 gem "after_commit_everywhere", "~> 1.6"
 
+# For pagination
+gem "pagy"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -619,6 +619,7 @@ DEPENDENCIES
   lograge
   omniauth-auth0
   omniauth-rails_csrf_protection
+  pagy
   paper_trail
   parallel_rspec
   pg (~> 1.6)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,15 +9,7 @@ class UsersController < WebController
   def index
     authorize current_user, :can_manage_user?
 
-    roles = User.roles.keys
-    @users = policy_scope(User).includes(:organisation).sort_by do |user|
-      [
-        user.organisation&.name || "",
-        user.has_access ? 0 : 1,
-        roles.index(user.role),
-        user.name || "",
-      ]
-    end
+    @users = policy_scope(User).for_users_list
 
     render template: "users/index", locals: { users: @users }
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < WebController
+  include Pagy::Backend
+
   after_action :verify_authorized
   after_action :verify_policy_scoped, only: :index
 
@@ -9,9 +11,9 @@ class UsersController < WebController
   def index
     authorize current_user, :can_manage_user?
 
-    @users = policy_scope(User).for_users_list
+    @pagy, @users = pagy(policy_scope(User).for_users_list, limit: 50)
 
-    render template: "users/index", locals: { users: @users }
+    render template: "users/index"
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,15 @@ class UsersController < WebController
   def index
     authorize current_user, :can_manage_user?
 
-    @pagy, @users = pagy(policy_scope(User).for_users_list, limit: 50)
+    users_query = policy_scope(User)
+                   .by_name(filter_params[:name])
+                   .by_email(filter_params[:email])
+                   .by_organisation_id(filter_params[:organisation_id])
+                   .for_users_list
+
+    @pagy, @users = pagy(users_query, limit: 50)
+
+    @filter_input = Users::FilterInput.new(filter_params)
 
     render template: "users/index"
   end
@@ -52,5 +60,9 @@ private
 
   def organisation_id_raw
     params.dig(:user, :organisation_id_raw)
+  end
+
+  def filter_params
+    params[:filter]&.permit(:name, :email, :organisation_id) || {}
   end
 end

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -4,6 +4,7 @@ $govuk-new-typography-scale: true;
 
 @import "pkg:govuk-frontend";
 @import "pkg:dfe-autocomplete";
+@import "../styles/app_filter";
 @import "../styles/app_form_states";
 @import "../styles/app_memorandum_of_understanding";
 @import "../styles/app_preview_area";

--- a/app/frontend/styles/_app_filter.scss
+++ b/app/frontend/styles/_app_filter.scss
@@ -1,0 +1,15 @@
+.app-filter {
+  form {
+    margin: govuk-spacing(3);
+    padding: govuk-spacing(3) 0;
+    background: govuk-colour("light-grey");
+  }
+
+  .govuk-hint {
+    color: $govuk-text-colour;
+  }
+
+  .autocomplete__input {
+    background: govuk-colour("white");
+  }
+}

--- a/app/input_objects/users/filter_input.rb
+++ b/app/input_objects/users/filter_input.rb
@@ -1,0 +1,5 @@
+module Users
+  class FilterInput < BaseInput
+    attr_accessor :email, :name, :organisation_id
+  end
+end

--- a/app/input_objects/users/filter_input.rb
+++ b/app/input_objects/users/filter_input.rb
@@ -1,5 +1,9 @@
 module Users
   class FilterInput < BaseInput
     attr_accessor :email, :name, :organisation_id
+
+    def has_filters?
+      [email, name, organisation_id].any?(&:present?)
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,14 @@ class User < ApplicationRecord
     standard: "standard",
   }
 
+  scope :for_users_list, lambda {
+    includes(:organisation)
+      .order(Arel.sql("organisation.name ASC NULLS FIRST"))
+      .order({ has_access: :desc })
+      .in_order_of(:role, roles.keys)
+      .order({ name: :asc })
+  }
+
   scope :by_name, lambda { |name|
     if name.present?
       where("lower(users.name) LIKE ?", "%#{sanitize_sql_like(name.downcase)}%")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,24 @@ class User < ApplicationRecord
     standard: "standard",
   }
 
+  scope :by_name, lambda { |name|
+    if name.present?
+      where("lower(users.name) LIKE ?", "%#{sanitize_sql_like(name.downcase)}%")
+    end
+  }
+
+  scope :by_email, lambda { |email|
+    if email.present?
+      where("lower(email) LIKE ?", "%#{sanitize_sql_like(email.downcase)}%")
+    end
+  }
+
+  scope :by_organisation_id, lambda { |organisation_id|
+    if organisation_id.present?
+      joins(:organisation).where(organisation: { id: organisation_id })
+    end
+  }
+
   validates :name, presence: true, if: :requires_name?
   validates :role, presence: true
   validates :organisation_id, presence: true, if: :requires_organisation?
@@ -66,7 +84,8 @@ class User < ApplicationRecord
 
       user.save!
       user
-    else # Create a new user.
+    else
+      # Create a new user.
       create!(attributes)
     end
   end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,39 @@
 <% set_page_title(t("users.index.title")) %>
+
 <h1 class="govuk-heading-l"><%= t("users.index.title") %></h1>
+
+<div class="app-filter govuk-grid-row">
+  <%= form_with(model: @filter_input, scope: :filter, url: users_path, method: 'get', local: true, class: 'govuk-clearfix') do |f| %>
+    <div class="govuk-grid-column-one-third">
+      <%= f.govuk_text_field :name,
+        label: { text: t('users.index.filter.name.label'), size: 's' },
+        hint: { text: t('users.index.filter.name.hint') } %>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= f.govuk_text_field :email,
+        label: { text: t('users.index.filter.email.label'), size: 's' },
+        hint: { text: t('users.index.filter.email.hint') } %>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= render DfE::Autocomplete::View.new(
+        f,
+        attribute_name: :organisation_id,
+        form_field: f.govuk_collection_select(:organisation_id,
+          Organisation.with_users.order(:name),
+          :id,
+          :name_with_abbreviation,
+          options: { prompt: t('users.index.filter.organisation.search_prompt') },
+          label: { text: t('users.index.filter.organisation.label'), size: 's' },
+          hint: { text: t('users.index.filter.organisation.hint') },
+        ),
+      ) %>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <%= f.govuk_submit(t("users.index.filter.submit")) %>
+    </div>
+  </div>
+<% end %>
 
 <% if @users.any? %>
   <%= govuk_pagination(pagy: @pagy) %>
@@ -21,13 +55,13 @@
       <%= table.with_body do |body|
         @users.each do |user|
           body.with_row do |row|
-            row.with_cell( text: user.name || t("users.index.name_blank"))
+            row.with_cell(text: user.name || t("users.index.name_blank"))
             row.with_cell do
               govuk_link_to(user.email, edit_user_path(user))
             end
-            row.with_cell( text: user.organisation&.name || t("users.index.organisation_blank"))
-            row.with_cell( text: t("users.roles.#{user.role}.name"))
-            row.with_cell( text: t("users.has_access.#{user.has_access}.name"))
+            row.with_cell(text: user.organisation&.name || t("users.index.organisation_blank"))
+            row.with_cell(text: t("users.roles.#{user.role}.name"))
+            row.with_cell(text: t("users.has_access.#{user.has_access}.name"))
             row.with_cell do
               govuk_button_to(t("users.act_as_user_html", user_email: user.email), act_as_user_start_path(user.id), method: :post, secondary: true) unless user.super_admin? || !user.has_access?
             end if Settings.act_as_user_enabled
@@ -40,3 +74,5 @@
 
   <%= govuk_pagination(pagy: @pagy) %>
 <% end %>
+
+<%= init_autocomplete_script(show_all_values: false, raw_attribute: true, source: false) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,10 +30,15 @@
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <%= f.govuk_submit(t("users.index.filter.submit")) %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit(t("users.index.filter.submit")) %>
+        <% if @filter_input.has_filters? %>
+          <%= govuk_link_to t('users.index.filter.clear_filter'), users_path, no_visited_state: true %>
+        <% end %>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>
 
 <% if @users.any? %>
   <%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,9 @@
 <% set_page_title(t("users.index.title")) %>
 <h1 class="govuk-heading-l"><%= t("users.index.title") %></h1>
 
-<% if users.any? %>
+<% if @users.any? %>
+  <%= govuk_pagination(pagy: @pagy) %>
+
   <%= render ScrollingWrapperComponent::View.new(aria_label: t("users.index.wrapper_aria_label")) do |table| %>
 
     <%= govuk_table do |table| %>
@@ -17,7 +19,7 @@
       end %>
 
       <%= table.with_body do |body|
-        users.each do |user|
+        @users.each do |user|
           body.with_row do |row|
             row.with_cell( text: user.name || t("users.index.name_blank"))
             row.with_cell do
@@ -33,5 +35,8 @@
         end
       end %>
     <% end %>
+
   <% end %>
+
+  <%= govuk_pagination(pagy: @pagy) %>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,11 +2,9 @@
 <h1 class="govuk-heading-l"><%= t("users.index.title") %></h1>
 
 <% if users.any? %>
-  <%= render ScrollingWrapperComponent::View.new(aria_label: t("users.index.users_caption")) do |table| %>
+  <%= render ScrollingWrapperComponent::View.new(aria_label: t("users.index.wrapper_aria_label")) do |table| %>
 
     <%= govuk_table do |table| %>
-      <%= table.with_caption(size: 'm', text: t("users.index.users_caption")) %>
-
       <%= table.with_head do |head|
         head.with_row do |row|
           row.with_cell(header: true, text: t("users.index.table_headings.name"))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1689,6 +1689,7 @@ en:
         name: Permitted
     index:
       filter:
+        clear_filter: Clear filter
         email:
           hint: Enter full or partial email
           label: Email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1688,6 +1688,18 @@ en:
         description: Can use GOV.UK Forms
         name: Permitted
     index:
+      filter:
+        email:
+          hint: Enter full or partial email
+          label: Email
+        name:
+          hint: Enter full or partial name
+          label: Name
+        organisation:
+          hint: Select an organisation
+          label: Organisation
+          search_prompt: Select an organisation
+        submit: Filter
       name_blank: No name set
       organisation_blank: No organisation set
       table_headings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1699,7 +1699,7 @@ en:
         role: Role
         signon_organisation: Signon organisation slug
       title: Users
-      users_caption: All users
+      wrapper_aria_label: Users
     roles:
       organisation_admin:
         description: Can manage groups and users in their organisation

--- a/db/migrate/20250917143112_add_index_on_name_to_users.rb
+++ b/db/migrate/20250917143112_add_index_on_name_to_users.rb
@@ -1,0 +1,12 @@
+class AddIndexOnNameToUsers < ActiveRecord::Migration[8.0]
+  def up
+    enable_extension "pg_trgm"
+
+    add_index :users, "LOWER(name) gin_trgm_ops", using: :gin
+  end
+
+  def down
+    remove_index :users, "LOWER(name) gin_trgm_ops"
+    disable_extension "pg_trgm"
+  end
+end

--- a/db/migrate/20250917152000_add_gin_index_on_email_to_users.rb
+++ b/db/migrate/20250917152000_add_gin_index_on_email_to_users.rb
@@ -1,0 +1,9 @@
+class AddGinIndexOnEmailToUsers < ActiveRecord::Migration[8.0]
+  def up
+    add_index :users, "LOWER(email) gin_trgm_ops", using: :gin
+  end
+
+  def down
+    remove_index :users, "LOWER(email) gin_trgm_ops"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_17_143112) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_17_152000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -209,6 +209,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_143112) do
     t.string "provider"
     t.datetime "terms_agreed_at"
     t.datetime "last_signed_in_at"
+    t.index "lower((email)::text) gin_trgm_ops", name: "index_users_on_LOWER_email_gin_trgm_ops", using: :gin
     t.index "lower((name)::text) gin_trgm_ops", name: "index_users_on_LOWER_name_gin_trgm_ops", using: :gin
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_20_140606) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_17_143112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "conditions", force: :cascade do |t|
     t.bigint "check_page_id", comment: "The question page this condition looks at to compare answers"
@@ -208,6 +209,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_140606) do
     t.string "provider"
     t.datetime "terms_agreed_at"
     t.datetime "last_signed_in_at"
+    t.index "lower((name)::text) gin_trgm_ops", name: "index_users_on_LOWER_name_gin_trgm_ops", using: :gin
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,10 +78,12 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     terms_agreed_at: Time.utc(2023, 3, 11, 6, 26),
     provider: :seed,
   )
+
+  # create organisation admins
   User.create!(
     email: "taylor@example.gov.uk",
     name: "Taylor",
-    role: :super_admin,
+    role: :organisation_admin,
     organisation: gds,
     created_at: Time.utc(2024, 4, 22, 9, 30),
     last_signed_in_at: Time.utc(2024, 4, 22, 9, 30),
@@ -118,6 +120,19 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
   User.create!(email: "kezz.strel101@example.gov.uk", role: :standard, provider: :seed)
   User.create!(email: "lauramipsum@example.gov.uk", role: :standard, provider: :seed)
   User.create!(email: "chidi.anagonye@example.gov.uk", role: :standard, provider: :seed)
+
+  # create extra users to test the pagination on the users page
+  100.times do
+    organisation = [test_org, mot_org, gds].sample
+    name = Faker::Name.unique.name
+    User.create!(
+      name:,
+      email: Faker::Internet.unique.email(name:, domain: "example.gov.uk"),
+      organisation:,
+      role: :standard,
+      provider: :seed,
+    )
+  end
 
   # create some test groups
   end_to_end_group = Group.create! name: "End to end tests", organisation: gds, status: :active

--- a/spec/input_objects/users/filter_input_spec.rb
+++ b/spec/input_objects/users/filter_input_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Users::FilterInput, type: :model do
+  describe "#has_filters?" do
+    context "when the name filter is set" do
+      subject(:input) { described_class.new(name: "foo") }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
+    context "when the email filter is set" do
+      subject(:input) { described_class.new(email: "foo") }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
+    context "when the organisation_id filter is set" do
+      subject(:input) { described_class.new(organisation_id: 1) }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
+    context "when no filters are set" do
+      subject(:input) { described_class.new }
+
+      it "returns false" do
+        expect(input.has_filters?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -141,6 +141,37 @@ describe User, type: :model do
   end
 
   describe "scopes" do
+    describe ".for_users_list" do
+      let(:organisation) { create :organisation, slug: "ministry-of-tests", name: "Ministry of Tests" }
+      let(:other_org) { create(:organisation, slug: "agriculture-department", name: "Agriculture Department") }
+
+      let!(:second_user_alphabetically) { create(:user, name: "Betty Test", organisation:, role: "standard") }
+      let!(:first_user_alphabetically) { create(:user, name: "Aaron Test", organisation:, role: "standard") }
+      let!(:org_admin_user) { create(:user, name: "Wesley Test", organisation:) }
+      let!(:super_admin_user) { create(:user, name: "Yvette Test", organisation:, role: "super_admin") }
+      let!(:without_access_user) { create(:user, name: "Amy Test", organisation:, has_access: false, role: "standard") }
+      let!(:user_with_first_org_alphabetically) { create(:user, name: "Tim Test", organisation: other_org, role: "standard") }
+      let!(:user_with_no_org) { create(:user, organisation: nil, name: "Annie Test") }
+
+      before do
+        create(:mou_signature, organisation:, user: first_user_alphabetically)
+        organisation.reload
+        org_admin_user.organisation_admin!
+      end
+
+      it "returns users ordered by org name, access, role then name" do
+        expect(described_class.for_users_list).to eq [
+          user_with_no_org,
+          user_with_first_org_alphabetically,
+          super_admin_user,
+          org_admin_user,
+          first_user_alphabetically,
+          second_user_alphabetically,
+          without_access_user,
+        ]
+      end
+    end
+
     describe "filter scopes" do
       before do
         other_org = create :organisation, slug: "other-org"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -140,6 +140,77 @@ describe User, type: :model do
     end
   end
 
+  describe "scopes" do
+    describe "filter scopes" do
+      before do
+        other_org = create :organisation, slug: "other-org"
+        create_list(:user, 2, organisation: other_org)
+      end
+
+      describe ".by_name" do
+        let!(:matched_user) { create(:user, name: "Sir John Doe") }
+        let!(:other_matched_user) { create(:user, name: "Lord John Smith") }
+
+        it "returns users with partial match" do
+          expect(described_class.by_name("John")).to contain_exactly(matched_user, other_matched_user)
+        end
+
+        it "returns users with case insensitive match" do
+          expect(described_class.by_name("doe")).to contain_exactly(matched_user)
+        end
+
+        it "returns all users when provided name is nil" do
+          expect(described_class.by_name(nil).size).to eq 4
+        end
+
+        it "returns all users when provided name is blank" do
+          expect(described_class.by_name("").size).to eq 4
+        end
+      end
+
+      describe ".by_email" do
+        let!(:matched_user) { create(:user, email: "sir.john.doe@example.com") }
+        let!(:other_matched_user) { create(:user, email: "lord.john.smith@example.com") }
+
+        it "returns users with partial match" do
+          expect(described_class.by_email(".john")).to contain_exactly(matched_user, other_matched_user)
+        end
+
+        it "returns the user with an exact match" do
+          expect(described_class.by_email("sir.john.doe@example.com")).to contain_exactly(matched_user)
+        end
+
+        it "returns users with case insensitive match" do
+          expect(described_class.by_email("DOE")).to contain_exactly(matched_user)
+        end
+
+        it "returns all users when provided email is nil" do
+          expect(described_class.by_email(nil).size).to eq 4
+        end
+
+        it "returns all users when provided email is blank" do
+          expect(described_class.by_email("").size).to eq 4
+        end
+      end
+
+      describe ".by_organisation_id" do
+        let!(:matched_user) { create(:user, organisation: organisation) }
+
+        it "returns users with given organisation_id" do
+          expect(described_class.by_organisation_id(organisation.id)).to contain_exactly(matched_user)
+        end
+
+        it "returns all users when organisation_id is nil" do
+          expect(described_class.by_organisation_id(nil).size).to eq 3
+        end
+
+        it "returns all users when organisation_id is blank" do
+          expect(described_class.by_organisation_id("").size).to eq 3
+        end
+      end
+    end
+  end
+
   describe ".find_for_auth" do
     let!(:user) do
       create :user, provider: "test", uid: "123456", name: "Test User", email: "test.User@example.com"

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -96,5 +96,19 @@ describe "users/index.html.erb" do
         ],
       )
     end
+
+    context "when there are no filters applied" do
+      it "does not have a link to clear the filters" do
+        expect(rendered).not_to have_link("Clear filter")
+      end
+    end
+
+    context "when there are filters applied" do
+      let(:filter_input) { Users::FilterInput.new(name: "foo") }
+
+      it "has a link to clear the filters" do
+        expect(rendered).to have_link("Clear filter")
+      end
+    end
   end
 end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -7,11 +7,18 @@ describe "users/index.html.erb" do
       user.id = i
     end
   end
+  let(:filter_input) { Users::FilterInput.new }
 
   before do
     allow(Settings).to receive(:act_as_user_enabled).and_return(act_as_user_enabled)
 
-    render template: "users/index", locals: { users: }
+    create :organisation, :with_org_admin, slug: "test-org"
+    create :organisation, :with_org_admin, slug: "ministry-of-testing"
+    create :organisation, :with_org_admin, slug: "department-for-tests", name: "Department for Tests", abbreviation: "DfT"
+
+    assign(:users, users)
+    assign(:filter_input, filter_input)
+    render template: "users/index"
   end
 
   it "contains page heading" do
@@ -75,6 +82,19 @@ describe "users/index.html.erb" do
 
     it "contains an 'Act as this user' button" do
       expect(rendered).to have_button("Act as this user")
+    end
+  end
+
+  describe "filter" do
+    it "has organisation select" do
+      expect(rendered).to have_select(
+        "Organisation",
+        with_options: [
+          "Department for Tests (DfT)",
+          "Ministry Of Testing (MOT)",
+          "Test Org (TO)",
+        ],
+      )
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/IlcvX9A9/186-add-filters-and-pagination-for-users-page

Add a filter component an pagination to the users page so it loads quicker and it's easier to find users.

50 users are displayed per page - this could be changed if desired.

Add indexes on the users table to make the search using the filters as efficient as possible.

<img width="1489" height="937" alt="Screenshot 2025-09-17 at 16 53 37" src="https://github.com/user-attachments/assets/d85d619c-95c3-4910-9ff0-54fc6bf1eb3a" />

<img width="1489" height="850" alt="Screenshot 2025-09-17 at 16 54 09" src="https://github.com/user-attachments/assets/f1370e68-215f-4c4f-99fd-fb27547cb15d" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
