### PR TITLE
Show routes welsh live archived pages

### DIFF
--- a/app/services/step_summary_card_presenter.rb
+++ b/app/services/step_summary_card_presenter.rb
@@ -34,6 +34,15 @@ class StepSummaryCardPresenter
     }
   end
 
+  def build_bilingual_table2
+    {
+      classes: %w[app-translation-table],
+      head: bilingual_table_header,
+      rows: step_summary_table_service.values_with_welsh_content2,
+      first_cell_is_header: true,
+    }
+  end
+
   def build_untranslated_content
     step_summary_table_service.untranslated_content
   end

--- a/app/services/step_summary_card_service.rb
+++ b/app/services/step_summary_card_service.rb
@@ -111,7 +111,7 @@ private
     return @step.show_selection_options unless @step.answer_settings.selection_options.length >= 1
 
     options = @step.answer_settings.selection_options.map(&:name)
-    options << I18n.t("step_summary_card.selection_type.none_of_the_above") if @step.is_optional?
+    options << I18n.t("step_summary_card.selection_type.none_of_the_above.en") if @step.is_optional?
     formatted_list = html_unordered_list(options)
 
     if options.length > 10

--- a/app/services/step_summary_table_service.rb
+++ b/app/services/step_summary_table_service.rb
@@ -24,6 +24,19 @@ class StepSummaryTableService
     rows
   end
 
+  def values_with_welsh_content2
+    rows = []
+
+    rows.push(page_heading_row) if @step.respond_to?(:page_heading) && @step.page_heading.present?
+    rows.push(guidance_markdown_row) if @step.respond_to?(:guidance_markdown) && @step.guidance_markdown.present?
+    rows.push(question_text_row) if @step.page_heading.present?
+    rows.push(hint_row) if @step.hint_text.present?
+    rows.concat(selection_rows) if @step.answer_type == "selection"
+    rows.concat(route_rows) if @step.routing_conditions.present?
+
+    rows
+  end
+
   def untranslated_content
     return text_row if @step.answer_type == "text"
     return date_row if @step.answer_type == "date"
@@ -116,6 +129,115 @@ private
       ]
     end
     rows
