### PR TITLE
Add env var for setting additional allowed hosts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,7 +86,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  config.hosts = HostPatterns::ALLOWED_HOST_PATTERNS
+  config.hosts = HostPatterns.allowed_host_patterns
 
   # Skip DNS rebinding protection for the default health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }

--- a/lib/host_patterns.rb
+++ b/lib/host_patterns.rb
@@ -1,9 +1,15 @@
 module HostPatterns
-  ALLOWED_HOST_PATTERNS = [
+  DEFAULT_HOST_PATTERNS = [
     /admin\.forms\.service\.gov\.uk/,
     /admin\.[^.]*\.forms\.service\.gov\.uk/,
     /admin\.internal.[^.]*\.forms\.service\.gov\.uk/,
     /pr-[^.]*\.admin\.review\.forms\.service\.gov\.uk/,
     /pr-[^.]*-admin\.submit\.review\.forms\.service\.gov\.uk/,
   ].freeze
+
+  def self.allowed_host_patterns
+    additional_patterns = ENV.fetch("ALLOWED_HOST_PATTERNS", "").split(",").map { |pattern| Regexp.new(pattern.strip) }
+
+    [*DEFAULT_HOST_PATTERNS, *additional_patterns]
+  end
 end

--- a/spec/lib/host_patterns_spec.rb
+++ b/spec/lib/host_patterns_spec.rb
@@ -2,7 +2,7 @@ require_relative "../../lib/host_patterns"
 require "rails_helper"
 
 RSpec.describe "Host Configuration" do
-  let(:host_patterns) { HostPatterns::ALLOWED_HOST_PATTERNS }
+  let(:host_patterns) { HostPatterns.allowed_host_patterns }
 
   # Used only for testing the regex
   def host_allowed?(host)
@@ -49,6 +49,25 @@ RSpec.describe "Host Configuration" do
        "admin.extra.dev.forms.service.gov.uk"].each do |host|
         expect(host_allowed?(host)).to be false
       end
+    end
+  end
+
+  context "with ALLOWED_HOST_PATTERNS environment variable set" do
+    before do
+      allow(ENV).to receive(:fetch).with("ALLOWED_HOST_PATTERNS", "").and_return("localhost:3000, foo.[^.]*.example\.gov\.uk")
+    end
+
+    it "allows the host pattern specified in the environment variable" do
+      expect(host_allowed?("localhost:3000")).to be true
+      expect(host_allowed?("foo.bar.example.gov.uk")).to be true
+    end
+
+    it "allows the default host patterns" do
+      expect(host_allowed?("admin.forms.service.gov.uk")).to be true
+    end
+
+    it "doesn't match not allowed domains" do
+      expect(host_allowed?("example.gov.uk")).to be false
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/YWJAZ2A9/2499-remove-forms-api-from-review-apps

Allow adding additional allowed host patterns configured using the config.hosts setting via a new ALLOWED_HOST_PATTERNS environment variable. This will allow us to permit localhost as a valid host in the review apps environment so that we can make internal requests from forms-runner to the forms-admin API without allowing localhost in our deployed environments.

Required for https://github.com/alphagov/forms-runner/pull/1654

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
