### PR TITLE
Remove n+1 queries from multiple routes

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -224,6 +224,14 @@ class Form < ApplicationRecord
     self.task_status_service = service
   end
 
+  # Return the next page or nil if there is no next page
+  # Use this when all pages are loaded to avoid N+1 queries,
+  # prefer Page.next_page for individual queries.
+  def next_page_after(current_page)
+    pair = pages.each_cons(2).find { |p, _next_p| p == current_page }
+    pair&.last
+  end
+
 private
 
   def set_external_id

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -26,14 +26,16 @@ class Routes::BuildService
   end
 
   def options_for_page(page)
-    return [] unless page.has_next_page?
+    next_page = form.next_page_after(page)
+
+    return [] unless next_page
 
     # Don't include the current page in the options
     options_without_page = all_goto_options.reject { |_, value| value == page.id }
 
     # Replace the next page with the default option
     options_without_page.map do |name, value|
-      if value == page.next_page
+      if value == next_page.id
         ["Go to question #{page.position.next}", Forms::RouteInput::DEFAULT_VALUE]
       else
         [name, value]

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -22,7 +22,7 @@
             row.with_value do
               capture do %>
               <p> <%= page.question_text %> </p>
-              <% if page.has_next_page? %>
+              <% if @routes_input.form.next_page_after(page).present? %>
                 <ul class="govuk-list">
                   <% routes.each do |route| %>
                     <li>

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1464,4 +1464,21 @@ RSpec.describe Form, type: :model do
       end
     end
   end
+
+  describe "#next_page_after" do
+    let(:pages) { [] }
+    let(:form) { build :form, pages: }
+
+    it "returns nil if there is no next page" do
+      expect(form.next_page_after(form.pages.first)).to be_nil
+    end
+
+    context "when there is a next page" do
+      let(:pages) { build_list :page, 5 }
+
+      it "returns the next page" do
+        expect(form.next_page_after(form.pages.second)).to eq(form.pages.third)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Reduce the number of DB queries needed for Routes

Trello card: https://trello.com/c/5lOqwgoO/3096-test-new-routes-page-with-a-long-form

When testing the new routes page with many options, the code makes a lot of queries against the database, 1024 to show the routes view with a form with a selection question with 250 options!

Checking locally, it's because we use has_next_page and next_page when calculating the options for each route and displaying the last page's routes differently.

Because we have already loaded all the pages for the form, we can use array position to get the next page.

This PR adds a new method to the form model for getting the next page for a page within the form. It returns nil when there isn't one.

Using this method in the view and route building service cuts down the number queries.
### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
