### PR TITLE
Add optional track

### DIFF
--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -7,7 +7,8 @@ import {
   installAnalyticsScript,
   sendPageViewEvent,
   attachExternalLinkTracker,
-  attachQuestionXsRoutesTracker
+  attachQuestionXsRoutesTracker,
+  attachOptionalLinkTracker
 } from '../javascript/google-tag'
 import { saveConsentStatus } from '../javascript/utils/cookie-consent'
 import ajaxMarkdownPreview from '../javascript/ajax-markdown-preview'
@@ -50,6 +51,7 @@ if (document.body.dataset.googleAnalyticsEnabled === 'true') {
   sendPageViewEvent()
   attachExternalLinkTracker()
   attachQuestionXsRoutesTracker()
+  attachOptionalLinkTracker()
 }
 
 initAll()

--- a/app/frontend/javascript/google-tag/index.js
+++ b/app/frontend/javascript/google-tag/index.js
@@ -68,6 +68,27 @@ export function attachExternalLinkTracker () {
   })
 }
 
+export function attachOptionalLinkTracker () {
+  const linksToTrack = document.querySelectorAll('a[data-track-link]')
+  linksToTrack.forEach(function (link) {
+    link.addEventListener('click', function (event) {
+      const target = event.target
+      const external = target.getAttribute('href').startsWith('http')
+      window.dataLayer.push({
+        event: 'event_data',
+        event_data: {
+          event_name: 'navigation',
+          external,
+          method: 'primary click',
+          text: target.textContent,
+          type: 'generic link',
+          url: target.href
+        }
+      })
+    })
+  })
+}
+
 export function attachQuestionXsRoutesTracker () {
   const showRoutesPathRegex = /^\/forms\/\d+\/pages\/\d+\/routes$/
   const path = window.location.pathname

--- a/app/frontend/javascript/google-tag/index.test.js
+++ b/app/frontend/javascript/google-tag/index.test.js
@@ -7,7 +7,8 @@ import {
   sendPageViewEvent,
   attachExternalLinkTracker,
   setDefaultConsent,
-  attachQuestionXsRoutesTracker
+  attachQuestionXsRoutesTracker,
+  attachOptionalLinkTracker
 } from '../google-tag'
 import { describe, afterEach, it, expect, beforeEach } from 'vitest'
 
@@ -241,6 +242,118 @@ describe('google_tag.mjs', () => {
           expect(window.dataLayer).toEqual([existingDataLayerObject])
         })
       })