+  end
+
+  def route_rows
+    [[I18n.t("page_conditions.route2", count: number_of_routes), routes_value(@step.routing_conditions), welsh_routes_value(@step.routing_conditions)]]
+  end
+
+  def number_of_routes
+    if @step.routing_conditions.length == 1
+      1
+    else
+      answer_value_groups(@step.routing_conditions).length
+    end
+  end
+
+  def routes_value(conditions)
+    if conditions.first.answer_value.present?
+      print_routes(conditions)
+    else
+      print_unconditional_route(conditions.first)
+    end
+  end
+
+  def welsh_routes_value(conditions)
+    if conditions.first.answer_value.present?
+      print_welsh_routes(conditions)
+    else
+      print_welsh_unconditional_route(conditions.first)
+    end
+  end
+
+  def print_routes(conditions)
+    answer_value_groups = answer_value_groups(conditions)
+    answer_value_groups.map { |goto_page_id, condition_group|
+      if goto_page_id.nil?
+        caption = content_tag(:p, I18n.t("page_conditions.go_to_the_end"))
+      else
+        goto_question = @steps.find { |page| page.id == condition_group.first.goto_page_id }
+        goto_page_question_text = ActionController::Base.helpers.sanitize(goto_question.question_text)
+        goto_page_question_number = @steps.find_index(goto_question) + 1
+
+        caption = content_tag(:p, I18n.t("page_conditions.go_to_page", goto_page_question_number:, goto_page_question_text:))
+      end
+
+      answer_values = condition_group.map { |condition| "‘#{format_answer_value(condition.answer_value)}’" }
+      formatted_list = html_unordered_list2(answer_values)
+      safe_join([caption, formatted_list])
+    }.join.html_safe
+  end
+
+  def print_welsh_routes(conditions)
+    answer_value_groups = answer_value_groups(conditions)
+    answer_value_groups.map { |goto_page_id, condition_group|
+      if goto_page_id.nil?
+        caption = content_tag(:p, I18n.t("page_conditions.go_to_the_end"))
+      else
+        welsh_goto_question = welsh_step_from_id(condition_group.first.goto_page_id)
+        welsh_goto_page_question_text = ActionController::Base.helpers.sanitize(welsh_goto_question.question_text)
+        goto_page_question_number = @welsh_steps.find_index(welsh_goto_question) + 1
+
+        caption = content_tag(:p, I18n.t("page_conditions.go_to_page", goto_page_question_number:, goto_page_question_text: welsh_goto_page_question_text))
+      end
+
+      answer_values = condition_group.map do |condition|
+        welsh_condition = welsh_condition_from_id(condition.id)
+        "‘#{format_answer_value(welsh_answer_value2(welsh_condition))}’"
+      end
+
+      formatted_list = html_unordered_list2(answer_values)
+      safe_join([caption, formatted_list])
+    }.join.html_safe
+  end
+
+  def print_unconditional_route(condition)
+    if condition.skip_to_end
+      I18n.t("page_conditions.unconditional_skip_to_end_of_form").html_safe
+    else
+      goto_question = @steps.find { |page| page.id == condition.goto_page_id }
+      goto_page_question_text = ActionController::Base.helpers.sanitize(goto_question.question_text)
+      goto_page_question_number = @steps.find_index(goto_question) + 1
+
+      I18n.t("page_conditions.unconditional_go_to_page", goto_page_question_number:, goto_page_question_text:).html_safe
+    end
+  end
+
+  def print_welsh_unconditional_route(condition)
+    if condition.skip_to_end
+      I18n.t("page_conditions.unconditional_skip_to_end_of_form").html_safe
+    else
+      welsh_goto_question = welsh_step_from_id(condition.goto_page_id)
+      welsh_goto_page_question_text = ActionController::Base.helpers.sanitize(welsh_goto_question.question_text)
+      goto_page_question_number = @welsh_steps.find_index(welsh_goto_question) + 1
+
+      I18n.t("page_conditions.unconditional_go_to_page", goto_page_question_number:, goto_page_question_text: welsh_goto_page_question_text).html_safe
+    end
+  end
+
+  def answer_value_groups(conditions)
+    answer_order = @step.answer_settings&.selection_options&.map(&:value) || []
+
+    conditions.group_by(&:goto_page_id).map { |goto_page_id, condition_group|
+      goto_page_position = @steps.find_index { |page| page.id == goto_page_id } + 1 unless goto_page_id.nil?
+      sorted_condition_group = condition_group.in_order_of(:answer_value, answer_order, filter: false)
+      [goto_page_position, sorted_condition_group]
+    }.sort_by { |goto_page_position, _| goto_page_position || Float::INFINITY }
+  end
+
+  def format_answer_value(answer_value)
+    answer_value = I18n.t("page_conditions.none_of_the_above") if answer_value == "none_of_the_above"
+    ActionController::Base.helpers.sanitize(answer_value)
   end
 
   def selection_answer_type
@@ -245,6 +367,10 @@ private
     content_tag(:ul, html_list_item(list_items), class: ["govuk-list", "govuk-list--bullet"])
   end
 
+  def html_unordered_list2(list_items)
+    content_tag(:ul, html_list_item(list_items), class: ["govuk-list", "govuk-list--bullet govuk-!-static-margin-bottom-4"])
+  end
+
   def html_list_item(item)
     item.map { |i| content_tag(:li, i) }.join.html_safe
   end
@@ -294,5 +420,13 @@ private
     return nil if welsh_condition.answer_value.blank?
 
     @welsh_steps.find { |step| step.id == welsh_condition.check_page_id }.answer_settings.selection_options.find { |option| option.value == welsh_condition.answer_value }.name
