### PR TITLE
Display multiple branches on add/edit page

### DIFF
--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -32,33 +32,57 @@
             </dd>
           </div>
 
-          <%  page.routing_conditions.each do |condition| %>
-            <% condition_page = self.condition_page(condition) %>
-            <% condition_page_position = self.condition_page_position(condition) %>
-            <div id="<%= PageListComponent::ErrorSummary::View.error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "govuk-form-group--error": condition.has_routing_errors?) %>">
-              <dt class="govuk-summary-list__key govuk-summary-list__key app-page-list__key">
-                <%= t("page_conditions.condition_name", question_number: condition_page_position) %>
+          <% if FeatureService.new(group: @form.group).enabled?(:multiple_branches) && page.routing_conditions.present? %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key app-page-list__key">
+                <%= t("page_conditions.condition_name", question_number: page.position) %>
               </dt>
-
               <dd class="govuk-summary-list__value">
-                <ul class="govuk-list govuk-!-margin-0">
-                  <% condition.validation_errors.each do |error| %>
-                    <li class="app-page_list__route-text--error">
-                      <%= PageListComponent::ErrorSummary::View.generate_error_message(error.name, condition:, page: condition_page) %>
-                    </li>
-                  <% end %>
-                </ul>
-
-                <p>
-                  <%= condition_description(condition) %>
-                </p>
-
-              <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
-                <%= govuk_link_to show_routes_path(form_id: @form.id, page_id: condition.check_page_id) do %>
-                  <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", question_number: condition_page_position)) %>
+                <% if page.routing_conditions.first.answer_value.present? %>
+                  <p><%= I18n.t("page_conditions.if_answer_is") %></p>
+                  <ul class="govuk-list govuk-list--bullet">
+                    <% page.routing_conditions.each do |condition| %>
+                      <li>
+                        <%= condition_description2(condition) %>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% else %>
+                  <p>
+                    <%= condition_description2(page.routing_conditions.first) %>
+                  </p>
                 <% end %>
               </dd>
             </div>
+          <% else %>
+            <%  page.routing_conditions.each do |condition| %>
+              <% condition_page = self.condition_page(condition) %>
+              <% condition_page_position = self.condition_page_position(condition) %>
+              <div id="<%= PageListComponent::ErrorSummary::View.error_id(condition.id) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "govuk-form-group--error": condition.has_routing_errors?) %>">
+                <dt class="govuk-summary-list__key govuk-summary-list__key app-page-list__key">
+                  <%= t("page_conditions.condition_name", question_number: condition_page_position) %>
+                </dt>
+
+                <dd class="govuk-summary-list__value">
+                  <ul class="govuk-list govuk-!-margin-0">
+                    <% condition.validation_errors.each do |error| %>
+                      <li class="app-page_list__route-text--error">
+                        <%= PageListComponent::ErrorSummary::View.generate_error_message(error.name, condition:, page: condition_page) %>
+                      </li>
+                    <% end %>
+                  </ul>
+
+                  <p>
+                    <%= condition_description(condition) %>
+                  </p>
+
+                <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
+                  <%= govuk_link_to show_routes_path(form_id: @form.id, page_id: condition.check_page_id) do %>
+                    <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", question_number: condition_page_position)) %>
+                  <% end %>
+                </dd>
+              </div>
+            <% end %>
           <% end %>
         <% end %>
       </dl>

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -28,6 +28,14 @@ module PageListComponent
       end
     end
 
+    def condition_description2(condition)
+      if condition.answer_value.present?
+        I18n.t("page_conditions.condition_description2", goto_page_question_text: goto_page_text_for_condition(condition), answer_value: answer_value_text_for_condition(condition))
+      else
+        I18n.t("page_conditions.unconditional_description", goto_page_question_text: goto_page_text_for_condition(condition))
+      end
+    end
+
     def condition_check_page_text(condition)
       check_page = @pages.find { |page| page.id == condition.check_page_id }
       I18n.t("page_conditions.condition_check_page_text", check_page_question_text: check_page.question_text)

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -22,7 +22,7 @@
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_link_to t("pages.index.add_question"), start_new_question_path(form_id: current_form.id), class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
-      <% if current_form.group&.multiple_branches_enabled %>
+      <% if FeatureService.new(group: current_form.group).enabled?(:multiple_branches) %>
         <%= govuk_button_link_to t("pages.index.routes"), routes_path(current_form.id), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>
       <% else %>
         <%= govuk_button_link_to t("pages.index.add_a_question_route"), routing_page_path(current_form.id), secondary: true, class:"govuk-!-margin-bottom-3 govuk-!-margin-top-3" %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -4,7 +4,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render PageListComponent::ErrorSummary::View.new(current_form) %>
+    <% unless FeatureService.new(group: current_form.group).enabled?(:multiple_branches) %>
+      <%= render PageListComponent::ErrorSummary::View.new(current_form) %>
+    <% end %>
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       <span class="govuk-caption-l"><%= current_form.name %></span><span class="govuk-visually-hidden"> - </span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1367,6 +1367,7 @@ en:
     condition_compact_html_secondary_skip: Go to %{goto_page_question_number}, “%{goto_page_question_text}”
     condition_compact_html_secondary_skip_to_end_of_form: Go to end of form
     condition_description: If %{check_page_question_text} is answered as %{answer_value} go to %{goto_page_question_text}
