### PR TITLE
Don't allow goto page to be before routing page for show/edit routes page

### DIFF
--- a/app/input_objects/forms/routes_input.rb
+++ b/app/input_objects/forms/routes_input.rb
@@ -33,7 +33,10 @@ class Forms::RoutesInput < BaseInput
       next unless page # Skip if page not found or doesn't belong to form
 
       Forms::RouteInput.new(
-        route_attrs.symbolize_keys.merge(page:, goto_options: route_build_service.options_for_page(page)),
+        route_attrs.symbolize_keys.merge(
+          page:,
+          goto_options: route_build_service.options_for_goto_page(page, route_attrs["goto"]),
+        ),
       )
     }.compact
   end

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -25,7 +25,7 @@ class Routes::BuildService
     end
   end
 
-  def options_for_page(page)
+  def options_for_goto_page(page, selected = nil)
     next_page = form.next_page_after(page)
 
     return [] unless next_page
@@ -62,7 +62,7 @@ private
         page:,
         answer_value:,
         goto: goto_value_for(condition),
-        goto_options: options_for_page(page),
+        goto_options: options_for_goto_page(page, condition&.goto_page_id),
         label: { text: "Option #{index}: #{answer_value_label}" },
       )
     end
@@ -78,15 +78,19 @@ private
         page_id: page.id,
         page:,
         goto: goto_value_for(condition),
-        goto_options: options_for_page(page),
+        goto_options: options_for_goto_page(page, condition&.goto_page_id),
         label: { text: "Go to", hidden: true },
       ),
     ]
   end
 
+  def option_for_select(page)
+    ["#{page.position}. #{page.question_text}", page.id]
+  end
+
   def all_goto_options
     @all_goto_options ||= begin
-      page_opts = form.pages.map { |p| ["#{p.position}. #{p.question_text}", p.id] }
+      page_opts = form.pages.map { |p| option_for_select(p) }
       page_opts + [END_OF_FORM_OPTION]
     end
   end

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -30,15 +30,26 @@ class Routes::BuildService
 
     return [] unless next_page
 
-    # Don't include the current page in the options
-    options_without_page = all_goto_options.reject { |_, value| value == page.id }
+    # Don't include the current page or pages before in the options,
+    # unless the goto page for the existing condition is before the current page,
+    # in which case do include that one. Also, change the option for the next page
+    # to a different default option.
+    next_page_id = next_page.id
+    drop = true
 
-    # Replace the next page with the default option
-    options_without_page.map do |name, value|
-      if value == next_page.id
-        ["Go to question #{page.position.next}", Forms::RouteInput::DEFAULT_VALUE]
+    all_goto_options.filter_map do |option|
+      _, value = option
+
+      if drop
+        if selected && value == selected
+          option
+        elsif value == next_page_id
+          drop = false
+          ["Go to question #{page.position.next}", Forms::RouteInput::DEFAULT_VALUE]
+        end
+        # return nil
       else
-        [name, value]
+        option
       end
     end
   end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -63,6 +63,12 @@ FactoryBot.define do
         add_welsh_translations_to_pages(form.pages) if form.available_languages.include?("cy")
       end
 
+      after(:stub) do |form|
+        link_pages_list(form.pages) if form.pages.present?
+        stub_conditions(form) if form.pages.present?
+        add_welsh_translations_to_pages(form.pages) if form.available_languages.include?("cy")
+      end
+
       question_section_completed { true }
     end
 
@@ -167,6 +173,14 @@ def link_pages_list(pages)
   end
 
   pages
+end
+
+def stub_conditions(form)
+  form.instance_eval do
+    def conditions
+      pages.flat_map(&:routing_conditions)
+    end
+  end
 end
 
 def add_welsh_translations_to_pages(pages)

--- a/spec/input_objects/forms/routes_input_spec.rb
+++ b/spec/input_objects/forms/routes_input_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Forms::RoutesInput do
 
   describe "#routes_attributes=" do
     let(:goto_options) { [["Go to page 2", pages.second.id]] }
-    let(:route_build_service) { instance_double(Routes::BuildService, options_for_page: goto_options) }
+    let(:route_build_service) { instance_double(Routes::BuildService, options_for_goto_page: goto_options) }
     let(:pages) { create_list(:page, 2) }
     let(:form) { create(:form, id: 1, pages:) }
 

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Routes::BuildService do
     end
   end
 
-  describe "#options_for_page" do
+  describe "#options_for_goto_page" do
     let(:pages) do
       create_list(:page, 3) do |page, i|
         page.id = 101 + i
@@ -191,11 +191,11 @@ RSpec.describe Routes::BuildService do
     end
 
     it "returns an empty array if the page has no next page" do
-      expect(service.options_for_page(pages.third)).to be_empty
+      expect(service.options_for_goto_page(pages.third)).to be_empty
     end
 
     it "returns a list of all possible goto options" do