+  end
+
+  def welsh_answer_value2(welsh_condition)
+    return nil if welsh_condition.answer_value.blank?
+
+    return I18n.t("step_summary_card.none_of_the_above.cy") if welsh_condition.answer_value == "none_of_the_above"
+
+    @welsh_steps.find { |step| step.id == welsh_condition.routing_page_id }.answer_settings.selection_options.find { |option| option.value == welsh_condition.answer_value }.name
   end
 end

--- a/app/services/step_summary_table_service.rb
+++ b/app/services/step_summary_table_service.rb
@@ -236,7 +236,7 @@ private
   end
 
   def format_answer_value(answer_value)
-    answer_value = I18n.t("page_conditions.none_of_the_above") if answer_value == "none_of_the_above"
+    answer_value = I18n.t("page_conditions.none_of_the_above") if answer_value == Condition::NONE_OF_THE_ABOVE
     ActionController::Base.helpers.sanitize(answer_value)
   end
 
@@ -419,7 +419,7 @@ private
   def welsh_answer_value(welsh_condition)
     return nil if welsh_condition.answer_value.blank?
 
-    return I18n.t("step_summary_card.selection_type.none_of_the_above.cy") if welsh_condition.answer_value == "none_of_the_above"
+    return I18n.t("step_summary_card.selection_type.none_of_the_above.cy") if welsh_condition.answer_value == Condition::NONE_OF_THE_ABOVE
 
     @welsh_steps.find { |step| step.id == welsh_condition.check_page_id }.answer_settings.selection_options.find { |option| option.value == welsh_condition.answer_value }.name
   end
@@ -427,7 +427,7 @@ private
   def welsh_answer_value2(welsh_condition)
     return nil if welsh_condition.answer_value.blank?
 
-    return I18n.t("step_summary_card.selection_type.none_of_the_above.cy") if welsh_condition.answer_value == "none_of_the_above"
+    return I18n.t("step_summary_card.selection_type.none_of_the_above.cy") if welsh_condition.answer_value == Condition::NONE_OF_THE_ABOVE
 
     @welsh_steps.find { |step| step.id == welsh_condition.routing_page_id }.answer_settings.selection_options.find { |option| option.value == welsh_condition.answer_value }.name
   end

