### PR TITLE
Add new groups confirmation page

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < WebController
-  before_action :set_group, except: %i[index new create confirm_new]
+  before_action :set_group, except: %i[index new create confirm_new confirm_new_submit]
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
 
@@ -32,6 +32,22 @@ class GroupsController < WebController
     authorize Group, :new?
     @confirm_new_input = Groups::ConfirmNewInput.new
     @organisation = @current_user.organisation
+  end
+
+  def confirm_new_submit
+    authorize Group, :new?
+    @confirm_new_input = Groups::ConfirmNewInput.new(confirm_new_input_params)
+    @organisation = @current_user.organisation
+
+    if @confirm_new_input.invalid?
+      return render :confirm_new, status: :unprocessable_content
+    end
+
+    if @confirm_new_input.confirmed?
+      redirect_to new_group_path
+    else
+      redirect_to groups_path
+    end
   end
 
   # GET /groups/new
@@ -193,5 +209,9 @@ private
 
   def search_params
     params[:search]&.permit(:organisation_id) || {}
+  end
+
+  def confirm_new_input_params
+    params.require(:groups_confirm_new_input).permit(:confirm)
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < WebController
-  before_action :set_group, except: %i[index new create]
+  before_action :set_group, except: %i[index new create confirm_new]
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
 
@@ -26,6 +26,12 @@ class GroupsController < WebController
 
     forms = @group.forms
     @form_list_presenter = FormListPresenter.call(forms:, group: @group, can_admin: @current_user.can_administer_org?(@group.organisation)) unless forms.empty?
+  end
+
+  def confirm_new
+    authorize Group, :new?
+    @confirm_new_input = Groups::ConfirmNewInput.new
+    @organisation = @current_user.organisation
   end
 
   # GET /groups/new

--- a/app/input_objects/groups/confirm_new_input.rb
+++ b/app/input_objects/groups/confirm_new_input.rb
@@ -1,0 +1,4 @@
+module Groups
+  class ConfirmNewInput < ConfirmActionInput
+  end
+end

