### PR TITLE
Use TaskStatusService in db seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -218,6 +218,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     what_happens_next_markdown: "Test",
     share_preview_completed: true,
   )
+  all_question_types_form.set_task_status_service(TaskStatusService.new(form: all_question_types_form, current_user: craig))
   all_question_types_form.make_live!
 
   e2e_s3_forms = Form.create!(
@@ -245,6 +246,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     submission_format: %w[csv],
     s3_bucket_region: "eu-west-2",
   )
+  e2e_s3_forms.set_task_status_service(TaskStatusService.new(form: e2e_s3_forms, current_user: craig))
   e2e_s3_forms.make_live!
 
   branch_route_form = Form.create!(
@@ -344,6 +346,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
         - Confirmed that you are eligible to submit this form
     MARKDOWN
   )
+  branch_route_form.set_task_status_service(TaskStatusService.new(form: branch_route_form, current_user: craig))
   branch_route_form.reload.make_live!
 
   none_of_the_above_form = Form.create!(
@@ -391,6 +394,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     what_happens_next_markdown: "Test",
     share_preview_completed: true,
   )
+  none_of_the_above_form.set_task_status_service(TaskStatusService.new(form: none_of_the_above_form, current_user: craig))
   none_of_the_above_form.make_live!
 
   welsh_form = Form.create!(
@@ -460,6 +464,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     welsh_completed: true,
   )
 
+  welsh_form.set_task_status_service(TaskStatusService.new(form: welsh_form, current_user: craig))
   welsh_form.make_live!
 
   multiple_branch_form = Form.create!(
@@ -569,6 +574,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     goto_page: multiple_branch_form.pages[5],
     answer_value: "Northern Ireland",
   )
+  multiple_branch_form.set_task_status_service(TaskStatusService.new(form: multiple_branch_form, current_user: craig))
   multiple_branch_form.make_live!
 
   # add forms to groups


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
In #2756 we decoupled some of the task status service logic from the form model. One result of this is that in cases where the TaskStatusService is called we now need to call it directly. This was missed from the database seeds, so this commit adds it.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
