### PR TITLE
Reduce the number of queries for the groups index page

### DIFF
--- a/app/components/group_list_component/view.html.erb
+++ b/app/components/group_list_component/view.html.erb
@@ -25,7 +25,7 @@
       @groups.each do |group|
         body.with_row do |row|
           row.with_cell { govuk_link_to(group.name, group) }
-          row.with_cell(numeric: true) { group.creator&.name.presence || t('groups.group_list.created_by_unknown') }
+          row.with_cell(numeric: true) { creator_name(group) }
         end
       end
     end %>

--- a/app/components/group_list_component/view.rb
+++ b/app/components/group_list_component/view.rb
@@ -6,6 +6,18 @@ module GroupListComponent
       @title = title
       @empty_message = empty_message
       @show_empty = show_empty
+      @creators = creators
+    end
+
+    def creators
+      creator_ids = @groups.map(&:creator_id).uniq
+      User.where(id: creator_ids)
+          .pluck(:id, :name)
+          .to_h
+    end
+
+    def creator_name(group)
+      @creators.fetch(group.creator_id, I18n.t("groups.group_list.created_by_unknown"))
     end
   end
 end

--- a/spec/components/group_list_component/view_spec.rb
+++ b/spec/components/group_list_component/view_spec.rb
@@ -51,10 +51,17 @@ RSpec.describe GroupListComponent::View, type: :component do
 
     context "when the group creator is known" do
       let(:user) { create :user }
-      let(:groups) { create_list(:group, 3, creator: user) }
+      let(:other_user) { create :user }
+      let(:groups) do
+        [
+          *create_list(:group, 3, creator: user),
+          create(:group, creator: other_user),
+        ]
+      end
 
       it "renders the creator's name" do
         expect(page).to have_css("tr", count: 3, text: user.name)
+        expect(page).to have_css("tr", count: 1, text: other_user.name)
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Previously, an SQL query was executed for each group to get the user that created the group.

Instead, we now retrieve all the creators in a single query and have a method to pull out the creator by the ID. This is the same strategy we use on the group forms page.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
