### PR TITLE
Update 3 successful deletion banner messages for style

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -349,7 +349,7 @@ en:
       delete:
         title: Are you sure you want to delete this draft?
       destroy:
-        success: Successfully deleted ‘%{form_name}’
+        success: The draft form, ‘%{form_name}’, has been deleted
     delete_form: Delete draft form
     form_overview:
       edit: Edit
@@ -505,7 +505,7 @@ en:
     delete:
       title: Are you sure you want to delete this group?
     destroy:
-      success: Successfully deleted ‘%{group_name}’
+      success: The group, ‘%{group_name}’, has been deleted
     edit:
       title: Change the name of this group
     form_table_caption: Forms in ‘%{group_name}’
@@ -1269,7 +1269,7 @@ en:
       title: Are you sure you want to delete this question?
     delete_question: Delete question
     destroy:
-      success: Successfully deleted ‘%{question_text}’
+      success: The question, ‘%{question_text}’, has been deleted
     exit_page:
       delete:
         back_link: Back to edit exit page

--- a/spec/integration/create_a_form_prevent_double_click_spec.rb
+++ b/spec/integration/create_a_form_prevent_double_click_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Create a form", type: :feature do
         choose "Yes"
         click_on "Continue"
 
-        expect(page).to have_selector ".govuk-notification-banner--success", text: "Successfully deleted"
+        expect(page).to have_selector ".govuk-notification-banner--success", text: "The group, ‘Test group’, has been deleted"
       end
     end
   end

--- a/spec/requests/forms/delete_confirmation_controller_spec.rb
+++ b/spec/requests/forms/delete_confirmation_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
       end
 
       it "displays a success flash message" do
-        expect(flash[:success]).to eq "Successfully deleted ‘Form 1’"
+        expect(flash[:success]).to eq "The draft form, ‘Form 1’, has been deleted"
       end
 
       context "when current user is not in group for form" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe "/groups", type: :request do
 
         it "displays a success flash message" do
           delete(group_url(group), params:)
-          expect(flash[:success]).to eq "Successfully deleted ‘Test Group’"
+          expect(flash[:success]).to eq "The group, ‘Test Group’, has been deleted"
         end
 
         context "but group has forms in it" do
@@ -570,7 +570,7 @@ RSpec.describe "/groups", type: :request do
 
         it "displays a success flash message" do
           delete(group_url(group), params:)
-          expect(flash[:success]).to eq "Successfully deleted ‘Test Group’"
+          expect(flash[:success]).to eq "The group, ‘Test Group’, has been deleted"
         end
 
         context "but group has forms in it" do

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe PagesController, type: :request do
         end
 
         it "displays a success flash message" do
-          expect(flash[:success]).to eq "Successfully deleted ‘#{page.question_text}’"
+          expect(flash[:success]).to eq "The question, ‘#{page.question_text}’, has been deleted"
         end
 
         it "destroys the page through the page repository" do


### PR DESCRIPTION
### What problem does this pull request solve?

This updates the wording of the success banner messages for deleting a group, a form and a question to make them more consistent with our other success banner messages. 

This will also aid clarity for people when they delete the draft of a form that has a live version - as it reinforces that it is the draft of the form that has been deleted.

This is related to this Trello card:https://trello.com/c/tP5Fd96d/2610-add-the-ability-to-delete-a-draft-of-a-live-form-with-a-confirmation-page

### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
