### PR TITLE
Fix content for none of the above option when adding and editing routes

### DIFF
--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -53,7 +53,7 @@ module PageListComponent
 
     def answer_value_text_for_condition(condition)
       if condition.answer_value.present?
-        answer_value = condition.answer_value == :none_of_the_above.to_s ? I18n.t("page_conditions.none_of_the_above") : condition.answer_value
+        answer_value = condition.answer_value == Condition::NONE_OF_THE_ABOVE ? I18n.t("page_conditions.none_of_the_above") : condition.answer_value
         I18n.t("page_conditions.condition_answer_value_text", answer_value:)
       else
         I18n.t("page_conditions.condition_answer_value_text_with_errors")
@@ -62,7 +62,7 @@ module PageListComponent
 
     def answer_value_text_for_condition2(condition)
       if condition.answer_value.present?
-        answer_value = condition.answer_value == :none_of_the_above.to_s ? I18n.t("page_conditions.none_of_the_above") : condition.answer_value
+        answer_value = condition.answer_value == Condition::NONE_OF_THE_ABOVE ? I18n.t("page_conditions.none_of_the_above") : condition.answer_value
         I18n.t("page_conditions.condition_answer_value_text2", answer_value:)
       else
         I18n.t("page_conditions.condition_answer_value_text_with_errors")

--- a/app/input_objects/pages/conditions_input.rb
+++ b/app/input_objects/pages/conditions_input.rb
@@ -41,7 +41,7 @@ class Pages::ConditionsInput < BaseInput
 
   def routing_answer_options
     options = page.answer_settings.selection_options.map { |option| OpenStruct.new(value: option[:name], label: option[:name]) }
-    options << OpenStruct.new(value: :none_of_the_above.to_s, label: I18n.t("page_conditions.none_of_the_above")) if page.is_optional
+    options << OpenStruct.new(value: Condition::NONE_OF_THE_ABOVE, label: I18n.t("page_conditions.none_of_the_above")) if page.is_optional
 
     options
   end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -2,6 +2,8 @@ class Condition < ApplicationRecord
   include ConditionMethods
   extend Mobility
 
+  NONE_OF_THE_ABOVE = :none_of_the_above.to_s
+
   belongs_to :routing_page, class_name: "Page"
   belongs_to :check_page, class_name: "Page", optional: true
   belongs_to :goto_page, class_name: "Page", optional: true
@@ -52,7 +54,7 @@ class Condition < ApplicationRecord
     return nil if has_precondition? && answer_value.nil?
 
     answer_options = check_page&.answer_settings&.dig("selection_options")&.pluck("name")
-    return nil if answer_options.blank? || answer_options.include?(answer_value) || answer_value == :none_of_the_above.to_s && check_page.is_optional?
+    return nil if answer_options.blank? || answer_options.include?(answer_value) || answer_value == NONE_OF_THE_ABOVE && check_page.is_optional?
 
     DataStruct.new(name: "answer_value_doesnt_exist")
   end

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -74,6 +74,12 @@ private
                        goto_question_name(routing_condition.goto_page_id)
                      end
 
+    answer_value_text = if routing_condition.answer_value == Condition::NONE_OF_THE_ABOVE
+                          I18n.t("page_route_card.none_of_the_above")
+                        else
+                          routing_condition.answer_value
+                        end
+
     check_value_error = format_error(I18n.t("page_route_card.errors.answer_value_doesnt_exist")) if routing_condition.validation_errors.any? { |error| error.name == "answer_value_doesnt_exist" }
     goto_page_next_error = format_error(I18n.t("page_route_card.errors.cannot_route_to_next_page")) if routing_condition.validation_errors.any? { |error| error.name == "cannot_route_to_next_page" }
     goto_page_before_error = format_error(I18n.t("page_route_card.errors.cannot_have_goto_page_before_routing_page", question_number: question_number(routing_condition.check_page_id))) if routing_condition.validation_errors.any? { |error| error.name == "cannot_have_goto_page_before_routing_page" }
