### PR TITLE
Bring existing org admin alerts into new structure

### DIFF
--- a/app/mailers/admin_alerts/draft_created_mailer.rb
+++ b/app/mailers/admin_alerts/draft_created_mailer.rb
@@ -1,7 +1,7 @@
-class OrgAdminAlerts::DraftCreatedMailer < GovukNotifyRails::Mailer
+class AdminAlerts::DraftCreatedMailer < GovukNotifyRails::Mailer
   include Rails.application.routes.url_helpers
   def new_draft_form_created(form:, user:, to_email:)
-    set_template(Settings.govuk_notify.org_admin_alerts.new_draft_form_created_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.new_draft_form_created_template_id)
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: form_url(form),
@@ -12,7 +12,7 @@ class OrgAdminAlerts::DraftCreatedMailer < GovukNotifyRails::Mailer
   end
 
   def copied_draft_form_created(form:, copied_from_form:, user:, to_email:)
-    set_template(Settings.govuk_notify.org_admin_alerts.copied_draft_form_created_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.copied_draft_form_created_template_id)
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: form_url(form),
@@ -25,7 +25,7 @@ class OrgAdminAlerts::DraftCreatedMailer < GovukNotifyRails::Mailer
   end
 
   def new_archived_form_draft_created(form:, user:, to_email:)
-    set_template(Settings.govuk_notify.org_admin_alerts.new_archived_form_draft_created_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.new_archived_form_draft_created_template_id)
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: form_url(form),
@@ -38,7 +38,7 @@ class OrgAdminAlerts::DraftCreatedMailer < GovukNotifyRails::Mailer
   end
 
   def new_live_form_draft_created(form:, user:, to_email:)
-    set_template(Settings.govuk_notify.org_admin_alerts.new_live_form_draft_created_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.new_live_form_draft_created_template_id)
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: form_url(form),

--- a/app/mailers/admin_alerts/group_delete_mailer.rb
+++ b/app/mailers/admin_alerts/group_delete_mailer.rb
@@ -1,12 +1,12 @@
-class GroupDeleteMailer < GovukNotifyRails::Mailer
+class AdminAlerts::GroupDeleteMailer < GovukNotifyRails::Mailer
   def group_deleted_email_org_admin(...)
-    set_template(Settings.govuk_notify.group_deleted_org_admin_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.group_deleted_org_admin_template_id)
 
     group_deleted_email(...)
   end
 
   def group_deleted_email_group_admins_and_editors(...)
-    set_template(Settings.govuk_notify.group_deleted_group_admin_editor_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.group_deleted_group_admin_editor_template_id)
 
     group_deleted_email(...)
   end

--- a/app/mailers/admin_alerts/group_forms_move_mailer.rb
+++ b/app/mailers/admin_alerts/group_forms_move_mailer.rb
@@ -1,12 +1,12 @@
-class GroupFormsMoveMailer < GovukNotifyRails::Mailer
+class AdminAlerts::GroupFormsMoveMailer < GovukNotifyRails::Mailer
   def form_moved_email_org_admin(...)
-    set_template(Settings.govuk_notify.group_form_moved_org_admin_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.group_form_moved_org_admin_template_id)
 
     form_moved_email(...)
   end
 
   def form_moved_email_group_admin(...)
-    set_template(Settings.govuk_notify.group_form_moved_group_admin_editor_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.group_form_moved_group_admin_editor_template_id)
 
     form_moved_email(...)
   end

--- a/app/mailers/admin_alerts/group_forms_move_mailer.rb
+++ b/app/mailers/admin_alerts/group_forms_move_mailer.rb
@@ -11,13 +11,16 @@ class AdminAlerts::GroupFormsMoveMailer < GovukNotifyRails::Mailer
     form_moved_email(...)
   end
 
-  def form_moved_email(to_email:, form_name:, old_group_name:, new_group_name:, org_admin_email:, org_admin_name:)
+  def form_moved_email(to_email:, form_name:, old_group_name:, new_group_name:, org_admin_email:, org_admin_name:, group_active:)
+    group_active_text = group_active ? "yes" : "no"
+
     set_personalisation(
       form_name:,
       old_group_name:,
       new_group_name:,
       org_admin_email:,
       org_admin_name:,
+      group_active: group_active_text,
     )
 
     mail(to: to_email)

--- a/app/mailers/admin_alerts/made_live_mailer.rb
+++ b/app/mailers/admin_alerts/made_live_mailer.rb
@@ -1,7 +1,7 @@
-class OrgAdminAlerts::MadeLiveMailer < GovukNotifyRails::Mailer
+class AdminAlerts::MadeLiveMailer < GovukNotifyRails::Mailer
   include Rails.application.routes.url_helpers
   def new_draft_form_made_live(form:, user:, to_email:)
