### PR TITLE
Make task status service aware of current user

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -25,7 +25,7 @@ private
 
   def load_form
     @current_form = Form.find(params[:form_id])
-    @current_form.set_task_status_service(TaskStatusService.new(form: @current_form))
+    @current_form.set_task_status_service(TaskStatusService.new(form: @current_form, current_user:))
     @initial_form_state = @current_form.state
   end
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -25,6 +25,7 @@ private
 
   def load_form
     @current_form = Form.find(params[:form_id])
+    @current_form.set_task_status_service(TaskStatusService.new(form: @current_form))
     @initial_form_state = @current_form.state
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -52,6 +52,8 @@ class Form < ApplicationRecord
   after_update :update_draft_form_document
   ATTRIBUTES_NOT_IN_FORM_DOCUMENT = %i[state external_id pages question_section_completed declaration_section_completed share_preview_completed welsh_completed].freeze
 
+  attr_accessor :task_status_service
+
   def save_question_changes!
     self.question_section_completed = false
     # Make sure the updated_at is updated as we use this to determine if the form has changed in forms-runner.
@@ -218,6 +220,10 @@ class Form < ApplicationRecord
       (previous_state.to_sym == :archived && archived_with_draft?)
   end
 
+  def set_task_status_service(service)
+    self.task_status_service = service
+  end
+
 private
 
   def set_external_id
@@ -226,13 +232,6 @@ private
 
   def update_draft_form_document
     FormDocumentSyncService.new(self).update_draft_form_document
-  end
-
-  def task_status_service
-    # TODO: refactor this in favour of dependency injection
-    # https://trello.com/c/TVN9BNxQ/3448-refactor-formtaskstatusservice-to-use-dependency-injection
-    # it can also lead to use of `allow_any_instance_of` in testing
-    @task_status_service ||= TaskStatusService.new(form: self)
   end
 
   def has_routing_conditions

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -12,7 +12,7 @@ class FormTaskListService
   def initialize(form:, current_user:)
     @current_user = current_user
     @form = form
-    @form.set_task_status_service(TaskStatusService.new(form:))
+    @form.set_task_status_service(TaskStatusService.new(form:, current_user:))
     @task_statuses = form.all_task_statuses
     @task_counts = status_counts
   end

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -12,6 +12,7 @@ class FormTaskListService
   def initialize(form:, current_user:)
     @current_user = current_user
     @form = form
+    @form.set_task_status_service(TaskStatusService.new(form:))
     @task_statuses = form.all_task_statuses
     @task_counts = status_counts
   end

--- a/app/services/task_status_service.rb
+++ b/app/services/task_status_service.rb
@@ -1,6 +1,7 @@
 class TaskStatusService
-  def initialize(form:)
+  def initialize(form:, current_user:)
     @form = form
+    @current_user = current_user
   end
 
   def mandatory_tasks_completed?(ignore_missing_welsh: false)
@@ -144,7 +145,7 @@ private
 
   def welsh_translations_invalid
     @welsh_translations_invalid ||= begin
-      translation_input = Forms::WelshTranslationInput.new(form: @form, mark_complete: true).assign_form_values
+      translation_input = Forms::WelshTranslationInput.new(form: @form, mark_complete: true, current_user: @current_user).assign_form_values
       translation_input.invalid?
     end
   end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -60,6 +60,7 @@ FactoryBot.define do
 
       after(:build) do |form|
         link_pages_list(form.pages) if form.pages.present?
+        add_welsh_translations_to_pages(form.pages) if form.available_languages.include?("cy")
       end
 
       question_section_completed { true }
@@ -150,8 +151,12 @@ FactoryBot.define do
 
     trait :with_welsh_translation do
       available_languages { %w[en cy] }
+      welsh_completed { true }
 
       name_cy { name.prepend("Welsh ") }
+      privacy_policy_url_cy { "#{privacy_policy_url}/cy" }
+      support_email_cy { support_email }
+      what_happens_next_markdown_cy { "Fel arfer, rydym yn ymateb i geisiadau o fewn 10 diwrnod gwaith." }
     end
   end
 end
@@ -159,6 +164,16 @@ end
 def link_pages_list(pages)
   pages.to_enum.with_index(1).each do |page, index|
     page.position = index
