### PR TITLE
Remove forms-api task from review apps

### DIFF
--- a/.review_apps/README.md
+++ b/.review_apps/README.md
@@ -5,8 +5,7 @@ The Terraform code in this directory is used to deploy a review copy of `forms-a
 It constructs a minimal, ephemeral version of a GOV.UK Forms environment in AWS ECS that can be used for reviews, then freely destroyed. This includes: 
 
 * a copy of `forms-admin` at the commit in question
-* a copy of the version of `forms-api` currently in production
-* a local PostgreSQL database with seed data for both `forms-api` and `forms-admin`
+* a local PostgreSQL database with seed data for `forms-admin`
 
 Review apps rely on a set of underlying infrastructure managed and deployed in `forms-deploy`. The Terraform will require you to be targeting the `integration` AWS account (where the `review` environment lives), and you should not override this.
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/YWJAZ2A9/2499-remove-forms-api-from-review-apps

Forms-admin no longer makes requests to forms-api, so we no longer need to create the forms-api container as part of the review-apps deployment.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
