### PR TITLE
Fix email domain validation for Welsh support email

### DIFF
--- a/app/controllers/forms/welsh_translation_controller.rb
+++ b/app/controllers/forms/welsh_translation_controller.rb
@@ -86,7 +86,7 @@ module Forms
           { selection_options_cy_attributes: %i[id name_cy] },
           { condition_translations_attributes: WelshConditionTranslationInput.attribute_names },
         ],
-      ).merge(form: current_form)
+      ).merge(current_user:, form: current_form)
     end
 
     def delete_welsh_translation_params

--- a/app/input_objects/forms/welsh_translation_input.rb
+++ b/app/input_objects/forms/welsh_translation_input.rb
@@ -2,7 +2,7 @@ class Forms::WelshTranslationInput < Forms::MarkCompleteInput
   include TextInputHelper
   include ActiveModel::Attributes
 
-  attr_accessor :form, :page_translations
+  attr_accessor :current_user, :form, :page_translations
 
   attribute :mark_complete
 

--- a/spec/input_objects/forms/welsh_translation_input_spec.rb
+++ b/spec/input_objects/forms/welsh_translation_input_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Forms::WelshTranslationInput, type: :model do
   subject(:welsh_translation_input) { described_class.new(new_input_data) }
 
+  let(:current_user) { build :user }
   let(:form) { build_form }
   let(:page) do
     create :page,
@@ -18,6 +19,7 @@ RSpec.describe Forms::WelshTranslationInput, type: :model do
 
   let(:new_input_data) do
     {
+      current_user:,
       form:,
       mark_complete:,
       name_cy: "New Welsh name",
@@ -193,6 +195,15 @@ RSpec.describe Forms::WelshTranslationInput, type: :model do
             it "is invalid" do
               expect(welsh_translation_input).not_to be_valid
               expect(welsh_translation_input.errors.full_messages_for(:support_email_cy)).to include "Support email cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.support_email_cy.non_government_email')}"
+            end
+
+            context "when the user has an email address with the same domain" do
+              let(:current_user) { build :user, email: "user@example.com" }
+
+              it "is valid" do
+                expect(welsh_translation_input).to be_valid
+                expect(welsh_translation_input.errors.full_messages_for(:support_email_cy)).to be_empty
+              end
             end
           end
         end

--- a/spec/requests/forms/welsh_translation_controller_spec.rb
+++ b/spec/requests/forms/welsh_translation_controller_spec.rb
@@ -112,6 +112,33 @@ RSpec.describe Forms::WelshTranslationController, type: :request do
       end
     end
 
+    context "when 'Yes' is selected and support email does not end in '.gov.uk'" do
+      let(:domain) { "ogd.ewxample" }
+      let(:support_email) { Faker::Internet.email(domain:) }
+
+      let(:form) { create(:form, :ready_for_routing, welsh_completed: false, support_email:) }
+      let(:params) { { forms_welsh_translation_input: { form:, mark_complete:, name_cy: "Gwneud cais am drwydded jyglo", privacy_policy_url_cy: "https://juggling.gov.uk/privacy_policy/cy", support_email_cy: support_email, page_translations_attributes: } } }
+
+      it "returns a 422, re-renders the page with an error, and does not display a success banner" do
+        post(welsh_translation_create_path(id), params:)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to render_template(:new)
+        expect(response.body).to include(I18n.t("activemodel.errors.models.forms/welsh_translation_input.attributes.support_email_cy.non_government_email"))
+        expect(flash).to be_empty
+      end
+
+      context "and the current user is signed in with an email address at the same domain" do
+        let(:standard_user) { build :user, :standard, organisation: test_org, email: Faker::Internet.email(domain:) }
+
+        it "redirects to the form task list and displays a success banner including text about being marked complete" do
+          post(welsh_translation_create_path(id), params:)
+          expect(response).to redirect_to(form_path(id))
+          expect(flash[:success]).to eq(I18n.t("banner.success.form.welsh_translation_saved_and_completed"))
+        end
+      end
+    end
+
     context "when the user is not authorized" do
       let(:current_user) { build :user }
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Users with email addresses not ending in gov.uk were experiencing errors when trying to provide a Welsh translation for their form because their support email was valid for the English version but not the Welsh version (see https://govuk.zendesk.com/agent/tickets/6565015).

This was happening even though both `support_email` and `support_email_cy` used the `allowed_domains` validator because the Welsh translation input object wasn't exposing the current user to the validator.

This PR fixes the validation so that it works as expected.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
