### PR TITLE
Don't raise an error if form creator tries to make live form live

### DIFF
--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -17,7 +17,7 @@ module Forms
       return redirect_to form_path(@make_live_input.form.id) unless @make_live_input.confirmed?
 
       @make_form_live_service = MakeFormLiveService.call(current_form:, current_user:)
-      @make_form_live_service.make_live
+      @make_form_live_service.make_live unless current_form.live?
 
       render "confirmation", locals: { current_form:, confirmation_page_title: @make_form_live_service.page_title, confirmation_page_body: @make_form_live_service.confirmation_page_body }
     end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Although we don't have a link to the page to make a form live if the form is live without draft changes, it has occasionally happened that users have managed to double submit the request to make a form live. When this happens they will see a 500 error page, because our state machine raises an exception if it receives the `make_live` event when the form is already live (and doesn't have any draft changes). This isn't helpful for anyone, so instead if the form is in the live state we just show the confirmation page without doing anything else.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?