--- a/app/views/groups/confirm_new.html.erb
+++ b/app/views/groups/confirm_new.html.erb
@@ -1,0 +1,33 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.group_confirm_new"), @confirm_new_input.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(groups_path,t("back_link.groups")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @confirm_new_input, url: confirm_new_groups_path) do |f| %>
+      <% if @confirm_new_input&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l"><%= t("page_titles.group_confirm_new") %></h1>
+
+      <% if @organisation.admin_users.empty? %>
+        <%= t(".without_org_admin.body_html") %>
+      <% else %>
+        <%= t(".with_org_admin.body_html") %>
+
+        <p><%= t(".with_org_admin.org_admin_list_title") %></p>
+        <ul class="govuk-list govuk-list--bullet">
+          <% @organisation.admin_users.order(:email).each do |user| %>
+            <li><%= user.email %></li>
+          <% end %>
+        </ul>
+      <% end %>
+
+      <%= f.govuk_collection_radio_buttons :confirm,
+        @confirm_new_input.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_action_input.options.' + "#{option}") },
+        legend: { text: t('groups.confirm_new.radios_legend'), size: 'm' },
+        inline: true %>
+      <%= f.govuk_submit t("continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -52,7 +52,7 @@
     <%= render GroupListComponent::View.new(groups: @active_groups, title: t('groups.index.active_title'), empty_message: t('groups.index.active_empty_message')) %>
     <%= render GroupListComponent::View.new(groups: @trial_groups, title: t('groups.index.trial_title'), empty_message: t('groups.index.trial_empty_message')) %>
 
-    <%= govuk_button_link_to t("groups.index.create_group"), new_group_path, class:"govuk-!-margin-top-3" %>
+    <%= govuk_button_link_to t("groups.index.create_group"), confirm_new_groups_path, class:"govuk-!-margin-top-3" %>
   </div>
 </div>
 

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,5 +1,5 @@
-<% set_page_title(title_with_error_prefix(t(".title"), @group.errors.any?)) %>
-<% content_for :back_link, govuk_back_link_to(groups_path,t("back_link.groups")) %>
+<% set_page_title(title_with_error_prefix(t("page_titles.new_group"), @group.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(confirm_new_groups_path,t(".back_link")) %>
 
 <%= form_with(model: @group) do |f| %>
 <div class="govuk-grid-row">
@@ -8,7 +8,7 @@
       <%= f.govuk_error_summary %>
     <% end %>
 
-    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+    <h1 class="govuk-heading-l"><%= t("page_titles.new_group") %></h1>
 
     <%= t(".body_html") %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -742,21 +742,18 @@ en:
         label: Move this group to another organisation
         prompt: Select an organisation
     new:
+      back_link: Back to create a new group
       body_html: |
-        <p>Each form needs to be created in a ‘group’. Once you have a group, you can add other people to create and edit forms in it.</p>
-
-        <p class="govuk-inset-text">When a group is first created it will be a ‘trial’ group. That means you cannot make any forms in the group live. You’ll be able to request for a group to be upgraded to an ‘active’ group if you need to make forms live.</p>
-
-        <p>Give your group a meaningful name that will reflect the forms you’ll create in the group, and make sense to the people that will be added to it. For example:</p>
-
+        <p>Give your group a meaningful name that will reflect the forms you’ll
+        create in the group, and make sense to the people that will be added to
+        it. For example:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>Licensing forms</li>
           <li>GOV.UK content team</li>
           <li>Juggling service forms</li>
+          <li>Test forms</li>
         </ul>
-
         <p>You can change the name later if you need to.</p>
-      title: Create a new group for forms
     review_upgrade:
       body_html: |
         <p>%{upgrade_requester_name} has asked to upgrade this group to an ‘active’ group.</p>
@@ -1496,6 +1493,7 @@ en:
     mou_signatures: MOUs and agreements
     move_form: Move this form to a different group
     name_settings: Ask for a person’s name
+    new_group: Give your group a name
     new_page: Edit question
     new_secondary_skip: 'Route for any other answer: set questions to skip'
     non_crown_agreement_confirmation: You’ve agreed to the GOV.UK Forms agreement

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -653,6 +653,20 @@ en:
       title: Add an editor to this group
       title_show_role_options: Add an editor or group admin to this group
   groups:
+    confirm_new:
+      radios_legend: Do you still want to create a new group?
+      with_org_admin:
+        body_html: |
+          <p>Each form needs to be created in a ‘group’. Once you have a group, you can add other people to create and edit forms in it.</p>
+          <p>When you first create a group, it will be a ‘trial’ group. That means you can test how the platform works, but you cannot make any forms in the group live.</p>
+          <p>You’ll only be able to make forms live if you get permission from your organisation’s GOV.UK Forms admin.</p>
+          <p>If you want to use this group to create live forms, or if you are not sure you should make a new group, contact your organisation’s GOV.UK Forms admin before you continue. They’ll be able to advise about how they’re managing the use of the platform and the creation of forms in your organisation.</p>
+        org_admin_list_title: 'Your organisation’s GOV.UK forms admins are:'
+      without_org_admin:
+        body_html: |
+          <p>Each form needs to be created in a ‘group’. Once you have a group, you can add other people to create and edit forms in it.</p>
+          <p>When you first create a group, it will be a ‘trial’ group. That means you can test how the platform works, but you cannot make any forms in the group live.</p>
+          <p>If you’re not sure if you should make a new group, or you want to use this group for live forms, contact your organisation’s GOV.UK publishing team.</p>
     confirm_upgrade:
       body_html: |
         <p>If you upgrade this group:</p>
@@ -1464,6 +1478,7 @@ en:
     error_prefix: 'Error: '
     exit_page_new: Add exit page
     forbidden: You cannot view this page
+    group_confirm_new: Create a new group for forms
     group_confirm_upgrade_request: Request to upgrade this trial group
     group_index: Your groups
     group_review_upgrade: Upgrade this group

--- a/config/locales/input_objects/confirm_new.yml
+++ b/config/locales/input_objects/confirm_new.yml
@@ -1,0 +1,9 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        groups/confirm_new_input:
+          attributes:
+            confirm:
+              blank: Select yes if you want to create a new group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,7 @@ Rails.application.routes.draw do
 
     collection do
       get "confirm-new", to: "groups#confirm_new"
+      post "confirm-new", to: "groups#confirm_new_submit"
     end
 
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,6 +219,11 @@ Rails.application.routes.draw do
   resources :groups do
     resources :forms, controller: :group_forms, only: %i[new create edit update]
     resources :members, controller: :group_members, only: %i[index new create]
+
+    collection do
+      get "confirm-new", to: "groups#confirm_new"
+    end
+
     member do
       get "delete", to: "groups#delete"
       get "move", to: "groups#move"

--- a/spec/features/groups/create_group_spec.rb
+++ b/spec/features/groups/create_group_spec.rb
@@ -8,6 +8,7 @@ feature "Create a new group", type: :feature do
   scenario "Form creator creates a new group" do
     when_i_visit_the_groups_page
     and_i_click_create_a_group
+    and_i_click_yes
     and_i_fill_in_the_group_name
     then_i_should_see_the_new_group
     and_i_use_the_back_link
@@ -23,6 +24,11 @@ feature "Create a new group", type: :feature do
   def and_i_click_create_a_group
     click_link "Create a group"
     expect_page_to_have_no_axe_errors(page)
+  end
+
+  def and_i_click_yes
+    choose "Yes"
+    click_button "Continue"
   end
 
   def and_i_fill_in_the_group_name

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -975,4 +975,39 @@ RSpec.describe "/groups", type: :request do
       expect(response).to be_successful
     end
   end
+
+  describe "POST /confirm_new" do
+    before do
+      post confirm_new_groups_url, params: { groups_confirm_new_input: { confirm: } }
+    end
+
+    context "when 'Yes' is selected" do
+      let(:confirm) { :yes }
+
+      it "redirects to the new group page" do
+        expect(response).to redirect_to(new_group_path)
+      end
+    end
+
+    context "when 'No' is selected" do
+      let(:confirm) { :no }
+
+      it "redirects to the groups page" do
+        expect(response).to redirect_to(groups_path)
+      end
+    end
+
+    context "when no option is selected" do
+      let(:confirm) { nil }
+
+      it "returns 422" do
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "re-renders the confirm new page with an error" do
+        expect(response).to render_template(:confirm_new)
+        expect(response.body).to include("Select yes if you want to create a new group")
+      end
+    end
+  end
 end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -968,4 +968,11 @@ RSpec.describe "/groups", type: :request do
       end
     end
   end
+
+  describe "GET /confirm_new" do
+    it "renders a successful response" do
+      get confirm_new_groups_url
+      expect(response).to be_successful
+    end
+  end
 end

--- a/spec/views/groups/confirm_new.html.erb_spec.rb
+++ b/spec/views/groups/confirm_new.html.erb_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "groups/confirm_new", type: :view do
+  let(:organisation) { build(:organisation) }
+  let(:confirm_new_input) { Groups::ConfirmNewInput.new }
+
+  before do
+    assign(:confirm_new_input, confirm_new_input)
+    assign(:organisation, organisation)
+    render
+  end
+
+  it "contains the page heading" do
+    expect(rendered).to have_css("h1", text: I18n.t("page_titles.group_confirm_new"))
+  end
+
+  it "contains a back link" do
+    expect(view.content_for(:back_link)).to have_link(I18n.t("back_link.groups"), href: groups_path)
+  end
+
+  it "renders the new group form" do
+    assert_select "form[action=?][method=?]", confirm_new_groups_path, "post"
+  end
+
+  it "includes a radio button for selecting yes" do
+    expect(rendered).to have_unchecked_field(I18n.t("helpers.label.confirm_action_input.options.yes"))
+  end
+
+  it "includes the body text for a group without an admin user" do
+    expect(rendered).to include(I18n.t("groups.confirm_new.without_org_admin.body_html"))
+  end
+
+  context "when the organisation has an admin user" do
+    let(:organisation) { create(:organisation, :with_org_admin) }
+
+    it "includes the body text for a group with an admin user" do
+      expect(rendered).to include(I18n.t("groups.confirm_new.with_org_admin.body_html"))
+    end
+
+    it "includes the list of admin users" do
+      expect(rendered).to include(I18n.t("groups.confirm_new.with_org_admin.org_admin_list_title"))
+      expect(rendered).to have_text(organisation.admin_users.first.email)
+    end
+  end
+end

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "groups/index", type: :view do
     end
 
     it "shows a create group button" do
-      expect(rendered).to have_link("Create a group", href: new_group_path)
+      expect(rendered).to have_link("Create a group", href: confirm_new_groups_path)
     end
 
     it "does not show an organisation selector" do

--- a/spec/views/groups/new.html.erb_spec.rb
+++ b/spec/views/groups/new.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "groups/new", type: :view do
   end
 
   it "contains the page heading" do
-    expect(rendered).to have_css("h1", text: I18n.t("groups.new.title"))
+    expect(rendered).to have_css("h1", text: I18n.t("page_titles.new_group"))
   end
 
   it "renders the new group form" do
@@ -24,5 +24,9 @@ RSpec.describe "groups/new", type: :view do
 
   it "includes the body text" do
     expect(rendered).to include(I18n.t("groups.new.body_html"))
+  end
+
+  it "has a back link" do
+    expect(view.content_for(:back_link)).to have_link(I18n.t("groups.new.back_link"), href: confirm_new_groups_path)
   end
 end


### PR DESCRIPTION
### Add a new page with content to slow when creating a new group

Trello card: https://trello.com/c/KETW4If8/3099-add-a-new-page-after-a-user-clicks-create-a-group

This PR adds a new page between clicking "Create group" and giving the group a name. It also updates the content on the new groups page.

The new page is to confirm the user wants to create a group and give them more information about what a group is. The content is different for organisations which have an admin.

The existing new group page can still be accessed directly through URL. The create group button link has been changed to this new page.

> [!NOTE]
> I made up some content for the validation message the user sees when they don't check yes or no and submit the page. 

## Without org admins 
<img width="707" height="700" alt="image" src="https://github.com/user-attachments/assets/18654fc2-092d-434f-aeb1-9224be09471e" />

## With org admins
<img width="824" height="810" alt="image" src="https://github.com/user-attachments/assets/e8da3039-b510-43da-b7b0-9555b09a0e87" />

## Without selecting yes/no
<img width="747" height="748" alt="image" src="https://github.com/user-attachments/assets/ede9a7ed-4782-4e60-be31-8396b3776ad8" />

## The updated new group page
<img width="716" height="603" alt="image" src="https://github.com/user-attachments/assets/095ca7e3-2523-40ee-9395-604270a51bbd" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
