### PR TITLE
Add rake task to list forms with no group

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -215,6 +215,17 @@ namespace :forms do
 
     Rails.logger.info "convert_declaration_text_to_markdown: finished"
   end
+
+  desc "List all forms that are not in a group"
+  task list_forms_without_group: :environment do
+    forms = Form.where.missing(:group_form)
+
+    Rails.logger.info "Found #{forms.count} forms without a group"
+    forms.find_each do |form|
+      creator = User.find(form.creator_id) if form.creator_id.present?
+      Rails.logger.info "Form #{form.id} (\"#{form.name}\") created by #{creator&.name || 'No creator'} with organisation #{creator&.organisation&.name || 'N/A'}"
+    end
+  end
 end
 
 def move_forms(form_ids, group_id)


### PR DESCRIPTION
### What problem does this pull request solve?

I want to find out whether there are still any forms without groups to see if we can remove some code that puts existing forms without a group in default trial groups when a user adds their name/organisation.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