+  end
+
+  pages
+end
+
+def add_welsh_translations_to_pages(pages)
+  pages.each do |page|
+    if page.question_text_cy.blank?
+      page.question_text_cy = "Welsh #{page.question_text}"
+    end
   end
 
   pages

--- a/spec/input_objects/forms/make_live_input_spec.rb
+++ b/spec/input_objects/forms/make_live_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Forms::MakeLiveInput, type: :model do
   let(:user) { build :user }
 
   before do
-    form.set_task_status_service(TaskStatusService.new(form:))
+    form.set_task_status_service(TaskStatusService.new(form:, current_user: user))
   end
 
   describe "validations" do

--- a/spec/input_objects/forms/make_live_input_spec.rb
+++ b/spec/input_objects/forms/make_live_input_spec.rb
@@ -2,6 +2,12 @@ require "rails_helper"
 
 RSpec.describe Forms::MakeLiveInput, type: :model do
   let(:error_message) { I18n.t("activemodel.errors.models.forms/make_live_input.attributes.confirm.blank") }
+  let(:form) { create :form, :ready_for_live }
+  let(:user) { build :user }
+
+  before do
+    form.set_task_status_service(TaskStatusService.new(form:))
+  end
 
   describe "validations" do
     it "is invalid if blank" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe Form, type: :model do
   subject(:form) { described_class.new }
 
+  let(:current_user) { build :user }
+
   describe "factory" do
     it "has a valid factory" do
       form = create :form
@@ -37,7 +39,7 @@ RSpec.describe Form, type: :model do
 
     describe "task status traits" do
       before do
-        form.set_task_status_service(TaskStatusService.new(form:))
+        form.set_task_status_service(TaskStatusService.new(form:, current_user:))
       end
 
       describe "ready for live trait" do
@@ -516,7 +518,7 @@ RSpec.describe Form, type: :model do
 
   describe "FormStateMachine" do
     before do
-      form.set_task_status_service(TaskStatusService.new(form: form))
+      form.set_task_status_service(TaskStatusService.new(form:, current_user:))
     end
 
     describe "#make_live!" do
@@ -878,7 +880,7 @@ RSpec.describe Form, type: :model do
 
   describe "#ready_for_live" do
     before do
-      form.set_task_status_service(TaskStatusService.new(form:))
+      form.set_task_status_service(TaskStatusService.new(form:, current_user:))
     end
 
     context "when a form is complete and ready to be made live" do
@@ -920,7 +922,7 @@ RSpec.describe Form, type: :model do
 
   describe "#all_incomplete_tasks" do
     before do
-      form.set_task_status_service(TaskStatusService.new(form: form))
+      form.set_task_status_service(TaskStatusService.new(form:, current_user:))
     end
 
     context "when a form is complete and ready to be made live" do
@@ -1022,10 +1024,10 @@ RSpec.describe Form, type: :model do
 
   describe "#all_task_statuses" do
     let(:group) { create :group }
-    let(:completed_form) { build :form, :live, :with_group, group: }
+    let(:form) { build :form, :live, :with_group, group: }
 
     before do
-      completed_form.set_task_status_service(TaskStatusService.new(form: completed_form))
+      form.set_task_status_service(TaskStatusService.new(form:, current_user:))
     end
 
     it "returns a hash with each of the task statuses" do
@@ -1045,7 +1047,7 @@ RSpec.describe Form, type: :model do
         share_preview_status: :completed,
         make_live_status: :completed,
       }
-      expect(completed_form.all_task_statuses).to eq expected_hash
+      expect(form.all_task_statuses).to eq expected_hash
     end
   end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -9,21 +9,6 @@ RSpec.describe Form, type: :model do
       expect(form).to be_valid
     end
 
-    it "has a ready for live trait" do
-      form = build :form, :ready_for_live, :with_group
-      expect(form.ready_for_live).to be true
-      expect(form.incomplete_tasks).to be_empty
-      expect(form.task_statuses).to include(
-        declaration_status: :completed,
-        make_live_status: :not_started,
-        name_status: :completed,
-        pages_status: :completed,
-        privacy_policy_status: :completed,
-        support_contact_details_status: :completed,
-        what_happens_next_status: :completed,
-      )
-    end
-
     it "has a live trait" do
       form = build :form, :live
       expect(form.state).to eq "live"
