### PR TITLE
Add NormaliseConditionsService to delete conditions that go to the next page

### DIFF
--- a/app/input_objects/forms/mark_pages_section_complete_input.rb
+++ b/app/input_objects/forms/mark_pages_section_complete_input.rb
@@ -14,7 +14,10 @@ class Forms::MarkPagesSectionCompleteInput < Forms::MarkCompleteInput
   end
 
   def has_routing_errors
-    NormaliseConditionsService.new(form:).normalise_conditions
+    if FeatureService.new(group: form.group).enabled?(:multiple_branches)
+      NormaliseConditionsService.new(form:).normalise_conditions
+    end
+
     errors.add :base, :has_routing_errors if form.has_routing_errors?
   end
 end

--- a/app/input_objects/forms/mark_pages_section_complete_input.rb
+++ b/app/input_objects/forms/mark_pages_section_complete_input.rb
@@ -14,6 +14,7 @@ class Forms::MarkPagesSectionCompleteInput < Forms::MarkCompleteInput
   end
 
   def has_routing_errors
+    NormaliseConditionsService.new(form:).normalise_conditions
     errors.add :base, :has_routing_errors if form.has_routing_errors?
   end
 end

--- a/app/services/normalise_conditions_service.rb
+++ b/app/services/normalise_conditions_service.rb
@@ -1,0 +1,33 @@
+class NormaliseConditionsService
+  attr_reader :form
+
+  def initialize(form:)
+    @form = form
+  end
+
+  def normalise_conditions
+    conditions = form.conditions
+
+    return false if conditions.any? { unfixable_validation_errors?(it) }
+
+    conditions
+      .filter { routes_to_next_page?(it) }
+      .each(&:destroy)
+
+    form.reload
+
+    conditions
+  end
+
+private
+
+  def routes_to_next_page?(condition)
+    !condition.warning_routing_to_next_page.nil?
+  end
+
+  def unfixable_validation_errors?(condition)
+    condition.validation_errors.any? do |validation_error|
+      validation_error.name != "cannot_route_to_next_page"
+    end
+  end
+end

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -43,11 +43,11 @@ class Routes::BuildService
       _, value = option
 
       if drop
-        if selected && value == selected
-          option
-        elsif value == next_page_id
+        if value == next_page_id
           drop = false
           ["Go to question #{page.position.next}", Forms::RouteInput::DEFAULT_VALUE]
+        elsif selected && value == selected
+          option
         end
         # return nil
       else

--- a/spec/features/form/routes/routes_that_go_to_the_next_page_spec.rb
+++ b/spec/features/form/routes/routes_that_go_to_the_next_page_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "Questions are moved or deleted such that a route becomes a default route", :feature_multiple_branches, type: :feature do
+  let(:organisation) { standard_user.organisation }
+  let(:group) { create :group, organisation: }
+  let(:user) { standard_user }
+
+  let(:form) { create :form, :ready_for_routing }
+
+  before do
+    group.update! multiple_branches_enabled: true
+    GroupForm.create! group:, form_id: form.id
+    create :membership, group:, user:, added_by: user
+
+    login_as user
+  end
+
+  scenario "Moving pages such that a route becomes a default route does not cause validation errors" do
+    routing_page = form.pages.first
+    goto_page = form.pages.third
+
+    # Given the form has a skip route
+    Condition.create! check_page: routing_page, routing_page:, goto_page:, answer_value: "Option 1"
+
+    # When I am editing the form's questions
+    visit form_pages_path(form)
+
+    # And I move the goto page to be next after the routing page
+    move_up_button = find :button, text: "Move up", value: goto_page.id
+    move_up_button.click
+    expect(page).to have_css ".govuk-notification-banner", text: /has moved up/
+
+    # Then I shouldn't see any validation errors
+    expect(page).not_to have_css ".govuk-error-summary"
+    expect(page).not_to have_css ".govuk-error"
+
+    # And I can save my questions
+    click_button text: "Save"
+    expect(page).to have_css ".govuk-notification-banner", text: "Your questions have been saved"
+  end
+
+  scenario "Routes that match the default route are deleted when the form creator has finished editing their questions" do
+    routing_page = form.pages.first
+    goto_page = form.pages.third
+
+    # Given the form has a skip route
+    create :condition, check_page: routing_page, routing_page:, goto_page:, answer_value: "Option 1"
+
+    # When I am editing the form's questions
+    visit form_pages_path(form)
+
+    # And I move the goto page to be next after the routing page
+    move_up_button = find :button, text: "Move up", value: goto_page.id
+    move_up_button.click
+    expect(page).to have_css ".govuk-notification-banner", text: /has moved up/
+
+    # When I answer yes to "Have you finished editing your questions?"
+    choose "Yes"
+    click_button text: "Save"
+    expect(page).to have_css ".govuk-notification-banner", text: "Your questions have been saved"
+
+    # Then the skip route is deleted
+    expect(Condition).not_to exist(routing_page:, goto_page:, answer_value: "Option 1")
+  end
+
+  scenario "Routes that match the default route are deleted when the routes are saved" do
+    routing_page = form.pages.first
+    goto_page = form.pages.third
+
+    # Given the form has a skip route
+    create :condition, check_page: routing_page, routing_page:, goto_page:, answer_value: "Option 1"
+
+    # When I am editing the form's questions
+    visit form_pages_path(form)
+
+    # And I move the goto page to be next after the routing page
+    move_up_button = find :button, text: "Move up", value: goto_page.id
+    move_up_button.click
+    expect(page).to have_css ".govuk-notification-banner", text: /has moved up/
+
+    # When I go to the edit routes page
+    visit routes_path(form)
+    expect(page).to have_title "Edit question routes"
+
+    # And save the routes
+    click_button text: "Save"
+    expect(page).to have_css ".govuk-notification-banner", text: "Your routes have been saved"
+
+    # Then the skip route is deleted
+    expect(Condition).not_to exist(routing_page:, goto_page:, answer_value: "Option 1")
+  end
+end

