### PR TITLE
Bump vite_ruby and dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,10 @@ updates:
       sentry:
         patterns:
           - "sentry-*"
+      vite_ruby:
+        patterns:
+          - "vite_rails"
+          - "vite_ruby"
 
   # Maintain dependencies for npm
   - package-ecosystem: npm

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -764,7 +764,7 @@ GEM
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
-    vite_rails (3.0.20)
+    vite_rails (3.10.0)
       railties (>= 5.1, < 9)
       vite_ruby (~> 3.0, >= 3.2.2)
     vite_ruby (3.10.1)
@@ -1127,7 +1127,7 @@ CHECKSUMS
   version_gem (1.1.8) sha256=a964767ecbe36551b9ff2e59099548c27569f2f7f94bdb09f609d76393a8e008
   view_component (4.1.1) sha256=179f63b0db1d1a8f6af635dd684456b2bcdf6b6f4da2ef276bbe0579c17b377e
   virtus (2.0.0) sha256=8841dae4eb7fcc097320ba5ea516bf1839e5d056c61ee27138aa4bddd6e3d1c2
-  vite_rails (3.0.20) sha256=582bf9aa3bc3b4d9b0a48c17862b4fa9bd17384ac597a57b7a38d2f95d96e682
+  vite_rails (3.10.0) sha256=8c4471554870c043e8d9ff7d379302a01d147ade2cd61476ddf020fed32a107a
   vite_ruby (3.10.1) sha256=f13b81f46bac616c1278e7d2301f11896a6e6313b0daee4ff40cf7eb9987d322
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   warden-oauth2 (0.0.1) sha256=9f8dfd89d23ef8936734ca897acd7dde86802c8139d6299774d6e6bf292921fd

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -767,7 +767,7 @@ GEM
     vite_rails (3.0.20)
       railties (>= 5.1, < 9)
       vite_ruby (~> 3.0, >= 3.2.2)
-    vite_ruby (3.9.3)
+    vite_ruby (3.10.1)
       dry-cli (>= 0.7, < 2)
       logger (~> 1.6)
       mutex_m
@@ -1128,7 +1128,7 @@ CHECKSUMS
   view_component (4.1.1) sha256=179f63b0db1d1a8f6af635dd684456b2bcdf6b6f4da2ef276bbe0579c17b377e
   virtus (2.0.0) sha256=8841dae4eb7fcc097320ba5ea516bf1839e5d056c61ee27138aa4bddd6e3d1c2
   vite_rails (3.0.20) sha256=582bf9aa3bc3b4d9b0a48c17862b4fa9bd17384ac597a57b7a38d2f95d96e682
-  vite_ruby (3.9.3) sha256=560afb7dc01eb1fb2349c21b02e206f016ef7d59075daf00510caaf459b04a13
+  vite_ruby (3.10.1) sha256=f13b81f46bac616c1278e7d2301f11896a6e6313b0daee4ff40cf7eb9987d322
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   warden-oauth2 (0.0.1) sha256=9f8dfd89d23ef8936734ca897acd7dde86802c8139d6299774d6e6bf292921fd
   webmock (3.26.1) sha256=4f696fb57c90a827c20aadb2d4f9058bbff10f7f043bd0d4c3f58791143b1cd7

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "stylelint": "^16.26.1",
         "stylelint-config-gds": "^2.0.0",
         "vite": "^7.3.1",
-        "vite-plugin-ruby": "^5.1.3",
+        "vite-plugin-ruby": "^5.2.0",
         "vitest": "^4.0.18"
       }
     },
@@ -7359,14 +7359,14 @@
       }
     },
     "node_modules/vite-plugin-ruby": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-ruby/-/vite-plugin-ruby-5.1.3.tgz",
-      "integrity": "sha512-vpTOKbR6AmnupmXvQccRcr/jIY+oobNuCbNJHUzkT8oQ2BBQSlp22Xec3zszBBc7GjwDGn2+E+IQoNRXdEY7Ig==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-ruby/-/vite-plugin-ruby-5.2.0.tgz",
+      "integrity": "sha512-FoCaok2pV7GrcAqdxniI1r5XWBlSg9HwEwaxdQdXUVFfYkyINVakPeyrSK4PqOVhonBCuoc633g6bDTEC7wkcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2"
+        "obug": "^2.0",
+        "tinyglobby": "^0.2.12"
       },
       "peerDependencies": {
         "vite": ">=5.0.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "stylelint": "^16.26.1",
     "stylelint-config-gds": "^2.0.0",
     "vite": "^7.3.1",
-    "vite-plugin-ruby": "^5.1.3",
+    "vite-plugin-ruby": "^5.2.0",
     "vitest": "^4.0.18"
   },
   "dependencies": {


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR rolls a bunch of Dependabot PRs bumping packages for Vite Ruby into one, as they need to be bumped together.

- **Bumps vite_ruby from 3.9.3 to 3.10.0**
- **Bumps vite_rails from 3.0.20 to 3.10.0**
- **Bumps vite-plugin-ruby from 5.1.3 to 5.2.0**

This PR also adds a Dependabot group to try and make it work better in future... I'm not hopeful though as Dependabot doesn't seem to have groups across package ecosystems (see https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-related-dependencies-together), so it's only possible to have a group for `vite_ruby` and `vite_rails`, which are both Ruby gems, but they can't also be in a group with `vite-plugin-ruby`, which is an NPM package.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