-    set_template(Settings.govuk_notify.org_admin_alerts.new_draft_form_made_live_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.new_draft_form_made_live_template_id)
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: live_form_url(form),
@@ -11,7 +11,7 @@ class OrgAdminAlerts::MadeLiveMailer < GovukNotifyRails::Mailer
   end
 
   def live_form_changes_made_live(form:, user:, to_email:)
-    set_template(Settings.govuk_notify.org_admin_alerts.live_form_changes_made_live_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.live_form_changes_made_live_template_id)
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: live_form_url(form),
@@ -21,7 +21,7 @@ class OrgAdminAlerts::MadeLiveMailer < GovukNotifyRails::Mailer
   end
 
   def archived_form_changes_made_live(form:, user:, to_email:)
-    set_template(Settings.govuk_notify.org_admin_alerts.archived_form_changes_made_live_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.archived_form_changes_made_live_template_id)
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: live_form_url(form),
@@ -31,7 +31,7 @@ class OrgAdminAlerts::MadeLiveMailer < GovukNotifyRails::Mailer
   end
 
   def copied_form_made_live(form:, copied_from_form:, user:, to_email:)
-    set_template(Settings.govuk_notify.org_admin_alerts.copied_form_made_live_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.copied_form_made_live_template_id)
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: live_form_url(form),
@@ -43,7 +43,7 @@ class OrgAdminAlerts::MadeLiveMailer < GovukNotifyRails::Mailer
   end
 
   def archived_form_made_live(form:, user:, to_email:)
-    set_template(Settings.govuk_notify.org_admin_alerts.archived_form_made_live_template_id)
+    set_template(Settings.govuk_notify.admin_alerts.archived_form_made_live_template_id)
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: live_form_url(form),

--- a/app/services/group_forms_service.rb
+++ b/app/services/group_forms_service.rb
@@ -39,6 +39,7 @@ private
       new_group_name: @group.name,
       org_admin_email: @current_user.email,
       org_admin_name: @current_user.name,
+      group_active: @group.active?,
     ).deliver_now
   end
 
@@ -50,6 +51,7 @@ private
       new_group_name: @group.name,
       org_admin_email: @current_user.email,
       org_admin_name: @current_user.name,
+      group_active: @group.active?,
     ).deliver_now
   end
 end

--- a/app/services/group_forms_service.rb
+++ b/app/services/group_forms_service.rb
@@ -32,7 +32,7 @@ private
   end
 
   def send_move_email_to_org_admin_user(to_email)
