### PR TITLE
Exclude NotFoundError from Sentry reporting

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,6 +9,7 @@ if Settings.sentry.dsn.present?
     config.debug = true
     config.enable_tracing = false
     config.environment = Settings.sentry.environment
+    config.excluded_exceptions += %w[NotFoundError]
 
     filter = ActiveSupport::ParameterFilter.new(
       [EmailParameterFilterProc.new(mask: Settings.sentry.filter_mask)],


### PR DESCRIPTION
This error is handled by showing a 404 page to the user, so it doesn't need to be reported to Sentry. Add it to the excluded_exceptions list in the Sentry initializer.