@@ -91,7 +97,7 @@ private
         {
           key: { text: I18n.t("page_route_card.if_answer_is") },
           html_attributes: { id: check_id(routing_condition), class: check_value_error ? "govuk-summary-list__row--error" : "" },
-          value: { text: safe_join([check_value_error, routing_condition.answer_value]) },
+          value: { text: safe_join([check_value_error, answer_value_text]) },
         },
         {
           key: { text: I18n.t("page_route_card.take_the_person_to") },

--- a/app/presenters/route_summary_card_data_presenter.rb
+++ b/app/presenters/route_summary_card_data_presenter.rb
@@ -91,7 +91,7 @@ private
         {
           key: { text: I18n.t("page_route_card.if_answer_is") },
           html_attributes: { id: check_id(routing_condition), class: check_value_error ? "govuk-summary-list__row--error" : "" },
-          value: { text: safe_join([check_value_error, I18n.t("page_route_card.conditional_answer_value", answer_value: routing_condition.answer_value)]) },
+          value: { text: safe_join([check_value_error, routing_condition.answer_value]) },
         },
         {
           key: { text: I18n.t("page_route_card.take_the_person_to") },

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -3,7 +3,7 @@
 # based on the pages and conditions.
 class Routes::BuildService
   END_OF_FORM_OPTION = [I18n.t("page_conditions.end_of_form"), Forms::RouteInput::END_OF_FORM_VALUE].freeze
-  NONE_OF_THE_ABOVE_OPTION = DataStruct.new(value: :none_of_the_above.to_s, name: I18n.t("page_conditions.none_of_the_above"))
+  NONE_OF_THE_ABOVE_OPTION = DataStruct.new(value: Condition::NONE_OF_THE_ABOVE, name: I18n.t("page_conditions.none_of_the_above"))
 
   attr_reader :form
 

--- a/app/services/step_summary_card_service.rb
+++ b/app/services/step_summary_card_service.rb
@@ -267,7 +267,7 @@ private
   end
 
   def format_answer_value(answer_value)
-    answer_value = I18n.t("page_conditions.none_of_the_above") if answer_value == "none_of_the_above"
+    answer_value = I18n.t("page_conditions.none_of_the_above") if answer_value == Condition::NONE_OF_THE_ABOVE
     ActionController::Base.helpers.sanitize(answer_value)
   end
 

--- a/app/views/pages/conditions/delete.html.erb
+++ b/app/views/pages/conditions/delete.html.erb
@@ -28,7 +28,7 @@
         end;
         summary_list.with_row do |row|
           row.with_key(text: t(".answered_as_key"))
-          row.with_value { delete_condition_input.answer_value }
+          row.with_value { delete_condition_input.answer_value == Condition::NONE_OF_THE_ABOVE ? t(".none_of_the_above") : delete_condition_input.answer_value }
         end;
         summary_list.with_row do |row|
           row.with_key(text: t(".skip_to_key"))

--- a/app/views/pages/secondary_skip/_form.html.erb
+++ b/app/views/pages/secondary_skip/_form.html.erb
@@ -16,7 +16,7 @@
   <%= govuk_summary_list(actions: false) do |summary_list|
     summary_list.with_row(classes: "govuk-summary-list__row--no-border") do |row|
       row.with_key { t("secondary_skip.new.primary_route_answer_key") }
-      row.with_value { secondary_skip_input.answer_value }
+      row.with_value { secondary_skip_input.answer_value == Condition::NONE_OF_THE_ABOVE ? t("secondary_skip.none_of_the_above") : secondary_skip_input.answer_value }
     end;
     summary_list.with_row do |row|
       row.with_key { t("secondary_skip.new.primary_route_continue_key") }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1479,6 +1479,7 @@ en:
       cannot_route_to_next_page_secondary_skip: The route for any other answer is not skipping any questions - edit or delete this route
     goto_page_invalid: Edit this route to select the question or page you want to take the person to, or delete the route
     if_answer_is: If the answer is
+    none_of_the_above: None of the above
     question_name_long: "%{question_number}. %{question_text}"
     question_name_short: Question %{question_number}
     route_title: Route %{route_number}
@@ -1618,6 +1619,7 @@ en:
         any_other_answer_warning: If you delete this route, the route for any other answer will also be deleted
         delete_condition_legend: Are you sure you want to delete this route?
         exit_page_warning: If you delete this route, the exit page it goes to will also be deleted
+        none_of_the_above: None of the above
         skip_to_key: skip the person to
       edit:
         back_link: Back to question %{question_number}’s routes
@@ -2012,6 +2014,7 @@ en:
         <p>If you need to, you can make them skip one or more consecutive questions that only people on route %{route_number} need to answer.</p>
       primary_route_answer_key: If the answer is
       primary_route_continue_key: skip the person to
+    none_of_the_above: None of the above
   selection_none_of_the_above:
     preamble: If someone selects ‘None of the above’, we’ll show them a text box to enter their answer.
     preamble_more_than_30_options: If someone selects ‘None of the above’, we’ll show them a text box to enter their answer. If your list has over 30 options, we’ll show this text box on the next page of the form.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1466,7 +1466,6 @@ en:
     unconditional_skip_to_end_text: Go to the end of the form
   page_route_card:
     any_other_answer: Route for any other answer
-    conditional_answer_value: "%{answer_value}"
     continue_to: Continue to
     delete: Delete
     delete_route: Delete all routes

--- a/spec/input_objects/pages/conditions_input_spec.rb
+++ b/spec/input_objects/pages/conditions_input_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Pages::ConditionsInput, type: :model do
         expect(result).to eq([
           OpenStruct.new(value: "Option 1", label: "Option 1"),
           OpenStruct.new(value: "Option 2", label: "Option 2"),
-          OpenStruct.new(value: :none_of_the_above.to_s,
+          OpenStruct.new(value: Condition::NONE_OF_THE_ABOVE,
                          label: I18n.t("page_conditions.none_of_the_above")),
         ])
       end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe Condition, type: :model do
     end
 
     context "when answer_value is 'None of the above" do
-      let(:condition) { create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, answer_value: :none_of_the_above.to_s }
+      let(:condition) { create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, answer_value: Condition::NONE_OF_THE_ABOVE }
       let(:check_page) { create :page, :with_selection_settings, form:, is_optional: }
 
       context "and routing page has 'None of the above' as an option" do

--- a/spec/presenters/route_summary_card_data_presenter_spec.rb
+++ b/spec/presenters/route_summary_card_data_presenter_spec.rb
@@ -46,6 +46,19 @@ describe RouteSummaryCardDataPresenter do
       end
     end
 
+    context "when the condition is for the none of the above answer" do
+      before do
+        page.update!(is_optional: true)
+        create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: pages.last.id, answer_value: Condition::NONE_OF_THE_ABOVE
+        pages.each(&:reload)
+      end
+
+      it "includes 'None of the above'" do
+        result = service.summary_card_data
+        expect(result[0][:rows][0][:value][:text]).to eq "None of the above"
+      end
+    end
+
     context "when the condition has an exit page data" do
       let!(:condition) { create :condition, :with_exit_page, routing_page_id: page.id, check_page_id: page.id, answer_value: "Option 1" }
 

--- a/spec/services/step_summary_card_service_spec.rb
+++ b/spec/services/step_summary_card_service_spec.rb
@@ -309,7 +309,7 @@ describe StepSummaryCardService do
 
         before do
           page.update!(is_optional: true)
-          create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: goto_page.id, answer_value: "none_of_the_above"
+          create :condition, routing_page_id: page.id, check_page_id: page.id, goto_page_id: goto_page.id, answer_value: Condition::NONE_OF_THE_ABOVE
 
           page.reload
           form.reload.make_live!

--- a/spec/views/pages/conditions/delete.html.erb_spec.rb
+++ b/spec/views/pages/conditions/delete.html.erb_spec.rb
@@ -33,6 +33,23 @@ describe "pages/conditions/delete.html.erb" do
     expect(rendered).to have_css(".govuk-summary-list__value", text: delete_condition_input.goto_page_question_text)
   end
 
+  context "when the condition is for a 'none of the above' answer" do
+    let(:condition) { create :condition, id: 1, routing_page_id: pages.first.id, check_page_id: pages.first.id, goto_page_id: pages.last.id, answer_value: Condition::NONE_OF_THE_ABOVE }
+
+    let(:page) do
+      page = pages.first
+      page.update!(is_optional: true)
+      page
+    end
+
+    it "contains the condition details" do
+      expect(rendered).to have_css(".govuk-summary-list__row") do |row|
+        row.has_css?(".govuk-summary-list__key", exact_text: "is answered as") &&
+          row.has_css?(".govuk-summary-list__value", exact_text: "None of the above")
+      end
+    end
+  end
+
   it "has a submit button" do
     expect(rendered).to have_css("button[type='submit'].govuk-button", text: I18n.t("save_and_continue"))
   end

--- a/spec/views/pages/secondary_skip/new.html.erb_spec.rb
+++ b/spec/views/pages/secondary_skip/new.html.erb_spec.rb
@@ -40,4 +40,33 @@ describe "pages/secondary_skip/new.html.erb" do
     expect(rendered).to have_selector("h1", text: "Question 1’s routes")
     expect(rendered).to have_selector("h1", text: I18n.t("page_titles.new_secondary_skip", route_index: 2))
   end
+
+  context "when the condition is for a 'none of the above' answer" do
+    let(:page) do
+      page = build(
+        :page,
+        :with_selection_settings,
+        id: 1,
+        position: 1,
+        answer_settings: DataStruct.new(
+          only_one_option: true,
+          selection_options: [
+            OpenStruct.new(attributes: { name: "Option 1" }),
+            OpenStruct.new(attributes: { name: "Option 2" }),
+          ],
+        ),
+      )
+      page.routing_conditions = [
+        build(:condition, id: 1, routing_page: page, check_page: page, goto_page_id: 2, skip_to_end: false, answer_value: Condition::NONE_OF_THE_ABOVE),
+      ]
+      page
+    end
+
+    it "has the correct answer value text" do
+      expect(rendered).to have_selector(".govuk-summary-list__row") do |row|
+        row.has_css?(".govuk-summary-list__key", exact_text: "If the answer is") &&
+          row.has_css?(".govuk-summary-list__value", exact_text: "None of the above")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

While working on multiple branches, we noticed that the existing routing implementation is missing content for the situation when the answer value for a condition is the none of the above option for an optional selection question; the pages rendered the answer value as `none_of_the_above`.

This PR adds the missing content.

### Screenshots

#### Showing a route

<img width="1085" height="1455" alt="Screenshot of http://localhost:3000/forms/8/pages/31/routes" src="https://github.com/user-attachments/assets/8cb44fd0-49e3-4e47-b5fb-e199a94a440a" />

#### Deleting a route

<img width="1085" height="1285" alt="Screenshot of http://localhost:3000/forms/8/pages/31/conditions/11/delete" src="https://github.com/user-attachments/assets/5d0cc188-25b3-4aed-87f8-107dbf4fe32b" />

#### Adding a secondary skip to a route

<img width="1085" height="1622" alt="Screenshot of http://localhost:3000/forms/8/pages/31/routes/any-other-answer/questions-to-skip/new" src="https://github.com/user-attachments/assets/bf8df944-a6a8-4a41-9588-93aeb0dda2de" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
