### PR TITLE
Change all goto page inputs on edit routes page to be the same width

### DIFF
--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -33,7 +33,13 @@
                           route_form.hidden_field(:id) +
                             route_form.hidden_field(:page_id) +
                             route_form.hidden_field(:answer_value) +
-                            route_form.govuk_select(:goto, options_for_select(route_form.object.goto_options, route_form.object.goto), label: route_form.object.label, id: route_form.field_id(:goto))
+                            route_form.govuk_select(
+                              :goto,
+                              options_for_select(route_form.object.goto_options, route_form.object.goto),
+                              label: route_form.object.label,
+                              id: route_form.field_id(:goto),
+                              class: ["govuk-!-width-full"],
+                            )
                         end %>
                       </li>
                     <% end %>


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The width of a select input depends on the longest option in the input; on the edit routes page which has lots of them each with different options the last select input on the page can end up much less wide than the others, which is visually distracting.

This commit fixes that issue by using a width override to make each input take up the full available space of the grid column. This doesn't take up the full width of the viewport, because of the grid, but is still a bit wider than strictly necessary; however all the other width overrides are not wide enough for a question of reasonable length.

Thanks @lorna-howes for spotting the issue!

### Screenshots

#### Before

<img width="780" height="647" alt="Screenshot of the edit routes page before this change, showing multiple select inputs with the last being much less wide than the ones before" src="https://github.com/user-attachments/assets/726ea91f-6868-40fa-ac3a-89018c8cf063" />

#### After

<img width="819" height="654" alt="Screenshot of the edit routes page after this change, showing multiple select inputs all the same width" src="https://github.com/user-attachments/assets/b44467b5-aa7f-4378-b75d-ab4a92bae45d" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
