### PR TITLE
Update Notify personalisation for move group alert

### DIFF
--- a/app/mailers/admin_alerts/group_forms_move_mailer.rb
+++ b/app/mailers/admin_alerts/group_forms_move_mailer.rb
@@ -12,7 +12,13 @@ class AdminAlerts::GroupFormsMoveMailer < GovukNotifyRails::Mailer
   end
 
   def form_moved_email(to_email:, form_name:, old_group_name:, new_group_name:, org_admin_email:, org_admin_name:, group_active:)
-    group_active_text = group_active ? "yes" : "no"
+    if group_active
+      group_active_text = "yes"
+      group_trial_text = "no"
+    else
+      group_active_text = "no"
+      group_trial_text = "yes"
+    end
 
     set_personalisation(
       form_name:,
@@ -21,6 +27,7 @@ class AdminAlerts::GroupFormsMoveMailer < GovukNotifyRails::Mailer
       org_admin_email:,
       org_admin_name:,
       group_active: group_active_text,
+      group_trial: group_trial_text,
     )
 
     mail(to: to_email)

--- a/spec/mailers/admin_alerts/group_forms_move_mailer_spec.rb
+++ b/spec/mailers/admin_alerts/group_forms_move_mailer_spec.rb
@@ -32,13 +32,15 @@ describe AdminAlerts::GroupFormsMoveMailer, type: :mailer do
         expect(mail.govuk_notify_personalisation[:org_admin_email]).to eq(current_user.email)
         expect(mail.govuk_notify_personalisation[:org_admin_name]).to eq(current_user.name)
         expect(mail.govuk_notify_personalisation[:group_active]).to eq("no")
+        expect(mail.govuk_notify_personalisation[:group_trial]).to eq("yes")
       end
 
       context "when group is active" do
         let(:group) { create :group, status: :active }
 
-        it "personalisation includes group active as yes" do
+        it "personalisation includes group active as yes instead of trial" do
           expect(mail.govuk_notify_personalisation[:group_active]).to eq("yes")
+          expect(mail.govuk_notify_personalisation[:group_trial]).to eq("no")
         end
       end
     end
@@ -67,6 +69,7 @@ describe AdminAlerts::GroupFormsMoveMailer, type: :mailer do
         expect(mail.govuk_notify_personalisation[:org_admin_email]).to eq(current_user.email)
         expect(mail.govuk_notify_personalisation[:org_admin_name]).to eq(current_user.name)
         expect(mail.govuk_notify_personalisation[:group_active]).to eq("no")
+        expect(mail.govuk_notify_personalisation[:group_trial]).to eq("yes")
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?
I missed the alternate content that shows when the group is in a trial state, and we'll need to toggle it on in those cases. 

https://trello.com/c/QpJ0wA3H/2919-bring-existing-org-admin-alerts-into-new-structure

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