-      options = service.options_for_page(pages.first)
+      options = service.options_for_goto_page(pages.first)
 
       expected_other_options = [
         ["3. question 3", pages.third.id],
@@ -207,14 +207,14 @@ RSpec.describe Routes::BuildService do
     end
 
     it "replaces the next page with the default option" do
-      options = service.options_for_page(pages.first)
+      options = service.options_for_goto_page(pages.first)
       default_option = options.find { |opt| opt[1] == Forms::RouteInput::DEFAULT_VALUE }
 
       expect(default_option).to eq(["Go to question 2", Forms::RouteInput::DEFAULT_VALUE])
     end
 
     it "does not include the current page in the options" do
-      options = service.options_for_page(pages.first)
+      options = service.options_for_goto_page(pages.first)
       page_ids = options.map(&:second)
 
       expect(page_ids).not_to include(pages.first.id)

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -219,5 +219,26 @@ RSpec.describe Routes::BuildService do
 
       expect(page_ids).not_to include(pages.first.id)
     end
+
+    it "does not include pages before the current page in the options" do
+      options = service.options_for_goto_page(pages.second)
+
+      expect(options).to eq [
+        ["Go to question 3", Forms::RouteInput::DEFAULT_VALUE],
+        ["End of the form", "end_of_form"],
+      ]
+    end
+
+    context "when there is a selected goto page and the goto page is before the current page" do
+      it "includes the goto page in the options" do
+        options = service.options_for_goto_page(pages.second, pages.first.id)
+
+        expect(options).to eq [
+          ["1. #{pages.first.question_text}", pages.first.id],
+          ["Go to question 3", Forms::RouteInput::DEFAULT_VALUE],
+          ["End of the form", "end_of_form"],
+        ]
+      end
+    end
   end
 end

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -88,7 +88,7 @@ describe "routes/show.html.erb" do
       end
 
       expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][1][goto]"]') do |field|
-        expect(select_options(field)).to end_with [
+        expect(select_options(field)).to eq [
           ["default", "Go to question 3"],
           ["end_of_form", "End of the form"],
         ]
@@ -107,6 +107,37 @@ describe "routes/show.html.erb" do
       expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][1][goto]"]') do |field|
         expect(field).to have_selector("option[selected]") do |option|
           expect(option["value"]).to eq "default"
+        end
+      end
+    end
+
+    context "when the route goes to a page before the routing page" do
+      let(:pages) do
+        [
+          build_stubbed(:page, id: 101),
+          build_stubbed(
+            :page,
+            id: 102,
+            routing_conditions: [
+              build_stubbed(
+                :condition,
+                routing_page_id: 102,
+                goto_page_id: 101,
+                answer_value: nil,
+              ),
+            ],
+          ),
+          build_stubbed(:page, id: 103),
+        ]
+      end
+
+      it "shows the selected goto page for the route" do
+        render_page
+
+        expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][1][goto]"]') do |field|
+          expect(field).to have_selector("option[selected]") do |option|
+            expect(option["value"]).to eq "101"
+          end
         end
       end
     end

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
 describe "routes/show.html.erb" do
-  let(:form) { build_stubbed :form, pages: }
+  let(:form) { build_stubbed :form, :with_pages, pages: }
   let(:pages) { [] }
-  let(:routes) { [] }
-  let(:routes_input) { build :routes_input, form:, routes: }
+  let(:routes_input) { build(:routes_input, form:).assign_form_values }
 
   def render_page
     assign(:current_form, form)
@@ -29,13 +28,30 @@ describe "routes/show.html.erb" do
   end
 
   context "when the form has pages and routes" do
-    let(:pages) { build_stubbed_list(:page, 3) }
-    let(:routes) do
+    let(:pages) do
       [
-        build(:route_input, page: pages.first, goto: pages.third.id, goto_options: []),
-        build(:route_input, :default, page: pages.second, goto_options: []),
-        build(:route_input, :default, page: pages.third, goto_options: []),
+        build_stubbed(
+          :page,
+          id: 101,
+          routing_conditions: [
+            build_stubbed(
+              :condition,
+              routing_page_id: 101,
+              goto_page_id: 103,
+              answer_value: nil,
+            ),
+          ],
+        ),
+        build_stubbed(:page, id: 102),
+        build_stubbed(:page, id: 103),
       ]
+    end
+
+    it "has a summary list with a row for each page" do
+      render_page
+      expect(rendered).to have_selector(".govuk-summary-list") do |summary_list|
+        expect(summary_list).to have_selector(".govuk-summary-list__row", count: pages.length)
+      end
     end
 
     it "displays the page's position and question text" do
@@ -47,6 +63,52 @@ describe "routes/show.html.erb" do
     it "includes the page's position in the id of the key" do
       render_page
       expect(rendered).to have_selector("#page-#{pages.first.position}")
+    end
+
+    it "has a select field for each page except the last one" do
+      render_page
+      expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][0][goto]"]')
+      expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][1][goto]"]')
+      expect(rendered).not_to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][2][goto]"]')
+    end
+
+    it "has options for where the route should go to for each select field" do
+      render_page
+
+      def select_options(select_field)
+        select_field.find_all("option").map { [it["value"], it.text] }
+      end
+
+      expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][0][goto]"]') do |field|
+        expect(select_options(field)).to eq [
+          ["default", "Go to question 2"],
+          ["103", "3. #{pages.third.question_text}"],
+          ["end_of_form", "End of the form"],
+        ]
+      end
+
+      expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][1][goto]"]') do |field|
+        expect(select_options(field)).to end_with [
+          ["default", "Go to question 3"],
+          ["end_of_form", "End of the form"],
+        ]
+      end
+    end
+
+    it "shows the selected goto page for the route" do
+      render_page
+
+      expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][0][goto]"]') do |field|
+        expect(field).to have_selector("option[selected]") do |option|
+          expect(option["value"]).to eq "103"
+        end
+      end
+
+      expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][1][goto]"]') do |field|
+        expect(field).to have_selector("option[selected]") do |option|
+          expect(option["value"]).to eq "default"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/58uS0Pah/3087-restrict-the-options-for-routes-next-page <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

On the page to edit routes for a form, we want each select field to only show pages after the page it is routing from.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