+    condition_description2: "%{answer_value} go to %{goto_page_question_text}"
     condition_goto_exit_page: exit page, “%{exit_page_heading}”
     condition_goto_page_end_of_form: end of form.
     condition_goto_page_text: "%{goto_page_question_number}, “%{goto_page_question_text}”"
@@ -1376,10 +1377,12 @@ en:
     end_of_form: End of form
     exit_page: Add an exit page
     exit_page_label: An ‘exit page’ to leave the form
+    if_answer_is: 'If the answer is:'
     none_of_the_above: None of the above
     route: Route
     secondary_skip_description: After %{check_page_question_text} go to %{goto_page_question_text}
     skip_condition_route_page_text: "%{route_page_question_number}, “%{route_page_question_text}”"
+    unconditional_description: Go to %{goto_page_question_text}
   page_route_card:
     any_other_answer: Route for any other answer
     conditional_answer_value: "%{answer_value}"

--- a/spec/components/page_list_component/page_list_component_preview.rb
+++ b/spec/components/page_list_component/page_list_component_preview.rb
@@ -1,9 +1,11 @@
 class PageListComponent::PageListComponentPreview < ViewComponent::Preview
   include FactoryBot::Syntax::Methods
 
+  # TODO: the :with_group trait for each form is only needed while the multiple_branches_enabled feature column is in
+  # use - we can remove it once we remove the feature flag column
   def default
     pages = []
-    form = build(:form, id: 0, pages:)
+    form = build(:form, :with_group, id: 0, pages:)
     render(PageListComponent::View.new(pages:, form:))
   end
 
