### PR TITLE
Assign cards to `TODO:` comments

### DIFF
--- a/app/components/page_list_component/error_summary/view.rb
+++ b/app/components/page_list_component/error_summary/view.rb
@@ -12,6 +12,7 @@ module PageListComponent
 
       def self.generate_error_message(error_name, condition:, page:)
         # TODO: route_number is hardcoded as 1 here because we know there can be only two conditions. It will need to change in future
+        # https://trello.com/c/BfkZEIgM/3446-set-route-count-dynamically-instead-of-hard-coding-it
         route_number = condition.secondary_skip? ? I18n.t("errors.page_conditions.route_number_for_any_other_answer") : 1
 
         interpolation_variables = { question_number: page.position, route_number: }

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -32,7 +32,8 @@ private
   end
 
   def group_member_params
-    ## TODO: We are passing in host here because the admin doesn't know it's own URL to use in emails
+    # TODO: We are passing in host here because the admin doesn't know it's own URL to use in emails
+    # https://trello.com/c/HkT90mFt/3447-configure-rails-apps-to-know-their-own-urls
     params.require(:group_member_input).permit(:member_email_address).merge(role: new_member_role, group: @group, creator: current_user, host: request.host)
   end
 

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -31,6 +31,7 @@ class Pages::ConditionsController < PagesController
         redirect_to new_exit_page_path(current_form.id, page.id, answer_value: condition_input.answer_value)
       else
         # TODO: Route number is hardcoded whilst we can only have one value for it
+        # https://trello.com/c/BfkZEIgM/3446-set-route-count-dynamically-instead-of-hard-coding-it
         redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_created", route_number: 1)
       end
     else

--- a/app/controllers/pages/exit_page_controller.rb
+++ b/app/controllers/pages/exit_page_controller.rb
@@ -13,6 +13,7 @@ class Pages::ExitPageController < PagesController
 
     if exit_page_input.submit
       # TODO: Route number is hardcoded whilst we can only have one value for it
+      # https://trello.com/c/BfkZEIgM/3446-set-route-count-dynamically-instead-of-hard-coding-it
       redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.exit_page_created")
     else
       render template: "pages/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: true }, status: :unprocessable_content

--- a/app/input_objects/forms/welsh_translation_input.rb
+++ b/app/input_objects/forms/welsh_translation_input.rb
@@ -97,7 +97,6 @@ class Forms::WelshTranslationInput < Forms::MarkCompleteInput
     # We add :cy to the available languages so that the welsh form can be
     # previewed. This means that if mark_complete is false, welsh form docs
     # will be generated.
-    # TODO: Add a button for removing the Welsh form
     form.available_languages = %w[en cy]
 
     form.save_draft!

--- a/app/input_objects/pages/question_input.rb
+++ b/app/input_objects/pages/question_input.rb
@@ -1,7 +1,8 @@
 class Pages::QuestionInput < BaseInput
   attr_accessor :question_text, :hint_text, :is_optional, :answer_type, :draft_question, :is_repeatable, :form_id
 
-  # TODO: We could lose these attributes once we have a Check your answers page
+  # TODO: We could lose these attributes once we have a 'Check your question' page
+  # https://trello.com/c/uSkzB4Sl/3-create-check-your-question-page
   attr_accessor :answer_settings, :page_heading, :guidance_markdown
 
   attr_reader :selection_options # only used for displaying error

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -229,6 +229,7 @@ private
 
   def task_status_service
     # TODO: refactor this in favour of dependency injection
+    # https://trello.com/c/TVN9BNxQ/3448-refactor-formtaskstatusservice-to-use-dependency-injection
     # it can also lead to use of `allow_any_instance_of` in testing
     @task_status_service ||= TaskStatusService.new(form: self)
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -166,6 +166,7 @@ private
     # We want to delete the secondary skip for the page at the start of the route
     # That association isn't in the database, so we need to dig it out
     # TODO: what if the page owning the routes has more than two routes?