-    GroupFormsMoveMailer.form_moved_email_org_admin(
+    AdminAlerts::GroupFormsMoveMailer.form_moved_email_org_admin(
       to_email: to_email,
       form_name: @form.name,
       old_group_name: @old_group.name,
@@ -43,7 +43,7 @@ private
   end
 
   def send_move_email_to_group_admin_user(to_email)
-    GroupFormsMoveMailer.form_moved_email_group_admin(
+    AdminAlerts::GroupFormsMoveMailer.form_moved_email_group_admin(
       to_email: to_email,
       form_name: @form.name,
       old_group_name: @old_group.name,

--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -96,7 +96,7 @@ private
   end
 
   def send_delete_email_to_org_admin_user(to_email)
-    GroupDeleteMailer.group_deleted_email_org_admin(
+    AdminAlerts::GroupDeleteMailer.group_deleted_email_org_admin(
       to_email: to_email,
       group_name: @group.name,
       org_admin_email_address: @current_user.email,
@@ -105,7 +105,7 @@ private
   end
 
   def send_delete_email_to_group_admin_or_editor_user(to_email)
-    GroupDeleteMailer.group_deleted_email_group_admins_and_editors(
+    AdminAlerts::GroupDeleteMailer.group_deleted_email_group_admins_and_editors(
       to_email: to_email,
       group_name: @group.name,
       org_admin_email_address: @current_user.email,

--- a/app/services/org_admin_alerts_service.rb
+++ b/app/services/org_admin_alerts_service.rb
@@ -34,11 +34,11 @@ private
     when :draft
       new_draft_made_live_email(to_email:)
     when :live_with_draft
-      OrgAdminAlerts::MadeLiveMailer.live_form_changes_made_live(form: @form, user: @current_user, to_email:)
+      AdminAlerts::MadeLiveMailer.live_form_changes_made_live(form: @form, user: @current_user, to_email:)
     when :archived
-      OrgAdminAlerts::MadeLiveMailer.archived_form_made_live(form: @form, user: @current_user, to_email:)
+      AdminAlerts::MadeLiveMailer.archived_form_made_live(form: @form, user: @current_user, to_email:)
     when :archived_with_draft
-      OrgAdminAlerts::MadeLiveMailer.archived_form_changes_made_live(form: @form, user: @current_user, to_email:)
+      AdminAlerts::MadeLiveMailer.archived_form_changes_made_live(form: @form, user: @current_user, to_email:)
     else
       raise StandardError, "Unexpected previous state: #{previous_state}"
     end
@@ -46,26 +46,26 @@ private
 
   def new_draft_made_live_email(to_email:)
     if copied_from_form
-      OrgAdminAlerts::MadeLiveMailer.copied_form_made_live(form: @form, copied_from_form:, user: @current_user, to_email:)
+      AdminAlerts::MadeLiveMailer.copied_form_made_live(form: @form, copied_from_form:, user: @current_user, to_email:)
     else
-      OrgAdminAlerts::MadeLiveMailer.new_draft_form_made_live(form: @form, user: @current_user, to_email:)
+      AdminAlerts::MadeLiveMailer.new_draft_form_made_live(form: @form, user: @current_user, to_email:)
     end
   end
 
   def new_draft_form_created_email(to_email:)
     if copied_from_form
-      OrgAdminAlerts::DraftCreatedMailer.copied_draft_form_created(form: @form, copied_from_form:, user: @current_user, to_email:)
+      AdminAlerts::DraftCreatedMailer.copied_draft_form_created(form: @form, copied_from_form:, user: @current_user, to_email:)
     else
-      OrgAdminAlerts::DraftCreatedMailer.new_draft_form_created(form: @form, user: @current_user, to_email:)
+      AdminAlerts::DraftCreatedMailer.new_draft_form_created(form: @form, user: @current_user, to_email:)
     end
   end
 
   def draft_of_existing_form_created_email(to_email:)
     case @form.state.to_sym
     when :live_with_draft
-      OrgAdminAlerts::DraftCreatedMailer.new_live_form_draft_created(form: @form, user: @current_user, to_email:)
+      AdminAlerts::DraftCreatedMailer.new_live_form_draft_created(form: @form, user: @current_user, to_email:)
     when :archived_with_draft
-      OrgAdminAlerts::DraftCreatedMailer.new_archived_form_draft_created(form: @form, user: @current_user, to_email:)
+      AdminAlerts::DraftCreatedMailer.new_archived_form_draft_created(form: @form, user: @current_user, to_email:)
     else
       raise StandardError, "Unexpected form state: #{@form.state}"
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,7 +32,7 @@ govuk_notify:
   group_upgrade_rejected_template_id: f494999a-1a38-4b01-a3c8-dbb2d60e6e5f
   group_deleted_group_admin_editor_template_id: b987d794-9214-40f5-8014-65d5b9c058d8
   group_deleted_org_admin_template_id: 4c6d6c67-e9f1-4012-adc2-05f23dc69638
-  org_admin_alerts:
+  admin_alerts:
     new_draft_form_made_live_template_id: 95065d23-e7ad-4af7-9a2f-7209276d74d0
     live_form_changes_made_live_template_id: 02c38f9b-197e-480d-8031-bba9498d5907
     archived_form_changes_made_live_template_id: 9db2d85b-9db4-48c3-bbc6-31aa0c742384

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,14 +24,10 @@ govuk_notify:
   submission_email_confirmation_code_email_template_id: ce2638ab-754c-416d-8df6-c0ccb5e1a688
   live_submission_email_of_no_further_form_submissions_template_id: a8c43931-af3d-48ff-b5b2-dbc444796dec
   zendesk_reply_to_id: 0acefa17-04b5-4614-a2ad-6c7f17dd26ab
-  group_form_moved_org_admin_template_id: 63c6c6ab-d497-4eb8-b1f8-6a89eab07ed1
-  group_form_moved_group_admin_editor_template_id: a9ddf06c-20f9-4665-a5a8-3ace2b953a76
   group_member_added_to_group_id: d1fc7267-7e27-4e6c-aa30-523b8be3d637
   group_upgraded_template_id: b5d0d3d4-fc24-403e-aba6-b421fdcebd55
   group_upgrade_requested_template_id: e2251c92-9365-429a-9857-56780263718f
   group_upgrade_rejected_template_id: f494999a-1a38-4b01-a3c8-dbb2d60e6e5f
-  group_deleted_group_admin_editor_template_id: b987d794-9214-40f5-8014-65d5b9c058d8
-  group_deleted_org_admin_template_id: 4c6d6c67-e9f1-4012-adc2-05f23dc69638
   admin_alerts:
     new_draft_form_made_live_template_id: 95065d23-e7ad-4af7-9a2f-7209276d74d0
     live_form_changes_made_live_template_id: 02c38f9b-197e-480d-8031-bba9498d5907
@@ -42,6 +38,10 @@ govuk_notify:
     copied_draft_form_created_template_id: a2d4f9a0-71b6-483d-ba83-0eb2e2592772
     new_archived_form_draft_created_template_id: 02228b71-e680-4152-a5bd-0bc4b8a4695f
     new_live_form_draft_created_template_id: 8c114e68-edd1-470b-bbf9-532733eaa0d1
+    group_deleted_group_admin_editor_template_id: b987d794-9214-40f5-8014-65d5b9c058d8
+    group_deleted_org_admin_template_id: 4c6d6c67-e9f1-4012-adc2-05f23dc69638
+    group_form_moved_org_admin_template_id: 63c6c6ab-d497-4eb8-b1f8-6a89eab07ed1
+    group_form_moved_group_admin_editor_template_id: a9ddf06c-20f9-4665-a5a8-3ace2b953a76
 
 # When set to true, any capybara tests will run chrome normally rather than in headless mode.
 show_browser_during_tests: false

--- a/spec/mailers/admin_alerts/draft_created_mailer_spec.rb
+++ b/spec/mailers/admin_alerts/draft_created_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe OrgAdminAlerts::DraftCreatedMailer, type: :mailer do
+describe AdminAlerts::DraftCreatedMailer, type: :mailer do
   let(:form) { create :form, :with_group }
   let(:user) { create :user }
   let(:to_email) { "admin@example.gov.uk" }
@@ -11,7 +11,7 @@ describe OrgAdminAlerts::DraftCreatedMailer, type: :mailer do
     end
 
     it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.org_admin_alerts.new_draft_form_created_template_id)
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.new_draft_form_created_template_id)
     end
 
     it "sends an email to the correct email address" do
@@ -35,7 +35,7 @@ describe OrgAdminAlerts::DraftCreatedMailer, type: :mailer do
     let(:copied_from_form) { create :form }
 
     it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.org_admin_alerts.copied_draft_form_created_template_id)
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.copied_draft_form_created_template_id)
     end
 
     it "sends an email to the correct email address" do
@@ -67,7 +67,7 @@ describe OrgAdminAlerts::DraftCreatedMailer, type: :mailer do
     end
 
     it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.org_admin_alerts.new_archived_form_draft_created_template_id)
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.new_archived_form_draft_created_template_id)
     end
 
     it "sends an email to the correct email address" do
@@ -99,7 +99,7 @@ describe OrgAdminAlerts::DraftCreatedMailer, type: :mailer do
     end
 
     it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.org_admin_alerts.new_live_form_draft_created_template_id)
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.new_live_form_draft_created_template_id)
     end
 
     it "sends an email to the correct email address" do

