### PR TITLE
Fix tests being skipped by Rake tasks aborting (and hopefully prevent same in future)

### DIFF
--- a/app/lib/application_logger.rb
+++ b/app/lib/application_logger.rb
@@ -32,7 +32,11 @@ private
     msg = yield if block_given?
 
     begin
-      message_to_hash(msg).merge(attribs || {}).merge(CurrentLoggingAttributes.attributes).compact
+      message_to_hash(msg)
+        .merge(attribs || {})
+        .merge(CurrentLoggingAttributes.attributes)
+        .merge(CurrentTaskLoggingAttributes.attributes)
+        .compact
     rescue NameError
       # if logs aren't attached to a request, CurrentLoggingAttributes will be uninitialized
       message_to_hash(msg).merge(attribs || {})

--- a/app/models/current_task_logging_attributes.rb
+++ b/app/models/current_task_logging_attributes.rb
@@ -1,0 +1,3 @@
+class CurrentTaskLoggingAttributes < ActiveSupport::CurrentAttributes
+  attribute :task_name
+end

--- a/lib/tasks/logging.rake
+++ b/lib/tasks/logging.rake
@@ -1,0 +1,43 @@
+require "English"
+
+Rake::Task.define_task(:environment).enhance do
+  task_finished_normally = false
+
+  at_exit do
+    unless task_finished_normally
+      exit_cause = $ERROR_INFO ? $ERROR_INFO.class.name : "Signal or exit"
+
+      Rails.logger.error "Task terminated early", {
+        task: Rake.application.top_level_tasks.first,
+        exit_cause:,
+      }
+    end
+  end
+
+  Rake.application.top_level_tasks.each do |task_name|
+    task_name_clean = task_name.gsub(/\[.*\]$/, "")
+    next unless Rake::Task.task_defined?(task_name_clean)
+
+    task = Rake::Task[task_name_clean]
+    original_actions = task.actions.dup
+    task.actions.clear
+
+    task.enhance do |t, args|
+      CurrentTaskLoggingAttributes.task_name = task_name_clean
+      Rails.logger.info "Task started", { args: args.to_a }
+
+      begin
+        original_actions.each { |action| action.call(t, args) }
+        Rails.logger.info "Task finished"
+      rescue SystemExit => e
+        Rails.logger.error "Task aborted", { exit_message: e.message }
+        raise e
+      rescue StandardError => e
+        Rails.logger.error "Task failed", { exception: [e.class.name, e.message] }
+        raise e
+      ensure
+        task_finished_normally = true
+      end
+    end
+  end
+end

--- a/spec/lib/application_logger_spec.rb
+++ b/spec/lib/application_logger_spec.rb
@@ -26,6 +26,25 @@ RSpec.describe ApplicationLogger, :capture_logging do
     end
   end
 
+  context "when CurrentTaskLoggingAttributes has attributes set" do
+    before do
+      CurrentTaskLoggingAttributes.task_name = "task:example"
+      logger.info("A message")
+    end
+
+    it "includes the message as a field" do
+      expect(log_line["message"]).to eq "A message"
+    end
+
+    it "includes attributes with values on the log line" do
+      expect(log_line["task_name"]).to eq "task:example"
+    end
+
+    it "does not include attributes without values on the log line" do
+      expect(log_line.keys).not_to include "user_id"
+    end
+  end
+
   context "when a hash is passed as an argument" do
     before do
       CurrentLoggingAttributes.request_id = "a-request-id"

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -1,16 +1,9 @@
-require "rake"
 require "rails_helper"
 
-RSpec.describe "forms.rake" do
-  before do
-    Rake.application.rake_require "tasks/forms"
-    Rake::Task.define_task(:environment)
-  end
-
+RSpec.describe "forms.rake", type: :task do
   describe "forms:move" do
     subject(:task) do
       Rake::Task["forms:move"]
-        .tap(&:reenable)
     end
 
     let(:group) { create :group }
@@ -129,7 +122,6 @@ RSpec.describe "forms.rake" do
   describe "forms:submission_email:update" do
     subject(:task) do
       Rake::Task["forms:submission_email:update"]
-        .tap(&:reenable)
     end
 
     let(:form) do
@@ -231,7 +223,6 @@ RSpec.describe "forms.rake" do
   describe "forms:submission_type:set_to_email" do
     subject(:task) do
       Rake::Task["forms:submission_type:set_to_email"]
