### PR TITLE
Make copy of answers feature flag configurable by group

### DIFF
--- a/app/controllers/forms/copy_of_answers_controller.rb
+++ b/app/controllers/forms/copy_of_answers_controller.rb
@@ -24,7 +24,7 @@ module Forms
     end
 
     def check_feature_flag
-      raise NotFoundError unless FeatureService.enabled?(:send_filler_answers)
+      raise NotFoundError unless FeatureService.new(group: current_form.group).enabled?(:send_filler_answers)
     end
 
     def copy_of_answers_input_params

--- a/app/controllers/forms/what_happens_next_controller.rb
+++ b/app/controllers/forms/what_happens_next_controller.rb
@@ -4,6 +4,7 @@ module Forms
       authorize current_form, :can_view_form?
       @what_happens_next_input = WhatHappensNextInput.new(form: current_form).assign_form_values
       @preview_html = preview_html(@what_happens_next_input)
+      render :new, locals: { current_form: }
     end
 
     def create
@@ -14,15 +15,15 @@ module Forms
       case params[:route_to].to_sym
       when :preview
         if @what_happens_next_input.valid?
-          render :new, status: :ok
+          render :new, status: :ok, locals: { current_form: }
         else
-          render :new, status: :unprocessable_content
+          render :new, status: :unprocessable_content, locals: { current_form: }
         end
       when :save_and_continue
         if @what_happens_next_input.submit
           redirect_to form_path(@what_happens_next_input.form.id), success: t("banner.success.form.what_happens_next_saved")
         else
-          render :new, status: :unprocessable_content
+          render :new, status: :unprocessable_content, locals: { current_form: }
         end
       end
     end

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -65,7 +65,7 @@ private
     rows = [
       { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.payment_link"), path: payment_link_path(@form.id), status: @task_statuses[:payment_link_status] },
     ]
-    if FeatureService.enabled?(:send_filler_answers)
+    if FeatureService.new(group: @form.group).enabled?(:send_filler_answers)
       rows << { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.copy_of_answers"), path: copy_of_answers_path(@form.id), status: @task_statuses[:copy_of_answers_status] }
     end
 

--- a/app/views/forms/what_happens_next/new.html.erb
+++ b/app/views/forms/what_happens_next/new.html.erb
@@ -24,7 +24,7 @@
 
       <%= t("what_happens_next.how_this_content_is_used_html") %>
 
-      <% if FeatureService.enabled?(:send_filler_answers) %>
+      <% if FeatureService.new(group: current_form.group).enabled?(:send_filler_answers) %>
         <p><%= t("what_happens_next.confirmation_email_send_filler_answers_enabled") %></p>
       <% else %>
         <p><%= t("what_happens_next.confirmation_email") %></p>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,8 @@ features:
     enabled_by_group: true
   multiple_branches:
     enabled_by_group: true
-  send_filler_answers: true
+  send_filler_answers:
+    enabled_by_group: true
 
 forms_api:
   # Authentication key to authenticate with forms-api

--- a/db/migrate/20260608112508_add_send_filler_answers_enabled_to_groups.rb
+++ b/db/migrate/20260608112508_add_send_filler_answers_enabled_to_groups.rb
@@ -1,0 +1,5 @@
+class AddSendFillerAnswersEnabledToGroups < ActiveRecord::Migration[8.1]
+  def change
+    add_column :groups, :send_filler_answers_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_112814) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_112508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -158,6 +158,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_112814) do
     t.boolean "multiple_branches_enabled", default: false
     t.string "name"
     t.bigint "organisation_id"
+    t.boolean "send_filler_answers_enabled", default: false
     t.string "status", default: "trial"
     t.datetime "updated_at", null: false
     t.bigint "upgrade_requester_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -127,7 +127,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
 
   # create some test groups
   end_to_end_group = Group.create! name: "End to end tests", organisation: gds, status: :active
