### PR TITLE
Add tasks for making individual languages live

### DIFF
--- a/app/controllers/forms/make_language_live_controller.rb
+++ b/app/controllers/forms/make_language_live_controller.rb
@@ -56,7 +56,7 @@ module Forms
     end
 
     def render_new(status: :ok)
-      render "new", status:, locals: { current_form:, language: params[:language] }
+      render "new", status:, locals: { current_form:, language: params[:language], page_title: new_page_title, page_body: new_page_body }
     end
 
     def render_confirmation(status: :ok)
@@ -72,6 +72,22 @@ module Forms
 
     def go_to_make_welsh_live_input_params
       params.require(:forms_go_to_make_welsh_live_input).permit(:confirm)
+    end
+
+    def new_page_title
+      return I18n.t("page_titles.make_your_changes_to_english_live") if making_english_changes_live?
+
+      I18n.t("page_titles.make_language_live.#{params[:language]}")
+    end
+
+    def new_page_body
+      return t("make_language_live.en.make_your_changes_to_english_live.body_html", submission_email: @current_form.submission_email) if making_english_changes_live?
+
+      t("make_language_live.#{params[:language]}.new.body_html", submission_email: @current_form.submission_email)
+    end
+
+    def making_english_changes_live?
+      @current_form.is_live? && params[:language] == "en"
     end
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -232,6 +232,16 @@ class Form < ApplicationRecord
     can_make_welsh_version_live? if language == "cy"
   end
 
+  def changed_from_live_version?(language:)
+    live_document = language == "cy" ? live_welsh_form_document : live_form_document
+    return false if live_document.blank?
+
+    ignored_keys = %w[live_at available_languages updated_at]
+    return false if live_document.content.except(*ignored_keys) == as_form_document(language:).except(*ignored_keys)
+
+    true
+  end
+
 private
 
   def set_external_id
@@ -296,7 +306,15 @@ private
   end
 
   def can_make_welsh_version_live?
-    has_live_version && all_ready_for_live? && welsh_completed? && live_form_document.present? && live_welsh_form_document.blank?
+    english_version_has_been_made_live? && !changed_from_live_version?(language: "en") && welsh_version_ready? && live_welsh_form_document.blank?
+  end
+
+  def english_version_has_been_made_live?
+    has_live_version && live_form_document.present?
+  end
+
+  def welsh_version_ready?
+    all_ready_for_live? && welsh_completed?
   end
 
   def after_archive

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -224,9 +224,12 @@ private
   def make_only_english_live_task
     status = @task_statuses[:make_only_english_live_status]
     can_make_form_live = status == :not_started
+    english_changes_to_make_live = @form.is_live? && @form.changed_from_live_version?(language: "en")
+
+    task_name = english_changes_to_make_live ? I18n.t("forms.task_list_edit.make_form_live_section.make_english_form_live") : I18n.t("forms.task_list_create.make_form_live_section.make_english_form_live")
 
     {
-      task_name: I18n.t("forms.task_list_create.make_form_live_section.make_english_form_live"),
+      task_name:,
       path: can_make_form_live ? make_language_live_path(@form.id, language: "en") : "",
       status:,
       active: can_make_form_live,

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -193,14 +193,20 @@ private
 
   def make_form_live_section_tasks
     [
-      {
-        task_name: share_preview_task_name,
-        path: share_preview_path(@form.id),
-        status: @task_statuses[:share_preview_status],
-        active: @form.pages.any?,
-      },
-      make_live_task,
-    ]
+      share_preview_task,
+      (make_live_task unless display_make_languages_live_tasks?),
+      (make_only_english_live_task if display_make_languages_live_tasks?),
+      (make_only_welsh_live_task if display_make_languages_live_tasks?),
+    ].compact
+  end
+
+  def share_preview_task
+    {
+      task_name: share_preview_task_name,
+      path: share_preview_path(@form.id),
+      status: @task_statuses[:share_preview_status],
+      active: @form.pages.any?,
+    }
   end
 
   def make_live_task
@@ -213,6 +219,34 @@ private
       status: status,
       active: can_make_form_live,
     }