--- a/spec/mailers/admin_alerts/group_delete_mailer_spec.rb
+++ b/spec/mailers/admin_alerts/group_delete_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe GroupDeleteMailer, type: :mailer do
+describe AdminAlerts::GroupDeleteMailer, type: :mailer do
   let(:current_user) { create :organisation_admin_user }
   let(:group) { create :group }
   let(:to_email) { "email@example.gov.uk" }
@@ -17,7 +17,7 @@ describe GroupDeleteMailer, type: :mailer do
       end
 
       it "sends an email with the correct template" do
-        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.group_deleted_org_admin_template_id)
+        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.group_deleted_org_admin_template_id)
       end
 
       it "includes the personalisation" do
@@ -38,7 +38,7 @@ describe GroupDeleteMailer, type: :mailer do
       end
 
       it "sends an email with the correct template" do
-        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.group_deleted_group_admin_editor_template_id)
+        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.group_deleted_group_admin_editor_template_id)
       end
 
       it "includes the personalisation" do

--- a/spec/mailers/admin_alerts/group_forms_move_mailer_spec.rb
+++ b/spec/mailers/admin_alerts/group_forms_move_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe GroupFormsMoveMailer, type: :mailer do
+describe AdminAlerts::GroupFormsMoveMailer, type: :mailer do
   let(:current_user) { create :organisation_admin_user }
   let(:group) { create :group }
   let(:old_group) { create :group }
@@ -21,7 +21,7 @@ describe GroupFormsMoveMailer, type: :mailer do
       end
 
       it "sends an email with the correct template" do
-        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.group_form_moved_org_admin_template_id)
+        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.group_form_moved_org_admin_template_id)
       end
 
       it "includes the personalisation" do
@@ -46,7 +46,7 @@ describe GroupFormsMoveMailer, type: :mailer do
       end
 
       it "sends an email with the correct template" do
-        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.group_form_moved_group_admin_editor_template_id)
+        expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.group_form_moved_group_admin_editor_template_id)
       end
 
       it "includes the personalisation" do

--- a/spec/mailers/admin_alerts/group_forms_move_mailer_spec.rb
+++ b/spec/mailers/admin_alerts/group_forms_move_mailer_spec.rb
@@ -17,6 +17,7 @@ describe AdminAlerts::GroupFormsMoveMailer, type: :mailer do
           new_group_name: group.name,
           org_admin_email: current_user.email,
           org_admin_name: current_user.name,
+          group_active: group.active?,
         )
       end
 