--- a/app/services/step_summary_table_service.rb
+++ b/app/services/step_summary_table_service.rb
@@ -50,7 +50,7 @@ class StepSummaryTableService
     conditions_for_step.map do |condition|
       welsh_condition = welsh_condition_from_id(condition.id)
       condition_data = {
-        answer_value: condition.answer_value,
+        answer_value: format_answer_value(condition.answer_value),
         answer_value_cy: welsh_answer_value(welsh_condition),
         goto_page: print_goto_page(condition, @steps),
         goto_page_cy: print_goto_page(welsh_condition, @welsh_steps),
@@ -250,7 +250,7 @@ private
     return @step.show_selection_options unless @step.answer_settings.selection_options.length >= 1
 
     options = @step.answer_settings.selection_options.map(&:name)
-    options << I18n.t("step_summary_card.selection_type.none_of_the_above") if @step.is_optional?
+    options << I18n.t("step_summary_card.selection_type.none_of_the_above.en") if @step.is_optional?
     formatted_list = html_unordered_list(options)
 
     if options.length > 10
@@ -268,7 +268,7 @@ private
     return welsh_step.show_selection_options unless welsh_step.answer_settings.selection_options.length >= 1
 
     options = welsh_step.answer_settings.selection_options.map(&:name)
-    options << I18n.t("step_summary_card.selection_type.none_of_the_above") if welsh_step.is_optional?
+    options << I18n.t("step_summary_card.selection_type.none_of_the_above.cy") if welsh_step.is_optional?
     formatted_list = html_unordered_list(options)
 
     if options.length > 10
@@ -419,13 +419,15 @@ private
   def welsh_answer_value(welsh_condition)
     return nil if welsh_condition.answer_value.blank?
 
+    return I18n.t("step_summary_card.selection_type.none_of_the_above.cy") if welsh_condition.answer_value == "none_of_the_above"
+
     @welsh_steps.find { |step| step.id == welsh_condition.check_page_id }.answer_settings.selection_options.find { |option| option.value == welsh_condition.answer_value }.name
   end
 
   def welsh_answer_value2(welsh_condition)
     return nil if welsh_condition.answer_value.blank?
 
-    return I18n.t("step_summary_card.none_of_the_above.cy") if welsh_condition.answer_value == "none_of_the_above"
+    return I18n.t("step_summary_card.selection_type.none_of_the_above.cy") if welsh_condition.answer_value == "none_of_the_above"
 
     @welsh_steps.find { |step| step.id == welsh_condition.routing_page_id }.answer_settings.selection_options.find { |option| option.value == welsh_condition.answer_value }.name
   end

--- a/app/services/step_summary_table_service.rb
+++ b/app/services/step_summary_table_service.rb
@@ -137,7 +137,7 @@ private
                                       .with_content(formatted_list)
                                       .call
     else
-      caption = content_tag(:p, I18n.t("page_settings_summary.selection.options_count", number_of_options: options.length), class: "govuk-body-s")
+      caption = content_tag(:p, I18n.t("page_settings_summary.selection.options_count", number_of_options: options.length))
       safe_join([caption, formatted_list])
     end
   end
@@ -155,7 +155,7 @@ private
                                       .with_content(formatted_list)
                                       .call
     else
-      caption = content_tag(:p, I18n.t("page_settings_summary.selection.options_count", number_of_options: options.length), class: "govuk-body-s")
+      caption = content_tag(:p, I18n.t("page_settings_summary.selection.options_count", number_of_options: options.length))
       safe_join([caption, formatted_list])
     end
   end

--- a/app/views/forms/_made_live_form_pages.html.erb
+++ b/app/views/forms/_made_live_form_pages.html.erb
@@ -16,13 +16,17 @@
     <% form_document.steps.each_with_index do |step, index| %>
       <%= govuk_summary_card(**StepSummaryCardPresenter.call(step:, steps: form_document.steps, welsh_steps: welsh_form_document&.steps).build_card) do %>
         <% if welsh_form_document.present? && welsh_form_document&.steps.any? %>
-          <%= govuk_table(**StepSummaryCardPresenter.call(step:, steps: form_document.steps, welsh_steps: welsh_form_document.steps).build_bilingual_table) %>
-          <% if StepSummaryCardPresenter.call(step:, steps: form_document.steps, welsh_steps: welsh_form_document.steps).build_route_tables.present? %>
-            <% StepSummaryCardPresenter.call(step:, steps: form_document.steps, welsh_steps: welsh_form_document.steps).build_route_tables.each do |condition_data| %>
-              <%= govuk_table(**condition_data[:route_table]) %>
+          <% if multiple_branches_enabled %>
+            <%= govuk_table(**StepSummaryCardPresenter.call(step:, steps: form_document.steps, welsh_steps: welsh_form_document.steps).build_bilingual_table2) %>
+          <% else %>
+            <%= govuk_table(**StepSummaryCardPresenter.call(step:, steps: form_document.steps, welsh_steps: welsh_form_document.steps).build_bilingual_table) %>
+            <% if StepSummaryCardPresenter.call(step:, steps: form_document.steps, welsh_steps: welsh_form_document.steps).build_route_tables.present? %>
+              <% StepSummaryCardPresenter.call(step:, steps: form_document.steps, welsh_steps: welsh_form_document.steps).build_route_tables.each do |condition_data| %>
+                <%= govuk_table(**condition_data[:route_table]) %>
 
-              <% if condition_data[:exit_page_table].present? %>
-                <%= govuk_table(**condition_data[:exit_page_table]) %>
+                <% if condition_data[:exit_page_table].present? %>
+                  <%= govuk_table(**condition_data[:exit_page_table]) %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2099,6 +2099,8 @@ en:
     name_type:
       title_not_selected: Title not needed
       title_selected: Title needed
+    none_of_the_above:
+      cy: Dim un o’r uchod
     none_of_the_above_question_optional: "%{question_text} (optional)"
     none_of_the_above_question_title: If ‘None of the above’ is selected
     options_title: Options

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2099,8 +2099,6 @@ en:
     name_type:
       title_not_selected: Title not needed
       title_selected: Title needed
-    none_of_the_above:
-      cy: Dim un o’r uchod
     none_of_the_above_question_optional: "%{question_text} (optional)"
     none_of_the_above_question_title: If ‘None of the above’ is selected
     options_title: Options
@@ -2108,7 +2106,9 @@ en:
     question_text: Question text
     selection_type:
       default: Selection from a list
-      none_of_the_above: None of the above
+      none_of_the_above:
+        cy: Dim un o’r uchod
+        en: None of the above
       only_one_option: Selection from a list, one option only
   task_statuses:
     cannot_start: Cannot start yet

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -5,7 +5,8 @@ describe StepSummaryTableService do
     described_class.new(step: form_document_step, steps: form_document_steps, welsh_steps: welsh_form_document_steps)
   end
 
-  let(:form) { create :form, :with_welsh_translation, :live, id: 1, pages: [page] }
+  let(:form) { create :form, :with_welsh_translation, :live, id: 1, pages: }
+  let(:pages) { [page] }
   let(:page) { create(:page) }
 
   let(:form_document_content) { FormDocument::Content.from_form_document(form.live_form_document) }
@@ -220,6 +221,218 @@ describe StepSummaryTableService do
         it "includes a row with the none of the above text" do
           expect(step_summary_table_service.values_with_welsh_content).to include [I18n.t("step_summary_card.none_of_the_above_question_title"), page.answer_settings[:none_of_the_above_question][:question_text], page.answer_settings_cy[:none_of_the_above_question][:question_text]]
         end
+      end
+    end
+  end
+
+  describe "#values_with_welsh_content2", :feature_multiple_branches do
+    let(:form) do
+      create :form,
+             :with_welsh_translation,
+             :ready_for_live,
+             id: 1,
+             name: "Apply for a juggling licence",
+             name_cy: "Apply for a juggling licence (Welsh)",
+             what_happens_next_markdown: "English what happens next",
+             what_happens_next_markdown_cy: "Welsh what happens next",
+             declaration_markdown: "English declaration",
+             declaration_markdown_cy: "Welsh declaration",
+             support_email: "english-support@example.gov.uk",
+             support_email_cy: "welsh-support@example.gov.uk",
+             support_phone: "01234 987654",
+             support_phone_cy: "01234 567891",
+             support_url_cy: "https://www.gov.uk/welsh-support",
+             support_url: "https://www.gov.uk/english-support",
+             support_url_text_cy: "Welsh Support",
+             support_url_text: "English Support",
+             privacy_policy_url: "https://www.gov.uk/english-privacy",
+             privacy_policy_url_cy: "https://www.gov.uk/welsh-privacy",
+             payment_url: "https://www.gov.uk/english-payment",
+             payment_url_cy: "https://www.gov.uk/payments/your-welsh-payment-link",
+             welsh_completed: true,
+             pages: [
+               create(
+                 :page,
+                 question_text: "Question",
+                 question_text_cy: "Question (Welsh)",
+               ),
+               create(
+                 :page,
+                 :with_selection_settings,
+                 question_text: "Branch question",
+                 question_text_cy: "Branch question (Welsh)",
+                 is_optional: true,
+                 answer_settings: DataStruct.new(
+                   only_one_option: "true",
+                   selection_options: [
+                     {
+                       name: "First branch",
+                       value: "First branch",
+                     },
+                     {
+                       name: "Second branch",
+                       value: "Second branch",
+                     },
+                     {
+                       name: "Also second branch",
+                       value: "Also second branch",
+                     },
+                     {
+                       name: "Skip the branches",
+                       value: "Skip the branches",
+                     },
+                   ],
+                 ),
+                 answer_settings_cy: DataStruct.new(
+                   only_one_option: "true",
+                   selection_options: [
+                     {
+                       name: "First branch (Welsh)",
+                       value: "First branch",
+                     },
+                     {
+                       name: "Second branch (Welsh)",
+                       value: "Second branch",
+                     },
+                     {
+                       name: "Also second branch (Welsh)",
+                       value: "Also second branch",
+                     },
+                     {
+                       name: "Skip the branches (Welsh)",
+                       value: "Skip the branches",
+                     },
+                   ],
+                 ),
+               ),
+               create(
+                 :page,
+                 question_text: "Question in branch 1",
+                 question_text_cy: "Question in branch 1 (Welsh)",
+               ),
+               create(
+                 :page,
+                 question_text: "Question at the end of branch 1",
+                 question_text_cy: "Question at the end of branch 1 (Welsh)",
+               ),
+               create(
+                 :page,
+                 question_text: "Question at the start of branch 2",
+                 question_text_cy: "Question at the start of branch 2 (Welsh)",
+               ),
+               create(
+                 :page,
+                 question_text: "Question in branch 2",
+                 question_text_cy: "Question in branch 2 (Welsh)",
+               ),
+               create(
+                 :page,
+                 question_text: "Question at the end of branch 2",
+                 question_text_cy: "Question at the end of branch 2 (Welsh)",
+               ),
+               create(
+                 :page,
+                 question_text: "Question",
+                 question_text_cy: "Question (Welsh)",
+               ),
+             ]
+    end
+
+    let(:pages) do
+      form.pages
+    end
+
+    let(:pages_with_routing) do
+      # Create conditions separately
+      create(
+        :condition,
+        answer_value: "Second branch",
+        goto_page_id: pages[4].id,
+        routing_page_id: pages[1].id,
+      )
+
+      create(
+        :condition,
+        answer_value: "Also second branch",
+        goto_page_id: pages[4].id,
+        routing_page_id: pages[1].id,
+      )
+
+      create(
+        :condition,
+        answer_value: "Also second branch",
+        goto_page_id: pages[7].id,
+        routing_page_id: pages[1].id,
+      )
+
+      create(
+        :condition,
+        answer_value: "none_of_the_above",
+        routing_page_id: pages[1].id,
+        skip_to_end: true,
+      )
+
+      create(
+        :condition,
+        routing_page_id: pages[3].id,
+        goto_page_id: pages[7].id,
+      )
+
+      create(
+        :condition,
+        routing_page_id: pages[6].id,
+        skip_to_end: true,
+      )
+
+      pages.each(&:reload)
+      form.save_draft!
+      form.make_live!
+      pages
+    end
+
+    before do
+      pages_with_routing
+      form.reload
+      pages.reload
+    end
+
+    context "when the page is a selection page with routing" do
+      let(:page) { pages_with_routing[1] }
+
+      it "includes a row for the routes" do
+        expect(step_summary_table_service.values_with_welsh_content2).to include([
+          "Routes",
+          "<p>Go to 5, ‘Question at the start of branch 2’ if the answer is:</p><ul class=\"govuk-list govuk-list--bullet govuk-!-static-margin-bottom-4\"><li>‘Second branch’</li><li>‘Also second branch’</li></ul>"\
+          "<p>Go to 8, ‘Question’ if the answer is:</p><ul class=\"govuk-list govuk-list--bullet govuk-!-static-margin-bottom-4\"><li>‘Also second branch’</li></ul>"\
+          "<p>Go to the end of the form if the answer is:</p><ul class=\"govuk-list govuk-list--bullet govuk-!-static-margin-bottom-4\"><li>‘None of the above’</li></ul>",
+          "<p>Go to 5, ‘Question at the start of branch 2 (Welsh)’ if the answer is:</p><ul class=\"govuk-list govuk-list--bullet govuk-!-static-margin-bottom-4\"><li>‘Second branch (Welsh)’</li><li>‘Also second branch (Welsh)’</li></ul>"\
+          "<p>Go to 8, ‘Question (Welsh)’ if the answer is:</p><ul class=\"govuk-list govuk-list--bullet govuk-!-static-margin-bottom-4\"><li>‘Also second branch (Welsh)’</li></ul>"\
+          "<p>Go to the end of the form if the answer is:</p><ul class=\"govuk-list govuk-list--bullet govuk-!-static-margin-bottom-4\"><li>‘Dim un o’r uchod’</li></ul>",
+        ])
+      end
+    end
+
+    context "when the page unconditionally skips to another page" do
+      let(:page) { pages_with_routing[3] }
+
+      it "includes a row for the routes" do
+        expect(step_summary_table_service.values_with_welsh_content2).to include([
+          "Route",
+          "Go to 8, ‘Question’",
+          "Go to 8, ‘Question (Welsh)’",
+        ])
+      end
+    end
+
+    context "when the page unconditionally skips to the end" do
+      let(:page) { pages_with_routing[6] }
+
+      it "includes a row for the routes" do
+        expect(step_summary_table_service.values_with_welsh_content2).to include([
+          "Route",
+          "Go to the end of the form",
+          "Go to the end of the form",
+        ])
       end
     end
   end

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -128,8 +128,8 @@ describe StepSummaryTableService do
       end
 
       it "includes a row for the selection options" do
-        selection_list = "<p class=\"govuk-body-s\">#{I18n.t('page_settings_summary.selection.options_count', number_of_options: 2)}</p><ul class=\"govuk-list govuk-list--bullet\"><li>Yes</li><li>No</li></ul>"
-        selection_list_cy = "<p class=\"govuk-body-s\">#{I18n.t('page_settings_summary.selection.options_count', number_of_options: 2)}</p><ul class=\"govuk-list govuk-list--bullet\"><li>Ydy</li><li>Nac ydy</li></ul>"
+        selection_list = "<p>#{I18n.t('page_settings_summary.selection.options_count', number_of_options: 2)}</p><ul class=\"govuk-list govuk-list--bullet\"><li>Yes</li><li>No</li></ul>"
+        selection_list_cy = "<p>#{I18n.t('page_settings_summary.selection.options_count', number_of_options: 2)}</p><ul class=\"govuk-list govuk-list--bullet\"><li>Ydy</li><li>Nac ydy</li></ul>"
         expect(step_summary_table_service.values_with_welsh_content).to include [I18n.t("step_summary_card.options_title"), selection_list, selection_list_cy]
       end
 

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -118,6 +118,7 @@ describe StepSummaryTableService do
                question_text: "Are you renewing a licence?",
                question_text_cy: "Ydych chi'n adnewyddu trwydded?",
                answer_type: "selection",
+               is_optional: true,
                answer_settings: {
                  "only_one_option" => "true",
                  "selection_options" => [{ name: "Yes", value: "Yes" }, { name: "No", value: "No" }],
@@ -129,8 +130,8 @@ describe StepSummaryTableService do
       end
 
       it "includes a row for the selection options" do
-        selection_list = "<p>#{I18n.t('page_settings_summary.selection.options_count', number_of_options: 2)}</p><ul class=\"govuk-list govuk-list--bullet\"><li>Yes</li><li>No</li></ul>"
-        selection_list_cy = "<p>#{I18n.t('page_settings_summary.selection.options_count', number_of_options: 2)}</p><ul class=\"govuk-list govuk-list--bullet\"><li>Ydy</li><li>Nac ydy</li></ul>"
+        selection_list = "<p>#{I18n.t('page_settings_summary.selection.options_count', number_of_options: 3)}</p><ul class=\"govuk-list govuk-list--bullet\"><li>Yes</li><li>No</li><li>None of the above</li></ul>"
+        selection_list_cy = "<p>#{I18n.t('page_settings_summary.selection.options_count', number_of_options: 3)}</p><ul class=\"govuk-list govuk-list--bullet\"><li>Ydy</li><li>Nac ydy</li><li>Dim un o’r uchod</li></ul>"
         expect(step_summary_table_service.values_with_welsh_content).to include [I18n.t("step_summary_card.options_title"), selection_list, selection_list_cy]
       end
 
@@ -772,6 +773,20 @@ describe StepSummaryTableService do
                      ],
                    ),
                  ),
