### PR TITLE
Add filters and pagination to users page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,9 @@ gem "aasm", "~> 5.5"
 # Used by AASM to autocommit state changes when even method is used with bang eg. make_live!
 gem "after_commit_everywhere", "~> 1.6"
 
+# For pagination
+gem "pagy"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -619,6 +619,7 @@ DEPENDENCIES
   lograge
   omniauth-auth0
   omniauth-rails_csrf_protection
+  pagy
   paper_trail
   parallel_rspec
   pg (~> 1.6)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,15 +9,7 @@ class UsersController < WebController
   def index
     authorize current_user, :can_manage_user?
 
-    roles = User.roles.keys
-    @users = policy_scope(User).includes(:organisation).sort_by do |user|
-      [
-        user.organisation&.name || "",
-        user.has_access ? 0 : 1,
-        roles.index(user.role),
-        user.name || "",
-      ]
-    end
+    @users = policy_scope(User).for_users_list
 
     render template: "users/index", locals: { users: @users }
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < WebController
+  include Pagy::Backend
+
   after_action :verify_authorized
   after_action :verify_policy_scoped, only: :index
 
@@ -9,9 +11,9 @@ class UsersController < WebController
   def index
     authorize current_user, :can_manage_user?
 
-    @users = policy_scope(User).for_users_list
+    @pagy, @users = pagy(policy_scope(User).for_users_list, limit: 50)
 
-    render template: "users/index", locals: { users: @users }
+    render template: "users/index"
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,6 +15,8 @@ class UsersController < WebController
                    .by_name(filter_params[:name])
                    .by_email(filter_params[:email])
                    .by_organisation_id(filter_params[:organisation_id])
+                   .by_role(filter_params[:role])
+                   .by_has_access(filter_params[:has_access])
                    .for_users_list
 
     @pagy, @users = pagy(users_query, limit: 50)
@@ -63,6 +65,6 @@ private
   end
 
   def filter_params
-    params[:filter]&.permit(:name, :email, :organisation_id) || {}
+    params[:filter]&.permit(:name, :email, :organisation_id, :role, :has_access) || {}
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,15 @@ class UsersController < WebController
   def index
     authorize current_user, :can_manage_user?
 
-    @pagy, @users = pagy(policy_scope(User).for_users_list, limit: 50)
+    users_query = policy_scope(User)
+                   .by_name(filter_params[:name])
+                   .by_email(filter_params[:email])
+                   .by_organisation_id(filter_params[:organisation_id])
+                   .for_users_list
+
+    @pagy, @users = pagy(users_query, limit: 50)
+
+    @filter_input = Users::FilterInput.new(filter_params)
 
     render template: "users/index"
   end
@@ -52,5 +60,9 @@ private
 
   def organisation_id_raw
     params.dig(:user, :organisation_id_raw)
+  end
+
+  def filter_params
+    params[:filter]&.permit(:name, :email, :organisation_id) || {}
   end
 end

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -4,6 +4,7 @@ $govuk-new-typography-scale: true;
 
 @import "pkg:govuk-frontend";
 @import "pkg:dfe-autocomplete";
+@import "../styles/app_filter";
 @import "../styles/app_form_states";
 @import "../styles/app_memorandum_of_understanding";
 @import "../styles/app_preview_area";

--- a/app/frontend/styles/_app_filter.scss
+++ b/app/frontend/styles/_app_filter.scss
@@ -1,0 +1,15 @@
+.app-filter {
+  form {
+    margin: govuk-spacing(3);
+    padding: govuk-spacing(3) 0;
+    background: govuk-colour("light-grey");
+  }
+
+  .govuk-hint {
+    color: $govuk-text-colour;
+  }
+
+  .autocomplete__input {
+    background: govuk-colour("white");
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,18 +73,6 @@ module ApplicationHelper
     { navigation_items: NavigationItemsService.call(user:).navigation_items }
   end
 
-  def user_role_options(roles = User.roles.keys)
-    roles.map do |role|
-      OpenStruct.new(label: t("users.roles.#{role}.name"), value: role, description: t("users.roles.#{role}.description"))
-    end
-  end
-
-  def user_access_options(access_options = %w[true false])
-    access_options.map do |access|
-      OpenStruct.new(label: t("users.has_access.#{access}.name"), value: access, description: t("users.has_access.#{access}.description"))
-    end
-  end
-
   def sign_in_button(is_e2e_user:)
     govuk_button_to t("sign_in_button"), omniauth_authorize_path, params: sign_in_params(is_e2e_user:), data: { module: "sign-in-button" }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,7 +106,7 @@ module ApplicationHelper
     end
   end
 
-  def init_autocomplete_script(show_all_values: false, raw_attribute: false, source: false, autoselect: true, default_value: nil, placeholder: nil, preserve_null_options: false)
+  def init_autocomplete_script(show_all_values: false, raw_attribute: false, source: false, autoselect: true, default_value: nil, placeholder: nil, preserve_null_options: false, overlay_menu: false)
     content_for(:body_end) do
       javascript_tag defer: true do
         "
@@ -118,6 +118,7 @@ module ApplicationHelper
             source: #{source},
             autoselect: #{autoselect},
             preserveNullOptions: #{preserve_null_options},
+            displayMenu: #{overlay_menu ? '"overlay"' : '"inline"'},
             #{"defaultValue: '#{default_value}'," unless default_value.nil?}
             #{"placeholder: '#{placeholder}'," unless placeholder.nil?}
           })

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module UsersHelper
+  def user_role_options(roles = User.roles.keys)
+    roles.map do |role|
+      OpenStruct.new(label: I18n.t("users.roles.#{role}.name"), value: role, description: I18n.t("users.roles.#{role}.description"))
+    end
+  end
+
+  def user_access_options(access_options = %w[true false])
+    access_options.map do |access|
+      OpenStruct.new(label: I18n.t("users.has_access.#{access}.name"), value: access, description: I18n.t("users.has_access.#{access}.description"))
+    end
+  end
+end