-        .tap(&:reenable)
     end
 
     let(:form) { create :form, :live, submission_type: "s3", submission_format: [] }
@@ -361,7 +352,6 @@ RSpec.describe "forms.rake" do
   describe "forms:submission_type:set_to_s3" do
     subject(:task) do
       Rake::Task["forms:submission_type:set_to_s3"]
-        .tap(&:reenable)
     end
 
     let(:form) { create :form, :live }
@@ -545,7 +535,6 @@ RSpec.describe "forms.rake" do
   describe "add_value_to_selection_options" do
     subject(:task) do
       Rake::Task["forms:add_value_to_selection_options"]
-        .tap(&:reenable)
     end
 
     let(:form) { create :form, pages: }
@@ -609,7 +598,6 @@ RSpec.describe "forms.rake" do
   describe "add_send_weekly_submission_batch_to_form_documents" do
     subject(:task) do
       Rake::Task["forms:add_send_weekly_submission_batch_to_form_documents"]
-        .tap(&:reenable)
     end
 
     let!(:form_with_send_weekly_submission_batch) { create :form, send_weekly_submission_batch: true }
@@ -635,7 +623,6 @@ RSpec.describe "forms.rake" do
   describe "convert_declaration_text_to_markdown" do
     subject(:task) do
       Rake::Task["forms:convert_declaration_text_to_markdown"]
-        .tap(&:reenable)
     end
 
     let(:form) { create :form, declaration_text: "<p>This is a declaration</p>" }

--- a/spec/lib/tasks/groups.rake_spec.rb
+++ b/spec/lib/tasks/groups.rake_spec.rb
@@ -1,14 +1,8 @@
-require "rake"
 require "rails_helper"
 
-RSpec.describe "groups.rake" do
-  before do
-    Rake.application.rake_require "tasks/groups"
-    Rake::Task.define_task(:environment)
-  end
-
+RSpec.describe "groups.rake", type: :task do
   describe "groups:remove_group" do
-    subject(:task) { Rake::Task["groups:remove_group"].tap(&:reenable) }
+    subject(:task) { Rake::Task["groups:remove_group"] }
 
     it "with correct arguments removes the group" do
       group = create(:group)
@@ -43,7 +37,7 @@ RSpec.describe "groups.rake" do
   end
 
   describe "groups:remove_group_dry_run" do
-    subject(:task) { Rake::Task["groups:remove_group_dry_run"].tap(&:reenable) }
+    subject(:task) { Rake::Task["groups:remove_group_dry_run"] }
 
     it "with correct arguments does not remove the group" do
       group = create(:group)

