### PR TITLE
Update list of forms to include indication of Welsh versions

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -14,6 +14,7 @@ class Form < ApplicationRecord
   has_one :live_welsh_form_document, -> { where tag: "live", language: :cy }, class_name: "FormDocument"
   has_one :archived_form_document, -> { where tag: "archived", language: :en }, class_name: "FormDocument"
   has_one :archived_welsh_form_document, -> { where tag: "archived", language: :cy }, class_name: "FormDocument"
+  has_one :draft_welsh_form_document, -> { where tag: "draft", language: :cy }, class_name: "FormDocument"
   has_one :draft_form_document, -> { where tag: "draft", language: :en }, class_name: "FormDocument"
   has_many :conditions, through: :pages, source: :routing_conditions
 

--- a/app/presenters/form_list_presenter.rb
+++ b/app/presenters/form_list_presenter.rb
@@ -50,7 +50,7 @@ private
 
   def rows
     rows = forms.sort_by { |form| [form.name.downcase, form.created_at] }.map do |form|
-      row = [{ text: form_name_link(form) },
+      row = [{ text: form_name_link(form) + welsh_status(form) },
              { text: find_creator_name(form) },
              { text: form_status_tags(form), numeric: true }]
 
@@ -72,6 +72,16 @@ private
       edit_group_form_path(group, id: form.id),
       visually_hidden_suffix: I18n.t("home.for", form_name: form.name),
     )
+  end
+
+  def welsh_status(form)
+    if form.live_welsh_form_document.present?
+      "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh Version</p>".html_safe
+    elsif form.draft_welsh_form_document.present?
+      "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh draft</p>".html_safe
+    elsif form.archived_welsh_form_document.present?
+      "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With archived Welsh version</p>".html_safe
+    end
   end
 
   def form_status_tags(form)

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -444,6 +444,36 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "draft_welsh_form_document" do
+    context "when there is no draft Welsh form document" do
+      subject(:form) { create :form }
+
+      it "returns nil" do
+        expect(form.draft_welsh_form_document).to be_nil
+      end
+    end
+
+    context "when there is a draft Welsh form document" do
+      subject(:form) { create :form, :draft, :with_welsh_translation }
+
+      it "returns nil" do
+        expect(form.draft_welsh_form_document).to be_a(FormDocument)
+      end
+    end
+
+    context "when there is only a live Welsh form document" do
+      subject(:form) { create :form, :live, :with_welsh_translation }
+
+      before do
+        FormDocument.find_by(form:, tag: "draft").destroy
+      end
+
+      it "returns nil" do
+        expect(form.draft_welsh_form_document).to be_nil
+      end
+    end
+  end
+
   describe "draft_form_document" do
     context "when there is no archived form document" do
       it "returns nil" do

--- a/spec/presenters/form_list_presenter_spec.rb
+++ b/spec/presenters/form_list_presenter_spec.rb
@@ -114,6 +114,32 @@ describe FormListPresenter do
           expect(rows[3][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/2\">b</a>")
         end
       end
+
+      context "when a welsh version of the form exists" do
+        let(:forms) do
+          [
+            create(:form, :live, :with_welsh_translation, id: 1, name: "form with a live Welsh Version"),
+            create(:form, :archived, :with_welsh_translation, id: 2, name: "form with an archived and a draft Welsh version"),
+            create(:form, :draft, :with_welsh_translation, id: 3, name: "form with Welsh draft"),
+            create(:form, id: 4, name: "form with no Welsh version"),
+            create(:form, :archived, :with_welsh_translation, id: 5, name: "form with only an archived Welsh version"),
+          ]
+        end
+
+        before do
+          # remove the draft version of the welsh translation for the form with only archived version.
+          FormDocument.find_by(form: forms[4], tag: "draft", language: "cy").destroy!
+        end
+
+        it "appends the correct text" do
+          rows = presenter.data[:rows]
+          expect(rows[0][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/1/live\">form with a live Welsh Version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh Version</p>")
+          expect(rows[1][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/2/archived\">form with an archived and a draft Welsh version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh draft</p>")
+          expect(rows[2][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/4\">form with no Welsh version</a>")
+          expect(rows[3][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/5/archived\">form with only an archived Welsh version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With archived Welsh version</p>")
+          expect(rows[4][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/3\">form with Welsh draft</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh draft</p>")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

form list now includes text underneath the form name to indicate if the form has a welsh version, and if that version is live archived or draft

Trello card: https://trello.com/c/kJZuRxGT/2893-update-list-of-forms-to-include-indication-of-welsh-versions
<img width="1049" height="360" alt="Screenshot 2026-03-24 at 13 40 41" src="https://github.com/user-attachments/assets/1f8ee558-f91c-4008-96b9-3bcc5f3816fe" />
<img width="1071" height="140" alt="Screenshot 2026-03-24 at 13 40 57" src="https://github.com/user-attachments/assets/f3db648b-6e25-40d5-b83d-cad247c17a1a" />


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