+  end
+
+  def make_only_english_live_task
+    status = @task_statuses[:make_only_english_live_status]
+    can_make_form_live = status == :not_started
+
+    {
+      task_name: I18n.t("forms.task_list_create.make_form_live_section.make_english_form_live"),
+      path: can_make_form_live ? make_language_live_path(@form.id, language: "en") : "",
+      status:,
+      active: can_make_form_live,
+    }
+  end
+
+  def make_only_welsh_live_task
+    status = @task_statuses[:make_only_welsh_live_status]
+    can_make_form_live = status == :not_started
+
+    {
+      task_name: I18n.t("forms.task_list_create.make_form_live_section.make_welsh_form_live"),
+      path: can_make_form_live ? make_language_live_path(@form.id, language: "cy") : "",
+      status:,
+      active: can_make_form_live,
+    }
+  end
+
+  def display_make_languages_live_tasks?
+    @form.live_welsh_form_document.blank? && @form.has_welsh_translation?
   end
 
   def live_title_name

--- a/app/services/task_status_service.rb
+++ b/app/services/task_status_service.rb
@@ -142,8 +142,8 @@ private
   end
 
   def make_only_english_live_status
+    return :completed if @form.has_live_version && !@form.changed_from_live_version?(language: "en")
     return :not_started if @form.can_make_language_live?(language: "en")
-    return :completed if @form.state == "live"
 
     :cannot_start
   end

--- a/app/services/task_status_service.rb
+++ b/app/services/task_status_service.rb
@@ -36,6 +36,8 @@ class TaskStatusService
       batch_submissions_status:,
       share_preview_status:,
       make_live_status:,
+      make_only_english_live_status:,
+      make_only_welsh_live_status:,
       welsh_language_status:,
       submission_email_status:,
       confirm_submission_email_status:,
@@ -137,6 +139,20 @@ private
     return :not_started if @form.has_been_archived
 
     :completed if @form.has_live_version
+  end
+
+  def make_only_english_live_status
+    return :not_started if @form.can_make_language_live?(language: "en")
+    return :completed if @form.state == "live"
+
+    :cannot_start
+  end
+
+  def make_only_welsh_live_status
+    return :not_started if @form.can_make_language_live?(language: "cy")
+    return :completed if @form.live_welsh_form_document.present?
+
+    :cannot_start
   end
 
   def make_live_status_for_draft

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -73,7 +73,7 @@ module FormStateMachine
         before :before_make_english_live
         after :after_make_english_live
 
-        transitions from: %i[draft live live_with_draft archived_with_draft], to: :live, guard: :can_make_english_version_live?
+        transitions from: %i[draft live live_with_draft archived_with_draft], to: :live_with_draft, guard: :can_make_english_version_live?
       end
 
       event :make_welsh_version_live do

--- a/app/views/forms/make_language_live/new.html.erb
+++ b/app/views/forms/make_language_live/new.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(title_with_error_prefix(t("page_titles.make_language_live.#{language}"), @make_language_live_input.errors.any?)) %>
+<% set_page_title(title_with_error_prefix((page_title), @make_language_live_input.errors.any?)) %>
 <% content_for :back_link, govuk_back_link_to(form_path, t("back_link.form_create")) %>
 
 <div class="govuk-grid-row">
@@ -10,10 +10,10 @@
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= @make_language_live_input.form.name %></span>
-        <%= t("page_titles.make_language_live.#{language}") %>
+        <%= page_title %>
       </h1>
 
-      <%= t("make_language_live.#{language}.new.body_html", submission_email: @make_language_live_input.form.submission_email) %>
+      <%= page_body %>
 
       <%= f.govuk_collection_radio_buttons :confirm,
                                            @make_language_live_input.values, ->(option) { option }, ->(option) { t("helpers.label.confirm_action_input.options.#{option}") },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -590,6 +590,7 @@ en:
           submission_attachments: Get a CSV or JSON file of each completed form
         title: Change how you get completed forms
       make_form_live_section:
+        make_english_form_live: Make changes to your English form live
         make_live: Make your changes live
         share_preview: Share a preview of your draft form
         title: Make your changes live
@@ -1237,6 +1238,10 @@ en:
           <p>The form will not be indexed by search engines, so people will not be able to find it easily. Contact your GOV.UK publishing team to publish links to your form on GOV.UK so people can find it.</p>
           <p>Completed forms will be sent to: <span class="govuk-!-text-break-word">%{submission_email}</span></p>
     en:
