### PR TITLE
Move too many options content to after interactive element

### DIFF
--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -23,11 +23,6 @@
               capture do %>
               <p> <%= page.question_text %> </p>
               <% if @routes_input.form.next_page_after(page).present? %>
-                <% if page.answer_type == "selection" &&
-                        page.answer_settings.only_one_option == "true" &&
-                          @routes_input.class.too_many_selection_options?(page) %>
-                  <%= t(".too_many_options_html") %>
-                <% end %>
                 <ul class="govuk-list">
                   <% routes.each do |route| %>
                     <li>
@@ -40,6 +35,11 @@
                     </li>
                   <% end %>
                 </ul>
+                <% if page.answer_type == "selection" &&
+                        page.answer_settings.only_one_option == "true" &&
+                          @routes_input.class.too_many_selection_options?(page) %>
+                  <%= t(".too_many_options_html") %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/pOOto1kO/3098-limit-branching-to-only-lists-with-10-or-fewer-options-for-now <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Move the content explaining why branching is not possible to a question to after the input field, to match what is in Mural.

As noted by @christophercameron-ixd, we tend to add content that is superfluous, or repeated, and doesn’t necessarily matter before you get to an interactive element after it to reduce unnecessary repetition.

### Screenshots

#### Before

<img width="658" height="247" alt="Screenshot of long list question in edit question routes page before this PR" src="https://github.com/user-attachments/assets/168a3e13-77e3-4b8a-98a9-77adba82ddab" />

#### After

<img width="659" height="237" alt="Screenshot of long list question in edit question routes page after this PR" src="https://github.com/user-attachments/assets/34410d1c-26df-424a-9f42-4cf7349fd91d" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
