### PR TITLE
Add edit link to multiple branches question page

### DIFF
--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -52,6 +52,11 @@
                     <%= condition_description2(page.routing_conditions.first) %>
                   </p>
                 <% end %>
+                <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
+                  <%= govuk_link_to routes_path(form_id: @form.id, anchor: page.page_position_id) do %>
+                    <%= t("forms.form_overview.edit_with_visually_hidden_text_html", visually_hidden_text: t("page_conditions.condition_name", question_number: page.position)) %>
+                  <% end %>
+                </dd>
               </dd>
             </div>
           <% else %>

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -133,6 +133,10 @@ class Page < ApplicationRecord
     routing_conditions.each(&:normalise_welsh!)
   end
 
+  def page_position_id
+    "page-#{position}"
+  end
+
 private
 
   def guidance_fields_presence

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -18,7 +18,7 @@
 
         @routes_input.routes.group_by(&:page).each do |page, routes|
           summary_list.with_row do |row|
-            row.with_key(classes: "app-routes-list__key", html_attributes: { id: "page-#{page.position}"}) { page.position.to_s }
+            row.with_key(classes: "app-routes-list__key", html_attributes: { id: page.page_position_id}) { page.position.to_s }
             row.with_value do
               capture do %>
               <p> <%= page.question_text %> </p>

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -182,6 +182,68 @@ RSpec.describe PageListComponent::View, type: :component do
     end
   end
 
+  describe "rendering component with multiple branches feature", :feature_multiple_branches do
+    context "when the form has multiple pages" do
+      let(:form) { create :form, :ready_for_routing }
+      let(:first_page) { form.pages.first }
+      let(:third_page) { form.pages.third }
+      let(:fourth_page) { form.pages.fourth }
+
+      context "when the page has a single condition" do
+        let!(:condition) { create :condition, routing_page_id: first_page.id, answer_value: "Option 1", goto_page_id: third_page.id }
+
+        before do
+          render_inline(page_list_component)
+        end
+
+        it "renders the condition description" do
+          condition_description = "If the answer is:"
+          condition_detail = "“#{condition.answer_value}” go to #{third_page.position}, “#{third_page.question_text}”"
+
+          expect(page).to have_css("dd.govuk-summary-list__value", text: condition_description)
+          expect(page).to have_css("dd.govuk-summary-list__value", text: condition_detail)
+        end
+
+        it "renders link" do
+          expect(page).to have_link("Edit", href: routes_path(form_id: form.id, anchor: "page-#{first_page.position}"))
+        end
+      end
+
+      context "when the page has branching conditions" do
+        let!(:first_condition) { create :condition, routing_page_id: first_page.id, answer_value: "Option 1", goto_page_id: third_page.id }
+        let!(:second_condition) { create :condition, routing_page_id: first_page.id, answer_value: "Option 2", goto_page_id: fourth_page.id }
+
+        before do
+          render_inline(page_list_component)
+        end
+
+        it "renders the condition description" do
+          condition_description = "If the answer is:"
+          first_condition_detail = "“#{first_condition.answer_value}” go to #{third_page.position}, “#{third_page.question_text}”"
+          second_condition_detail = "“#{second_condition.answer_value}” go to #{fourth_page.position}, “#{fourth_page.question_text}”"
+
+          expect(page).to have_css("dd.govuk-summary-list__value", text: condition_description)
+          expect(page).to have_css("dd.govuk-summary-list__value", text: first_condition_detail)
+          expect(page).to have_css("dd.govuk-summary-list__value", text: second_condition_detail)
+        end
+      end
+
+      context "when the page has an unconditional route" do
+        before do
+          create :condition, routing_page_id: first_page.id, goto_page_id: third_page.id
+
+          render_inline(page_list_component)
+        end
+
+        it "renders the condition description" do
+          unconditional_route_description = "Go to #{third_page.position}, “#{third_page.question_text}”"
+
+          expect(page).to have_css("dd.govuk-summary-list__value", text: unconditional_route_description)
+        end
+      end
+    end
+  end
+
   describe "class methods", feature_multiple_branches: false do
     let(:form) { create :form, :with_pages }
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -872,4 +872,10 @@ RSpec.describe Page, type: :model do
       end
     end
   end
+
+  describe "#page_position_id" do
+    it "returns a string for the page position id" do
+      expect(page.page_position_id).to eq "page-#{page.position}"
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/XWjpXkLl/3082-add-edit-routes-link-for-each-route-in-question-list

Adds edit links to routes on the `Add and edit your questions` page which should anchor to the routes page depending on the question position they correspond to. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