@@ -30,6 +31,15 @@ describe AdminAlerts::GroupFormsMoveMailer, type: :mailer do
         expect(mail.govuk_notify_personalisation[:new_group_name]).to eq(group.name)
         expect(mail.govuk_notify_personalisation[:org_admin_email]).to eq(current_user.email)
         expect(mail.govuk_notify_personalisation[:org_admin_name]).to eq(current_user.name)
+        expect(mail.govuk_notify_personalisation[:group_active]).to eq("no")
+      end
+
+      context "when group is active" do
+        let(:group) { create :group, status: :active }
+
+        it "personalisation includes group active as yes" do
+          expect(mail.govuk_notify_personalisation[:group_active]).to eq("yes")
+        end
       end
     end
 
@@ -42,6 +52,7 @@ describe AdminAlerts::GroupFormsMoveMailer, type: :mailer do
           new_group_name: group.name,
           org_admin_email: current_user.email,
           org_admin_name: current_user.name,
+          group_active: group.active?,
         )
       end
 
@@ -55,6 +66,7 @@ describe AdminAlerts::GroupFormsMoveMailer, type: :mailer do
         expect(mail.govuk_notify_personalisation[:new_group_name]).to eq(group.name)
         expect(mail.govuk_notify_personalisation[:org_admin_email]).to eq(current_user.email)
         expect(mail.govuk_notify_personalisation[:org_admin_name]).to eq(current_user.name)
+        expect(mail.govuk_notify_personalisation[:group_active]).to eq("no")
       end
     end
   end

--- a/spec/mailers/admin_alerts/made_live_mailer_spec.rb
+++ b/spec/mailers/admin_alerts/made_live_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe OrgAdminAlerts::MadeLiveMailer, type: :mailer do
+describe AdminAlerts::MadeLiveMailer, type: :mailer do
   let(:form) { create :form, :live }
   let(:user) { create :user }
   let(:to_email) { "admin@example.gov.uk" }
@@ -15,7 +15,7 @@ describe OrgAdminAlerts::MadeLiveMailer, type: :mailer do
     end
 
     it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.org_admin_alerts.new_draft_form_made_live_template_id)
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.new_draft_form_made_live_template_id)
     end
 
     it "sends an email to the correct email address" do
@@ -40,7 +40,7 @@ describe OrgAdminAlerts::MadeLiveMailer, type: :mailer do
     end
 
     it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.org_admin_alerts.live_form_changes_made_live_template_id)
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.live_form_changes_made_live_template_id)
     end
 
     it "sends an email to the correct email address" do
@@ -65,7 +65,7 @@ describe OrgAdminAlerts::MadeLiveMailer, type: :mailer do
     end
 
     it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.org_admin_alerts.archived_form_changes_made_live_template_id)
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.archived_form_changes_made_live_template_id)
     end
 
     it "sends an email to the correct email address" do
@@ -93,7 +93,7 @@ describe OrgAdminAlerts::MadeLiveMailer, type: :mailer do
     let(:copied_from_form) { create :form }
 
     it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.org_admin_alerts.copied_form_made_live_template_id)
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.copied_form_made_live_template_id)
     end
 
     it "sends an email to the correct email address" do
@@ -120,7 +120,7 @@ describe OrgAdminAlerts::MadeLiveMailer, type: :mailer do
     end
 
     it "sends an email with the correct template" do
-      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.org_admin_alerts.archived_form_made_live_template_id)
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.admin_alerts.archived_form_made_live_template_id)
     end
 
     it "sends an email to the correct email address" do

--- a/spec/requests/forms/copy_controller_spec.rb
+++ b/spec/requests/forms/copy_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Forms::CopyController, type: :request do
         post create_copy_form_path(id), params: { forms_copy_input: { name: "Copied Form", tag: "draft" } }
         expect(ActionMailer::Base.deliveries.count).to eq(1)
 
-        template_id = Settings.govuk_notify.org_admin_alerts.copied_draft_form_created_template_id
+        template_id = Settings.govuk_notify.admin_alerts.copied_draft_form_created_template_id
         expect(ActionMailer::Base.deliveries.last.govuk_notify_template).to eq(template_id)
       end
     end

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
         post(make_live_path(form_id: form.id), params: form_params)
         expect(ActionMailer::Base.deliveries.count).to eq(1)
 
-        template_id = Settings.govuk_notify.org_admin_alerts.new_draft_form_made_live_template_id
+        template_id = Settings.govuk_notify.admin_alerts.new_draft_form_made_live_template_id
         expect(ActionMailer::Base.deliveries.last.govuk_notify_template).to eq(template_id)
       end
 

--- a/spec/requests/forms/unarchive_controller_spec.rb
+++ b/spec/requests/forms/unarchive_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Forms::UnarchiveController, type: :request do
         post(unarchive_create_path(form_id: form.id), params: form_params)
         expect(ActionMailer::Base.deliveries.count).to eq(1)
 