--- a/spec/lib/tasks/logging.rake_spec.rb
+++ b/spec/lib/tasks/logging.rake_spec.rb
@@ -1,0 +1,72 @@
+require "rake"
+require "rails_helper"
+
+RSpec.describe "Logging Rake Tasks" do
+  let(:rake) { Rake::Application.new }
+
+  before do
+    Rake.application = rake
+
+    Rake::Task.define_task(:environment)
+    my_task
+
+    allow(rake).to receive(:top_level_tasks).and_return(%w[my_task])
+
+    load Rails.root.join("lib/tasks/logging.rake")
+
+    rake["environment"].invoke
+  end
+
+  context "when the task runs successfully" do
+    let(:my_task) { Rake::Task.define_task(my_task: :environment) }
+
+    it "logs when the task starts and finishes" do
+      expect(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
+
+      expect(Rails.logger).to receive(:info).with("Task finished")
+
+      rake["my_task"].invoke
+    end
+
+    it "logs the arguments passed in to the task" do
+      expect(Rails.logger).to receive(:info).with("Task started", hash_including(args: %w[arg1 arg2]))
+
+      allow(Rails.logger).to receive(:info).with("Task finished")
+
+      rake["my_task"].invoke("arg1", "arg2")
+    end
+  end
+
+  context "when the task raises an error" do
+    let(:my_task) do
+      Rake::Task.define_task(my_task: :environment) do
+        raise StandardError, "Something went wrong"
+      end
+    end
+
+    it "logs an error with the exception" do
+      allow(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
+      expect(Rails.logger).to receive(:error).with(
+        "Task failed",
+        { exception: ["StandardError", "Something went wrong"] },
+      )
+
+      expect { rake["my_task"].invoke }.to raise_error(StandardError, "Something went wrong")
+    end
+  end
+
+  context "when the task is aborted with SystemExit" do
+    let(:my_task) do
+      Rake::Task.define_task(my_task: :environment) do
+        raise SystemExit.new(0, "exit")
+      end
+    end
+
+    it "logs an error with the exit message" do
+      allow(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
+      expect(Rails.logger).to receive(:error).with("Task aborted", { exit_message: "exit" })
+
+      expect { rake["my_task"].invoke }.to output(/exit/).to_stderr
+    end
+  end
+end

--- a/spec/lib/tasks/logging.rake_spec.rb
+++ b/spec/lib/tasks/logging.rake_spec.rb
@@ -1,13 +1,9 @@
-require "rake"
 require "rails_helper"
 
-RSpec.describe "Logging Rake Tasks" do
-  let(:rake) { Rake::Application.new }
+RSpec.describe "Logging Rake Tasks", rakefile: false, type: :task do
+  let(:rake) { Rake.application }
 
   before do
-    Rake.application = rake
-
-    Rake::Task.define_task(:environment)
     my_task
 
     allow(rake).to receive(:top_level_tasks).and_return(%w[my_task])

--- a/spec/lib/tasks/logging.rake_spec.rb
+++ b/spec/lib/tasks/logging.rake_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Logging Rake Tasks", rakefile: false, type: :task do
   context "when the task is aborted with SystemExit" do
     let(:my_task) do
       Rake::Task.define_task(my_task: :environment) do
-        raise SystemExit.new(0, "exit")
+        abort "exit" # rubocop:disable Rails/Exit
       end
     end
 
@@ -62,7 +62,9 @@ RSpec.describe "Logging Rake Tasks", rakefile: false, type: :task do
       allow(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
       expect(Rails.logger).to receive(:error).with("Task aborted", { exit_message: "exit" })
 
-      expect { rake["my_task"].invoke }.to output(/exit/).to_stderr
+      expect { rake["my_task"].invoke }
+        .to raise_error(SystemExit)
+        .and output(/exit/).to_stderr
     end
   end
 end

--- a/spec/lib/tasks/mailchimp.rake_spec.rb
+++ b/spec/lib/tasks/mailchimp.rake_spec.rb
@@ -1,17 +1,9 @@
-require "rake"
-
 require "rails_helper"
 
-RSpec.describe "mailchimp.rake" do
+RSpec.describe "mailchimp.rake", type: :task do
   describe "synchronize_audiences" do
     subject(:task) do
       Rake::Task["mailchimp:synchronize_audiences"]
-        .tap(&:reenable)
-    end
-
-    before do
-      Rake.application.rake_require "tasks/mailchimp"
-      Rake::Task.define_task(:environment)
     end
 
     it "creates a ListSyncService and calls synchronize_lists" do

--- a/spec/lib/tasks/mou_signatures.rake_spec.rb
+++ b/spec/lib/tasks/mou_signatures.rake_spec.rb
@@ -1,17 +1,9 @@
-require "rake"
-
 require "rails_helper"
 
-RSpec.describe "mou_signatures.rake" do
-  before do
-    Rake.application.rake_require "tasks/mou_signatures"
-    Rake::Task.define_task(:environment)
-  end
-
+RSpec.describe "mou_signatures.rake", type: :task do
   describe "mou_signatures:create" do
     subject(:task) do
       Rake::Task["mou_signatures:create"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     let(:user) { create :user, name: "A Person" }
@@ -69,7 +61,6 @@ RSpec.describe "mou_signatures.rake" do
   describe "mou_signatures:update_organisation" do
     subject(:task) do
       Rake::Task["mou_signatures:update_organisation"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     let(:user) { create :user }
@@ -117,7 +108,6 @@ RSpec.describe "mou_signatures.rake" do
   describe "mou_signatures:revoke_user_signature" do
     subject(:task) do
       Rake::Task["mou_signatures:revoke_user_signature"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     let(:user) { create :user }

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -1,17 +1,9 @@
-require "rake"
-
 require "rails_helper"
 
-RSpec.describe "organisations.rake" do
-  before do
-    Rake.application.rake_require "tasks/organisations"
-    Rake::Task.define_task(:environment)
-  end
-
+RSpec.describe "organisations.rake", type: :task do
   describe "organisations:create" do
     subject(:task) do
       Rake::Task["organisations:create"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     it "creates an organisation" do
@@ -54,7 +46,6 @@ RSpec.describe "organisations.rake" do
   describe "organisations:fetch" do
     subject(:task) do
       Rake::Task["organisations:fetch"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     it "fetches organisations" do
@@ -71,7 +62,6 @@ RSpec.describe "organisations.rake" do
   describe "organisations:rename" do
     subject(:task) do
       Rake::Task["organisations:rename"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     it "renames an organisation" do
@@ -103,7 +93,6 @@ RSpec.describe "organisations.rake" do
   describe "organisations:merge" do
     subject(:task) do
       Rake::Task["organisations:merge"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     let!(:source_org) { create :organisation, slug: "old-organisation", closed: true }
@@ -196,7 +185,6 @@ RSpec.describe "organisations.rake" do
     describe ":dry_run" do
       subject(:task) do
         Rake::Task["organisations:merge:dry_run"]
-          .tap(&:reenable) # make sure task is invoked every time
       end
 
       let(:invoked_task) do
@@ -210,7 +198,6 @@ RSpec.describe "organisations.rake" do
   describe "organisations:make_internal" do
     subject(:task) do
       Rake::Task["organisations:make_internal"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     it "sets an organisation's internal flag to true" do
@@ -245,7 +232,6 @@ RSpec.describe "organisations.rake" do
   describe "organisations:make_external" do
     subject(:task) do
       Rake::Task["organisations:make_external"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     it "sets an organisation's internal flag to false" do

--- a/spec/lib/tasks/users.rake_spec.rb
+++ b/spec/lib/tasks/users.rake_spec.rb
@@ -1,17 +1,9 @@
-require "rake"
-
 require "rails_helper"
 
-RSpec.describe "users.rake" do
-  before do
-    Rake.application.rake_require "tasks/users"
-    Rake::Task.define_task(:environment)
-  end
-
+RSpec.describe "users.rake", type: :task do
   describe "users:delete_user_dry_run" do
     subject(:task) do
       Rake::Task["users:delete_user_dry_run"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     let!(:user_to_delete) { create(:user) }
@@ -45,7 +37,6 @@ RSpec.describe "users.rake" do
   describe "users:delete_user" do
     subject(:task) do
       Rake::Task["users:delete_user"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     let!(:user_to_delete) { create(:user) }
@@ -78,7 +69,6 @@ RSpec.describe "users.rake" do
   describe "users:delete_users_with_no_name_or_org" do
     subject(:task) do
       Rake::Task["users:delete_users_with_no_name_or_org"]
-        .tap(&:reenable) # make sure task is invoked every time
     end
 
     let(:users) do
@@ -188,7 +178,6 @@ RSpec.describe "users.rake" do
     describe ":dry_run" do
       subject(:dry_run_task) do
         Rake::Task["users:delete_users_with_no_name_or_org:dry_run"]
-          .tap(&:reenable) # make sure task is invoked every time
       end
 
       let(:user_in_group) { users.fifth }

--- a/spec/support/rake_task_helpers.rb
+++ b/spec/support/rake_task_helpers.rb
@@ -1,0 +1,37 @@
+require "rake"
+
+module RakeTaskHelpers
+  class UnexpectedSystemExit < StandardError; end
+
+  def self.included(base)
+    base.class_eval do
+      before do
+        metadata = self.class.metadata
+        rakefile = metadata.include?(:rakefile) ? metadata[:rakefile] : self.class.top_level_description
+
+        Rake.application = Rake::Application.new
+        Rake.load_rakefile("lib/tasks/#{rakefile}") if rakefile
+
+        Rake::Task.define_task(:environment)
+      end
+
+      around do |example|
+        example.run
+      rescue SystemExit => e
+        message = <<~MSG
+          SystemExit raised but not expected in this example
+
+          This may be because a task was invoked that calls `abort`.
+          If the task was supposed to abort in this example, make
+          sure to expect the SystemExit exception with
+          `expect { }.to raise_error(SystemExit)`.
+        MSG
+        raise UnexpectedSystemExit, message, e.backtrace, cause: e
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include RakeTaskHelpers, type: :task
+end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We had an issue recently where tests were being silently skipped in CI because a test added in PR #2691 was raising SystemExit and not catching it, and we had to revert that PR.

This PR restores the changes in that PR, adds a guard to try and catch similar issues in future (where Rake tasks call `abort` in specs and it's not `expect`ed), and fixes the (now) failing tests that caused the problems before.

We also refactor the way we write Rake task specs a bit to reduce boilerplate, and hopefully make it easier to write them (as well as safer).

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
