### PR TITLE
Add fallback submission email address for database seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ To run this project, your database will need to have a user in it. The `bin/setu
 ./bin/rails db:seed
 ```
 
+The database seed will also create a number of test forms, by default the submissions for these forms will be sent by email to the email address that you have configured in Git. If you want to override this, or are running this app in a container where git or its configuration is not present, then you can use set the `EMAIL` environment variable. If neither `EMAIL` or the git email address are set, the database seed will fallback to a generic test email address.
+
 ## Changing configuration
 
 ### Changing settings

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -134,7 +134,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
 
   Membership.create! user: default_user, group: end_to_end_group, added_by: default_user, role: :group_admin
 
-  submission_email = ENV["EMAIL"] || `git config --get user.email`.strip
+  submission_email = ENV["EMAIL"].presence || `git config --get user.email`.strip.presence || "example@example.com"
 
   all_question_types_form = Form.create!(
     name: "All question types form",


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Forms can't be made live without a submission email address, so if the `EMAIL` environment is not set or an email address can't be retrieved with git then initializing the database will fail.

This commit uses an example email address as a fallback so that the database seed can always be applied. We also update the README to document the behaviour of the submission emails for test forms.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