--- a/spec/input_objects/forms/mark_pages_section_complete_input_spec.rb
+++ b/spec/input_objects/forms/mark_pages_section_complete_input_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Forms::MarkPagesSectionCompleteInput, type: :model do
   let(:mark_complete) { "true" }
 
   describe "validations" do
-    context "when form has routing validation errors" do
+    context "when form has routing validation errors", feature_multiple_branches: false do
       let(:form) { create :form, :ready_for_routing }
 
       before do
-        create :condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, goto_page_id: form.pages.third.id, answer_value: "Doesn't exist"
+        create :condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, goto_page_id: form.pages.second.id, answer_value: "Option 1"
         form.reload
       end
 
@@ -33,7 +33,7 @@ RSpec.describe Forms::MarkPagesSectionCompleteInput, type: :model do
       end
     end
 
-    context "when form has routing validation errors that can be fixed by normalisation" do
+    context "when form has routing validation errors that can be fixed by normalisation", :feature_multiple_branches do
       let(:form) { create :form, :ready_for_routing }
 
       before do

--- a/spec/input_objects/forms/mark_pages_section_complete_input_spec.rb
+++ b/spec/input_objects/forms/mark_pages_section_complete_input_spec.rb
@@ -32,9 +32,50 @@ RSpec.describe Forms::MarkPagesSectionCompleteInput, type: :model do
         end
       end
     end
+
+    context "when form has routing validation errors that can be fixed by normalisation" do
+      let(:form) { create :form, :ready_for_routing }
+
+      before do
+        create :condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, goto_page_id: form.pages.second.id, answer_value: "Option 1"
+        form.reload
+      end
+
+      context "when mark_complete is true" do
+        let(:mark_complete) { "true" }
+
+        it "normalises the routing conditions" do
+          normalise_conditions_service = NormaliseConditionsService.new(form:)
+          allow(NormaliseConditionsService).to receive(:new).with(form:).and_return(normalise_conditions_service)
+          allow(normalise_conditions_service).to receive(:normalise_conditions).and_call_original
+
+          mark_complete_input.validate
+
+          expect(normalise_conditions_service).to have_received(:normalise_conditions)
+        end
+
+        it "is valid" do
+          expect(mark_complete_input).to be_valid
+        end
+      end
+
+      context "when mark_complete is false" do
+        let(:mark_complete) { "false" }
+
+        it "is valid" do
+          expect(mark_complete_input).to be_valid
+        end
+
+        it "does not normalise the routing conditions" do
+          expect(NormaliseConditionsService).not_to receive(:new)
+
+          mark_complete_input.validate
+        end
+      end
+    end
   end
 
-  describe "#save" do
+  describe "#submit" do
     context "when mark_complete_input is valid" do
       before do
         allow(mark_complete_input).to receive_messages(invalid?: false, form:)

