### PR TITLE
Rename step type for questions from "question_page" to "question"

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -107,7 +107,7 @@ class Page < ApplicationRecord
       "id" => external_id,
       "position" => position,
       "next_step_id" => next_page&.external_id,
-      "type" => "question_page",
+      "type" => "question",
       "data" => slice(*%w[question_text hint_text answer_type is_optional answer_settings page_heading guidance_markdown is_repeatable]),
       "routing_conditions" => routing_conditions.map(&:as_form_document_condition),
     }

--- a/spec/factories/models/form_document/form_document_steps.rb
+++ b/spec/factories/models/form_document/form_document_steps.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :form_document_step, class: "FormDocument::Step" do
     id { |n| n }
-    type { "question_page" }
+    type { "question" }
     position { |n| n }
     next_step_id { nil }
     data do

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe ReportHelper, type: :helper do
 
   let(:questions) do
     [
-      { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" } },
-      { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "organisation_name" => "Ministry of Tests" } },
+      { "type" => "question", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => "live", "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" } },
+      { "type" => "question", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => "live", "content" => { "name" => "Branch route form" }, "organisation_name" => "Ministry of Tests" } },
     ]
   end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1207,11 +1207,11 @@ RSpec.describe Form, type: :model do
     it "includes steps" do
       expect(form.as_form_document["steps"].count).to eq(form.pages.count)
       expect(form.as_form_document["steps"].first).to match a_hash_including(
-        "type" => "question_page",
+        "type" => "question",
         "next_step_id" => form.pages.second.external_id,
       )
       expect(form.as_form_document["steps"].last).to match a_hash_including(
-        "type" => "question_page",
+        "type" => "question",
         "next_step_id" => nil,
       )
     end

--- a/spec/views/reports/feature_report.html.erb_spec.rb
+++ b/spec/views/reports/feature_report.html.erb_spec.rb
@@ -200,8 +200,8 @@ describe "reports/feature_report" do
     let(:type) { :questions }
     let(:records) do
       [
-        { "type" => "question_page", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" } },
-        { "type" => "question_page", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "organisation_name" => "Government Digital Service" } },
+        { "type" => "question", "data" => { "question_text" => "Email address" }, "form" => { "form_id" => 1, "tag" => tag, "content" => { "name" => "All question types form" }, "organisation_name" => "Government Digital Service" } },
+        { "type" => "question", "data" => { "question_text" => "What’s your email address?" }, "form" => { "form_id" => 3, "tag" => tag, "content" => { "name" => "Branch route form" }, "organisation_name" => "Government Digital Service" } },
       ]
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/02H0xEqG

The "type" was added as part of the v2 API so we can distinguish between steps that represent a single question and other future types of steps, for example a pamyent step or a repeatable set of questions.

The "type" isn't currently consumed by forms-runner.

A question can be multiple web pages, and we use the term "step" rather than "page" in the API so the "_page" suffix is unnecessary.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