--- a/app/input_objects/users/filter_input.rb
+++ b/app/input_objects/users/filter_input.rb
@@ -1,0 +1,5 @@
+module Users
+  class FilterInput < BaseInput
+    attr_accessor :email, :name, :organisation_id
+  end
+end

--- a/app/input_objects/users/filter_input.rb
+++ b/app/input_objects/users/filter_input.rb
@@ -1,5 +1,9 @@
 module Users
   class FilterInput < BaseInput
     attr_accessor :email, :name, :organisation_id
+
+    def has_filters?
+      [email, name, organisation_id].any?(&:present?)
+    end
   end
 end

--- a/app/input_objects/users/filter_input.rb
+++ b/app/input_objects/users/filter_input.rb
@@ -1,9 +1,19 @@
 module Users
   class FilterInput < BaseInput
-    attr_accessor :email, :name, :organisation_id
+    include UsersHelper
+
+    attr_accessor :email, :name, :organisation_id, :role, :has_access
 
     def has_filters?
-      [email, name, organisation_id].any?(&:present?)
+      [email, name, organisation_id, role, has_access].any?(&:present?)
+    end
+
+    def access_options
+      user_access_options.unshift(OpenStruct.new(label: I18n.t("users.has_access.any")))
+    end
+
+    def role_options
+      user_role_options.unshift(OpenStruct.new(label: I18n.t("users.roles.all")))
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,14 @@ class User < ApplicationRecord
     standard: "standard",
   }
 
+  scope :for_users_list, lambda {
+    includes(:organisation)
+      .order(Arel.sql("organisation.name ASC NULLS FIRST"))
+      .order({ has_access: :desc })
+      .in_order_of(:role, roles.keys)
+      .order({ name: :asc })
+  }
+
   scope :by_name, lambda { |name|
     if name.present?
       where("lower(users.name) LIKE ?", "%#{sanitize_sql_like(name.downcase)}%")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,18 @@ class User < ApplicationRecord
     end
   }
 
+  scope :by_role, lambda { |role|
+    if role.present?
+      where(role:)
+    end
+  }
+
+  scope :by_has_access, lambda { |has_access|
+    if has_access.present?
+      where(has_access:)
+    end
+  }
+
   validates :name, presence: true, if: :requires_name?
   validates :role, presence: true
   validates :organisation_id, presence: true, if: :requires_organisation?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,24 @@ class User < ApplicationRecord
     standard: "standard",
   }
 
+  scope :by_name, lambda { |name|
+    if name.present?
+      where("lower(users.name) LIKE ?", "%#{sanitize_sql_like(name.downcase)}%")
+    end
+  }
+
+  scope :by_email, lambda { |email|
+    if email.present?
+      where("lower(email) LIKE ?", "%#{sanitize_sql_like(email.downcase)}%")
+    end
+  }
+
+  scope :by_organisation_id, lambda { |organisation_id|
+    if organisation_id.present?
+      joins(:organisation).where(organisation: { id: organisation_id })
+    end
+  }
+
   validates :name, presence: true, if: :requires_name?
   validates :role, presence: true
   validates :organisation_id, presence: true, if: :requires_organisation?
@@ -66,7 +84,8 @@ class User < ApplicationRecord
 
       user.save!
       user