-        template_id = Settings.govuk_notify.org_admin_alerts.archived_form_made_live_template_id
+        template_id = Settings.govuk_notify.admin_alerts.archived_form_made_live_template_id
         expect(ActionMailer::Base.deliveries.last.govuk_notify_template).to eq(template_id)
       end
     end

--- a/spec/requests/forms_controller_spec.rb
+++ b/spec/requests/forms_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe FormsController, type: :request do
         expect(form.reload).to be_live_with_draft
         expect(ActionMailer::Base.deliveries.count).to eq(1)
 
-        template_id = Settings.govuk_notify.org_admin_alerts.new_live_form_draft_created_template_id
+        template_id = Settings.govuk_notify.admin_alerts.new_live_form_draft_created_template_id
         expect(ActionMailer::Base.deliveries.last.govuk_notify_template).to eq(template_id)
       end
     end

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
         post group_forms_url(group), params: { forms_name_input: valid_attributes }
         expect(ActionMailer::Base.deliveries.count).to eq(1)
 
-        template_id = Settings.govuk_notify.org_admin_alerts.new_draft_form_created_template_id
+        template_id = Settings.govuk_notify.admin_alerts.new_draft_form_created_template_id
         expect(ActionMailer::Base.deliveries.last.govuk_notify_template).to eq(template_id)
       end
     end

--- a/spec/services/group_forms_service_spec.rb
+++ b/spec/services/group_forms_service_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe GroupFormsService do
               new_group_name: group.name,
               org_admin_email: current_user.email,
               org_admin_name: current_user.name,
+              group_active: group.active?,
             )
           end
         end
@@ -80,6 +81,7 @@ RSpec.describe GroupFormsService do
               new_group_name: group.name,
               org_admin_email: current_user.email,
               org_admin_name: current_user.name,
+              group_active: group.active?,
             )
           end
         end

--- a/spec/services/group_forms_service_spec.rb
+++ b/spec/services/group_forms_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe GroupFormsService do
 
     describe "sending emails" do
       before do
-        allow(GroupFormsMoveMailer).to receive_messages(form_moved_email_org_admin: delivery, form_moved_email_group_admin: delivery)
+        allow(AdminAlerts::GroupFormsMoveMailer).to receive_messages(form_moved_email_org_admin: delivery, form_moved_email_group_admin: delivery)
         allow(delivery).to receive(:deliver_now).with(any_args)
       end
 
@@ -46,7 +46,7 @@ RSpec.describe GroupFormsService do
           expect(delivery).to have_received(:deliver_now).with(any_args).exactly(2).times
 
           org_admins.each do |org_admin|