+                 create(
+                   :page,
+                   :with_selection_settings,
+                   question_text: "Question with none of the above",
+                   question_text_cy: "Question with none of the above (Welsh)",
+                   is_optional: true,
+                   answer_settings: DataStruct.new(only_one_option: "true", selection_options: [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }]),
+                   answer_settings_cy: DataStruct.new(only_one_option: "true", selection_options: [{ name: "Option 1 (Welsh)", value: "Option 1" }, { name: "Option 2 (Welsh)", value: "Option 2" }]),
+                 ),
+                 create(
+                   :page,
+                   question_text: "Question",
+                   question_text_cy: "Question (Welsh)",
+                 ),
                ]
       end
 
@@ -834,6 +849,14 @@ describe StepSummaryTableService do
           exit_page_markdown_cy: "Exit page markdown (Welsh)",
         )
 
+        create(
+          :condition,
+          answer_value: "none_of_the_above",
+          check_page_id: pages[13].id,
+          routing_page_id: pages[13].id,
+          skip_to_end: true,
+        )
+
         pages.each(&:reload)
         form.save_draft!
         form.make_live!
@@ -878,6 +901,10 @@ describe StepSummaryTableService do
 
       let(:page_with_exit_page) do
         pages_with_routing[12]
+      end
+
+      let(:page_with_none_of_the_above) do
+        pages_with_routing[13]
       end
 
       let(:exit_page) do
