### PR TITLE
Update routing content from "check your answers page" to "end of form"

### DIFF
--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -47,7 +47,7 @@ module PageListComponent
         goto_page = @pages.find { |page| page.id == condition.goto_page_id }
         I18n.t("page_conditions.condition_goto_page_text", goto_page_question_number: goto_page.position, goto_page_question_text: goto_page.question_text)
       elsif condition.skip_to_end
-        I18n.t("page_conditions.condition_goto_page_check_your_answers")
+        I18n.t("page_conditions.condition_goto_page_end_of_form")
       elsif condition.exit_page?
         I18n.t("page_conditions.condition_goto_exit_page", exit_page_heading: condition.exit_page_heading)
       else

--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -48,7 +48,7 @@ class Pages::ConditionsInput < BaseInput
 
   def goto_page_options
     page_options = pages_after_position(page.position + 1).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) }
-    page_options << OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers"))
+    page_options << OpenStruct.new(id: "end_of_form", question_text: I18n.t("page_conditions.end_of_form"))
 
     page_options
   end
@@ -61,7 +61,7 @@ class Pages::ConditionsInput < BaseInput
 
   def assign_condition_values
     if goto_page_id.nil? && skip_to_end
-      self.goto_page_id = "check_your_answers"
+      self.goto_page_id = "end_of_form"
     end
     if record.exit_page?
       self.goto_page_id = "exit_page"
@@ -70,7 +70,7 @@ class Pages::ConditionsInput < BaseInput
   end
 
   def assign_skip_to_end
-    if goto_page_id == "check_your_answers"
+    if goto_page_id == "end_of_form"
       self.goto_page_id = nil
       self.skip_to_end = true
     else
@@ -97,7 +97,7 @@ private
 
   def goto_page_id_valid
     return if goto_page_id.nil?
