### PR TITLE
Add column to store enabling/disabling Copy of answers on forms

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -34,6 +34,11 @@ class Form < ApplicationRecord
     s3: "s3",
   }
 
+  enum :send_copy_of_answers, {
+    disabled: "disabled",
+    enabled: "enabled",
+  }
+
   # ActiveRecord doesn't support enums with arrays
   # enum :submission_format, {
   #   csv: "csv",
@@ -44,6 +49,7 @@ class Form < ApplicationRecord
   validates :payment_url, url: true, allow_blank: true
   validate :marking_complete_with_errors
   validates :submission_type, presence: true
+  validates :send_copy_of_answers, presence: true
   validates :available_languages, presence: true, inclusion: { in: SUPPORTED_LANGUAGES }
   validates :submission_email, email_address: { message: :invalid_email }, allow_blank: true
   validates :support_email, email_address: { message: :invalid_email }, allow_blank: true

--- a/app/models/form_document/content.rb
+++ b/app/models/form_document/content.rb
@@ -32,6 +32,7 @@ class FormDocument::Content
   attribute :what_happens_next_markdown, :string
   attribute :send_daily_submission_batch, :boolean
   attribute :send_weekly_submission_batch, :boolean
+  attribute :send_copy_of_answers, :string
 
   alias_attribute :id, :form_id
 

--- a/db/migrate/20260508112814_add_answer_email_copy_to_forms.rb
+++ b/db/migrate/20260508112814_add_answer_email_copy_to_forms.rb
@@ -1,0 +1,5 @@
+class AddAnswerEmailCopyToForms < ActiveRecord::Migration[8.1]
+  def change
+    add_column :forms, :send_copy_of_answers, :string, null: false, default: "disabled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_143146) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_112814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -133,6 +133,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_143146) do
     t.string "s3_bucket_aws_account_id"
     t.string "s3_bucket_name"
     t.string "s3_bucket_region"
+    t.string "send_copy_of_answers", default: "disabled", null: false
     t.boolean "send_daily_submission_batch", default: false
     t.boolean "send_weekly_submission_batch", default: false
     t.boolean "share_preview_completed", default: false, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -578,6 +578,32 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
   multiple_branch_form.set_task_status_service(TaskStatusService.new(form: multiple_branch_form, current_user: craig))
   multiple_branch_form.make_live!
 
+  copy_of_answers_form = Form.create!(
+    name: "Copy of answers form",
+    pages: [
+      Page.create(
+        question_text: "What is your full name?",
+        answer_type: "name",
+        answer_settings: {
+          input_type: "full_name",
+          title_needed: false,
+        },
+        is_optional: false,
+      ),
+    ],
+    question_section_completed: true,
+    declaration_markdown: "",
+    declaration_section_completed: true,
+    privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
+    submission_email:,
+    support_email: "your.email+fakedata84701@gmail.com.gov.uk",
+    support_phone: "08000800",
+    what_happens_next_markdown: "Test",
+    share_preview_completed: true,
+    send_copy_of_answers: "enabled",
+  )
+  copy_of_answers_form.make_live!
+
   # add forms to groups
   GroupForm.create! group: end_to_end_group, form_id: all_question_types_form.id # All question types form
   GroupForm.create! group: end_to_end_group, form_id: e2e_s3_forms.id # s3 submission test form
@@ -585,4 +611,5 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
   GroupForm.create! group: test_group, form_id: none_of_the_above_form.id # None of the above form
   GroupForm.create! group: test_group, form_id: welsh_form.id # Welsh form
   GroupForm.create! group: multiple_branches_test_group, form_id: multiple_branch_form.id
+  GroupForm.create! group: test_group, form_id: copy_of_answers_form.id
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -951,6 +951,21 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "answer email copy" do
+    describe "enum" do
+      it "returns a list of email copy answers values" do
+        expect(described_class.send_copy_of_answers.keys).to eq(%w[disabled enabled])
+        expect(described_class.send_copy_of_answers.values).to eq(%w[disabled enabled])
+      end
+    end
+
+    it "defaults to disabled" do
+      form = build(:form)
+      expect(form.send_copy_of_answers).to eq("disabled")
+      expect(form.disabled?).to be true
+    end
+  end
+
   describe "submission format" do
     let(:form) { create :form }
 


### PR DESCRIPTION
### What problem does this pull request solve?

This is a small PR to add the database column that stores whether a Form can be set to ask fillers if they want a Copy Of Their Answers.

Trello card: https://trello.com/c/KZuqH0bA 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