+    })
+  })
+
+  describe('attachOptionalLinkTracker', () => {
+    const preventDefault = (event) => {
+      event.preventDefault()
+    }
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <a id="externalHTTP" href="http://example.com/" data-track-link>A link to example.com</a>
+        <a id="noTrack" href="http://example.com/">A link to example.com</a>
+        <a id="externalHTTPS" href="https://example.com/" data-track-link>A secure link to example.com</a>
+        <a id="internal" href="a_csv_file.csv" data-track-link>Download a CSV file</a>
+        <a id="mailto" href="mailto:example@example.com" data-track-link>A link to example@example.com</a>
+      `
+      window.dataLayer = []
+
+      // stop link clicks from navigating, since jsdom can't do navigation
+      document.querySelector('a').addEventListener('click', preventDefault)
+    })
+
+    afterEach(() => {
+      document.querySelector('a').removeEventListener('click', preventDefault)
+      window.dataLayer = []
+    })
+
+    it('tracks clicks on external HTTP link with data-track-link attribute', () => {
+      attachOptionalLinkTracker()
+
+      const externalLink = document.getElementById('externalHTTP')
+      externalLink.click()
+      expect(window.dataLayer).toEqual([
+        {
+          event: 'event_data',
+          event_data: {
+            event_name: 'navigation',
+            external: true,
+            method: 'primary click',
+            text: 'A link to example.com',
+            type: 'generic link',
+            url: 'http://example.com/'
+          }
+        }
+      ])
+    })
+
+    it('tracks clicks on external HTTPS link with data-track-link attribute', () => {
+      attachOptionalLinkTracker()
+
+      const externalLink = document.getElementById('externalHTTPS')
+      externalLink.click()
+      expect(window.dataLayer).toEqual([
+        {
+          event: 'event_data',
+          event_data: {
+            event_name: 'navigation',
+            external: true,
+            method: 'primary click',
+            text: 'A secure link to example.com',
+            type: 'generic link',
+            url: 'https://example.com/'
+          }
+        }
+      ])
+    })
+
+    it('tracks clicks on internal link with data-track-link attribute', () => {
+      attachOptionalLinkTracker()
+
+      const internalLink = document.getElementById('internal')
+      internalLink.click()
+      expect(window.dataLayer).toEqual([
+        {
+          event: 'event_data',
+          event_data: {
+            event_name: 'navigation',
+            external: false,
+            method: 'primary click',
+            text: 'Download a CSV file',
+            type: 'generic link',
+            url: 'http://localhost:3000/a_csv_file.csv'
+          }
+        }
+      ])
+    })
+
+    it('does not track clicks on links without data-track-link attribute', () => {
+      attachOptionalLinkTracker()
+
+      const link = document.getElementById('noTrack')
+      link.click()
+      expect(window.dataLayer).toEqual([])
+    })
+
+    it('tracks clicks on mailto link with data-track-link attribute', () => {
+      attachOptionalLinkTracker()
+
+      const link = document.getElementById('mailto')
+      link.click()
+      expect(window.dataLayer).toEqual([
+        {
+          event: 'event_data',
+          event_data: {
+            event_name: 'navigation',
+            external: false,
+            method: 'primary click',
+            text: 'A link to example@example.com',
+            type: 'generic link',
+            url: 'mailto:example@example.com'
+          }
+        }
+      ])
     })
   })
 })

--- a/app/views/forms/welsh_translation/new.html.erb
+++ b/app/views/forms/welsh_translation/new.html.erb
@@ -14,7 +14,7 @@
       </h1>
 
       <div class="govuk-button-group">
-        <%= govuk_button_link_to t(".csv_download"), welsh_translation_download_path(@welsh_translation_input.form), secondary: true, data: { "track-link": true }  %>
+        <%= govuk_button_link_to t(".csv_download"), welsh_translation_download_path(@welsh_translation_input.form, format: :csv), secondary: true, data: { "track-link": true }  %>
         <%= render PreviewLinkComponent::View.new(@welsh_translation_input.form.pages, preview_link(@welsh_translation_input.form, locale: :cy), t(".preview_link_text")) %>
       </div>
     </div>

--- a/app/views/forms/welsh_translation/new.html.erb
+++ b/app/views/forms/welsh_translation/new.html.erb
@@ -14,7 +14,7 @@
       </h1>
 
       <div class="govuk-button-group">
-        <%= govuk_button_link_to t(".csv_download"), welsh_translation_download_path(@welsh_translation_input.form), secondary: true %>
+        <%= govuk_button_link_to t(".csv_download"), welsh_translation_download_path(@welsh_translation_input.form), secondary: true, data: { "track-link": true }  %>
         <%= render PreviewLinkComponent::View.new(@welsh_translation_input.form.pages, preview_link(@welsh_translation_input.form, locale: :cy), t(".preview_link_text")) %>
       </div>
     </div>


### PR DESCRIPTION
### Track the CSV download on the Welsh translation page

Trello card: https://trello.com/c/oIf48Bv9/2862-add-google-analytics-event-for-downloading-the-translation-spreadsheet

This PR adds some new javascript to track links which have the `data-track-link` attribute set.

For example:
```HTML
<a href="/path" data-track-link>Link text</a>
```

It then adds this attribute to the Welsh CSV download link so that it should be tracked, in the same way we track external links.

It also adds the CSV format to the Welsh download link, to make it clearer that it's a CSV file.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
