### PR TITLE
Correct capitalisation of 'Version'

### DIFF
--- a/app/presenters/form_list_presenter.rb
+++ b/app/presenters/form_list_presenter.rb
@@ -76,7 +76,7 @@ private
 
   def welsh_status(form)
     if form.live_welsh_form_document.present?
-      "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh Version</p>".html_safe
+      "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh version</p>".html_safe
     elsif form.draft_welsh_form_document.present?
       "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh draft</p>".html_safe
     elsif form.archived_welsh_form_document.present?

--- a/spec/presenters/form_list_presenter_spec.rb
+++ b/spec/presenters/form_list_presenter_spec.rb
@@ -118,7 +118,7 @@ describe FormListPresenter do
       context "when a welsh version of the form exists" do
         let(:forms) do
           [
-            create(:form, :live, :with_welsh_translation, id: 1, name: "form with a live Welsh Version"),
+            create(:form, :live, :with_welsh_translation, id: 1, name: "form with a live Welsh version"),
             create(:form, :archived, :with_welsh_translation, id: 2, name: "form with an archived and a draft Welsh version"),
             create(:form, :draft, :with_welsh_translation, id: 3, name: "form with Welsh draft"),
             create(:form, id: 4, name: "form with no Welsh version"),
@@ -133,7 +133,7 @@ describe FormListPresenter do
 
         it "appends the correct text" do
           rows = presenter.data[:rows]
-          expect(rows[0][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/1/live\">form with a live Welsh Version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh version</p>")
+          expect(rows[0][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/1/live\">form with a live Welsh version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh version</p>")
           expect(rows[1][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/2/archived\">form with an archived and a draft Welsh version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh draft</p>")
           expect(rows[2][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/4\">form with no Welsh version</a>")
           expect(rows[3][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/5/archived\">form with only an archived Welsh version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With archived Welsh version</p>")

--- a/spec/presenters/form_list_presenter_spec.rb
+++ b/spec/presenters/form_list_presenter_spec.rb
@@ -133,7 +133,7 @@ describe FormListPresenter do
 
         it "appends the correct text" do
           rows = presenter.data[:rows]
-          expect(rows[0][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/1/live\">form with a live Welsh Version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh Version</p>")
+          expect(rows[0][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/1/live\">form with a live Welsh Version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh version</p>")
           expect(rows[1][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/2/archived\">form with an archived and a draft Welsh version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh draft</p>")
           expect(rows[2][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/4\">form with no Welsh version</a>")
           expect(rows[3][0][:text]).to eq("<a class=\"govuk-link\" href=\"/forms/5/archived\">form with only an archived Welsh version</a><p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With archived Welsh version</p>")


### PR DESCRIPTION
### What problem does this pull request solve?

Corrects capitalisation of 'Version' in "With Welsh Version" caption - it should be lower case. 

Trello card:https://trello.com/c/kJZuRxGT/2893-update-list-of-forms-to-include-indication-of-welsh-versions