### PR TITLE
Order selection options

### DIFF
--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -101,7 +101,12 @@ module PageListComponent
     end
 
     def answer_value_groups(page)
-      page.routing_conditions.group_by(&:goto_page_id).sort_by { |goto_page_id, _| goto_page_id || Float::INFINITY }
+      answer_order = page.answer_settings&.selection_options&.map(&:value) || []
+
+      page.routing_conditions.to_a
+        .in_order_of(:answer_value, answer_order, filter: false)
+        .group_by(&:goto_page_id)
+        .sort_by { |goto_page_id, _| goto_page_id || Float::INFINITY }
     end
   end
 end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -563,5 +563,26 @@ RSpec.describe PageListComponent::View, type: :component do
       result = page_list_component.answer_value_groups(pages.first)
       expect(result).to eq expected
     end
+
+    context "when given a different order of selection options" do
+      let(:selection_options) do
+        [
+          { value: "Option 3" },
+          { value: "Option 2" },
+          { value: "Option 1" },
+        ]
+      end
+
+      it "returns the conditions in the same order" do
+        expected = [
+          [103, [conditions.second, conditions.first]],
+          [104, [conditions.third]],
+          [nil, [conditions.fourth]],
+        ]
+
+        result = page_list_component.answer_value_groups(pages.first)
+        expect(result).to eq expected
+      end
+    end
   end
 end

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -520,21 +520,48 @@ RSpec.describe PageListComponent::View, type: :component do
   end
 
   describe "#answer_value_groups" do
-    let(:form) { create :form, :ready_for_routing }
-    let(:pages) { form.reload.pages }
-    let!(:first_condition) { create :condition, routing_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.third.id }
-    let!(:second_condition) { create :condition, routing_page_id: pages.first.id, answer_value: "Option 2", goto_page_id: pages.third.id }
-    let!(:third_condition) { create :condition, routing_page_id: pages.first.id, answer_value: "Option 3", goto_page_id: pages.fourth.id }
-    let!(:fourth_condition) { create :condition, routing_page_id: pages.first.id, answer_value: "Option 3", goto_page_id: nil, skip_to_end: true }
+    let(:form) { build_stubbed :form, :ready_for_routing }
+
+    let(:pages) do
+      [
+        build_stubbed(
+          :page,
+          :with_selection_settings,
+          id: 101,
+          selection_options:,
+          routing_conditions: conditions,
+        ),
+        build_stubbed(:page, id: 102),
+        build_stubbed(:page, id: 103),
+        build_stubbed(:page, id: 104),
+      ]
+    end
+
+    let(:selection_options) do
+      [
+        { value: "Option 1" },
+        { value: "Option 2" },
+        { value: "Option 3" },
+      ]
+    end
+
+    let(:conditions) do
+      [
+        build_stubbed(:condition, routing_page_id: 101, answer_value: "Option 1", goto_page_id: 103),
+        build_stubbed(:condition, routing_page_id: 101, answer_value: "Option 2", goto_page_id: 103),
+        build_stubbed(:condition, routing_page_id: 101, answer_value: "Option 3", goto_page_id: 104),
+        build_stubbed(:condition, routing_page_id: 101, answer_value: nil, goto_page_id: nil, skip_to_end: true),
+      ]
+    end
 
     it "groups conditions by goto_page_id" do
-      expect(page_list_component.answer_value_groups(pages.first.reload)).to eq(
-        [
-          [pages.third.id, [first_condition, second_condition]],
-          [pages.fourth.id, [third_condition]],
-          [nil, [fourth_condition]],
-        ],
-      )
+      expected = [
+        [103, [conditions.first, conditions.second]],
+        [104, [conditions.third]],
+        [nil, [conditions.fourth]],
+      ]
+      result = page_list_component.answer_value_groups(pages.first)
+      expect(result).to eq expected
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/x0opnWol/3108-order-condition-description-answer-values-based-on-selection-options

In the pagelist view, show routes in the same order as the page's selection options.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
