### PR TITLE
Fix row order for Welsh form CSV

### DIFF
--- a/app/services/welsh_csv_service.rb
+++ b/app/services/welsh_csv_service.rb
@@ -38,12 +38,12 @@ private
 
   def add_page_content(csv)
     form.pages.each do |page|
+      add_page_heading(csv, page)
+      add_guidance_text(csv, page)
       add_question_content(csv, page)
       add_selection_options(csv, page) if page.answer_type == "selection"
       add_none_of_above_question(csv, page) if has_none_of_the_above?(page)
       add_routing_conditions(csv, page)
-      add_page_heading(csv, page)
-      add_guidance_text(csv, page)
     end
   end
 

--- a/spec/services/welsh_csv_service_spec.rb
+++ b/spec/services/welsh_csv_service_spec.rb
@@ -269,9 +269,9 @@ RSpec.describe "WelshCsvService" do
                         ["Question 1 - question or label if ‘None of the above’ is selected", "None of the above question?", "Welsh None of the above question?"],
                         ["Question 1 - exit page heading", "Exit page heading", "Welsh exit page heading"],
                         ["Question 1 - exit page content", "Exit page markdown", "Welsh exit page markdown"],
-                        ["Question 2 - question text", "What?", "Welsh What?"],
                         ["Question 2 - page heading", "Page heading", "Welsh Page heading"],
                         ["Question 2 - guidance text", "This is the guidance.", "Welsh This is the guidance."],
+                        ["Question 2 - question text", "What?", "Welsh What?"],
                         ["Declaration", "Declaration text", ""],
                         ["Information about what happens next", "English what happens next", "Welsh what happens next"],
                         ["GOV⁠.⁠UK Pay payment link", "https://www.gov.uk/payment", "https://www.gov.uk/payment_cy"],
@@ -280,7 +280,7 @@ RSpec.describe "WelshCsvService" do
                         ["Contact details for support - phone number and opening times", "English support phone", "Welsh support phone"],
                         ["Contact details for support - online contact link", "https://www.gov.uk/support", "https://www.gov.uk/support_cy"],
                         ["Contact details for support - online contact link text", "Support URL text", "Welsh Support URL text"]]
-        expect(csv).to match_array(expected_csv)
+        expect(csv).to eq(expected_csv)
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/JYUtlVzE/3117-content-for-guidance-questions-not-in-same-order-on-welsh-csv-as-on-add-welsh-content-page

The correct order for a question's details in a CSV is
 - Page heading
 - Guidance text
 - Question text
 - Hint text (if relevant)
 - List of options (if relevant)

This matches how the translations are displayed on the Welsh Translations page

The test for this has switched from using `match_array` to `eq` so that the ordering is taken into account.