@@ -993,6 +1020,27 @@ describe StepSummaryTableService do
                                                                     routing_page: "13. Exit page question",
                                                                     routing_page_cy: "13. Exit page question (Welsh)",
                                                                     secondary_skip: false }]
+        end
+      end
+
+      context "when a page has a route based on a none of the above answer" do
+        let(:page) { page_with_none_of_the_above }
+
+        it "returns an array containing the none of the above answer" do
+          expect(step_summary_table_service.route_content).to eq [{ answer_value: "None of the above",
+                                                                    answer_value_cy: "Dim un o’r uchod",
+                                                                    goto_page: "End of the form",
+                                                                    goto_page_cy: "End of the form",
+                                                                    routing_page: "14. Question with none of the above",
+                                                                    routing_page_cy: "14. Question with none of the above (Welsh)",
+                                                                    check_page: "14. Question with none of the above",
+                                                                    check_page_cy: "14. Question with none of the above (Welsh)",
+                                                                    secondary_skip: false,
+                                                                    exit_page: false,
+                                                                    exit_page_heading: nil,
+                                                                    exit_page_heading_cy: nil,
+                                                                    exit_page_markdown: nil,
+                                                                    exit_page_markdown_cy: nil }]
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/LtIlAUBk/3072-show-new-routes-in-live-archived-view

For groups with multiple branches enabled, forms that have a live/archived Welsh version will show new table format. 

--- 

<img width="795" height="1261" alt="image" src="https://github.com/user-attachments/assets/bdcbc959-524c-4259-a49c-65c864bcb388" />

---

Additionally fixed some issues with how we were displaying `None of the above` in these tables. In fact, that page just didn't work!

**Before**

<img width="1234" height="526" alt="image" src="https://github.com/user-attachments/assets/d341973c-728b-45de-bde5-e3ba1086f823" />

**After**

<img width="825" height="548" alt="image" src="https://github.com/user-attachments/assets/5ab10b3e-ceb6-4c40-9e6e-748507161225" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