@@ -50,9 +35,36 @@ RSpec.describe Form, type: :model do
       expect(form.pages.map(&:position)).to eq [1, 2, 3, 4, 5]
     end
 
-    it "has a missing pages trait" do
-      form = build :form, :missing_pages
-      expect(form.incomplete_tasks).to eq %i[missing_pages]
+    describe "task status traits" do
+      before do
+        form.set_task_status_service(TaskStatusService.new(form:))
+      end
+
+      describe "ready for live trait" do
+        let(:form) { build :form, :ready_for_live, :with_group }
+
+        it "creates a form that is ready to be made live" do
+          expect(form.ready_for_live).to be true
+          expect(form.incomplete_tasks).to be_empty
+          expect(form.task_statuses).to include(
+            declaration_status: :completed,
+            make_live_status: :not_started,
+            name_status: :completed,
+            pages_status: :completed,
+            privacy_policy_status: :completed,
+            support_contact_details_status: :completed,
+            what_happens_next_status: :completed,
+          )
+        end
+      end
+
+      describe "missing pages trait" do
+        let(:form) { build :form, :missing_pages }
+
+        it "creates a form with missing pages" do
+          expect(form.incomplete_tasks).to eq %i[missing_pages]
+        end
+      end
     end
   end
 
@@ -503,6 +515,10 @@ RSpec.describe Form, type: :model do
   end
 
   describe "FormStateMachine" do
+    before do
+      form.set_task_status_service(TaskStatusService.new(form: form))
+    end
+
     describe "#make_live!" do
       let(:form) { create :form, :ready_for_live }
 
@@ -861,16 +877,20 @@ RSpec.describe Form, type: :model do
   end
 
   describe "#ready_for_live" do
+    before do
+      form.set_task_status_service(TaskStatusService.new(form:))
+    end
+
     context "when a form is complete and ready to be made live" do
-      let(:completed_form) { create(:form, :live) }
+      let(:form) { create(:form, :live) }
 
       it "returns true" do
-        expect(completed_form.ready_for_live).to be true
+        expect(form.ready_for_live).to be true
       end
     end
 
     context "when a form is incomplete and should still be in draft state" do
-      let(:new_form) { build :form, :new_form }
+      let(:form) { build :form, :new_form }
 
       [
         {
@@ -891,27 +911,31 @@ RSpec.describe Form, type: :model do
         },
       ].each do |scenario|
         it "returns false if #{scenario[:attribute]} is missing" do
-          new_form.send("#{scenario[:attribute]}=", scenario[:attribute_value])
-          expect(new_form.ready_for_live).to be false
+          form.send("#{scenario[:attribute]}=", scenario[:attribute_value])
+          expect(form.ready_for_live).to be false
         end
       end
     end
   end
 
   describe "#all_incomplete_tasks" do
+    before do
+      form.set_task_status_service(TaskStatusService.new(form: form))
+    end
+
     context "when a form is complete and ready to be made live" do
-      let(:completed_form) { build :form, :live }
+      let(:form) { build :form, :live }
 
       it "returns no missing sections" do
-        expect(completed_form.all_incomplete_tasks).to be_empty
+        expect(form.all_incomplete_tasks).to be_empty
       end
     end
 
     context "when a form is incomplete and should still be in draft state" do
-      let(:new_form) { build :form, :new_form }
+      let(:form) { build :form, :new_form }
 
       it "returns a set of keys related to missing fields" do
-        expect(new_form.all_incomplete_tasks).to match_array(%i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed])
+        expect(form.all_incomplete_tasks).to match_array(%i[missing_pages missing_submission_email missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed])
       end
     end
   end
@@ -975,6 +999,8 @@ RSpec.describe Form, type: :model do
       task_status_service = instance_double(TaskStatusService)
       allow(TaskStatusService).to receive(:new).and_return(task_status_service)
       allow(task_status_service).to receive(:mandatory_tasks_completed?).and_return(mandatory_tasks_completed)
+
+      form.set_task_status_service(task_status_service)
     end
 
     context "when not all mandatory tasks have been completed" do
@@ -997,6 +1023,10 @@ RSpec.describe Form, type: :model do
   describe "#all_task_statuses" do
     let(:group) { create :group }
     let(:completed_form) { build :form, :live, :with_group, group: }