-    else # Create a new user.
+    else
+      # Create a new user.
       create!(attributes)
     end
   end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,37 +4,61 @@
 
 <div class="app-filter govuk-grid-row">
   <%= form_with(model: @filter_input, scope: :filter, url: users_path, method: 'get', local: true, class: 'govuk-clearfix') do |f| %>
-    <div class="govuk-grid-column-one-third">
-      <%= f.govuk_text_field :name,
-        label: { text: t('users.index.filter.name.label'), size: 's' },
-        hint: { text: t('users.index.filter.name.hint') } %>
+    <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-padding-right-3">
+      <div class="govuk-grid-column-one-third">
+        <%= f.govuk_text_field :name,
+          label: { text: t('users.index.filter.name.label'), size: 's' },
+          hint: { text: t('users.index.filter.name.hint') } %>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= f.govuk_text_field :email,
+          label: { text: t('users.index.filter.email.label'), size: 's' },
+          hint: { text: t('users.index.filter.email.hint') } %>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= render DfE::Autocomplete::View.new(
+          f,
+          attribute_name: :organisation_id,
+          form_field: f.govuk_collection_select(:organisation_id,
+            Organisation.with_users.order(:name),
+            :id,
+            :name_with_abbreviation,
+            options: { prompt: t('users.index.filter.organisation.search_prompt') },
+            label: { text: t('users.index.filter.organisation.label'), size: 's' },
+            hint: { text: t('users.index.filter.organisation.hint') },
+          ),
+        ) %>
+      </div>
     </div>
-    <div class="govuk-grid-column-one-third">
-      <%= f.govuk_text_field :email,
-        label: { text: t('users.index.filter.email.label'), size: 's' },
-        hint: { text: t('users.index.filter.email.hint') } %>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <%= render DfE::Autocomplete::View.new(
-        f,
-        attribute_name: :organisation_id,
-        form_field: f.govuk_collection_select(:organisation_id,
-          Organisation.with_users.order(:name),
-          :id,
-          :name_with_abbreviation,
-          options: { prompt: t('users.index.filter.organisation.search_prompt') },
-          label: { text: t('users.index.filter.organisation.label'), size: 's' },
-          hint: { text: t('users.index.filter.organisation.hint') },
-        ),
-      ) %>
+    <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-padding-right-3">
+      <div class="govuk-grid-column-one-third">
+        <%= f.govuk_collection_select :role,
+          @filter_input.role_options,
+          :value,
+          :label,
+          class: ["govuk-!-width-full"],
+          label: { text: t('users.index.filter.role.label'), size: 's' },
+          hint: { text: t('users.index.filter.role.hint'), size: 's' } %>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= f.govuk_collection_select :has_access,
+          @filter_input.access_options,
+          :value,
+          :label,
+          class: ["govuk-!-width-full"],
+          label: { text: t('users.index.filter.has_access.label'), size: 's' },
+          hint: { text: t('users.index.filter.has_access.hint') } %>
+      </div>
     </div>
 
-    <div class="govuk-grid-column-one-third">
-      <div class="govuk-button-group">
-        <%= f.govuk_submit(t("users.index.filter.submit")) %>
-        <% if @filter_input.has_filters? %>
-          <%= govuk_link_to t('users.index.filter.clear_filter'), users_path, no_visited_state: true %>
-        <% end %>
+    <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-padding-right-3">
+      <div class="govuk-grid-column-one-third">
+        <div class="govuk-button-group">
+          <%= f.govuk_submit(t("users.index.filter.submit")) %>
+          <% if @filter_input.has_filters? %>
+            <%= govuk_link_to t('users.index.filter.clear_filter'), users_path, no_visited_state: true %>
+          <% end %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,39 @@
 <% set_page_title(t("users.index.title")) %>
+
 <h1 class="govuk-heading-l"><%= t("users.index.title") %></h1>
+
+<div class="app-filter govuk-grid-row">
+  <%= form_with(model: @filter_input, scope: :filter, url: users_path, method: 'get', local: true, class: 'govuk-clearfix') do |f| %>
+    <div class="govuk-grid-column-one-third">
+      <%= f.govuk_text_field :name,
+        label: { text: t('users.index.filter.name.label'), size: 's' },
+        hint: { text: t('users.index.filter.name.hint') } %>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= f.govuk_text_field :email,
+        label: { text: t('users.index.filter.email.label'), size: 's' },
+        hint: { text: t('users.index.filter.email.hint') } %>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= render DfE::Autocomplete::View.new(
+        f,
+        attribute_name: :organisation_id,
+        form_field: f.govuk_collection_select(:organisation_id,
+          Organisation.with_users.order(:name),
+          :id,
+          :name_with_abbreviation,
+          options: { prompt: t('users.index.filter.organisation.search_prompt') },
+          label: { text: t('users.index.filter.organisation.label'), size: 's' },
+          hint: { text: t('users.index.filter.organisation.hint') },
+        ),
+      ) %>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <%= f.govuk_submit(t("users.index.filter.submit")) %>
+    </div>
+  </div>
+<% end %>
 
 <% if @users.any? %>
   <%= govuk_pagination(pagy: @pagy) %>