-    return if %w[check_your_answers create_exit_page exit_page].include? goto_page_id
+    return if %w[end_of_form create_exit_page exit_page].include? goto_page_id
     return if form.pages.find { |page| page.id.to_s == goto_page_id.to_s }
 
     errors.add(:goto_page_id, :invalid, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.invalid"))

--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -2,6 +2,7 @@ class Pages::ConditionsInput < BaseInput
   attr_accessor :form, :page, :check_page_id, :routing_page_id, :answer_value, :goto_page_id, :record, :skip_to_end
 
   validates :answer_value, :goto_page_id, presence: true
+  validate :goto_page_id_valid
 
   def submit
     return false if invalid?
@@ -93,6 +94,14 @@ class Pages::ConditionsInput < BaseInput
   end
 
 private
+
+  def goto_page_id_valid
+    return if goto_page_id.nil?
+    return if %w[check_your_answers create_exit_page exit_page].include? goto_page_id
+    return if form.pages.find { |page| page.id.to_s == goto_page_id.to_s }
+
+    errors.add(:goto_page_id, :invalid, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.invalid"))
+  end
 
   def pages_after_position(position)
     all_pages = form.pages

--- a/app/input_objects/pages/delete_condition_input.rb
+++ b/app/input_objects/pages/delete_condition_input.rb
@@ -11,7 +11,7 @@ class Pages::DeleteConditionInput < ConfirmActionInput
   end
 
   def goto_page_question_text
-    return I18n.t("page_conditions.check_your_answers") if goto_page_id.nil? && record.skip_to_end
+    return I18n.t("page_conditions.end_of_form") if goto_page_id.nil? && record.skip_to_end
 
     pages.filter { |p| p.id == goto_page_id }.first&.question_text
   end

--- a/app/input_objects/pages/secondary_skip_input.rb
+++ b/app/input_objects/pages/secondary_skip_input.rb
@@ -2,7 +2,7 @@ class Pages::SecondarySkipInput < BaseInput
   attr_accessor :form, :page, :routing_page_id, :goto_page_id, :record
 
   validates :routing_page_id, :goto_page_id, presence: true
-  validate :pages_in_valid_order
+  validate :goto_page_id_valid, :pages_in_valid_order
 
   def submit
     return false if invalid?
@@ -102,6 +102,14 @@ private
     !skip_to_end?
   end
 
+  def goto_page_id_valid
+    return if goto_page_id.nil?
+    return if goto_page_id == "check_your_answers"
+    return if form.pages.find { |page| page.id.to_s == goto_page_id.to_s }
+
+    errors.add(:goto_page_id, :invalid, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.invalid"))
+  end
+
   def pages_in_valid_order
     if routing_page_id.present? && goto_page_id.present?
 
@@ -112,7 +120,7 @@ private
         errors.add(:goto_page_id, :equal, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.equal"))
       end
 
-      if goto_question_page?
+      if goto_page && goto_question_page?
         if routing_page.position > goto_page.position
           errors.add(:goto_page_id, :routing_page_after, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.routing_page_after"))
         end

--- a/app/input_objects/pages/secondary_skip_input.rb
+++ b/app/input_objects/pages/secondary_skip_input.rb
@@ -35,7 +35,7 @@ class Pages::SecondarySkipInput < BaseInput
   def goto_page_options
     [
       *pages_after_current_page(form.pages, page).map { |p| OpenStruct.new(id: p.id, question_text: p.question_with_number) },
-      OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
+      OpenStruct.new(id: "end_of_form", question_text: I18n.t("page_conditions.end_of_form")),
     ]
   end
 
@@ -44,7 +44,7 @@ class Pages::SecondarySkipInput < BaseInput
   end
 
   def end_page_name
-    I18n.t("page_route_card.check_your_answers")
+    I18n.t("page_route_card.end_of_form")
   end
 
   def answer_value
@@ -55,7 +55,7 @@ class Pages::SecondarySkipInput < BaseInput
     primary_route = page.routing_conditions.find { |rc| rc.answer_value.present? }
 
     if primary_route.skip_to_end?
-      return I18n.t("page_route_card.check_your_answers")
+      return I18n.t("page_route_card.end_of_form")
     end
 
     question_name(primary_route.goto_page_id) || I18n.t("page_route_card.goto_page_invalid")
@@ -84,7 +84,7 @@ class Pages::SecondarySkipInput < BaseInput
 
   def assign_values
     self.routing_page_id = record.routing_page_id
-    self.goto_page_id = record.goto_page_id.nil? ? "check_your_answers" : record.goto_page_id
+    self.goto_page_id = record.goto_page_id.nil? ? "end_of_form" : record.goto_page_id
     self
   end
 
@@ -95,7 +95,7 @@ private
   end
 
   def skip_to_end?
-    goto_page_id == "check_your_answers"
+    goto_page_id == "end_of_form"
   end
 
   def goto_question_page?
@@ -104,7 +104,7 @@ private
 
   def goto_page_id_valid
     return if goto_page_id.nil?
-    return if goto_page_id == "check_your_answers"
+    return if goto_page_id == "end_of_form"
     return if form.pages.find { |page| page.id.to_s == goto_page_id.to_s }
 
     errors.add(:goto_page_id, :invalid, message: I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.invalid"))

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -40,7 +40,7 @@ class Condition < ApplicationRecord
   def warning_goto_page_doesnt_exist
     return nil if is_exit_page?
     # goto_page_id isn't needed if the route is skipping to the end of the form
-    return nil if is_check_your_answers?
+    return nil if is_end_of_form?
 
     page = form.pages.find_by(id: goto_page_id)
     return nil if page.present?
@@ -58,10 +58,10 @@ class Condition < ApplicationRecord
   end
 
   def warning_routing_to_next_page
-    return nil if check_page.nil? || goto_page.nil? && !is_check_your_answers?
+    return nil if check_page.nil? || goto_page.nil? && !is_end_of_form?
 
     routing_page_position = routing_page.position
-    goto_page_position = is_check_your_answers? ? form.pages.last.position + 1 : goto_page.position
+    goto_page_position = is_end_of_form? ? form.pages.last.position + 1 : goto_page.position
 
     return DataStruct.new(name: "cannot_route_to_next_page") if goto_page_position == (routing_page_position + 1)
 
@@ -74,7 +74,7 @@ class Condition < ApplicationRecord
     end
   end
 
-  def is_check_your_answers?
+  def is_end_of_form?
     goto_page.nil? && skip_to_end
   end
 

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -182,7 +182,7 @@ private
   end
 
   def end_page_name
-    I18n.t("page_route_card.check_your_answers")
+    I18n.t("page_route_card.end_of_form")
   end
 
   def question_number(page_id)

--- a/app/services/step_summary_table_service.rb
+++ b/app/services/step_summary_table_service.rb
@@ -276,7 +276,7 @@ private
   end
 
   def print_goto_page(condition, steps, locale: "en")
-    return I18n.t("step_summary_card.check_your_answers.#{locale}") if condition.skip_to_end
+    return I18n.t("step_summary_card.end_of_form.#{locale}") if condition.skip_to_end
     return condition.exit_page_heading if condition.exit_page?
 
     build_title(steps.find { |step| step.id == condition.goto_page_id })

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -28,7 +28,7 @@
 
       <%= f.govuk_select(:goto_page_id, label: { class: "govuk-!-font-weight-bold" }, options: { include_blank: t("helpers.label.pages_conditions_input.default_goto_page_id") }) do %>
         <% condition_input.goto_page_options.each do |option| %>
-          <option value=<%= option.id %> <% if condition_input.record.goto_page_id == option.id || (condition_input.record.skip_to_end? && option.id == "check_your_answers") %>selected<% end %>>
+          <option value=<%= option.id %> <% if condition_input.record.goto_page_id == option.id || (condition_input.record.skip_to_end? && option.id == "end_of_form") %>selected<% end %>>
           <%= option.question_text %>
           </option>
         <% end %>

--- a/app/views/pages/routes/show.html.erb
+++ b/app/views/pages/routes/show.html.erb
@@ -33,7 +33,7 @@
             <%= govuk_button_link_to t(".any_other_answer.set_questions_to_skip"), new_secondary_skip_path(current_form.id, page.id), secondary: true %>
           <% end %>
         <% else %>
-          <p class="govuk-body"><%= t(".any_other_answer.will_continue_to_check_your_answers") %></p>
+          <p class="govuk-body"><%= t(".any_other_answer.will_continue_to_end_of_form") %></p>
         <% end %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1358,7 +1358,6 @@ en:
       If you pasted the web address, check you copied the entire address.
     title: Page not found
   page_conditions:
-    check_your_answers: End of form
     condition_answer_value_text: "“%{answer_value}”"
     condition_answer_value_text_with_errors: "[Answer not selected]"
     condition_check_page_text: "“%{check_page_question_text}”"
@@ -1374,6 +1373,7 @@ en:
     condition_goto_page_text_with_errors: "[Question not selected]"
     condition_name: Question %{question_number}’s routes
     edit_exit_page: Edit “%{exit_page_heading}”
+    end_of_form: End of form
     exit_page: Add an exit page
     exit_page_label: An ‘exit page’ to leave the form
     none_of_the_above: None of the above

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1368,7 +1368,7 @@ en:
     condition_compact_html_secondary_skip_to_end_of_form: Go to end of form
     condition_description: If %{check_page_question_text} is answered as %{answer_value} go to %{goto_page_question_text}
     condition_goto_exit_page: exit page, “%{exit_page_heading}”
-    condition_goto_page_check_your_answers: end of form.
+    condition_goto_page_end_of_form: end of form.
     condition_goto_page_text: "%{goto_page_question_number}, “%{goto_page_question_text}”"
     condition_goto_page_text_with_errors: "[Question not selected]"
     condition_name: Question %{question_number}’s routes
@@ -1382,12 +1382,12 @@ en:
     skip_condition_route_page_text: "%{route_page_question_number}, “%{route_page_question_text}”"
   page_route_card:
     any_other_answer: Route for any other answer
-    check_your_answers: End of form
     conditional_answer_value: "%{answer_value}"
     continue_to: Continue to
     delete: Delete
     delete_route: Delete all routes
     edit: Edit
+    end_of_form: End of form
     errors:
       answer_value_doesnt_exist: The answer that route 1 is based on no longer exists - edit or delete this route
       cannot_have_goto_page_before_routing_page: The question route 1 skips to cannot be before question %{question_number} - edit or delete this route
@@ -1594,7 +1594,7 @@ en:
           set_questions_to_skip: Set questions to skip
           skip_later: If you need to, you can make them skip one or more questions that only people on route 1 need to answer.
           will_continue_to: People who select any other answer will continue to question %{next_question_number} and through the rest of the form.
-          will_continue_to_check_your_answers: People who select any other answer will continue to the end of the form.
+          will_continue_to_end_of_form: People who select any other answer will continue to the end of the form.
     submit_save: Save question
   payment_link_input:
     body_html: |
@@ -1986,12 +1986,12 @@ en:
     status: Status
   step_summary_card:
     answer_type: Answer type
-    check_your_answers:
-      cy: End of form
-      en: End of form
     date_type:
       date_of_birth: Date of birth
       other_date: Date
+    end_of_form:
+      cy: End of form
+      en: End of form
     guidance_markdown: Guidance
     hint_text: Hint text
     name_type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,7 @@ en:
               already_consecutive: The question or page to skip to cannot be straight after the question to skip from
               blank: Select the question or page to skip to
               equal: The question to skip to cannot be the same as the question to skip from
+              invalid: Select the question or page to skip to
               routing_page_after: The question to skip to cannot be before the question to skip from
             routing_page_id:
               blank: Select the question to skip from

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1357,18 +1357,18 @@ en:
       If you pasted the web address, check you copied the entire address.
     title: Page not found
   page_conditions:
-    check_your_answers: Check your answers before submitting
+    check_your_answers: End of form
     condition_answer_value_text: "“%{answer_value}”"
     condition_answer_value_text_with_errors: "[Answer not selected]"
     condition_check_page_text: "“%{check_page_question_text}”"
     condition_compact_html: If the answer is “%{answer_value}” go to %{goto_page_question_number}, “%{goto_page_question_text}”
-    condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to “Check your answers before submitting”
+    condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to end of form
     condition_compact_html_exit_page: If the answer is “%{answer_value}” go to the exit page, “%{exit_page_heading}”
     condition_compact_html_secondary_skip: Go to %{goto_page_question_number}, “%{goto_page_question_text}”
-    condition_compact_html_secondary_skip_to_end_of_form: Go to “Check your answers before submitting”
+    condition_compact_html_secondary_skip_to_end_of_form: Go to end of form
     condition_description: If %{check_page_question_text} is answered as %{answer_value} go to %{goto_page_question_text}
     condition_goto_exit_page: exit page, “%{exit_page_heading}”
-    condition_goto_page_check_your_answers: "“Check your answers before submitting”."
+    condition_goto_page_check_your_answers: end of form.
     condition_goto_page_text: "%{goto_page_question_number}, “%{goto_page_question_text}”"
     condition_goto_page_text_with_errors: "[Question not selected]"
     condition_name: Question %{question_number}’s routes
@@ -1381,7 +1381,7 @@ en:
     skip_condition_route_page_text: "%{route_page_question_number}, “%{route_page_question_text}”"
   page_route_card:
     any_other_answer: Route for any other answer
-    check_your_answers: Check your answers before submitting
+    check_your_answers: End of form
     conditional_answer_value: "%{answer_value}"
     continue_to: Continue to
     delete: Delete
@@ -1593,7 +1593,7 @@ en:
           set_questions_to_skip: Set questions to skip
           skip_later: If you need to, you can make them skip one or more questions that only people on route 1 need to answer.
           will_continue_to: People who select any other answer will continue to question %{next_question_number} and through the rest of the form.
-          will_continue_to_check_your_answers: People who select any other answer will continue to “Check your answers before submitting”.
+          will_continue_to_check_your_answers: People who select any other answer will continue to the end of the form.
     submit_save: Save question
   payment_link_input:
     body_html: |
@@ -1986,8 +1986,8 @@ en:
   step_summary_card:
     answer_type: Answer type
     check_your_answers:
-      cy: Check your answers before submitting
-      en: Check your answers before submitting
+      cy: End of form
+      en: End of form
     date_type:
       date_of_birth: Date of birth
       other_date: Date

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -13,6 +13,7 @@ en:
               cannot_have_goto_page_before_routing_page: Select the question or page to skip to, or delete this route
               cannot_route_to_next_page: Select the question or page to skip to, or delete this route
               goto_page_doesnt_exist: Select the question or page you want to take the person to, or delete this route
+              invalid: Select the question or page to skip to
         pages/delete_condition_input:
           attributes:
             confirm:

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe PageListComponent::View, type: :component do
         end
 
         it "returns description with 'Check your answers' text" do
-          expected_text = "If “#{pages.first.question_text}” is answered as “#{condition.answer_value}” go to “Check your answers before submitting”."
+          expected_text = "If “#{pages.first.question_text}” is answered as “#{condition.answer_value}” go to end of form."
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
         end
       end

--- a/spec/features/form/add_or_edit_questions/add_branching_to_a_form_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_branching_to_a_form_spec.rb
@@ -86,7 +86,7 @@ private
 
   def and_i_select_a_skip_page_and_goto_page
     select form.pages[3].question_text, from: "pages_secondary_skip_input[routing_page_id]"
-    select "Check your answers before submitting", from: "pages_secondary_skip_input[goto_page_id]"
+    select "End of form", from: "pages_secondary_skip_input[goto_page_id]"
 
     create(:condition, id: 2, check_page_id: form.pages.first.id, routing_page_id: form.pages[3].id, goto_page_id: nil, skip_to_end: true)
     form.pages.each(&:reload)
@@ -98,7 +98,7 @@ private
     expect(page).to have_text "Route for any other answer"
     expect(page).to have_text "Continue to"
     expect(page).to have_text form.pages[3].question_text
-    expect(page).to have_text "Check your answers before submitting"
+    expect(page).to have_text "End of form"
     expect_page_to_have_no_axe_errors(page)
   end
 end

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       expect(conditions_input).to be_valid
     end
 
-    %w[check_your_answers create_exit_page exit_page].each do |goto_page_id|
+    %w[end_of_form create_exit_page exit_page].each do |goto_page_id|
       it "is valid when the goto_page_id is #{goto_page_id}" do
         conditions_input.goto_page_id = goto_page_id
         conditions_input.answer_value = "Rabbit"
@@ -143,7 +143,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
           OpenStruct.new(value: "Option 1", label: "Option 1"),
           OpenStruct.new(value: "Option 2", label: "Option 2"),
           OpenStruct.new(value: :none_of_the_above.to_s,
-            label: I18n.t("page_conditions.none_of_the_above")),
+                         label: I18n.t("page_conditions.none_of_the_above")),
         ])
       end
     end
@@ -171,7 +171,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
 
       it "includes 'Check your answers before submitting'" do
         expect(goto_page_options).to include(
-          OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
+          OpenStruct.new(id: "end_of_form", question_text: I18n.t("page_conditions.end_of_form")),
         )
       end
     end
@@ -199,7 +199,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
 
       it "includes 'Check your answers before submitting'" do
         expect(goto_page_options).to include(
-          OpenStruct.new(id: "check_your_answers", question_text: I18n.t("page_conditions.check_your_answers")),
+          OpenStruct.new(id: "end_of_form", question_text: I18n.t("page_conditions.end_of_form")),
         )
       end
     end
@@ -224,14 +224,14 @@ RSpec.describe Pages::ConditionsInput, type: :model do
     context "when goto_page is nil and skip_to_end is set to true" do
       let(:skip_to_end) { true }
 
-      it "sets goto_page_id to 'check_your_answers'" do
+      it "sets goto_page_id to 'end_of_form'" do
         conditions_input.assign_condition_values
-        expect(conditions_input.goto_page_id).to eq "check_your_answers"
+        expect(conditions_input.goto_page_id).to eq "end_of_form"
       end
     end
 
     context "when goto_page is nil and skip_to_end is set to false" do
-      it "sets goto_page_id to 'check_your_answers'" do
+      it "sets goto_page_id to 'end_of_form'" do
         conditions_input.assign_condition_values
         expect(conditions_input.goto_page_id).to be_nil
       end
@@ -241,7 +241,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       let(:goto_page_id) { 3 }
       let(:skip_to_end) { true }
 
-      it "sets goto_page_id to 'check_your_answers'" do
+      it "sets goto_page_id to 'end_of_form'" do
         conditions_input.assign_condition_values
         expect(conditions_input.goto_page_id).to eq 3
       end
@@ -262,8 +262,8 @@ RSpec.describe Pages::ConditionsInput, type: :model do
     let(:goto_page_id) { 3 }
     let(:skip_to_end) { false }
 
-    context "when goto_page is 'check_your_answers" do
-      let(:goto_page_id) { "check_your_answers" }
+    context "when goto_page is 'end_of_form" do
+      let(:goto_page_id) { "end_of_form" }
 
       it "sets goto_page_id to nil and skip_to_end to true" do
         conditions_input.assign_skip_to_end
@@ -272,7 +272,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       end
     end
 
-    context "when goto_page is not 'check_your_answers" do
+    context "when goto_page is not 'end_of_form" do
       let(:goto_page_id) { 3 }
       let(:skip_to_end) { true }
 

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe Pages::ConditionsInput, type: :model do
   let(:condition) { nil }
 
   describe "validations" do
+    it "is valid given valid params" do
+      conditions_input.goto_page_id = page.id
+      conditions_input.answer_value = "Rabbit"
+      expect(conditions_input).to be_valid
+    end
+
+    %w[check_your_answers create_exit_page exit_page].each do |goto_page_id|
+      it "is valid when the goto_page_id is #{goto_page_id}" do
+        conditions_input.goto_page_id = goto_page_id
+        conditions_input.answer_value = "Rabbit"
+        expect(conditions_input).to be_valid
+      end
+    end
+
     it "is invalid if answer_value is nil" do
       error_message = I18n.t("activemodel.errors.models.pages/conditions_input.attributes.answer_value.blank")
       conditions_input.answer_value = nil
@@ -31,13 +45,20 @@ RSpec.describe Pages::ConditionsInput, type: :model do
       expect(conditions_input).to be_invalid
       expect(conditions_input.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
     end
+
+    it "is invalid when the goto_page_id is not a page ID or end_of_form" do
+      error_message = I18n.t("activemodel.errors.models.pages/conditions_input.attributes.goto_page_id.invalid")
+      conditions_input.goto_page_id = "invalid_page_id"
+      expect(conditions_input).to be_invalid
+      expect(conditions_input.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
+    end
   end
 
   describe "#submit" do
     context "when validation pass" do
       before do
         conditions_input.answer_value = "Rabbit"
-        conditions_input.goto_page_id = 4
+        conditions_input.goto_page_id = pages.last.id
       end
 
       it "calls assign_skip_to_end" do
@@ -122,7 +143,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
           OpenStruct.new(value: "Option 1", label: "Option 1"),
           OpenStruct.new(value: "Option 2", label: "Option 2"),
           OpenStruct.new(value: :none_of_the_above.to_s,
-                         label: I18n.t("page_conditions.none_of_the_above")),
+            label: I18n.t("page_conditions.none_of_the_above")),
         ])
       end
     end

--- a/spec/input_objects/pages/delete_condition_input_spec.rb
+++ b/spec/input_objects/pages/delete_condition_input_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Pages::DeleteConditionInput, type: :model do
       let(:skip_to_end) { true }
 
       it "returns the check your answers translation" do
-        expect(delete_condition_input.goto_page_question_text).to eq I18n.t("page_conditions.check_your_answers")
+        expect(delete_condition_input.goto_page_question_text).to eq I18n.t("page_conditions.end_of_form")
       end
     end
   end

--- a/spec/input_objects/pages/secondary_skip_input_spec.rb
+++ b/spec/input_objects/pages/secondary_skip_input_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe Pages::SecondarySkipInput, type: :model do
       expect(secondary_skip_input).to be_valid
     end
 
+    it "is valid when the goto_page_id is check_your_answers" do
+      secondary_skip_input.routing_page_id = form.pages.first.id.to_s
+      secondary_skip_input.goto_page_id = "check_your_answers"
+      expect(secondary_skip_input).to be_valid
+    end
+
     it "is invalid if goto_page_id is nil" do
       error_message = I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.blank")
       secondary_skip_input.goto_page_id = nil
@@ -50,6 +56,14 @@ RSpec.describe Pages::SecondarySkipInput, type: :model do
       error_message = I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.equal")
       secondary_skip_input.routing_page_id = form.pages.first.id.to_s
       secondary_skip_input.goto_page_id = form.pages.first.id.to_s
+      expect(secondary_skip_input).to be_invalid
+      expect(secondary_skip_input.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
+    end
+
+    it "is invalid when the goto_page_id is not a page ID or check_your_answers" do
+      error_message = I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.invalid")
+      secondary_skip_input.routing_page_id = form.pages.first.id.to_s
+      secondary_skip_input.goto_page_id = "invalid_page_id"
       expect(secondary_skip_input).to be_invalid
       expect(secondary_skip_input.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
     end

--- a/spec/input_objects/pages/secondary_skip_input_spec.rb
+++ b/spec/input_objects/pages/secondary_skip_input_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Pages::SecondarySkipInput, type: :model do
       expect(secondary_skip_input).to be_valid
     end
 
-    it "is valid when the goto_page_id is check_your_answers" do
+    it "is valid when the goto_page_id is end_of_form" do
       secondary_skip_input.routing_page_id = form.pages.first.id.to_s
-      secondary_skip_input.goto_page_id = "check_your_answers"
+      secondary_skip_input.goto_page_id = "end_of_form"
       expect(secondary_skip_input).to be_valid
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Pages::SecondarySkipInput, type: :model do
       expect(secondary_skip_input.errors.full_messages_for(:goto_page_id)).to include("Goto page #{error_message}")
     end
 
-    it "is invalid when the goto_page_id is not a page ID or check_your_answers" do
+    it "is invalid when the goto_page_id is not a page ID or end_of_form" do
       error_message = I18n.t("activemodel.errors.models.pages/secondary_skip_input.attributes.goto_page_id.invalid")
       secondary_skip_input.routing_page_id = form.pages.first.id.to_s
       secondary_skip_input.goto_page_id = "invalid_page_id"

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -546,7 +546,7 @@ RSpec.describe Condition, type: :model do
     end
   end
 
-  describe "#is_check_your_answers?" do
+  describe "#is_end_of_form?" do
     let(:form) { create :form }
     let(:check_page) { create :page, :with_selection_settings, form: }
     let(:goto_page) { create :page, form: }
@@ -555,7 +555,7 @@ RSpec.describe Condition, type: :model do
       let(:condition) { create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: nil, skip_to_end: false }
 
       it "returns nil" do
-        expect(condition.is_check_your_answers?).to be false
+        expect(condition.is_end_of_form?).to be false
       end
     end
 
@@ -563,7 +563,7 @@ RSpec.describe Condition, type: :model do
       let(:condition) { create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: nil, skip_to_end: true }
 
       it "returns nil" do
-        expect(condition.is_check_your_answers?).to be true
+        expect(condition.is_end_of_form?).to be true
       end
     end
 
@@ -571,7 +571,7 @@ RSpec.describe Condition, type: :model do
       let(:condition) { create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, skip_to_end: false }
 
       it "returns nil" do
-        expect(condition.is_check_your_answers?).to be false
+        expect(condition.is_end_of_form?).to be false
       end
     end
 
@@ -579,7 +579,7 @@ RSpec.describe Condition, type: :model do
       let(:condition) { create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, skip_to_end: true }
 
       it "returns nil" do
-        expect(condition.is_check_your_answers?).to be false
+        expect(condition.is_end_of_form?).to be false
       end
     end
   end

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -65,9 +65,9 @@ describe RouteSummaryCardDataPresenter do
         pages.each(&:reload)
       end
 
-      it 'shows "Check your answers" as destination' do
+      it 'shows "End of form" as destination' do
         result = service.summary_card_data
-        expect(result[0][:rows][1][:value][:text]).to eq("Check your answers before submitting")
+        expect(result[0][:rows][1][:value][:text]).to eq("End of form")
       end
     end
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
   describe "#update_change_exit_page" do
     let(:condition) { create :condition, :with_exit_page, routing_page_id: page.id, check_page_id: page.id }
     let(:answer_value) { "Option 1" }
-    let(:goto_page_id) { "2" }
+    let(:goto_page_id) { pages.last.id }
     let(:confirm) { "yes" }
     let(:update_condition_result) { nil }
 

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -738,7 +738,7 @@ describe StepSummaryTableService do
       context "when a page has a route which skips to the end of the form" do
         let(:page) { page_with_skip_to_end }
 
-        it "returns an array containing condition data including text about the 'Check your answers' page" do
+        it "returns an array containing condition data including text about skipping to the end of the form" do
           expect(step_summary_table_service.route_content).to eq [{ answer_value: "Skip to end",
                                                                     answer_value_cy: "Skip to end (Welsh)",
                                                                     check_page: "11. Question to be skipped",
@@ -748,8 +748,8 @@ describe StepSummaryTableService do
                                                                     exit_page_heading_cy: nil,
                                                                     exit_page_markdown: nil,
                                                                     exit_page_markdown_cy: nil,
-                                                                    goto_page: "Check your answers before submitting",
-                                                                    goto_page_cy: "Check your answers before submitting",
+                                                                    goto_page: "End of form",
+                                                                    goto_page_cy: "End of form",
                                                                     routing_page: "11. Question to be skipped",
                                                                     routing_page_cy: "11. Question to be skipped (Welsh)",
                                                                     secondary_skip: false }]

--- a/spec/views/pages/routes/show.html.erb_spec.rb
+++ b/spec/views/pages/routes/show.html.erb_spec.rb
@@ -101,7 +101,7 @@ describe "pages/routes/show.html.erb" do
         end
 
         it "shows the check your answers page as the next question in the form" do
-          expect(rendered).to have_text "People who select any other answer will continue to “Check your answers before submitting”."
+          expect(rendered).to have_text "People who select any other answer will continue to the end of the form."
         end
 
         it "does not have a link to set questions to skip" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/LLGjGbXI

In the new journey flow, the ‘end’ of a form will now be the question about whether the user wants a copy of their answers (if this setting is turned on).

Update the wording for routing from "check your answers page" to "end of form" to reflect this.

Also update the internal values used in the code for adding routing to refer to "end_of_form" rather than "check_your_answers". Have added some input object validation to make sure we don't break routing for users if anyone is adding/editing a route when this change is deployed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