-            expect(GroupFormsMoveMailer).to have_received(:form_moved_email_org_admin).with(
+            expect(AdminAlerts::GroupFormsMoveMailer).to have_received(:form_moved_email_org_admin).with(
               to_email: org_admin.email,
               form_name: form.name,
               old_group_name: old_group.name,
@@ -73,7 +73,7 @@ RSpec.describe GroupFormsService do
           expect(delivery).to have_received(:deliver_now).with(any_args).exactly(2).times
 
           group_admins.each do |user|
-            expect(GroupFormsMoveMailer).to have_received(:form_moved_email_group_admin).with(
+            expect(AdminAlerts::GroupFormsMoveMailer).to have_received(:form_moved_email_group_admin).with(
               to_email: user.email,
               form_name: form.name,
               old_group_name: old_group.name,

--- a/spec/services/group_service_spec.rb
+++ b/spec/services/group_service_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe GroupService do
     let(:delivery) { double }
 
     before do
-      allow(GroupDeleteMailer).to receive_messages(group_deleted_email_org_admin: delivery, group_deleted_email_group_admins_and_editors: delivery)
+      allow(AdminAlerts::GroupDeleteMailer).to receive_messages(group_deleted_email_org_admin: delivery, group_deleted_email_group_admins_and_editors: delivery)
       allow(delivery).to receive(:deliver_now).with(any_args)
     end
 
@@ -207,7 +207,7 @@ RSpec.describe GroupService do
         expect(delivery).to have_received(:deliver_now).with(any_args).exactly(2).times
 
         org_admins.each do |org_admin|
-          expect(GroupDeleteMailer).to have_received(:group_deleted_email_org_admin).with(
+          expect(AdminAlerts::GroupDeleteMailer).to have_received(:group_deleted_email_org_admin).with(
             to_email: org_admin.email,
             org_admin_name: current_user.name,
             org_admin_email_address: current_user.email,
@@ -232,7 +232,7 @@ RSpec.describe GroupService do
         expect(delivery).to have_received(:deliver_now).with(any_args).exactly(2).times
 
         group_admins.each do |user|
-          expect(GroupDeleteMailer).to have_received(:group_deleted_email_group_admins_and_editors).with(
+          expect(AdminAlerts::GroupDeleteMailer).to have_received(:group_deleted_email_group_admins_and_editors).with(
             to_email: user.email,
             org_admin_name: current_user.name,
             org_admin_email_address: current_user.email,
@@ -257,7 +257,7 @@ RSpec.describe GroupService do
         expect(delivery).to have_received(:deliver_now).with(any_args).exactly(2).times
 
         group_editors.each do |user|
-          expect(GroupDeleteMailer).to have_received(:group_deleted_email_group_admins_and_editors).with(
+          expect(AdminAlerts::GroupDeleteMailer).to have_received(:group_deleted_email_group_admins_and_editors).with(
             to_email: user.email,
             org_admin_name: current_user.name,
             org_admin_email_address: current_user.email,

--- a/spec/services/org_admin_alerts_service_spec.rb
+++ b/spec/services/org_admin_alerts_service_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe OrgAdminAlertsService do
 
       context "when form was not copied from another form" do
         it "sends the new draft form made live email to the organisation admins" do
-          expect(OrgAdminAlerts::MadeLiveMailer).to receive(:new_draft_form_made_live).with(
+          expect(AdminAlerts::MadeLiveMailer).to receive(:new_draft_form_made_live).with(
             form: form,
             user: current_user,
             to_email: organisation_admins.first.email,
           ).and_call_original
 
-          expect(OrgAdminAlerts::MadeLiveMailer).to receive(:new_draft_form_made_live).with(
+          expect(AdminAlerts::MadeLiveMailer).to receive(:new_draft_form_made_live).with(
             form: form,
             user: current_user,
             to_email: organisation_admins.second.email,
@@ -42,10 +42,10 @@ RSpec.describe OrgAdminAlertsService do
         end
 
         it "does not send an email to the current user" do
-          allow(OrgAdminAlerts::MadeLiveMailer).to receive(:new_draft_form_made_live).and_call_original
+          allow(AdminAlerts::MadeLiveMailer).to receive(:new_draft_form_made_live).and_call_original
           service.form_made_live
 
-          expect(OrgAdminAlerts::MadeLiveMailer).not_to have_received(:new_draft_form_made_live).with(
+          expect(AdminAlerts::MadeLiveMailer).not_to have_received(:new_draft_form_made_live).with(
             form: form,
             user: current_user,
             to_email: current_user.email,
@@ -58,14 +58,14 @@ RSpec.describe OrgAdminAlertsService do
         let(:form) { create(:form, :ready_for_live, state: previous_state, copied_from_id: copied_from_form.id) }
 
         it "sends the copied form made live email to the organisation admins" do
-          expect(OrgAdminAlerts::MadeLiveMailer).to receive(:copied_form_made_live).with(
+          expect(AdminAlerts::MadeLiveMailer).to receive(:copied_form_made_live).with(
             form: form,
             copied_from_form: copied_from_form,
             user: current_user,
             to_email: organisation_admins.first.email,
           ).and_call_original
 
-          expect(OrgAdminAlerts::MadeLiveMailer).to receive(:copied_form_made_live).with(
+          expect(AdminAlerts::MadeLiveMailer).to receive(:copied_form_made_live).with(
             form: form,
             copied_from_form: copied_from_form,
             user: current_user,
@@ -83,13 +83,13 @@ RSpec.describe OrgAdminAlertsService do
       let(:previous_state) { :live_with_draft }
 
       it "sends the live form changes made live email to the organisation admins" do
-        expect(OrgAdminAlerts::MadeLiveMailer).to receive(:live_form_changes_made_live).with(
+        expect(AdminAlerts::MadeLiveMailer).to receive(:live_form_changes_made_live).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.first.email,
         ).and_call_original
 
-        expect(OrgAdminAlerts::MadeLiveMailer).to receive(:live_form_changes_made_live).with(
+        expect(AdminAlerts::MadeLiveMailer).to receive(:live_form_changes_made_live).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.second.email,
@@ -105,13 +105,13 @@ RSpec.describe OrgAdminAlertsService do
       let(:previous_state) { :archived }
 
       it "sends the archived form made live email to the organisation admins" do
-        expect(OrgAdminAlerts::MadeLiveMailer).to receive(:archived_form_made_live).with(
+        expect(AdminAlerts::MadeLiveMailer).to receive(:archived_form_made_live).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.first.email,
         ).and_call_original
 
-        expect(OrgAdminAlerts::MadeLiveMailer).to receive(:archived_form_made_live).with(
+        expect(AdminAlerts::MadeLiveMailer).to receive(:archived_form_made_live).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.second.email,
@@ -127,13 +127,13 @@ RSpec.describe OrgAdminAlertsService do
       let(:previous_state) { :archived_with_draft }
 
       it "sends the archived form changes made live email to the organisation admins" do
-        expect(OrgAdminAlerts::MadeLiveMailer).to receive(:archived_form_changes_made_live).with(
+        expect(AdminAlerts::MadeLiveMailer).to receive(:archived_form_changes_made_live).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.first.email,
         ).and_call_original
 
-        expect(OrgAdminAlerts::MadeLiveMailer).to receive(:archived_form_changes_made_live).with(
+        expect(AdminAlerts::MadeLiveMailer).to receive(:archived_form_changes_made_live).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.second.email,
@@ -163,13 +163,13 @@ RSpec.describe OrgAdminAlertsService do
 
     context "when form was not copied from another form" do
       it "sends the new draft form created email to the organisation admins" do
-        expect(OrgAdminAlerts::DraftCreatedMailer).to receive(:new_draft_form_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).to receive(:new_draft_form_created).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.first.email,
         ).and_call_original
 
-        expect(OrgAdminAlerts::DraftCreatedMailer).to receive(:new_draft_form_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).to receive(:new_draft_form_created).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.second.email,
@@ -181,10 +181,10 @@ RSpec.describe OrgAdminAlertsService do
       end
 
       it "does not send an email to the current user" do
-        allow(OrgAdminAlerts::DraftCreatedMailer).to receive(:new_draft_form_created).and_call_original
+        allow(AdminAlerts::DraftCreatedMailer).to receive(:new_draft_form_created).and_call_original
         service.new_draft_form_created
 
-        expect(OrgAdminAlerts::DraftCreatedMailer).not_to have_received(:new_draft_form_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).not_to have_received(:new_draft_form_created).with(
           form: form,
           user: current_user,
           to_email: current_user.email,
@@ -197,14 +197,14 @@ RSpec.describe OrgAdminAlertsService do
       let(:form) { create(:form, :ready_for_live, copied_from_id: copied_from_form.id) }
 
       it "sends the copied draft form created email to the organisation admins" do
-        expect(OrgAdminAlerts::DraftCreatedMailer).to receive(:copied_draft_form_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).to receive(:copied_draft_form_created).with(
           form: form,
           copied_from_form: copied_from_form,
           user: current_user,
           to_email: organisation_admins.first.email,
         ).and_call_original
 
-        expect(OrgAdminAlerts::DraftCreatedMailer).to receive(:copied_draft_form_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).to receive(:copied_draft_form_created).with(
           form: form,
           copied_from_form: copied_from_form,
           user: current_user,
@@ -235,13 +235,13 @@ RSpec.describe OrgAdminAlertsService do
       let(:form) { create(:form, :live_with_draft) }
 
       it "sends the live form changes made live email to the organisation admins" do
-        expect(OrgAdminAlerts::DraftCreatedMailer).to receive(:new_live_form_draft_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).to receive(:new_live_form_draft_created).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.first.email,
         ).and_call_original
 
-        expect(OrgAdminAlerts::DraftCreatedMailer).to receive(:new_live_form_draft_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).to receive(:new_live_form_draft_created).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.second.email,
@@ -253,10 +253,10 @@ RSpec.describe OrgAdminAlertsService do
       end
 
       it "does not send an email to the current user" do
-        allow(OrgAdminAlerts::DraftCreatedMailer).to receive(:new_live_form_draft_created).and_call_original
+        allow(AdminAlerts::DraftCreatedMailer).to receive(:new_live_form_draft_created).and_call_original
         service.draft_of_existing_form_created
 
-        expect(OrgAdminAlerts::DraftCreatedMailer).not_to have_received(:new_live_form_draft_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).not_to have_received(:new_live_form_draft_created).with(
           form: form,
           user: current_user,
           to_email: current_user.email,
@@ -268,13 +268,13 @@ RSpec.describe OrgAdminAlertsService do
       let(:form) { create(:form, :archived_with_draft) }
 
       it "sends the archived form changes made live email to the organisation admins" do
-        expect(OrgAdminAlerts::DraftCreatedMailer).to receive(:new_archived_form_draft_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).to receive(:new_archived_form_draft_created).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.first.email,
         ).and_call_original
 
-        expect(OrgAdminAlerts::DraftCreatedMailer).to receive(:new_archived_form_draft_created).with(
+        expect(AdminAlerts::DraftCreatedMailer).to receive(:new_archived_form_draft_created).with(
           form: form,
           user: current_user,
           to_email: organisation_admins.second.email,


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/QpJ0wA3H/2919-bring-existing-org-admin-alerts-into-new-structure

 - `org_admin_alerts` has been renamed to `admin_alerts`, as there are alerts that are sent to group_admins as well as org_admins that will come under this heading. 
 - Existing alerts that are sent to org and group admins have been relocated under `admin_alerts`. 
 - An update to the Notify personalisation for the alerts when a form moves group - this will need to go in before the Notify template gets updated. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
