### PR TITLE
Add message to routes#show when not enough pages

### DIFF
--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -9,46 +9,50 @@
       <%= t("page_titles.routes") %>
     </h1>
 
-    <%= form_with(model: @routes_input, url: routes_path(@routes_input.form)) do |f| %>
-      <% if @routes_input&.errors&.present? %>
-        <%= f.govuk_error_summary(presenter: ErrorSummaryPresenter.new(@routes_input.errors)) %>
-      <% end %>
+    <%if @routes_input.form.pages.length < 2 %>
+      <%= t(".not_enough_pages_html", pages_link: form_pages_path(@current_form)) %>
+    <% else %>
+      <%= form_with(model: @routes_input, url: routes_path(@routes_input.form)) do |f| %>
+        <% if @routes_input&.errors&.present? %>
+          <%= f.govuk_error_summary(presenter: ErrorSummaryPresenter.new(@routes_input.errors)) %>
+        <% end %>
 
-      <%= govuk_summary_list(actions: false) do |summary_list|
+        <%= govuk_summary_list(actions: false) do |summary_list|
 
-        @routes_input.routes.group_by(&:page).each do |page, routes|
-          summary_list.with_row do |row|
-            row.with_key(classes: "app-routes-list__key", html_attributes: { id: page.page_position_id}) { page.position.to_s }
-            row.with_value do
-              capture do %>
-              <p> <%= page.question_text %> </p>
-              <% if @routes_input.form.next_page_after(page).present? %>
-                <ul class="govuk-list">
-                  <% routes.each do |route| %>
-                    <li>
-                      <%= f.fields_for :routes, route do |route_form|
-                        route_form.hidden_field(:id) +
-                          route_form.hidden_field(:page_id) +
-                          route_form.hidden_field(:answer_value) +
-                          route_form.govuk_select(:goto, options_for_select(route_form.object.goto_options, route_form.object.goto), label: route_form.object.label)
-                      end %>
-                    </li>
+          @routes_input.routes.group_by(&:page).each do |page, routes|
+            summary_list.with_row do |row|
+              row.with_key(classes: "app-routes-list__key", html_attributes: { id: page.page_position_id}) { page.position.to_s }
+              row.with_value do
+                capture do %>
+                <p> <%= page.question_text %> </p>
+                <% if @routes_input.form.next_page_after(page).present? %>
+                  <ul class="govuk-list">
+                    <% routes.each do |route| %>
+                      <li>
+                        <%= f.fields_for :routes, route do |route_form|
+                          route_form.hidden_field(:id) +
+                            route_form.hidden_field(:page_id) +
+                            route_form.hidden_field(:answer_value) +
+                            route_form.govuk_select(:goto, options_for_select(route_form.object.goto_options, route_form.object.goto), label: route_form.object.label)
+                        end %>
+                      </li>
+                    <% end %>
+                  </ul>
+                  <% if page.answer_type == "selection" &&
+                          page.answer_settings.only_one_option == "true" &&
+                            @routes_input.class.too_many_selection_options?(page) %>
+                    <%= t(".too_many_options_html") %>
                   <% end %>
-                </ul>
-                <% if page.answer_type == "selection" &&
-                        page.answer_settings.only_one_option == "true" &&
-                          @routes_input.class.too_many_selection_options?(page) %>
-                  <%= t(".too_many_options_html") %>
                 <% end %>
               <% end %>
             <% end %>
           <% end %>
         <% end %>
       <% end %>
+
+      <%= f.govuk_submit t("save_and_continue") %>
+
     <% end %>
-
-    <%= f.govuk_submit t("save_and_continue") %>
-
   <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1957,6 +1957,9 @@ en:
       title: Number of users per organisation
   routes:
     show:
+      not_enough_pages_html: |
+        <p>You need more than one question in your form before you can add any routes.</p>
+        <p><a href="%{pages_link}">Back to your questions</a></p>
       too_many_options_html: |
         <p>This question has a list with more than 10 options.</p>
 

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -215,4 +215,22 @@ describe "routes/show.html.erb" do
       end
     end
   end
+
+  context "when there are not enoough pages" do
+    let(:pages) do
+      [
+        build_stubbed(:page, id: 101),
+      ]
+    end
+
+    it "shows a warning" do
+      render_page
+      expect(rendered).to have_content("You need more than one question in your form before you can add any routes.")
+    end
+
+    it "shows a link to the question pages" do
+      render_page
+      expect(rendered).to have_link("Back to your questions", href: form_pages_path(form.id))
+    end
+  end
 end


### PR DESCRIPTION
### Stop showing an empty form on the routes page

Trello card: https://trello.com/c/bOtP0QNS/3086-remove-the-save-and-continue-button-from-the-routes-page-when-there-are-less-than-2-pages-in-the-form

Instead of showing the routes form when there are not enough pages, show a warning and a link to the question pages.

We show the message when there is 0 or 1 page.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
