### PR TITLE
add send_filler_answers feature flag

### DIFF
--- a/.review_apps/ecs_task_definition.tf
+++ b/.review_apps/ecs_task_definition.tf
@@ -24,7 +24,8 @@ locals {
     { name = "SETTINGS__ACT_AS_USER_ENABLED", value = "true" },
     { name = "SETTINGS__AUTH_PROVIDER", value = "developer" },
     { name = "SETTINGS__FORMS_ENV", value = "review" },
-    { name = "SETTINGS__FORMS_RUNNER__URL", value = "https://forms.service.gov.uk" }
+    { name = "SETTINGS__FORMS_RUNNER__URL", value = "https://forms.service.gov.uk" },
+    { name = "SETTINGS__FEATURES__SEND_FILLER_ANSWERS", value = "true" }
   ]
 }
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,7 @@ features:
     enabled_by_group: true
   multiple_branches:
     enabled_by_group: true
+  send_filler_answers: true
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -24,6 +24,7 @@ describe "Settings" do
 
     include_examples expected_value_test, :exit_pages, features, { "enabled_by_group" => true }
     include_examples expected_value_test, :multiple_branches, features, { "enabled_by_group" => true }
+    include_examples expected_value_test, :send_filler_answers, features, true
   end
 
   describe "forms_api" do


### PR DESCRIPTION
### What problem does this pull request solve?

added the feature flag to enable or disable sending a filler's answers to them. This is a feature flag for the whole environment rather than a group level flag.

This feature flag isn't being used to toggle functionality yet, this is in advance of the implementation of sending the filler's answers.


Trello card: https://trello.com/c/lr2stOI0/2905-create-new-feature-flag-in-admin-for-send-fillers-answers-feature

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