@@ -21,13 +55,13 @@
       <%= table.with_body do |body|
         @users.each do |user|
           body.with_row do |row|
-            row.with_cell( text: user.name || t("users.index.name_blank"))
+            row.with_cell(text: user.name || t("users.index.name_blank"))
             row.with_cell do
               govuk_link_to(user.email, edit_user_path(user))
             end
-            row.with_cell( text: user.organisation&.name || t("users.index.organisation_blank"))
-            row.with_cell( text: t("users.roles.#{user.role}.name"))
-            row.with_cell( text: t("users.has_access.#{user.has_access}.name"))
+            row.with_cell(text: user.organisation&.name || t("users.index.organisation_blank"))
+            row.with_cell(text: t("users.roles.#{user.role}.name"))
+            row.with_cell(text: t("users.has_access.#{user.has_access}.name"))
             row.with_cell do
               govuk_button_to(t("users.act_as_user_html", user_email: user.email), act_as_user_start_path(user.id), method: :post, secondary: true) unless user.super_admin? || !user.has_access?
             end if Settings.act_as_user_enabled
@@ -40,3 +74,5 @@
 
   <%= govuk_pagination(pagy: @pagy) %>
 <% end %>
+
+<%= init_autocomplete_script(show_all_values: true, raw_attribute: true, source: false) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,10 +30,15 @@
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <%= f.govuk_submit(t("users.index.filter.submit")) %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit(t("users.index.filter.submit")) %>
+        <% if @filter_input.has_filters? %>
+          <%= govuk_link_to t('users.index.filter.clear_filter'), users_path, no_visited_state: true %>
+        <% end %>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>
 
 <% if @users.any? %>
   <%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,9 @@
 <% set_page_title(t("users.index.title")) %>
 <h1 class="govuk-heading-l"><%= t("users.index.title") %></h1>
 
-<% if users.any? %>
+<% if @users.any? %>
+  <%= govuk_pagination(pagy: @pagy) %>
+
   <%= render ScrollingWrapperComponent::View.new(aria_label: t("users.index.wrapper_aria_label")) do |table| %>
 
     <%= govuk_table do |table| %>
@@ -17,7 +19,7 @@
       end %>
 
       <%= table.with_body do |body|
-        users.each do |user|
+        @users.each do |user|
           body.with_row do |row|
             row.with_cell( text: user.name || t("users.index.name_blank"))
             row.with_cell do
@@ -33,5 +35,8 @@
         end
       end %>
     <% end %>
+
   <% end %>
+
+  <%= govuk_pagination(pagy: @pagy) %>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,11 +2,9 @@
 <h1 class="govuk-heading-l"><%= t("users.index.title") %></h1>
 
 <% if users.any? %>
-  <%= render ScrollingWrapperComponent::View.new(aria_label: t("users.index.users_caption")) do |table| %>
+  <%= render ScrollingWrapperComponent::View.new(aria_label: t("users.index.wrapper_aria_label")) do |table| %>
 
     <%= govuk_table do |table| %>
-      <%= table.with_caption(size: 'm', text: t("users.index.users_caption")) %>
-
       <%= table.with_head do |head|
         head.with_row do |row|
           row.with_cell(header: true, text: t("users.index.table_headings.name"))

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -80,4 +80,4 @@
   <%= govuk_pagination(pagy: @pagy) %>
 <% end %>
 
-<%= init_autocomplete_script(show_all_values: true, raw_attribute: true, source: false) %>
+<%= init_autocomplete_script(show_all_values: true, raw_attribute: true, source: false, overlay_menu: true) %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,29 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
+      "fingerprint": "4aef20c77272b01619b5f67292f088db289359805fe0e21ef7bc05b6191d87ce",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/users_controller.rb",
+      "line": 68,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params[:filter].permit(:name, :email, :organisation_id, :role, :has_access)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "UsersController",
+        "method": "filter_params"
+      },
+      "user_input": ":role",
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "note": "These parameters are just used for filtering, so having the role as a parameter is safe"
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
       "fingerprint": "5011c2eef8a2a8400a7700cb5127ec34d988b403470b71484c7ea37f000d0669",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