+    # https://trello.com/c/ZPFCV1C7/3462-rewrite-destroysecondaryskipconditions-to-handle-a-routing-page-with-more-than-two-routes
     goto_conditions
       .filter { |condition| condition.check_page_id == condition.routing_page_id }
       .map(&:check_page)

--- a/app/validators/allowed_email_domain_validator.rb
+++ b/app/validators/allowed_email_domain_validator.rb
@@ -5,6 +5,7 @@ class AllowedEmailDomainValidator < ActiveModel::EachValidator
 
       # TODO: we might not want to check against current user domain
       # when we have a proper allow list?
+      # https://trello.com/c/NQj6zljA/3449-make-email-domain-validation-check-against-allowed-domains-rather-than-just-govuk-and-the-users-current-domain
       if record.respond_to?(:current_user) && record.current_user.present?
         user_domain_with_at = record.current_user.email
           .then { |email| email[email.rindex("@")..] }

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -15,6 +15,7 @@
     <link rel="apple-touch-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-icon-180.png"%>">
     <%# This manifest file and the icons it references are currently being served from the `public` folder. %>
     <%# TODO: update the build to either generate the manifest with references to fingerprinted assets, or automatically copy the manifest and its dependencies to `public`. %>
+    <%# https://trello.com/c/zXttaPrR/3450-update-frontend-build-to-handle-manifestjson-automatically %>
     <link rel="manifest" href="/manifest.json">
     <meta property="og:image" content="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-opengraph-image.png" %>">
 

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -1,4 +1,5 @@
 <%# TODO: route_number is hardcoded as 1 here because we know there can be only two conditions. It will need to change in the future %>
+<%# https://trello.com/c/BfkZEIgM/3446-set-route-count-dynamically-instead-of-hard-coding-it %>
 <% set_page_title(title_with_error_prefix(t('page_titles.routing_page_edit', question_number: condition_input.page.position, route_number: 1), condition_input.errors&.any?)) %>
 <% content_for :back_link, govuk_back_link_to(show_routes_path(condition_input.form.id, page_id: condition_input.page.id), t(".back_link", question_number: condition_input.page.position)) %>
 

--- a/app/views/pages/conditions/new.html.erb
+++ b/app/views/pages/conditions/new.html.erb
@@ -1,4 +1,5 @@
 <%# TODO: route_number is hardcoded as 1 here because we know there can be only two conditions. It will need to change in the future %>
+<%# https://trello.com/c/BfkZEIgM/3446-set-route-count-dynamically-instead-of-hard-coding-it %>
 <% set_page_title(title_with_error_prefix(t('page_titles.routing_page_new', route_number: 1), condition_input.errors&.any?)) %>
 <% content_for :back_link, govuk_back_link_to(routing_page_path(condition_input.form.id, routing_page_id: condition_input.page.id)) %>
 

--- a/app/views/pages/secondary_skip/new.html.erb
+++ b/app/views/pages/secondary_skip/new.html.erb
@@ -6,6 +6,7 @@
     <span class="govuk-caption-l"><%= t("secondary_skip.new.caption", question_number: secondary_skip_input.page.position) %></span>
     <%= t("page_titles.new_secondary_skip", route_index: 2) %>
     <%# TODO: route_number is hardcoded as 2 here because we know there can be only two conditions. It will need to change in the future %>
+    <%# https://trello.com/c/BfkZEIgM/3446-set-route-count-dynamically-instead-of-hard-coding-it %>
   </h1>
 <% end %>
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/hK0527GN/219-review-todo-comments-and-make-product-cards-for-any-that-are-still-relevant

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
As part of firebreak work we've reviewed the outstanding TODO: comments in this repo and made tech debt cards for them.

This PR adds references to those tech debt cards in the codebase, so that anyone tackling the TODO tasks in future can easily check the card for additional context.

It also removes a TODO comment for something we've already implemented.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