+      make_your_changes_to_english_live:
+        body_html: |
+          <p>The form will not be indexed by search engines, so people will not be able to find it easily. Contact your GOV.UK publishing team to publish links to your form on GOV.UK so people can find it.</p>
+          <p>Completed forms will be sent to: <span class="govuk-!-text-break-word">%{submission_email}</span></p>
       new:
         body_html: |
           <p>When you make your form live you’ll get a new URL for the English version.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -554,7 +554,9 @@ en:
 
               A group admin can request to upgrade the group so forms can be made live. You can <a href="%{group_members_path}">view the members of the group</a> to find a group admin.
           no_org_admin: You cannot make this form live because it’s in a ‘trial’ group.
+        make_english_form_live: Make your English form live
         make_live: Make your form live
+        make_welsh_form_live: Make your Welsh form live
         share_preview: Share a preview of your draft form
         title: Make your form live
         user_cannot_administer:

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1644,13 +1644,43 @@ RSpec.describe Form, type: :model do
             context "when the Welsh task is still in progress" do
               let(:form) { create :form, :ready_for_live, :with_welsh_translation, state: "live", welsh_completed: false }
 
-              it "returns true" do
+              it "returns false" do
                 expect(form.can_make_language_live?(language:)).to be false
               end
             end
 
             context "when the Welsh task is complete" do
               let(:form) { create :form, :ready_for_live, :with_welsh_translation, state: "live" }
+
+              it "returns true" do
+                expect(form.can_make_language_live?(language:)).to be true
+              end
+
+              context "when there are changes which have not yet been made live on the English version" do
+                before do
+                  form.name = "A new form name"
+                  form.save_draft!
+
+                  form.share_preview_completed = true
+                  form.save_draft!
+                end
+
+                it "returns false" do
+                  expect(form.can_make_language_live?(language:)).to be false
+                end
+              end
+            end
+
+            context "when the Welsh task has been completed since the English form was made live" do
+              let(:form) { create :form, :ready_for_live, :with_welsh_translation, state: "live", welsh_completed: false }
+
+              before do
+                form.welsh_completed = true
+                form.save_draft!
+
+                form.share_preview_completed = true
+                form.save_draft!
+              end
 
               it "returns true" do
                 expect(form.can_make_language_live?(language:)).to be true

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1020,6 +1020,8 @@ RSpec.describe Form, type: :model do
         welsh_language_status: :optional,
         share_preview_status: :completed,
         make_live_status: :completed,
+        make_only_english_live_status: :completed,
+        make_only_welsh_live_status: :cannot_start,
       }
       expect(form.all_task_statuses).to eq expected_hash
     end

--- a/spec/requests/forms/make_language_live_controller_spec.rb
+++ b/spec/requests/forms/make_language_live_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Forms::MakeLanguageLiveController, type: :request do
             expect {
               post(make_language_live_path(form_id: form.id, language:), params: form_params)
             }.to change { FormDocument.where(language:).count }.by(1)
-            .and change { form.reload.state }.to("live")
+            .and change { form.reload.state }.to("live_with_draft")
           end
 
           it "sets the English FormDocument's live_at time to be equal to the form's updated_at time" do
@@ -127,7 +127,7 @@ RSpec.describe Forms::MakeLanguageLiveController, type: :request do
             expect {
               post(make_language_live_path(form_id: form.id, language:), params: form_params)
             }.to change { FormDocument.where(language:).count }.by(1)
-            .and change { form.reload.state }.to("live")
+            .and change { form.reload.state }.to("live_with_draft")
           end
         end
       end

--- a/spec/requests/forms/make_language_live_controller_spec.rb
+++ b/spec/requests/forms/make_language_live_controller_spec.rb
@@ -24,14 +24,19 @@ RSpec.describe Forms::MakeLanguageLiveController, type: :request do
       get make_language_live_path(form_id: form.id, language:)
       expect(response).to render_template("make_language_live/new")
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include(I18n.t("page_titles.make_language_live.en"))
+      expect(response.body).to include(I18n.t("make_language_live.en.new.body_html", submission_email: form.submission_email))
     end
 
     context "when editing a draft of an existing live form" do
-      let(:form) { create(:form, :live) }
+      let(:form) { create(:form, :live_with_draft) }
 
-      it "redirects to the form task list" do
+      it "renders make your form live" do
         get make_language_live_path(form_id: form.id, language:)