@@ -11,7 +13,7 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     pages = [build(:page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: []),
              build(:page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
              build(:page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    form = build(:form, id: 0, pages:)
+    form = build(:form, :with_group, id: 0, pages:)
     render(PageListComponent::View.new(pages:, form:))
   end
 
@@ -20,7 +22,7 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     pages = [build(:page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: [condition]),
              build(:page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
              build(:page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    form = build(:form, id: 0, pages:)
+    form = build(:form, :with_group, id: 0, pages:)
 
     # We need to build the records rather than create them so that we don't save them to the database when we view the
     # preview. However, this means that the associations aren't available so we need to manually set the associations
@@ -41,7 +43,7 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: routing_conditions_1),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: routing_conditions_2),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    form = build(:form, id: 0, pages:)
+    form = build(:form, :with_group, id: 0, pages:)
 
     # We need to build the records rather than create them so that we don't save them to the database when we view the
     # preview. However, this means that the associations aren't available so we need to manually set the associations
@@ -65,7 +67,7 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: routing_conditions_1),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: routing_conditions_2),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    form = build(:form, id: 1, pages:)
+    form = build(:form, :with_group, id: 1, pages:)
 
     # We need to build the records rather than create them so that we don't save them to the database when we view the
     # preview. However, this means that the associations aren't available so we need to manually set the associations
@@ -73,6 +75,34 @@ class PageListComponent::PageListComponentPreview < ViewComponent::Preview
     (routing_conditions_1 + routing_conditions_2).each do |condition|
       condition.routing_page = pages.select { |page| page.id == condition.routing_page_id }.first
       condition.check_page = pages.select { |page| page.id == condition.check_page_id }.first
+      condition.goto_page = pages.select { |page| page.id == condition.goto_page_id }.first
+      condition.form = form
+    end
+
+    render(PageListComponent::View.new(pages:, form:))
+  end
+
+  def with_multiple_branches
+    routing_conditions_1 = [
+      (build :condition, id: 1, routing_page_id: 1, check_page_id: nil, goto_page_id: 3, answer_value: "Wales"),
+      (build :condition, id: 2, routing_page_id: 1, check_page_id: nil, goto_page_id: 4, answer_value: "England"),
+      (build :condition, id: 3, routing_page_id: 1, check_page_id: nil, goto_page_id: 5, answer_value: "Scotland"),
+    ]
+
+    routing_conditions_2 = [build(:condition, id: 4, routing_page_id: 2, check_page_id: nil, answer_value: "Don't know", goto_page_id: nil, skip_to_end: true)]
+
+    pages = [
+      (build :page, id: 1, position: 1, question_text: "What country are you in?", routing_conditions: routing_conditions_1),
+      (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: routing_conditions_2),
+      (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: []),
+      (build :page, id: 4, position: 4, question_text: "What kind of pet do you want?", routing_conditions: []),
+    ]
+
+    form = build(:form, :with_group, id: 1, pages:)
+    form.group.multiple_branches_enabled = true
+
+    (routing_conditions_1 + routing_conditions_2).each do |condition|
+      condition.routing_page = pages.select { |page| page.id == condition.routing_page_id }.first
       condition.goto_page = pages.select { |page| page.id == condition.goto_page_id }.first
       condition.form = form
     end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PageListComponent::View, type: :component do
   let(:pages) { form.reload.pages }
   let(:page_list_component) { described_class.new(pages:, form:) }
 
-  describe "rendering component" do
+  describe "rendering component", feature_multiple_branches: false do
     context "when there are no pages" do
       before do
         render_inline(page_list_component)
@@ -182,7 +182,7 @@ RSpec.describe PageListComponent::View, type: :component do
     end
   end
 
-  describe "class methods" do
+  describe "class methods", feature_multiple_branches: false do
     let(:form) { create :form, :with_pages }
 
     describe "show_up_button" do
@@ -319,6 +319,77 @@ RSpec.describe PageListComponent::View, type: :component do
         it "returns correct description" do
           expected_text = "After #{pages.second.position}, “#{pages.second.question_text}” go to #{pages.fourth.position}, “#{pages.fourth.question_text}”"
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
+        end
+      end
+    end
+
+    describe "#condition_description2", :feature_multiple_branches do
+      context "when condition has all values set" do
+        let(:condition) do
+          create(
+            :condition,
+            routing_page_id: pages.first.id,
+            check_page_id: pages.first.id,
+            answer_value: "Option 1",
+            goto_page_id: pages.third.id,
+          )
+        end
+
+        it "returns complete condition description" do
+          expected_text = "“#{condition.answer_value}” go to #{pages.third.position}, “#{pages.third.question_text}”"
+          expect(page_list_component.condition_description2(condition)).to eq(expected_text)
+        end
+      end
+
+      context "when answer value is 'none_of_the_above'" do
+        let(:condition) do
+          create(
+            :condition,
+            routing_page_id: pages.first.id,
+            check_page_id: pages.first.id,
+            answer_value: "none_of_the_above",
+            goto_page_id: pages.third.id,
+          )
+        end
+
+        it "returns description with 'None of the above' text" do
+          expected_text = "“None of the above” go to #{pages.third.position}, “#{pages.third.question_text}”"
+          expect(page_list_component.condition_description2(condition)).to eq(expected_text)
+        end
+      end
+
+      context "when skip_to_end is true" do
+        let(:condition) do
+          create(
+            :condition,
+            routing_page_id: pages.first.id,
+            check_page_id: pages.first.id,
+            answer_value: "Option 1",
+            goto_page_id: nil,
+            skip_to_end: true,
+          )
+        end
+
+        it "returns description with 'Check your answers' text" do
+          expected_text = "“#{condition.answer_value}” go to end of form."
+          expect(page_list_component.condition_description2(condition)).to eq(expected_text)
+        end
+      end
+
+      context "when showing an unconditional route" do
+        let(:condition) do
+          create(
+            :condition,
+            routing_page_id: pages.second.id,
+            check_page_id: pages.first.id,
+            answer_value: nil,
+            goto_page_id: pages.fourth.id,
+          )
+        end
+
+        it "returns correct description" do
+          expected_text = "Go to #{pages.fourth.position}, “#{pages.fourth.question_text}”"
+          expect(page_list_component.condition_description2(condition)).to eq(expected_text)
         end
       end
     end

--- a/spec/views/pages/index.html.erb_spec.rb
+++ b/spec/views/pages/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "pages/index.html.erb", :feature_multiple_branches do
+describe "pages/index.html.erb", feature_multiple_branches: false do
   let(:form) { create :form, pages: }
   let(:pages) { [] }
   let(:mark_complete_input) { Forms::MarkPagesSectionCompleteInput.new(form:).assign_form_values }
@@ -43,9 +43,8 @@ describe "pages/index.html.erb", :feature_multiple_branches do
     end
   end
 
-  describe "when the group has multiple branches enabled" do
-    let(:group) { create(:group, multiple_branches_enabled: true) }
-    let(:form) { create(:form, :with_group, group:) }
+  describe "when the multiple branches feature is enabled", :feature_multiple_branches do
+    let(:form) { create(:form) }
 
     it "has a link to add a page routing" do
       expect(rendered).to have_link("Edit question routes", href: routes_path(form.id))

--- a/spec/views/pages/index.html.erb_spec.rb
+++ b/spec/views/pages/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "pages/index.html.erb" do
+describe "pages/index.html.erb", :feature_multiple_branches do
   let(:form) { create :form, pages: }
   let(:pages) { [] }
   let(:mark_complete_input) { Forms::MarkPagesSectionCompleteInput.new(form:).assign_form_values }


### PR DESCRIPTION
This is based on the Group's multiple_branches_enabled feature flag - so if this is toggled off, then it will use the original add and edit page view.

When the flag is turned on for the group, the display logic assumes that the form has been created using the new Routes process, and will not be particularly compatible with forms that have been created using the old routing pages (although it might work if the routing is relatively simple).

There is no validation displayed for these changes, as we're not ready to start deciding how to validate the new multiple-branch routes.

I've removed the edit links for now, we'll need to add them in once we've got the questions listed out on the routes page, as they should be anchored links. 

### What problem does this pull request solve?

https://trello.com/c/IgUz33Ml/3070-make-edit-questions-list-display-with-new-routes

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
