### PR TITLE
Add API endpoint to get the group for a form

### DIFF
--- a/app/controllers/api/form_documents_controller.rb
+++ b/app/controllers/api/form_documents_controller.rb
@@ -3,6 +3,10 @@ class Api::FormDocumentsController < ApplicationController
     render json: form_document.content
   end
 
+  def group
+    render json: Form.find_by!(id: form_id).group
+  end
+
 private
 
   def form_document
@@ -16,5 +20,9 @@ private
     permitted_params[:language] ||= "en"
 
     permitted_params
+  end
+
+  def form_id
+    params.require(:form_id)
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -34,9 +34,19 @@ class Group < ApplicationRecord
     external_id
   end
 
+  def as_json(options = {})
+    options[:only] ||= %i[name external_id]
+    options[:methods] ||= %i[group_admin_users organisation]
+    super(options)
+  end
+
 private
 
   def set_external_id
     self.external_id = ExternalIdProvider.generate_unique_id_for(Group)
+  end
+
+  def group_admin_users
+    users.group_admins
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -20,4 +20,12 @@ class Organisation < ApplicationRecord
   def admin_users
     users.organisation_admin
   end
+
+  alias_method :organisation_admin_users, :admin_users
+
+  def as_json(options = {})
+    options[:only] ||= %i[id name]
+    options[:methods] ||= %i[organisation_admin_users]
+    super(options)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -159,6 +159,11 @@ class User < ApplicationRecord
     update!(last_signed_in_at: Time.zone.now)
   end
 
+  def as_json(options = {})
+    options[:only] ||= %i[name email]
+    super(options)
+  end
+
 private
 
   def requires_name?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -272,6 +272,7 @@ Rails.application.routes.draw do
   scope "api/v2", as: "api_v2" do
     scope "forms/:form_id" do
       get "/:tag", to: "api/form_documents#show", as: :form_document, constraints: { tag: /draft|live|archived/ }
+      get "/group", to: "api/form_documents#group", as: :form_group
     end
   end
 

--- a/spec/requests/api/form_documents_controller_spec.rb
+++ b/spec/requests/api/form_documents_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::FormDocumentsController, type: :request do
   let(:headers) { { "ACCEPT": "application/json" } }
 
-  describe "GET /show" do
+  describe "#show" do
     context "when the form exists" do
       context "when the tag is draft" do
         let(:draft_form_name) { "Draft form" }
@@ -145,6 +145,51 @@ RSpec.describe Api::FormDocumentsController, type: :request do
 
       it "when given a language which doesn't exist returns http not found" do
         get("/api/v2/forms/#{form.id}/live?language=unknown-language", headers:)
+        expect(response).to have_http_status(:not_found)
+        expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+      end
+    end
+  end
+
+  describe "#group" do
+    context "when the form exists" do
+      let(:form) { create(:form) }
+      let(:group) { create(:group, organisation: test_org) }
+      let(:group_admin) { create(:user) }
+
+      before do
+        organisation_admin_user
+        create(:membership, user: group_admin, group:, role: :group_admin)
+        create(:membership, user: create(:user), group:, role: :editor)
+
+        group.group_forms.create!(form_id: form.id)
+      end
+
+      it "returns the group" do
+        get("/api/v2/forms/#{form.id}/group", headers:)
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body).to eq({
+          "external_id" => group.external_id,
+          "name" => group.name,
+          "group_admin_users" => [
+            { "name" => group_admin.name, "email" => group_admin.email },
+          ],
+          "organisation" => {
+            "id" => test_org.id,
+            "name" => test_org.name,
+            "organisation_admin_users" => [
+              { "name" => organisation_admin_user.name, "email" => organisation_admin_user.email },
+            ],
+          },
+        })
+      end
+    end
+
+    context "when the form doesn't exist" do
+      it "returns http not found" do
+        get("/api/v2/forms/non-existent/group", headers:)
+
         expect(response).to have_http_status(:not_found)
         expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/CsEqMtDL

Add an API endpoint that returns the group details for the form with the given ID. This includes the group admin users, and the organisation details including the organisation admin users as embedded resources.

This endpoint will be used by forms-runner to get the group and organisation details for the form and the contact details for the group and organisation admin users in order to send email notifications when submissions bounce.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