-  test_group = Group.create! name: "Test Group", organisation: gds, creator: default_user, status: :active
+  test_group = Group.create! name: "Test Group", organisation: gds, creator: default_user, status: :active, send_filler_answers_enabled: true
   multiple_branches_test_group = Group.create! name: "Test Group with multiple branches", organisation: gds, creator: default_user, status: :active, multiple_branches_enabled: true
   Group.create! name: "Ministry of Tests forms", organisation: mot_org
   Group.create! name: "Ministry of Tests forms - secret!", organisation: mot_org, creator: mot_user

--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -41,6 +41,13 @@ namespace :groups do
     abort usage_message if args[:group_id].blank?
     toggle_multiple_branches_enabled(args[:group_id])
   end
+
+  desc "Toggle send_filler_answers_enabled for a group"
+  task :toggle_send_filler_answers_enabled, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:toggle_send_filler_answers_enabled[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+    toggle_send_filler_answers_enabled(args[:group_id])
+  end
 end
 
 def run_task(task_name, args, rollback:)
@@ -115,4 +122,13 @@ def toggle_multiple_branches_enabled(group_id)
   group.save!
 
   Rails.logger.info "multiple_branches_enabled for #{fmt_group(group)} is now set to #{group.reload.multiple_branches_enabled}"
+end
+
+def toggle_send_filler_answers_enabled(group_id)
+  group = Group.find_by!(external_id: group_id)
+
+  group.send_filler_answers_enabled = !group.send_filler_answers_enabled
+  group.save!
+
+  Rails.logger.info "send_filler_answers_enabled for #{fmt_group(group)} is now set to #{group.reload.send_filler_answers_enabled}"
 end

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -24,7 +24,7 @@ describe "Settings" do
 
     include_examples expected_value_test, :exit_pages, features, { "enabled_by_group" => true }
     include_examples expected_value_test, :multiple_branches, features, { "enabled_by_group" => true }
-    include_examples expected_value_test, :send_filler_answers, features, true
+    include_examples expected_value_test, :send_filler_answers, features, { "enabled_by_group" => true }
   end
 
   describe "forms_api" do

--- a/spec/controllers/forms/copy_of_answers_controller_spec.rb
+++ b/spec/controllers/forms/copy_of_answers_controller_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
-RSpec.describe Forms::CopyOfAnswersController, :feature_send_filler_answers, type: :request do
+RSpec.describe Forms::CopyOfAnswersController, type: :request do
   let(:form) { create(:form, :live, send_copy_of_answers: send_copy_of_answers_original_value) }
   let(:send_copy_of_answers_original_value) { "disabled" }
   let(:current_user) { standard_user }
-  let(:group) { create(:group, organisation: standard_user.organisation) }
+  let(:group) { create(:group, organisation: standard_user.organisation, send_filler_answers_enabled:) }
+  let(:send_filler_answers_enabled) { true }
 
   before do
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -34,7 +35,9 @@ RSpec.describe Forms::CopyOfAnswersController, :feature_send_filler_answers, typ
       end
     end
 
-    context "when the feature flag is disabled", feature_send_filler_answers: false do
+    context "when the feature flag is disabled" do
+      let(:send_filler_answers_enabled) { false }
+
       it "returns 404" do
         expect(response).to have_http_status(:not_found)
       end
@@ -111,7 +114,9 @@ RSpec.describe Forms::CopyOfAnswersController, :feature_send_filler_answers, typ
       end
     end
 
-    context "when the feature flag is disabled", feature_send_filler_answers: false do
+    context "when the feature flag is disabled" do
+      let(:send_filler_answers_enabled) { false }
+
       it "returns 404" do
         post(copy_of_answers_create_path(form_id: form.id), params:)
         expect(response).to have_http_status(:not_found)

--- a/spec/services/form_task_list_service_spec.rb
+++ b/spec/services/form_task_list_service_spec.rb
@@ -6,8 +6,9 @@ describe FormTaskListService do
   let(:organisation) { build :organisation, :with_signed_mou, id: 1 }
   let(:form) { create(:form, :new_form, pages:) }
   let(:pages) { [] }
-  let(:group) { create(:group, name: "Group 1", organisation:, status: group_status) }
+  let(:group) { create(:group, name: "Group 1", organisation:, status: group_status, send_filler_answers_enabled:) }
   let(:group_status) { :trial }
+  let(:send_filler_answers_enabled) { true }
 
   let(:can_view_form) { true }
   let(:can_make_form_live) { false }
@@ -155,14 +156,16 @@ describe FormTaskListService do
         expect(section_rows.first[:path]).to eq "/forms/#{form.id}/payment-link"
       end
 
-      context "when the send_filler_answers feature is enabled", :feature_send_filler_answers do
+      context "when the send_filler_answers feature is enabled" do
         it "has link to copy of answers settings" do
           expect(section_rows[1][:task_name]).to eq "Give people the option to ask for a copy of their answers"
           expect(section_rows[1][:path]).to eq "/forms/#{form.id}/copy-of-answers"
         end
       end
 
-      context "when the send_filler_answers feature is disabled", feature_send_filler_answers: false do
+      context "when the send_filler_answers feature is disabled" do
+        let(:send_filler_answers_enabled) { false }
+
         it "does not have link to copy of answers settings" do
           expect(section_rows.count).to eq 1
         end
@@ -504,7 +507,6 @@ describe FormTaskListService do
 
     context "when editing an existing form" do
       let(:form) { create(:form, :live) }
-      let(:group) { create(:group, name: "Group 1", organisation:, status: group_status) }
       let(:can_make_form_live) { true }
 
       it "has the expected section titles" do

--- a/spec/views/forms/what_happens_next/new.html.erb_spec.rb
+++ b/spec/views/forms/what_happens_next/new.html.erb_spec.rb
@@ -1,14 +1,17 @@
 require "rails_helper"
 
 describe "forms/what_happens_next/new.html.erb" do
-  let(:current_form) { OpenStruct.new(id: 1, name: "Form 1", form_slug: "form-1") }
+  let(:current_form) { create :form }
+  let(:group) { create(:group, send_filler_answers_enabled:) }
+  let(:send_filler_answers_enabled) { true }
   let(:what_happens_next_input) { Forms::WhatHappensNextInput.new(form: current_form).assign_form_values }
   let(:preview_html) { "" }
 
   before do
+    GroupForm.create!(form_id: current_form.id, group_id: group.id)
     assign(:what_happens_next_input, what_happens_next_input)
     assign(:preview_html, preview_html)
-    render template: "forms/what_happens_next/new"
+    render template: "forms/what_happens_next/new", locals: { current_form: }
   end
 
   it "contains an example" do
@@ -28,13 +31,15 @@ describe "forms/what_happens_next/new.html.erb" do
     expect(rendered).to have_text(I18n.t("what_happens_next.reference_numbers"))
   end
 
-  context "when send_filler_answers feature flag is enabled", :feature_send_filler_answers do
+  context "when send_filler_answers feature flag is enabled" do
     it "has content saying that answers might be included in the confirmation email" do
       expect(rendered).to have_text(I18n.t("what_happens_next.confirmation_email_send_filler_answers_enabled"))
     end
   end
 
-  context "when send_filler_answers feature flag is disabled", feature_send_filler_answers: false do
+  context "when send_filler_answers feature flag is disabled" do
+    let(:send_filler_answers_enabled) { false }
+
     it "has content saying answers will not be included in the confirmation email" do
       expect(rendered).to have_text(I18n.t("what_happens_next.confirmation_email"))
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/lnW6zOUs/

So that we can enable the e2e to test the copy of answers feature on all environments before releasing the feature, make the feature flag a per group flag. This will also allow us to manually check the integration with the live One Login environment on prod before releasing.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