@@ -22,31 +45,7 @@
         915
       ],
       "note": "Changing role for Membership is allowed."
-    },
-    {
-      "warning_type": "Mass Assignment",
-      "warning_code": 105,
-      "fingerprint": "b95336ebd6bb9c957cacd45eb7ebb65f098195a8e7d0d202093c56ff0db17f97",
-      "check_name": "PermitAttributes",
-      "message": "Potentially dangerous key allowed for mass assignment",
-      "file": "app/controllers/users_controller.rb",
-      "line": 32,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:user).permit(:has_access, :role, :organisation_id)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "UsersController",
-        "method": "user_params"
-      },
-      "user_input": ":role",
-      "confidence": "Medium",
-      "cwe_id": [
-        915
-      ],
-      "note": ""
     }
   ],
-  "updated": "2024-04-30 16:43:23 +0100",
-  "brakeman_version": "6.1.2"
+  "brakeman_version": "7.1.0"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1689,6 +1689,7 @@ en:
         name: Permitted
     index:
       filter:
+        clear_filter: Clear filter
         email:
           hint: Enter full or partial email
           label: Email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1688,6 +1688,18 @@ en:
         description: Can use GOV.UK Forms
         name: Permitted
     index:
+      filter:
+        email:
+          hint: Enter full or partial email
+          label: Email
+        name:
+          hint: Enter full or partial name
+          label: Name
+        organisation:
+          hint: Select an organisation
+          label: Organisation
+          search_prompt: Select an organisation
+        submit: Filter
       name_blank: No name set
       organisation_blank: No organisation set
       table_headings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1699,7 +1699,7 @@ en:
         role: Role
         signon_organisation: Signon organisation slug
       title: Users
-      users_caption: All users
+      wrapper_aria_label: Users
     roles:
       organisation_admin:
         description: Can manage groups and users in their organisation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1681,6 +1681,7 @@ en:
       role: Role
       title: Edit user
     has_access:
+      any: Any access
       'false':
         description: Cannot use GOV.UK Forms
         name: Denied
@@ -1693,6 +1694,9 @@ en:
         email:
           hint: Enter full or partial email
           label: Email
+        has_access:
+          hint: Select access permission
+          label: Access
         name:
           hint: Enter full or partial name
           label: Name
@@ -1700,6 +1704,9 @@ en:
           hint: Select an organisation
           label: Organisation
           search_prompt: Select an organisation
+        role:
+          hint: Select a role
+          label: Role
         submit: Filter
       name_blank: No name set
       organisation_blank: No organisation set
@@ -1714,6 +1721,7 @@ en:
       title: Users
       wrapper_aria_label: Users
     roles:
+      all: All roles
       organisation_admin:
         description: Can manage groups and users in their organisation
         name: Organisation admin

--- a/db/migrate/20250917143112_add_index_on_name_to_users.rb
+++ b/db/migrate/20250917143112_add_index_on_name_to_users.rb
@@ -1,0 +1,12 @@
+class AddIndexOnNameToUsers < ActiveRecord::Migration[8.0]
+  def up
+    enable_extension "pg_trgm"
+
+    add_index :users, "LOWER(name) gin_trgm_ops", using: :gin
+  end
+
+  def down
+    remove_index :users, "LOWER(name) gin_trgm_ops"
+    disable_extension "pg_trgm"
+  end
+end

--- a/db/migrate/20250917152000_add_gin_index_on_email_to_users.rb
+++ b/db/migrate/20250917152000_add_gin_index_on_email_to_users.rb
@@ -1,0 +1,9 @@
+class AddGinIndexOnEmailToUsers < ActiveRecord::Migration[8.0]
+  def up
+    add_index :users, "LOWER(email) gin_trgm_ops", using: :gin
+  end
+
+  def down
+    remove_index :users, "LOWER(email) gin_trgm_ops"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_17_143112) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_17_152000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -209,6 +209,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_143112) do
     t.string "provider"
     t.datetime "terms_agreed_at"
     t.datetime "last_signed_in_at"
+    t.index "lower((email)::text) gin_trgm_ops", name: "index_users_on_LOWER_email_gin_trgm_ops", using: :gin
     t.index "lower((name)::text) gin_trgm_ops", name: "index_users_on_LOWER_name_gin_trgm_ops", using: :gin
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_20_140606) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_17_143112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "conditions", force: :cascade do |t|
     t.bigint "check_page_id", comment: "The question page this condition looks at to compare answers"
@@ -208,6 +209,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_140606) do
     t.string "provider"
     t.datetime "terms_agreed_at"
     t.datetime "last_signed_in_at"
