### PR TITLE
Limit branching to only lists with 10 or fewer options (for now)

### DIFF
--- a/app/input_objects/forms/routes_input.rb
+++ b/app/input_objects/forms/routes_input.rb
@@ -1,6 +1,10 @@
 class Forms::RoutesInput < BaseInput
   attr_accessor :form, :routes
 
+  def self.too_many_selection_options?(page)
+    page.answer_settings["selection_options"].length > 10
+  end
+
   def initialize(attributes = {})
     @form = attributes.delete(:form)
     super

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -17,7 +17,9 @@ class Routes::BuildService
     end
 
     form.pages.flat_map do |page|
-      if page.answer_type == "selection" && page.answer_settings.only_one_option == "true"
+      if page.answer_type == "selection" &&
+          page.answer_settings.only_one_option == "true" &&
+          !Forms::RoutesInput.too_many_selection_options?(page)
         build_routes_for_selection_page(page, conditions_by_key)
       else
         build_route_for_generic_page(page, conditions_by_key)

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -23,6 +23,11 @@
               capture do %>
               <p> <%= page.question_text %> </p>
               <% if @routes_input.form.next_page_after(page).present? %>
+                <% if page.answer_type == "selection" &&
+                        page.answer_settings.only_one_option == "true" &&
+                          @routes_input.class.too_many_selection_options?(page) %>
+                  <%= t(".too_many_options_html") %>
+                <% end %>
                 <ul class="govuk-list">
                   <% routes.each do |route| %>
                     <li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1915,6 +1915,12 @@ en:
         total_number_of_users: Total Number of Users
         user_count: User count
       title: Number of users per organisation
+  routes:
+    show:
+      too_many_options_html: |
+        <p>This question has a list with more than 10 options.</p>
+
+        <p>You cannot add routes from answers if the question has more than 10 options.</p>
   routing_page:
     body_html: |
       <p> You can add a route to a question so if someone selects one specific answer, they’ll be skipped to: </p>

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -107,6 +107,22 @@ RSpec.describe Routes::BuildService do
           expect(route_for_no.label).to eq({ text: "Option 2: No" })
         end
 
+        context "when the selection page has more than 10 options" do
+          let(:selection_options) do
+            (1..11).map do |i|
+              { name: "Option #{i}", value: "Option #{i}" }
+            end
+          end
+
+          it "builds a single route input for the selection page" do
+            routes = service.build_routes
+
+            expect(routes.length).to eq(3)
+            expect(routes).to all be_a(Forms::RouteInput)
+            expect(routes.filter { it.page_id == pages.first.id }.length).to eq(1)
+          end
+        end
+
         context "when the selection page is optional" do
           let(:pages) do
             [

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -141,5 +141,40 @@ describe "routes/show.html.erb" do
         end
       end
     end
+
+    context "when a page is a select from a list question" do
+      let(:pages) do
+        [
+          build_stubbed(:page, :with_selection_settings, id: 101, selection_options:),
+          build_stubbed(:page, id: 102),
+          build_stubbed(:page, id: 103),
+        ]
+      end
+
+      let(:selection_options) do
+        [{ name: "Yes", value: "Yes" }, { name: "No", value: "No" }]
+      end
+
+      it "has inputs for each answer option" do
+        render_page
+
+        expect(rendered).to have_selector(".govuk-summary-list") do |summary_list|
+          rows = summary_list.find_all(".govuk-summary-list__row")
+
+          expect(rows[0]).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][0][goto]"]')
+          expect(rows[0]).to have_selector('input[name="forms_routes_input[routes_attributes][0][page_id]"][value="101"]', visible: :hidden)
+          expect(rows[0]).to have_selector('input[name="forms_routes_input[routes_attributes][0][answer_value]"][value="Yes"]', visible: :hidden)
+
+          expect(rows[0]).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][1][goto]"]')
+          expect(rows[0]).to have_selector('input[name="forms_routes_input[routes_attributes][1][page_id]"][value="101"]', visible: :hidden)
+          expect(rows[0]).to have_selector('input[name="forms_routes_input[routes_attributes][1][answer_value]"][value="No"]', visible: :hidden)
+
+          expect(rows[1]).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][2][goto]"]')
+          expect(rows[1]).to have_selector('input[name="forms_routes_input[routes_attributes][2][page_id]"][value="102"]', visible: :hidden)
+
+          expect(rows[2]).not_to have_selector(".govuk-select")
+        end
+      end
+    end
   end
 end

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -175,6 +175,44 @@ describe "routes/show.html.erb" do
           expect(rows[2]).not_to have_selector(".govuk-select")
         end
       end
+
+      context "with more than 10 options" do
+        let(:selection_options) do
+          (1..11).map do |i|
+            { name: "Option #{i}", value: "Option #{i}" }
+          end
+        end
+
+        it "has one route input for that question" do
+          render_page
+
+          expect(rendered).to have_selector(".govuk-summary-list") do |summary_list|
+            rows = summary_list.find_all(".govuk-summary-list__row")
+
+            expect(rows[0]).to have_selector(".govuk-select", count: 1)
+            expect(rows[1]).to have_selector(".govuk-select", count: 1)
+            expect(rows[2]).not_to have_selector(".govuk-select")
+          end
+        end
+
+        it "has content explaining that routes cannot be added" do
+          render_page
+
+          expected_content = <<~TEXT
+            This question has a list with more than 10 options.
+
+            You cannot add routes from answers if the question has more than 10 options.
+          TEXT
+
+          expect(rendered).to have_selector(".govuk-summary-list") do |summary_list|
+            rows = summary_list.find_all(".govuk-summary-list__row")
+
+            expect(rows[0]).to have_text(expected_content)
+            expect(rows[1]).not_to have_text(expected_content)
+            expect(rows[2]).not_to have_text(expected_content)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/pOOto1kO/3098-limit-branching-to-only-lists-with-10-or-fewer-options-for-now <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We've decided for now to avoid presenting form creators with a very long routing page if they have a selection question with a long list of options.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
