### PR TITLE
Change 'end of form' to 'end of the form'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1364,13 +1364,13 @@ en:
     condition_answer_value_text_with_errors: "[Answer not selected]"
     condition_check_page_text: "“%{check_page_question_text}”"
     condition_compact_html: If the answer is “%{answer_value}” go to %{goto_page_question_number}, “%{goto_page_question_text}”
-    condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to end of form
+    condition_compact_html_end_of_form: If the answer is “%{answer_value}”<br> then skip to the end of the form
     condition_compact_html_exit_page: If the answer is “%{answer_value}” go to the exit page, “%{exit_page_heading}”
     condition_compact_html_secondary_skip: Go to %{goto_page_question_number}, “%{goto_page_question_text}”
-    condition_compact_html_secondary_skip_to_end_of_form: Go to end of form
+    condition_compact_html_secondary_skip_to_end_of_form: Go to the end of the form
     condition_description: If %{check_page_question_text} is answered as %{answer_value} go to %{goto_page_question_text}
     condition_goto_exit_page: exit page, “%{exit_page_heading}”
-    condition_goto_page_end_of_form: end of form.
+    condition_goto_page_end_of_form: the end of the form.
     condition_goto_page_text: "%{goto_page_question_number}, “%{goto_page_question_text}”"
     condition_goto_page_text_with_errors: "[Question not selected]"
     condition_group_description: 'Go to %{goto_page_question_number}, ‘%{goto_page_question_text}’ if the answer is:'
@@ -1380,7 +1380,7 @@ en:
       other: Question %{question_number}’s routes
     condition_name: Question %{question_number}’s routes
     edit_exit_page: Edit “%{exit_page_heading}”
-    end_of_form: End of form
+    end_of_form: End of the form
     exit_page: Add an exit page
     exit_page_label: An ‘exit page’ to leave the form
     none_of_the_above: None of the above
@@ -1396,7 +1396,7 @@ en:
     delete: Delete
     delete_route: Delete all routes
     edit: Edit
-    end_of_form: End of form
+    end_of_form: End of the form
     errors:
       answer_value_doesnt_exist: The answer that route 1 is based on no longer exists - edit or delete this route
       cannot_have_goto_page_before_routing_page: The question route 1 skips to cannot be before question %{question_number} - edit or delete this route
@@ -2001,8 +2001,8 @@ en:
       date_of_birth: Date of birth
       other_date: Date
     end_of_form:
-      cy: End of form
-      en: End of form
+      cy: End of the form
+      en: End of the form
     guidance_markdown: Guidance
     hint_text: Hint text
     name_type:

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe PageListComponent::View, type: :component do
         end
 
         it "returns description with 'Check your answers' text" do
-          expected_text = "If “#{pages.first.question_text}” is answered as “#{condition.answer_value}” go to end of form."
+          expected_text = "If “#{pages.first.question_text}” is answered as “#{condition.answer_value}” go to the end of the form."
           expect(page_list_component.condition_description(condition)).to eq(expected_text)
         end
       end

--- a/spec/features/form/add_or_edit_questions/add_branching_to_a_form_spec.rb
+++ b/spec/features/form/add_or_edit_questions/add_branching_to_a_form_spec.rb
@@ -86,7 +86,7 @@ private
 
   def and_i_select_a_skip_page_and_goto_page
     select form.pages[3].question_text, from: "pages_secondary_skip_input[routing_page_id]"
-    select "End of form", from: "pages_secondary_skip_input[goto_page_id]"
+    select "End of the form", from: "pages_secondary_skip_input[goto_page_id]"
 
     create(:condition, id: 2, check_page_id: form.pages.first.id, routing_page_id: form.pages[3].id, goto_page_id: nil, skip_to_end: true)
     form.pages.each(&:reload)
@@ -98,7 +98,7 @@ private
     expect(page).to have_text "Route for any other answer"
     expect(page).to have_text "Continue to"
     expect(page).to have_text form.pages[3].question_text
-    expect(page).to have_text "End of form"
+    expect(page).to have_text "End of the form"
     expect_page_to_have_no_axe_errors(page)
   end
 end

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -65,9 +65,9 @@ describe RouteSummaryCardDataPresenter do
         pages.each(&:reload)
       end
 
-      it 'shows "End of form" as destination' do
+      it 'shows "End of the form" as destination' do
         result = service.summary_card_data
-        expect(result[0][:rows][1][:value][:text]).to eq("End of form")
+        expect(result[0][:rows][1][:value][:text]).to eq("End of the form")
       end
     end
 

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Routes::BuildService do
 
       expected_other_options = [
         ["3. question 3", pages.third.id],
-        ["End of form", "end_of_form"],
+        ["End of the form", "end_of_form"],
       ]
       all_other_options = options.reject { |opt| opt[1] == Forms::RouteInput::DEFAULT_VALUE }
 

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -754,8 +754,8 @@ describe StepSummaryTableService do
                                                                     exit_page_heading_cy: nil,
                                                                     exit_page_markdown: nil,
                                                                     exit_page_markdown_cy: nil,
-                                                                    goto_page: "End of form",
-                                                                    goto_page_cy: "End of form",
+                                                                    goto_page: "End of the form",
+                                                                    goto_page_cy: "End of the form",
                                                                     routing_page: "11. Question to be skipped",
                                                                     routing_page_cy: "11. Question to be skipped (Welsh)",
                                                                     secondary_skip: false }]


### PR DESCRIPTION
### What problem does this pull request solve?

This changes:

- 'end of form' to 'the end of the form' where it's part of a sentence
- 'End of form' to 'End of the form' where it's a fragment

This is for style, consistency and readability.

Trello card:https://trello.com/c/JciJ9SsL/3549-card-in-progress-correct-end-of-form-to-end-of-the-form-or-the-end-of-the-form-as-relevant

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

- I can't run this locally so I hope it all looks ok! I will be checking in the review apps! 
- I hope I have caught all the tests etc...
- I haven't been able to squash these commits as it turns out I can't have github desktop on my new computer. Sorry about that! If someone can easily do that for me (I think that's possible?), that would be super! 
- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