--- a/spec/services/normalise_conditions_service_spec.rb
+++ b/spec/services/normalise_conditions_service_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+RSpec.describe NormaliseConditionsService do
+  subject(:service) { described_class.new(form:) }
+
+  let(:form) { create :form, :ready_for_routing }
+  let(:conditions) { [] }
+
+  before do
+    conditions
+    form.reload
+  end
+
+  describe "#normalise_conditions" do
+    context "when form has no conditions" do
+      it "does nothing" do
+        expect { service.normalise_conditions }.not_to raise_error
+      end
+    end
+
+    context "when form has conditions with no routing errors" do
+      let(:conditions) do
+        [
+          create(
+            :condition,
+            check_page: form.pages.first,
+            routing_page: form.pages.first,
+            goto_page: form.pages.third,
+            answer_value: "Option 1",
+          ),
+        ]
+      end
+
+      it "does not raise an error" do
+        expect { service.normalise_conditions }.not_to raise_error
+      end
+
+      it "does nothing" do
+        expect {
+          service.normalise_conditions
+        }.not_to change(Condition, :count)
+        expect(form).not_to have_routing_errors
+      end
+    end
+
+    context "when form has conditions with route to next page routing errors" do
+      let(:conditions) do
+        [
+          create(
+            :condition,
+            check_page: form.pages.first,
+            routing_page: form.pages.first,
+            goto_page: form.pages.second,
+            answer_value: "Option 1",
+          ),
+          create(
+            :condition,
+            check_page: form.pages.first,
+            routing_page: form.pages.first,
+            goto_page: form.pages.third,
+            answer_value: "Option 2",
+          ),
+          create(
+            :condition,
+            check_page: form.pages.third,
+            routing_page: form.pages.third,
+            goto_page: form.pages.fourth,
+            answer_value: "Option 2",
+          ),
+        ]
+      end
+
+      it "fixes the routing errors" do
+        expect {
+          service.normalise_conditions
+        }.to change(form, :has_routing_errors?).from(true).to(false)
+      end
+
+      it "deletes the conditions that route to the next page" do
+        expect {
+          service.normalise_conditions
+        }.to change(Condition, :count).by(-2)
+      end
+
+      it "does not delete conditions that do not route to the next page" do
+        service.normalise_conditions
+
+        expect(Condition.exists?(
+                 routing_page: form.pages.first,
+                 goto_page: form.pages.third,
+               )).to be true
+      end
+    end
+
+    context "when form has conditions with other validation errors" do
+      let(:conditions) do
+        [
+          # Condition that routes to next page
+          create(
+            :condition,
+            check_page: form.pages.first,
+            routing_page: form.pages.first,
+            goto_page: form.pages.second,
+            answer_value: "Option 1",
+          ),
+          # Valid condition
+          create(
+            :condition,
+            check_page: form.pages.first,
+            routing_page: form.pages.first,
+            goto_page: form.pages.third,
+            answer_value: "Option 2",
+          ),
+          # Condition that has an invalid answer_value
+          create(
+            :condition,
+            check_page: form.pages.first,
+            routing_page: form.pages.first,
+            goto_page: form.pages.third,
+            answer_value: "Not an option",
+          ),
+          # Condition that routes backwards
+          create(
+            :condition,
+            check_page: form.pages.third,
+            routing_page: form.pages.third,
+            goto_page: form.pages.first,
+            answer_value: "Option 1",
+          ),
+          # Condition that routes to next page and has an invalid answer_value
+          create(
+            :condition,
+            check_page: form.pages.third,
+            routing_page: form.pages.third,
+            goto_page: form.pages.fourth,
+            answer_value: "Not an option",
+          ),
+        ]
+      end
+
+      it "does not raise an error" do
+        expect { service.normalise_conditions }.not_to raise_error
+      end
+
+      it "does nothing" do
+        expect {
+          service.normalise_conditions
+        }.not_to change(Condition, :count)
+        expect(form).to have_routing_errors
+      end
+    end
+  end
+end

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -69,6 +69,22 @@ RSpec.describe Routes::BuildService do
             expect(route_for_page1.goto).to eq(Forms::RouteInput::END_OF_FORM_VALUE)
           end
         end
+
+        context "when a condition goes to the next page" do
+          before do
+            create(:condition, form:, routing_page: pages.first, goto_page: pages.second, answer_value: nil)
+          end
+
+          it "sets the goto value to the next page ID" do
+            route_for_page1 = service.build_routes.first
+            expect(route_for_page1.goto).to eq(pages.second.id)
+          end
+
+          it "has a goto option for each page after" do
+            route_for_page1 = service.build_routes.first
+            expect(route_for_page1.goto_options.length).to eq 3
+          end
+        end
       end
 
       context "with a selection page (radios)" do

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -111,6 +111,37 @@ describe "routes/show.html.erb" do
       end
     end
 
+    context "when the route goes to the next page" do
+      let(:pages) do
+        [
+          build_stubbed(
+            :page,
+            id: 101,
+            routing_conditions: [
+              build_stubbed(
+                :condition,
+                routing_page_id: 101,
+                goto_page_id: 102,
+                answer_value: nil,
+              ),
+            ],
+          ),
+          build_stubbed(:page, id: 102),
+          build_stubbed(:page, id: 103),
+        ]
+      end
+
+      it "shows the selected goto page for the route" do
+        render_page
+
+        expect(rendered).to have_css('.govuk-select[name="forms_routes_input[routes_attributes][0][goto]"]') do |field|
+          expect(field).to have_css("option", count: 3)
+          expect(field).not_to have_css("option[selected]") # if no option is has the selected attribute, the first option will be selected by default
+          expect(field.first("option")["value"]).to eq "default"
+        end
+      end
+    end
+
     context "when the route goes to a page before the routing page" do
       let(:pages) do
         [


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/MWY6jwTQ/3113-add-code-to-delete-conditions-that-go-to-the-next-page <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When the multiple branches feature is enabled, we want to stop reporting conditions that go to the next page as a routing error to the user, and instead silently delete those conditions for them.

This PR adds a new `NormaliseConditionsService` to delete those conditions, and uses it to delete conditions to route to the next page when the form creator finishes editing the questions for their forms.

It also fixes a bug in the edit routes page that occurs when a condition is set to route to the next page.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