+    t.index "lower((name)::text) gin_trgm_ops", name: "index_users_on_LOWER_name_gin_trgm_ops", using: :gin
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -195,23 +195,6 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#user_role_options" do
-    before do
-      allow(I18n).to receive(:translate).with("users.roles.role1.name", any_args).and_return("name1")
-      allow(I18n).to receive(:translate).with("users.roles.role1.description", any_args).and_return("description1")
-
-      allow(I18n).to receive(:translate).with("users.roles.role2.name", any_args).and_return("name2")
-      allow(I18n).to receive(:translate).with("users.roles.role2.description", any_args).and_return("description2")
-    end
-
-    it "returns the correct options" do
-      expect(helper.user_role_options(%i[role1 role2])).to eq(
-        [OpenStruct.new(label: "name1", value: :role1, description: "description1"),
-         OpenStruct.new(label: "name2", value: :role2, description: "description2")],
-      )
-    end
-  end
-
   describe "#sign_in_button" do
     context "when user is an e2e user and auth_provider is auth0" do
       before do

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe UsersHelper, type: :helper do
+  describe "#user_role_options" do
+    before do
+      allow(I18n).to receive(:t).with("users.roles.role1.name", any_args).and_return("name1")
+      allow(I18n).to receive(:t).with("users.roles.role1.description", any_args).and_return("description1")
+
+      allow(I18n).to receive(:t).with("users.roles.role2.name", any_args).and_return("name2")
+      allow(I18n).to receive(:t).with("users.roles.role2.description", any_args).and_return("description2")
+    end
+
+    it "returns the correct options" do
+      expect(helper.user_role_options(%i[role1 role2])).to eq(
+        [OpenStruct.new(label: "name1", value: :role1, description: "description1"),
+         OpenStruct.new(label: "name2", value: :role2, description: "description2")],
+      )
+    end
+  end
+end

--- a/spec/input_objects/users/filter_input_spec.rb
+++ b/spec/input_objects/users/filter_input_spec.rb
@@ -26,12 +26,51 @@ RSpec.describe Users::FilterInput, type: :model do
       end
     end
 
+    context "when the role filter is set" do
+      subject(:input) { described_class.new(role: "standard") }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
+    context "when the has_access filter is set" do
+      subject(:input) { described_class.new(has_access: true) }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
     context "when no filters are set" do
       subject(:input) { described_class.new }
 
       it "returns false" do
         expect(input.has_filters?).to be false
       end
+    end
+  end
+
+  describe "#access_options" do
+    it "returns the correct options" do
+      expect(described_class.new.access_options).to eq([
+        OpenStruct.new(label: I18n.t("users.has_access.any")),
+        OpenStruct.new(label: I18n.t("users.has_access.true.name"), value: "true", description: I18n.t("users.has_access.true.description")),
+        OpenStruct.new(label: I18n.t("users.has_access.false.name"), value: "false", description: I18n.t("users.has_access.false.description")),
+      ])
+    end
+  end
+
+  describe "#role_options" do
+    it "returns the correct options" do
+      expect(described_class.new.role_options).to eq(
+        [
+          OpenStruct.new(label: I18n.t("users.roles.all")),
+          OpenStruct.new(label: I18n.t("users.roles.super_admin.name"), value: "super_admin", description: I18n.t("users.roles.super_admin.description")),
+          OpenStruct.new(label: I18n.t("users.roles.organisation_admin.name"), value: "organisation_admin", description: I18n.t("users.roles.organisation_admin.description")),
+          OpenStruct.new(label: I18n.t("users.roles.standard.name"), value: "standard", description: I18n.t("users.roles.standard.description")),
+        ],
+      )
     end
   end
 end