-        expect(response).to redirect_to(form_path(form_id: form.id))
+        expect(response).to render_template("make_language_live/new")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("page_titles.make_your_changes_to_english_live"))
+        expect(response.body).to include(I18n.t("make_language_live.en.make_your_changes_to_english_live.body_html", submission_email: form.submission_email))
       end
     end
 

--- a/spec/services/form_task_list_service_spec.rb
+++ b/spec/services/form_task_list_service_spec.rb
@@ -492,7 +492,7 @@ describe FormTaskListService do
 
             context "when form is live" do
               before do
-                allow(form).to receive(:is_live?).and_return(true)
+                allow(form).to receive_messages(is_live?: true, has_live_version: true)
               end
 
               it "has tasks" do
@@ -512,28 +512,65 @@ describe FormTaskListService do
                   allow(form).to receive(:has_welsh_translation?).and_return(true)
                 end
 
-                it "has a link to make the English form live" do
-                  expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_english_form_live")
-                  expect(section_rows.second[:path]).to eq "/forms/#{form.id}/make-live/en"
-                  expect(section_rows.second[:status]).to eq :not_started
-                end
-
-                it "has the make Welsh live task without a link" do
-                  expect(section_rows.third[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_welsh_form_live")
-                  expect(section_rows.third[:path]).to eq ""
-                  expect(section_rows.third[:status]).to eq :cannot_start
-                end
-
-                context "when the Welsh version can be made live" do
+                context "when the form has English changes that are not yet live" do
                   before do
-                    allow(form).to receive(:can_make_language_live?).with(language: "en").and_return(true)
-                    allow(form).to receive(:can_make_language_live?).with(language: "cy").and_return(true)
+                    allow(form).to receive(:changed_from_live_version?).with(language: "en").and_return(true)
                   end
 
-                  it "has a link to make the Welsh form live" do
-                    expect(section_rows.third[:task_name]).to eq "Make your Welsh form live"
-                    expect(section_rows.third[:path]).to eq "/forms/#{form.id}/make-live/cy"
-                    expect(section_rows.third[:status]).to eq :not_started
+                  it "has a link to make the English form live" do
+                    expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_edit.make_form_live_section.make_english_form_live")
+                    expect(section_rows.second[:path]).to eq "/forms/#{form.id}/make-live/en"
+                    expect(section_rows.second[:status]).to eq :not_started
+                  end
+
+                  it "has the make Welsh live task without a link" do
+                    expect(section_rows.third[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_welsh_form_live")
+                    expect(section_rows.third[:path]).to eq ""
+                    expect(section_rows.third[:status]).to eq :cannot_start
+                  end
+
+                  context "when the Welsh version can be made live" do
+                    before do
+                      allow(form).to receive(:can_make_language_live?).with(language: "en").and_return(true)
+                      allow(form).to receive(:can_make_language_live?).with(language: "cy").and_return(true)
+                    end
+
+                    it "has a link to make the Welsh form live" do
+                      expect(section_rows.third[:task_name]).to eq "Make your Welsh form live"
+                      expect(section_rows.third[:path]).to eq "/forms/#{form.id}/make-live/cy"
+                      expect(section_rows.third[:status]).to eq :not_started
+                    end
+                  end
+                end
+
+                context "when the form has no draft English changes" do
+                  before do
+                    allow(form).to receive(:changed_from_live_version?).with(language: "en").and_return(false)
+                  end
+
+                  it "has the make English live task without a link" do
+                    expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_english_form_live")
+                    expect(section_rows.second[:path]).to eq ""
+                    expect(section_rows.second[:status]).to eq :completed
+                  end
+
+                  it "has the make Welsh live task without a link" do
+                    expect(section_rows.third[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_welsh_form_live")
+                    expect(section_rows.third[:path]).to eq ""
+                    expect(section_rows.third[:status]).to eq :cannot_start
+                  end
+
+                  context "when the Welsh version can be made live" do
+                    before do
+                      allow(form).to receive(:can_make_language_live?).with(language: "en").and_return(true)
+                      allow(form).to receive(:can_make_language_live?).with(language: "cy").and_return(true)
+                    end
+
+                    it "has a link to make the Welsh form live" do
+                      expect(section_rows.third[:task_name]).to eq "Make your Welsh form live"
+                      expect(section_rows.third[:path]).to eq "/forms/#{form.id}/make-live/cy"
+                      expect(section_rows.third[:status]).to eq :not_started
+                    end
                   end
                 end
               end

--- a/spec/services/form_task_list_service_spec.rb
+++ b/spec/services/form_task_list_service_spec.rb
@@ -472,6 +472,22 @@ describe FormTaskListService do
               it "has the correct default status" do
                 expect(section_rows.second[:status]).to eq :not_started
               end
+
+              context "when the form has Welsh translations" do
+                let(:form) { create(:form, :ready_for_live, :with_welsh_translation, welsh_completed: false) }
+
+                it "has a link to make the English form live" do
+                  expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_english_form_live")
+                  expect(section_rows.second[:path]).to eq "/forms/#{form.id}/make-live/en"
+                  expect(section_rows.second[:status]).to eq :not_started
+                end
+
+                it "has the make Welsh live task without a link" do
+                  expect(section_rows.third[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_welsh_form_live")
+                  expect(section_rows.third[:path]).to eq ""
+                  expect(section_rows.third[:status]).to eq :cannot_start
+                end
+              end
             end
 
             context "when form is live" do
@@ -490,6 +506,37 @@ describe FormTaskListService do
               it "describes the task correctly" do
                 expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_edit.make_form_live_section.make_live")
               end
+
+              context "when the form has a draft with welsh translations" do
+                before do
+                  allow(form).to receive(:has_welsh_translation?).and_return(true)
+                end
+
+                it "has a link to make the English form live" do
+                  expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_english_form_live")
+                  expect(section_rows.second[:path]).to eq "/forms/#{form.id}/make-live/en"
+                  expect(section_rows.second[:status]).to eq :not_started
+                end
+
+                it "has the make Welsh live task without a link" do
+                  expect(section_rows.third[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_welsh_form_live")
+                  expect(section_rows.third[:path]).to eq ""
+                  expect(section_rows.third[:status]).to eq :cannot_start
+                end
+
+                context "when the Welsh version can be made live" do
+                  before do
+                    allow(form).to receive(:can_make_language_live?).with(language: "en").and_return(true)
+                    allow(form).to receive(:can_make_language_live?).with(language: "cy").and_return(true)
+                  end
+
+                  it "has a link to make the Welsh form live" do
+                    expect(section_rows.third[:task_name]).to eq "Make your Welsh form live"
+                    expect(section_rows.third[:path]).to eq "/forms/#{form.id}/make-live/cy"
+                    expect(section_rows.third[:status]).to eq :not_started
+                  end
+                end
+              end
             end
 
             context "when the form is archived" do
@@ -498,6 +545,26 @@ describe FormTaskListService do
               it "has link to make the form live" do
                 expect(section_rows.second[:task_name]).to eq "Make your form live"
                 expect(section_rows.second[:path]).to eq "/forms/#{form.id}/make-live"
+              end
+
+              context "when the form has a draft with welsh translations" do
+                let(:form) { create(:form, :archived_with_draft) }
+
+                before do
+                  allow(form).to receive(:has_welsh_translation?).and_return(true)
+                end
+
+                it "has a link to make the English form live" do
+                  expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_english_form_live")
+                  expect(section_rows.second[:path]).to eq "/forms/#{form.id}/make-live/en"
+                  expect(section_rows.second[:status]).to eq :not_started
+                end
+
+                it "has the make Welsh live task without a link" do
+                  expect(section_rows.third[:task_name]).to eq I18n.t("forms.task_list_create.make_form_live_section.make_welsh_form_live")
+                  expect(section_rows.third[:path]).to eq ""
+                  expect(section_rows.third[:status]).to eq :cannot_start
+                end
               end
             end
           end

--- a/spec/services/make_form_live_service_spec.rb
+++ b/spec/services/make_form_live_service_spec.rb
@@ -64,7 +64,7 @@ describe MakeFormLiveService do
         it "makes the English form live" do
           expect {
             make_form_live_service.make_language_live
-          }.to change(current_form, :state).to("live")
+          }.to change(current_form, :state).to("live_with_draft")
           .and change(FormDocument.where(form: current_form, tag: "live", language: "en"), :count).by(1)
           .and not_change(FormDocument.where(form: current_form, tag: "live", language: "cy"), :count)
         end
@@ -80,7 +80,7 @@ describe MakeFormLiveService do
       let(:language) { "cy" }
 
       context "when the form has a live English version" do
-        let(:current_form) { create :form, :ready_for_live, :with_welsh_translation}
+        let(:current_form) { create :form, :ready_for_live, :with_welsh_translation }
 
         before do
           current_form.make_english_version_live!

--- a/spec/services/make_form_live_service_spec.rb
+++ b/spec/services/make_form_live_service_spec.rb
@@ -80,10 +80,10 @@ describe MakeFormLiveService do
       let(:language) { "cy" }
 
       context "when the form has a live English version" do
-        let(:current_form) { create :form, :ready_for_live, :with_welsh_translation, state: "live" }
+        let(:current_form) { create :form, :ready_for_live, :with_welsh_translation}
 
         before do
-          create :form_document, :live, form: current_form, language: "en", content: current_form.as_form_document
+          current_form.make_english_version_live!
         end
 
         it "makes the Welsh form live" do

--- a/spec/services/task_status_service_spec.rb
+++ b/spec/services/task_status_service_spec.rb
@@ -9,6 +9,10 @@ describe TaskStatusService do
 
   let(:current_user) { build(:user, role: :standard) }
 
+  before do
+    form.set_task_status_service(task_status_service)
+  end
+
   describe "statuses" do
     describe "name status" do
       let(:form) { build(:form, :new_form, :with_group, group:) }
@@ -391,6 +395,129 @@ describe TaskStatusService do
         end
       end
     end
+
+    describe "make_only_english_live_status" do
+      let(:can_make_english_live) { false }
+      let(:can_make_welsh_live) { false }
+
+      let(:form) { build(:form, :with_group, group:) }
+
+      before do
+        allow(form).to receive(:can_make_language_live?).with(language: "en").and_return(can_make_english_live)
+        allow(form).to receive(:can_make_language_live?).with(language: "cy").and_return(can_make_welsh_live)
+      end
+
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, :with_group, group:) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :cannot_start
+        end
+      end
+
+      context "when the English version can be made live" do
+        let(:can_make_english_live) { true }
+
+        it "returns not started" do
+          expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :not_started
+        end
+      end
+
+      context "when the English version cannot be made live" do
+        let(:can_make_english_live) { false }
+
+        context "when the form is live" do
+          let(:form) { build(:form, :live, :with_group, group:) }
+
+          it "returns completed" do
+            expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :completed
+          end
+        end
+
+        context "when the form is a draft" do
+          let(:form) { build(:form, :ready_for_live, :with_group, group:) }
+
+          it "returns cannot_start" do
+            expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :cannot_start
+          end
+        end
+
+        context "when the form is live with draft" do
+          let(:form) { build(:form, :live_with_draft, :with_group, group:) }
+
+          it "returns cannot_start" do
+            expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :cannot_start
+          end
+        end
+
+        context "when the form is archived" do
+          let(:form) { build(:form, :archived, :with_group, group:) }
+
+          it "returns cannot_start" do
+            expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :cannot_start
+          end
+        end
+
+        context "when the form is archived with draft" do
+          let(:form) { build(:form, :archived_with_draft, :with_group, group:) }
+
+          it "returns cannot_start" do
+            expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :cannot_start
+          end
+        end
+      end
+    end
+
+    describe "make_only_welsh_live_status" do
+      let(:can_make_english_live) { true }
+      let(:can_make_welsh_live) { false }
+
+      let(:form) { build(:form, :with_group, group:) }
+
+      before do
+        allow(form).to receive(:can_make_language_live?).with(language: "en").and_return(can_make_english_live)
+        allow(form).to receive(:can_make_language_live?).with(language: "cy").and_return(can_make_welsh_live)
+      end
+
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, :with_group, group:) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.all_task_statuses[:make_only_welsh_live_status]).to eq :cannot_start
+        end
+      end
+
+      context "when the Welsh version can be made live" do
+        let(:can_make_welsh_live) { true }
+
+        it "returns not started" do
+          expect(task_status_service.all_task_statuses[:make_only_welsh_live_status]).to eq :not_started
+        end
+      end
+
+      context "when the Welsh version cannot be made live" do
+        let(:can_make_welsh_live) { false }
+        let(:welsh_form_document) { build(:form_document, :live, form:, language: "cy", content: form.as_form_document) }
+
+        before do
+          allow(form).to receive(:live_welsh_form_document).and_return(welsh_form_document)
+        end
+
+        context "when the form already has a live Welsh version" do
+          it "returns completed" do
+            expect(task_status_service.all_task_statuses[:make_only_welsh_live_status]).to eq :completed
+          end
+        end
+
+        context "when the form does not have a live Welsh version" do
+          let(:welsh_form_document) { nil }
+
+          it "returns cannot start" do
+            expect(task_status_service.all_task_statuses[:make_only_welsh_live_status]).to eq :cannot_start
+          end
+        end
+      end
+    end
   end
 
   describe "#mandatory_tasks_completed" do
@@ -537,6 +664,8 @@ describe TaskStatusService do
         share_preview_status: :completed,
         submission_email_status: :completed,
         confirm_submission_email_status: :completed,
+        make_only_english_live_status: :completed,
+        make_only_welsh_live_status: :cannot_start,
       }
       expect(task_status_service.all_task_statuses).to eq expected_hash
     end

--- a/spec/services/task_status_service_spec.rb
+++ b/spec/services/task_status_service_spec.rb
@@ -399,11 +399,13 @@ describe TaskStatusService do
     describe "make_only_english_live_status" do
       let(:can_make_english_live) { false }
       let(:can_make_welsh_live) { false }
+      let(:changed_from_live_version) { false }
 
       let(:form) { build(:form, :with_group, group:) }
 
       before do
         allow(form).to receive(:can_make_language_live?).with(language: "en").and_return(can_make_english_live)
+        allow(form).to receive(:changed_from_live_version?).with(language: "en").and_return(changed_from_live_version)
         allow(form).to receive(:can_make_language_live?).with(language: "cy").and_return(can_make_welsh_live)
       end
 
@@ -434,16 +436,28 @@ describe TaskStatusService do
           end
         end
 
-        context "when the form is a draft" do
-          let(:form) { build(:form, :ready_for_live, :with_group, group:) }
+        context "when the form is live with draft" do
+          let(:form) { build(:form, :live_with_draft, :with_group, group:) }
 
-          it "returns cannot_start" do
-            expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :cannot_start
+          context "when there are changes from the English form document" do
+            let(:changed_from_live_version) { true }
+
+            it "returns cannot_start" do
+              expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :cannot_start
+            end
+          end
+
+          context "when there are no changes from the English form document" do
+            let(:changed_from_live_version) { false }
+
+            it "returns completed" do
+              expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :completed
+            end
           end
         end
 
-        context "when the form is live with draft" do
-          let(:form) { build(:form, :live_with_draft, :with_group, group:) }
+        context "when the form is a draft" do
+          let(:form) { build(:form, :ready_for_live, :with_group, group:) }
 
           it "returns cannot_start" do
             expect(task_status_service.all_task_statuses[:make_only_english_live_status]).to eq :cannot_start

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe FormStateMachine do
       end
 
       it "transitions to live state" do
-        expect(form).to transition_from(form_state).to(:live).on_event(:make_english_version_live)
+        expect(form).to transition_from(form_state).to(:live_with_draft).on_event(:make_english_version_live)
       end
 
       it "calls the before_make_english_live callback" do

--- a/spec/views/forms/make_language_live/new.html.erb_spec.rb
+++ b/spec/views/forms/make_language_live/new.html.erb_spec.rb
@@ -15,22 +15,24 @@ describe "forms/make_language_live/new.html.erb" do
 
   context "when there are no errors" do
     before do
-      render template: "forms/make_language_live/new", locals: { current_form:, language: }
+      render template: "forms/make_language_live/new", locals: { current_form:, language:, page_title:, page_body: }
     end
 
     context "when the language being made live is English" do
       let(:language) { "en" }
+      let(:page_title) { t("page_titles.make_language_live.en") }
+      let(:page_body) { t("make_language_live.en.new.body_html", submission_email: current_form.submission_email) }
 
       it "has the correct page title" do
-        expect(view.content_for(:title)).to eq t("page_titles.make_language_live.en")
+        expect(view.content_for(:title)).to eq page_title
       end
 
       it "contains a heading" do
-        expect(rendered).to have_css("h1", text: t("page_titles.make_language_live.en"))
+        expect(rendered).to have_css("h1", text: page_title)
       end
 
       it "contains the body text" do
-        expect(rendered).to include(t("make_language_live.en.new.body_html", submission_email: current_form.submission_email))
+        expect(rendered).to include page_body
       end
 
       it "renders radio buttons for making the draft changes live" do
@@ -46,17 +48,19 @@ describe "forms/make_language_live/new.html.erb" do
 
     context "when the language being made live is Welsh" do
       let(:language) { "cy" }
+      let(:page_title) { t("page_titles.make_language_live.cy") }
+      let(:page_body) { t("make_language_live.cy.new.body_html", submission_email: current_form.submission_email) }
 
       it "has the correct page title" do
-        expect(view.content_for(:title)).to eq t("page_titles.make_language_live.cy")
+        expect(view.content_for(:title)).to eq page_title
       end
 
       it "contains a heading" do
-        expect(rendered).to have_css("h1", text: t("page_titles.make_language_live.cy"))
+        expect(rendered).to have_css("h1", text: page_title)
       end
 
       it "contains the body text" do
-        expect(rendered).to include(t("make_language_live.cy.new.body_html", submission_email: current_form.submission_email))
+        expect(rendered).to include page_body
       end
 
       it "renders radio buttons for making the draft changes live" do
@@ -76,11 +80,13 @@ describe "forms/make_language_live/new.html.erb" do
       make_language_live_input.errors.add(:confirm, "An error")
 
       assign(:make_language_live_input, make_language_live_input)
-      render template: "forms/make_language_live/new", locals: { current_form:, language: }
+      render template: "forms/make_language_live/new", locals: { current_form:, language:, page_title:, page_body: }
     end
 
     context "when the language being made live is English" do
       let(:language) { "en" }
+      let(:page_title) { t("page_titles.make_language_live.en") }
+      let(:page_body) { t("make_language_live.en.new.body_html", submission_email: current_form.submission_email) }
 
       it "displays the error summary" do
         expect(rendered).to have_selector(".govuk-error-summary")
@@ -91,12 +97,14 @@ describe "forms/make_language_live/new.html.erb" do
       end
 
       it "sets the page title with error prefix" do
-        expect(view.content_for(:title)).to eq(title_with_error_prefix(t("page_titles.make_language_live.en"), true))
+        expect(view.content_for(:title)).to eq(title_with_error_prefix(page_title, true))
       end
     end
 
     context "when the language being made live is Welsh" do
       let(:language) { "cy" }
+      let(:page_title) { t("page_titles.make_language_live.cy") }
+      let(:page_body) { t("make_language_live.cy.new.body_html", submission_email: current_form.submission_email) }
 
       it "displays the error summary" do
         expect(rendered).to have_selector(".govuk-error-summary")
@@ -107,7 +115,7 @@ describe "forms/make_language_live/new.html.erb" do
       end
 
       it "sets the page title with error prefix" do
-        expect(view.content_for(:title)).to eq(title_with_error_prefix(t("page_titles.make_language_live.cy"), true))
+        expect(view.content_for(:title)).to eq(title_with_error_prefix(page_title, true))
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/nE8FUqW4/2892-separate-make-your-english-welsh-form-live-task-on-task-page

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds new tasks to the task list, which will appear when the form:

- has any Welsh content, and
- does not have a live Welsh version

These replace the existing make live task for Welsh forms.

### Screenshots
A form with Welsh content and an unpublished English version:
<img width="691" height="215" alt="image" src="https://github.com/user-attachments/assets/b62ff27d-b7ed-45ad-a5ee-c3a968780e4c" />

A form with Welsh content and unpublished English changes:
<img width="668" height="210" alt="image" src="https://github.com/user-attachments/assets/ed95801a-5d32-4fdc-86b2-1171436f21e9" />

A form with Welsh content and a live English version:
<img width="692" height="213" alt="image" src="https://github.com/user-attachments/assets/8aa65d16-3fa8-4d81-8760-d3c0225489f1" />

A draft form with no Welsh content:
<img width="680" height="164" alt="image" src="https://github.com/user-attachments/assets/824c56b8-c8f6-4051-905c-4a3f1735d0dd" />

A live form with a live Welsh version:
<img width="685" height="174" alt="image" src="https://github.com/user-attachments/assets/3fcaf6bc-3d15-4b9e-bda3-cf40a016a9fd" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
