### PR TITLE
Mark slow specs with `:slow` tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: bin/rails db:schema:load
       # Add or replace test runners here
       - name: Run Ruby tests
-        run: bundle exec rspec
+        run: bundle exec rspec --profile
       - name: Run JS tests
         run: npm test
       # Add or replace any other lints here

--- a/config/vite.json
+++ b/config/vite.json
@@ -19,6 +19,7 @@
     "autoBuild": true
   },
   "test": {
+    "host": "::1",
     "port": 3037,
     "autoBuild": true
   }

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -2,7 +2,7 @@
 
 require "i18n/tasks"
 
-RSpec.describe I18n do
+RSpec.describe I18n, :slow do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe AuthenticationController, type: :request do
         GDS::SSO::Config.auth_valid_for = Settings.auth_valid_for
       end
 
-      it "re-authenticates after the configured time" do
+      it "re-authenticates after the configured time", :slow do
         login_as_standard_user
 
         get root_path

--- a/spec/support/mark_feature_specs_as_slow.rb
+++ b/spec/support/mark_feature_specs_as_slow.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.define_derived_metadata(type: :feature) do |metadata|
+    metadata[:slow] ||= true
+  end
+end

--- a/spec/views/pages/selection/options.html.erb_spec.rb
+++ b/spec/views/pages/selection/options.html.erb_spec.rb
@@ -63,8 +63,8 @@ describe "pages/selection/options.html.erb", type: :view do
       context "when there are fewer than 3000 options" do
         let(:selection_options) { (1..2999).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
 
-        it "has an add another button", :slow do
-          expect(rendered).to have_button(I18n.t("selection_options.add_another"))
+        it "has an add another button" do
+          expect(rendered).to have_button(text: I18n.t("selection_options.add_another"))
         end
 
         it "does not have inset text stating you cannot add more options" do
@@ -75,8 +75,8 @@ describe "pages/selection/options.html.erb", type: :view do
       context "when there are 3000 options" do
         let(:selection_options) { (1..3000).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
 
-        it "does not have an add another button", :slow do
-          expect(rendered).not_to have_button(I18n.t("selection_options.add_another"))
+        it "does not have an add another button" do
+          expect(rendered).not_to have_button(text: I18n.t("selection_options.add_another"))
         end
 
         it "has inset text stating you cannot add more options" do

--- a/spec/views/pages/selection/options.html.erb_spec.rb
+++ b/spec/views/pages/selection/options.html.erb_spec.rb
@@ -63,7 +63,7 @@ describe "pages/selection/options.html.erb", type: :view do
       context "when there are fewer than 3000 options" do
         let(:selection_options) { (1..2999).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
 
-        it "has an add another button" do
+        it "has an add another button", :slow do
           expect(rendered).to have_button(I18n.t("selection_options.add_another"))
         end
 
@@ -75,7 +75,7 @@ describe "pages/selection/options.html.erb", type: :view do
       context "when there are 3000 options" do
         let(:selection_options) { (1..3000).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
 
-        it "does not have an add another button" do
+        it "does not have an add another button", :slow do
           expect(rendered).not_to have_button(I18n.t("selection_options.add_another"))
         end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

On my machine (MacBook Pro, Apple M1 Pro, 16 GB RAM, macOS Tahoe 26.4.1), running the specs in this repo takes around 17 minutes.

This PR adds a `:slow` tag to examples that consistently take over 1 second to run on my machine.

This is partly for documentation purposes, but also allows developers to skip slow specs when running tests locally with

```
rspec --tag ~slow
```

See the [RSpec docs on the `--tag` option](https://rspec.info/features/3-12/rspec-core/command-line/tag/) for details on how this works.

The changes in this PR should not affect how the tests/PR checks run in CI.

On my machine, with the changes from this PR, running `rspec --tag ~slow` takes around 7 minutes.

#### Notes on slow tests

While trying to figure what to tag as slow, I found three different kinds of slow tests:

1. Tests that rely on browser automation

  Anything that uses headless Chrome for testing is automatically a resource hog; I didn't look too closely at these. Instead I just added a bit of configuration to make all feature specs be marked as slow.

  In theory we could try and speed some feature specs up by seeing which ones require a real browser and which could use the RackTest simulator that comes with Capybara [[1](https://github.com/teamcapybara/capybara/#racktest)]. However, in practice, most of our feature specs require a real browser because they a) rely on JavaScript for the sign in journey, and b) test for WCAG failures with aXe tools, which requires Chrome. So it would be quite a lot of work to try and speed up our feature specs this way (although it might become worth it at some point).

2. Tests that are consistently slow

  There were a few specs that were consistently significantly slower than a second when run on their own. These mostly appear to be weird outliers, and there also aren't that many of them. I've fixed two (see commit messages for details), and left the rest marked with the `:slow` tag.

3. Tests that are intermittently slow

  This was the biggest category of issue I found. When repeatedly running tests with `rspec --profile --tag ~slow`, after having marked tests in the above two categories, I found there was little consistency between runs in which tests were in the top ten slowest list.

  After doing some profiling with [ruby-prof](https://ruby-prof.github.io/) using a modified version of https://gist.github.com/palkan/73395cc201a565ecd3ff61aac44ad5ae, I found one issue related to ViteRuby and added a workaround for that (see commit messages for details), but adding that workaround did not fully resolve the intermittent slowness. I also found that some specs can be slow when run in isolation, but quick when run as part of a group, likely because there is some shared caching happening.

  Basically, some of the slowness is likely caused by a combination of Factory Bot (a known issue generally), bootsnap caching, thread contention, and general operating system constraints, and these are all difficult to pin down and fix.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
