### PR TITLE
Add multiple branch screen

### DIFF
--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -1,0 +1,20 @@
+class RoutesController < FormsController
+  before_action :check_multiple_branches_enabled
+  before_action :check_user_has_permission
+
+  def show
+    authorize current_form, :can_view_form?
+  end
+
+private
+
+  def check_user_has_permission
+    authorize current_form, :can_edit_form?
+  end
+
+  def check_multiple_branches_enabled
+    return if current_form.group.multiple_branches_enabled
+
+    render "errors/not_found", status: :not_found, formats: :html
+  end
+end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -20,7 +20,11 @@
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), start_new_question_path(form_id: current_form.id), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
-      <%= govuk_button_link_to t("pages.index.add_a_question_route"), routing_page_path(current_form.id), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
+      <% if current_form.group&.multiple_branches_enabled %>
+        <%= govuk_button_link_to t("pages.index.routes"), routes_path(current_form.id), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
+      <% else %>
+        <%= govuk_button_link_to t("pages.index.add_a_question_route"), routing_page_path(current_form.id), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
+      <% end %>
 
       <%= render PreviewLinkComponent::View.new(@pages, link_to_runner(Settings.forms_runner.url, current_form.id, current_form.form_slug)) %>
     </div>

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -1,0 +1,12 @@
+<% set_page_title(t("page_titles.routes")) %>
+<% content_for :back_link, govuk_back_link_to(form_pages_path(@current_form.id), t("back_link.form_view")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @current_form.name %></span>
+      <span class="govuk-visually-hidden"> - </span>
+      <%= t("page_titles.routes") %>
+    </h1>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1581,6 +1581,7 @@ en:
       change_order: Change your question order
       mark_complete:
         legend: Have you finished editing your questions?
+      routes: Edit question routes
       title: Add and edit your questions
     optional: "%{question_text} (optional)"
     question: Question

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1480,6 +1480,7 @@ en:
     payment_link: Add a link to a payment page on GOV.UK Pay
     privacy_policy: Provide a link to privacy information for this form
     question_text: What’s your question?
+    routes: Edit question routes
     routes_show: Question %{question_number}’s routes
     routing_page: Add a route from a question
     routing_page_caption: Question %{question_number}’s routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,8 @@ Rails.application.routes.draw do
     post "/batch-submissions" => "forms/batch_submissions#create", as: :batch_submissions_create
     get "/metrics" => "forms/metrics#metrics_csv", as: :metrics_csv
 
+    resource :routes, only: %i[show]
+
     scope "/pages-by-external-id/:page_external_id" do
       get "/edit-question" => "forms/redirect_from_forms_runner#edit_question", as: :edit_question_by_external_id
       get "/routes" => "forms/redirect_from_forms_runner#routes", as: :show_routes_by_external_id

--- a/spec/requests/routes_controller_spec.rb
+++ b/spec/requests/routes_controller_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe RoutesController, type: :request do
+  let(:form) { create(:form, :with_group, group:) }
+  let(:membership) { create :membership, group:, user: standard_user }
+  let(:group) { create(:group, multiple_branches_enabled: true) }
+
+  before do
+    membership
+    login_as_standard_user
+  end
+
+  describe "#show" do
+    it "returns a 200 status code" do
+      get routes_path(form.id)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the routes#show template" do
+      get routes_path(form.id)
+      expect(response).to render_template("routes/show")
+    end
+
+    context "when the user is not in the form's group" do
+      let(:membership) { nil }
+
+      it "returns a forbidden status code" do
+        get routes_path(form.id)
+        expect(response).to have_http_status :forbidden
+      end
+    end
+
+    context "when the multiple_branches feature is not enabled" do
+      let(:group) { create(:group, multiple_branches_enabled: false) }
+
+      it "returns a 404" do
+        get routes_path(form.id)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/views/pages/index.html.erb_spec.rb
+++ b/spec/views/pages/index.html.erb_spec.rb
@@ -6,35 +6,24 @@ describe "pages/index.html.erb" do
   let(:mark_complete_input) { Forms::MarkPagesSectionCompleteInput.new(form:).assign_form_values }
 
   before do
-    # mock the path helper
-    without_partial_double_verification do
-      allow(view).to receive_messages(
-        form_path: "/forms/1",
-        type_of_answer_new_path: "/forms/1/pages/new/type-of-answer",
-        edit_question_path: "/forms/1/pages/2/edit/question",
-        form_pages_path: "/forms/1/pages",
-        routing_page_path: "/forms/1/new-condition",
-        current_form: form,
-      )
-    end
     assign(:pages, pages)
     assign(:mark_complete_input, mark_complete_input)
-    render template: "pages/index"
+    render template: "pages/index", locals: { current_form: form }
   end
 
   it "has the correct title" do
     expect(view.content_for(:title)).to eq I18n.t("pages.index.title")
   end
 
+  it "allows the user to add a page" do
+    expect(rendered).to have_link(I18n.t("pages.index.add_question"), href: start_new_question_path(form.id))
+  end
+
+  it "has a link to branch routing page" do
+    expect(rendered).to have_link("Add a question route", href: routing_page_path(form.id))
+  end
+
   describe "when there are no pages to display" do
-    it "allows the user to add a page" do
-      expect(rendered).to have_link(I18n.t("pages.index.add_question"), href: start_new_question_path(form.id))
-    end
-
-    it "does not contain a link to add page routing" do
-      expect(rendered).not_to have_link("Add a question route", href: routing_page_path(form.id))
-    end
-
     it "does not contain a list of pages" do
       expect(rendered).not_to have_text I18n.t("forms.form_overview.your_questions")
       expect(rendered).not_to have_css ".govuk-summary-list"
@@ -43,10 +32,6 @@ describe "pages/index.html.erb" do
 
   describe "when there are more than one page to display" do
     let(:pages) { [(build :page, id: 1, position: 1, form_id: 1), (build :page, id: 2, position: 2, form_id: 1), (build :page, id: 3, position: 3, form_id: 1)] }
-
-    it "allows the user to add a page" do
-      expect(rendered).to have_link(I18n.t("pages.index.add_question"), href: start_new_question_path(form.id))
-    end
 
     it "does contain a summary list entry each page" do
       expect(rendered).to have_text I18n.t("forms.form_overview.your_questions")

--- a/spec/views/pages/index.html.erb_spec.rb
+++ b/spec/views/pages/index.html.erb_spec.rb
@@ -42,4 +42,13 @@ describe "pages/index.html.erb" do
       expect(rendered).to have_link("Change your question order", href: change_order_new_path(form.id))
     end
   end
+
+  describe "when the group has multiple branches enabled" do
+    let(:group) { create(:group, multiple_branches_enabled: true) }
+    let(:form) { create(:form, :with_group, group:) }
+
+    it "has a link to add a page routing" do
+      expect(rendered).to have_link("Edit question routes", href: routes_path(form.id))
+    end
+  end
 end

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe "routes/show.html.erb" do
+  let(:form) { build_stubbed :form }
+
+  def render_page
+    assign(:current_form, form)
+    render template: "routes/show", locals: { current_form: form }
+  end
+
+  it "has the correct title" do
+    render_page
+    expect(view.content_for(:title)).to have_content("Edit question routes")
+  end
+
+  it "has the correct back link" do
+    render_page
+    expect(view.content_for(:back_link)).to have_link("Back to your form", href: form_pages_path(form.id))
+  end
+
+  it "has the correct heading and caption" do
+    render_page
+    expect(rendered).to have_selector("h1", text: form.name)
+    expect(rendered).to have_selector("h1", text: "Edit question routes")
+  end
+end


### PR DESCRIPTION
### Add a placeholder routes page with link

Trello card: https://trello.com/c/d912GOE9/3068-add-new-routing-screen-to-admin

This PR adds a new route and page to show the routes for a form. The link on the question list page only shows if the feature is enabled for the form's group.

The controller returns 404 if the flag isn't enabeld.

The page:
<img width="609" height="565" alt="image" src="https://github.com/user-attachments/assets/576af9ca-77b1-4562-93e6-6a899b1e7347" />

The link:
<img width="661" height="249" alt="image" src="https://github.com/user-attachments/assets/807b1733-bab3-4bfa-bbc7-f858526ffb7c" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