+
+    before do
+      completed_form.set_task_status_service(TaskStatusService.new(form: completed_form))
+    end
 
     it "returns a hash with each of the task statuses" do
       expected_hash = {

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
   let(:group) { create(:group, organisation:, status: :active) }
 
   before do
-    form.set_task_status_service(TaskStatusService.new(form:))
+    form.set_task_status_service(TaskStatusService.new(form:, current_user: user))
   end
 
   describe "#new" do

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Forms::MakeLiveController, type: :request do
   let(:group_role) { :group_admin }
   let(:group) { create(:group, organisation:, status: :active) }
 
+  before do
+    form.set_task_status_service(TaskStatusService.new(form:))
+  end
+
   describe "#new" do
     before do
       Membership.create!(group_id: group.id, user:, added_by: user, role: group_role)

--- a/spec/services/make_form_live_service_spec.rb
+++ b/spec/services/make_form_live_service_spec.rb
@@ -7,7 +7,7 @@ describe MakeFormLiveService do
   let(:current_user) { build :user }
 
   before do
-    current_form.set_task_status_service(TaskStatusService.new(form: current_form))
+    current_form.set_task_status_service(TaskStatusService.new(form: current_form, current_user:))
   end
 
   describe "#make_live" do

--- a/spec/services/make_form_live_service_spec.rb
+++ b/spec/services/make_form_live_service_spec.rb
@@ -6,6 +6,10 @@ describe MakeFormLiveService do
   let(:live_form_document) { current_form.live_form_document }
   let(:current_user) { build :user }
 
+  before do
+    current_form.set_task_status_service(TaskStatusService.new(form: current_form))
+  end
+
   describe "#make_live" do
     it "makes the form live" do
       expect {

--- a/spec/services/org_admin_alerts_service_spec.rb
+++ b/spec/services/org_admin_alerts_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe OrgAdminAlertsService do
 
   before do
     GroupForm.create!(form: form, group:)
-    form.set_task_status_service(TaskStatusService.new(form:))
+    form.set_task_status_service(TaskStatusService.new(form:, current_user:))
   end
 
   describe "#form_made_live" do

--- a/spec/services/org_admin_alerts_service_spec.rb
+++ b/spec/services/org_admin_alerts_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe OrgAdminAlertsService do
 
   before do
     GroupForm.create!(form: form, group:)
+    form.set_task_status_service(TaskStatusService.new(form:))
   end
 
   describe "#form_made_live" do

--- a/spec/services/step_summary_card_service_spec.rb
+++ b/spec/services/step_summary_card_service_spec.rb
@@ -13,8 +13,10 @@ describe StepSummaryCardService do
 
   let(:pages) { form.pages }
 
+  let(:current_user) { build :user }
+
   before do
-    form.set_task_status_service(TaskStatusService.new(form:))
+    form.set_task_status_service(TaskStatusService.new(form:, current_user:))
   end
 
   describe "#all_options_for_answer_type" do

--- a/spec/services/step_summary_card_service_spec.rb
+++ b/spec/services/step_summary_card_service_spec.rb
@@ -13,6 +13,10 @@ describe StepSummaryCardService do
 
   let(:pages) { form.pages }
 
+  before do
+    form.set_task_status_service(TaskStatusService.new(form:))
+  end
+
   describe "#all_options_for_answer_type" do
     context "with uk and international address" do
       let(:page) { create :page, :with_address_settings, form:, uk_address: "true", international_address: "true" }

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -15,8 +15,10 @@ describe StepSummaryTableService do
   let(:form_document_step) { FormDocument::Step.new(page.as_form_document_step(nil)) }
   let(:welsh_form_document) { FormDocument::Content.from_form_document(form.live_welsh_form_document) }
 
+  let(:current_user) { build :user }
+
   before do
-    form.set_task_status_service(TaskStatusService.new(form:))
+    form.set_task_status_service(TaskStatusService.new(form:, current_user:))
   end
 
   def create_form(attributes = {})

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -15,6 +15,10 @@ describe StepSummaryTableService do
   let(:form_document_step) { FormDocument::Step.new(page.as_form_document_step(nil)) }
   let(:welsh_form_document) { FormDocument::Content.from_form_document(form.live_welsh_form_document) }
 
+  before do
+    form.set_task_status_service(TaskStatusService.new(form:))
+  end
+
   def create_form(attributes = {})
     default_attributes = {
       id: 1,

--- a/spec/services/task_status_service_spec.rb
+++ b/spec/services/task_status_service_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 describe TaskStatusService do
-  let(:group) { create :group }
-  let(:task_status_service) do
-    described_class.new(form:)
+  subject(:task_status_service) do
+    described_class.new(form:, current_user:)
   end
 
-  let(:current_user) { build(:user, role: :editor) }
+  let(:group) { create :group }
+
+  let(:current_user) { build(:user, role: :standard) }
 
   describe "statuses" do
     describe "name status" do
@@ -274,16 +275,19 @@ describe TaskStatusService do
       end
 
       context "and Welsh translation is completed" do
-        let(:form) { create(:form, :live, :with_group, available_languages: %w[en cy], welsh_completed: true, group:) }
-
-        before do
-          welsh_translation_input = instance_double(Forms::WelshTranslationInput)
-          allow(welsh_translation_input).to receive_messages(assign_form_values: welsh_translation_input, invalid?: false)
-          allow(Forms::WelshTranslationInput).to receive(:new).and_return(welsh_translation_input)
-        end
+        let(:form) { create(:form, :live, :with_group, :with_welsh_translation, group:) }
 
         it "returns completed" do
           expect(task_status_service.task_statuses[:welsh_language_status]).to eq :completed
+        end
+
+        context "and the support email contains a non-gov.uk email with the same domain as the user" do
+          let(:current_user) { build(:user, role: :standard, email: "example@example.com") }
+          let(:form) { create(:form, :ready_for_live, :with_group, :with_welsh_translation, welsh_completed: true, group:, support_email_cy: "support@example.com") }
+
+          it "returns completed" do
+            expect(task_status_service.task_statuses[:welsh_language_status]).to eq :completed
+          end
         end
       end
 

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -404,7 +404,8 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "when the form has a Welsh translation" do
-    let(:form_metadata) { create :form, :live, :with_welsh_translation, what_happens_next_markdown:, submission_type:, submission_format: }
+    let(:what_happens_next_markdown_cy) { "Os nad ydych wedi derbyn ymateb o fewn 5 diwrnod gwaith, [cysylltwch â’n tîm cymorth defnyddwyr](https://example.com)." }
+    let(:form_metadata) { create :form, :live, :with_welsh_translation, what_happens_next_markdown:, what_happens_next_markdown_cy:, submission_type:, submission_format: }
     let(:welsh_form_document) do
       form_document_content = FormDocument::Content.from_form_document(form_metadata.live_welsh_form_document)
       form_document_content.first_made_live_at = 1.week.ago
@@ -439,7 +440,7 @@ describe "forms/_made_live_form.html.erb" do
       expect(rendered).to have_css("th", text: "English content")
       expect(rendered).to include("<p class=\"govuk-body\">If you have not received a response within 5 working days, <a href=\"https://example.com\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">contact our user support team (opens in new tab)</a>.</p>")
       expect(rendered).to have_css("th", text: "Welsh content")
-      expect(rendered).to include("<p class=\"govuk-body\">If you have not received a response within 5 working days, <a href=\"https://example.com\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">contact our user support team (agor mewn tab newydd)</a>.</p>")
+      expect(rendered).to include("<p class=\"govuk-body\">Os nad ydych wedi derbyn ymateb o fewn 5 diwrnod gwaith, <a href=\"https://example.com\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">cysylltwch â’n tîm cymorth defnyddwyr (agor mewn tab newydd)</a>.</p>")
     end
 
     context "when the form has a declaration" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->No card for main change, but also includes https://trello.com/c/TVN9BNxQ/3448-refactor-formtaskstatusservice-to-use-dependency-injection

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Passes the current user to the task status service. This follows the work in https://github.com/govuk-forms/forms-admin/pull/2745 so that the task statuses are consistent everywhere.

This resolves an issue we were seeing where:
- the Welsh translation page had a non-gov.uk email address which matched the user's domain
- the page as a whole was valid and marked complete
- but the task in the task list was still showing as 'In progress' 
- the form could not be made live.

Also includes a factory change to make testing Welsh forms easier (cherry-picked from https://github.com/govuk-forms/forms-admin/pull/2717)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