--- a/spec/input_objects/users/filter_input_spec.rb
+++ b/spec/input_objects/users/filter_input_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Users::FilterInput, type: :model do
+  describe "#has_filters?" do
+    context "when the name filter is set" do
+      subject(:input) { described_class.new(name: "foo") }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
+    context "when the email filter is set" do
+      subject(:input) { described_class.new(email: "foo") }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
+    context "when the organisation_id filter is set" do
+      subject(:input) { described_class.new(organisation_id: 1) }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
+    context "when no filters are set" do
+      subject(:input) { described_class.new }
+
+      it "returns false" do
+        expect(input.has_filters?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -239,6 +239,42 @@ describe User, type: :model do
           expect(described_class.by_organisation_id("").size).to eq 3
         end
       end
+
+      describe ".by_role" do
+        let!(:matched_user) { create(:user, role: :super_admin) }
+
+        it "returns users with given role" do
+          expect(described_class.by_role("super_admin")).to contain_exactly(matched_user)
+        end
+
+        it "returns all users when role is nil" do
+          expect(described_class.by_role(nil).size).to eq 3
+        end
+
+        it "returns all users when role is blank" do
+          expect(described_class.by_role("").size).to eq 3
+        end
+      end
+
+      describe ".by_has_access" do
+        let!(:user_without_access) { create(:user, has_access: false) }
+
+        it "returns users without access" do
+          expect(described_class.by_has_access("false")).to contain_exactly(user_without_access)
+        end
+
+        it "returns users with access" do
+          expect(described_class.by_has_access("true").size).to eq 2
+        end
+
+        it "returns all users when has_access is nil" do
+          expect(described_class.by_has_access(nil).size).to eq 3
+        end
+
+        it "returns all users when has_access is blank" do
+          expect(described_class.by_has_access("").size).to eq 3
+        end
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -141,6 +141,37 @@ describe User, type: :model do
   end
 
   describe "scopes" do
+    describe ".for_users_list" do
+      let(:organisation) { create :organisation, slug: "ministry-of-tests", name: "Ministry of Tests" }
+      let(:other_org) { create(:organisation, slug: "agriculture-department", name: "Agriculture Department") }
+
+      let!(:second_user_alphabetically) { create(:user, name: "Betty Test", organisation:, role: "standard") }
+      let!(:first_user_alphabetically) { create(:user, name: "Aaron Test", organisation:, role: "standard") }
+      let!(:org_admin_user) { create(:user, name: "Wesley Test", organisation:) }
+      let!(:super_admin_user) { create(:user, name: "Yvette Test", organisation:, role: "super_admin") }
+      let!(:without_access_user) { create(:user, name: "Amy Test", organisation:, has_access: false, role: "standard") }
+      let!(:user_with_first_org_alphabetically) { create(:user, name: "Tim Test", organisation: other_org, role: "standard") }
+      let!(:user_with_no_org) { create(:user, organisation: nil, name: "Annie Test") }
+
+      before do
+        create(:mou_signature, organisation:, user: first_user_alphabetically)
+        organisation.reload
+        org_admin_user.organisation_admin!
+      end
+
+      it "returns users ordered by org name, access, role then name" do
+        expect(described_class.for_users_list).to eq [
+          user_with_no_org,
+          user_with_first_org_alphabetically,
+          super_admin_user,
+          org_admin_user,
+          first_user_alphabetically,
+          second_user_alphabetically,
+          without_access_user,
+        ]
+      end
+    end
+
     describe "filter scopes" do
       before do
         other_org = create :organisation, slug: "other-org"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -140,6 +140,77 @@ describe User, type: :model do
     end
   end
 
+  describe "scopes" do
+    describe "filter scopes" do
+      before do
+        other_org = create :organisation, slug: "other-org"
+        create_list(:user, 2, organisation: other_org)
+      end
+
+      describe ".by_name" do
+        let!(:matched_user) { create(:user, name: "Sir John Doe") }
+        let!(:other_matched_user) { create(:user, name: "Lord John Smith") }
+
+        it "returns users with partial match" do
+          expect(described_class.by_name("John")).to contain_exactly(matched_user, other_matched_user)
+        end
+
+        it "returns users with case insensitive match" do
+          expect(described_class.by_name("doe")).to contain_exactly(matched_user)
+        end
+
+        it "returns all users when provided name is nil" do
+          expect(described_class.by_name(nil).size).to eq 4
+        end
+
+        it "returns all users when provided name is blank" do
+          expect(described_class.by_name("").size).to eq 4
+        end
+      end
+
+      describe ".by_email" do
+        let!(:matched_user) { create(:user, email: "sir.john.doe@example.com") }
+        let!(:other_matched_user) { create(:user, email: "lord.john.smith@example.com") }
+
+        it "returns users with partial match" do
+          expect(described_class.by_email(".john")).to contain_exactly(matched_user, other_matched_user)
+        end
+
+        it "returns the user with an exact match" do
+          expect(described_class.by_email("sir.john.doe@example.com")).to contain_exactly(matched_user)
+        end
+
+        it "returns users with case insensitive match" do
+          expect(described_class.by_email("DOE")).to contain_exactly(matched_user)
+        end
+
+        it "returns all users when provided email is nil" do
+          expect(described_class.by_email(nil).size).to eq 4
+        end
+
+        it "returns all users when provided email is blank" do
+          expect(described_class.by_email("").size).to eq 4
+        end
+      end
+
+      describe ".by_organisation_id" do
+        let!(:matched_user) { create(:user, organisation: organisation) }
+
+        it "returns users with given organisation_id" do
+          expect(described_class.by_organisation_id(organisation.id)).to contain_exactly(matched_user)
+        end
+
+        it "returns all users when organisation_id is nil" do
+          expect(described_class.by_organisation_id(nil).size).to eq 3
+        end
+
+        it "returns all users when organisation_id is blank" do
+          expect(described_class.by_organisation_id("").size).to eq 3
+        end
+      end
+    end
+  end
+
   describe ".find_for_auth" do
     let!(:user) do
       create :user, provider: "test", uid: "123456", name: "Test User", email: "test.User@example.com"

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe UsersController, type: :request do
           user.update(name: "Charlie", email: "charlie@example.gov.uk")
         end
       end
-      let!(:andy) { create :user, name: "Andy Test", email: "andy@example.gov.uk", organisation: test_org }
+      let!(:andy) { create :user, name: "Andy Test", email: "andy-123@example.gov.uk", organisation: test_org }
       let!(:bob) { create :user, name: "Bob Test", email: "bob-123@example.gov.uk", organisation: test_org }
-      let!(:diana) { create :user, name: "Diana Test", email: "diana-123@example.gov.uk", organisation: test_org }
       let(:params) { {} }
 
       before do
@@ -32,7 +31,7 @@ RSpec.describe UsersController, type: :request do
         end
 
         it "assigns sorted users" do
-          expect(assigns[:users]).to eq [super_admin_user, andy, bob, charlie, diana]
+          expect(assigns[:users]).to eq [super_admin_user, andy, bob, charlie]
         end
       end
 
@@ -43,18 +42,26 @@ RSpec.describe UsersController, type: :request do
               name: "Test",
               email: "123",
               organisation_id: test_org.id,
+              role: "standard",
+              has_access: "true",
             },
           }
         end
 
         before do
+          # create users that won't match the filters
+          create :user, name: "Diana Test", email: "diana@example.gov.uk", organisation: test_org
+          create :user, name: "Emily Test", email: "emily-123@example.gov.uk", organisation: test_org, has_access: false
+          create :user, name: "Frank Test", email: "frank-123@example.gov.uk", organisation: test_org, role: :organisation_admin
+
           other_org = create(:organisation, slug: "other-org")
-          create(:user, organisation: other_org)
+          create(:user, name: "Gina Test", email: "gina-123@example.gov.uk", organisation: other_org)
+
           get users_path, params:
         end
 
         it "only assigns users that match the filters" do
-          expect(assigns[:users]).to eq [bob, diana]
+          expect(assigns[:users]).to eq [andy, bob]
         end
       end
     end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -96,5 +96,19 @@ describe "users/index.html.erb" do
         ],
       )
     end
+
+    context "when there are no filters applied" do
+      it "does not have a link to clear the filters" do
+        expect(rendered).not_to have_link("Clear filter")
+      end
+    end
+
+    context "when there are filters applied" do
+      let(:filter_input) { Users::FilterInput.new(name: "foo") }
+
+      it "has a link to clear the filters" do
+        expect(rendered).to have_link("Clear filter")
+      end
+    end
   end
 end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -7,11 +7,18 @@ describe "users/index.html.erb" do
       user.id = i
     end
   end
+  let(:filter_input) { Users::FilterInput.new }
 
   before do
     allow(Settings).to receive(:act_as_user_enabled).and_return(act_as_user_enabled)
 
-    render template: "users/index", locals: { users: }
+    create :organisation, :with_org_admin, slug: "test-org"
+    create :organisation, :with_org_admin, slug: "ministry-of-testing"
+    create :organisation, :with_org_admin, slug: "department-for-tests", name: "Department for Tests", abbreviation: "DfT"
+
+    assign(:users, users)
+    assign(:filter_input, filter_input)
+    render template: "users/index"
   end
 
   it "contains page heading" do
@@ -75,6 +82,19 @@ describe "users/index.html.erb" do
 
     it "contains an 'Act as this user' button" do
       expect(rendered).to have_button("Act as this user")
+    end
+  end
+
+  describe "filter" do
+    it "has organisation select" do
+      expect(rendered).to have_select(
+        "Organisation",
+        with_options: [
+          "Department for Tests (DfT)",
+          "Ministry Of Testing (MOT)",
+          "Test Org (TO)",
+        ],
+      )
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/IlcvX9A9/186-add-filters-and-pagination-for-users-page

Add a filter component an pagination to the users page so it loads quicker and it's easier to find users.

50 users are displayed per page - this could be changed if desired.

Add indexes on the users table to make the search using the filters as efficient as possible.

<img width="1078" height="912" alt="Screenshot 2025-09-18 at 16 46 11" src="https://github.com/user-attachments/assets/7c315e30-e0c2-4e7e-aae8-c99d5f428d61" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
