### PR TITLE
Fix stale_conditions same answer value conditions

### DIFF
--- a/app/services/routes/sync_service.rb
+++ b/app/services/routes/sync_service.rb
@@ -30,6 +30,7 @@ private
       condition.assign_attributes(
         route.condition_attributes,
       )
+
       condition.save!
     end
   end
@@ -40,10 +41,14 @@ private
     # If there are no routes marked as default, there's nothing to destroy.
     return if default_routes.none?
 
+    stale_route_pairs = default_routes.map do |route|
+      [route.page_id, route.answer_value.presence]
+    end
+
     stale_conditions = form.conditions.where(
-      routing_page_id: default_routes.map(&:page_id),
-      answer_value: default_routes.map { |r| r.answer_value.presence },
+      %i[routing_page_id answer_value] => stale_route_pairs,
     )
+
     stale_conditions.destroy_all
   end
 end

--- a/spec/services/routes/sync_service_spec.rb
+++ b/spec/services/routes/sync_service_spec.rb
@@ -71,16 +71,31 @@ RSpec.describe Routes::SyncService do
         create(:condition, routing_page_id: pages.first.id, answer_value: "Yes", goto_page_id: pages.second.id)
       end
 
+      # Create a condition that shouldn't be removed
+      let!(:healthy_condition) do
+        create(:condition, routing_page_id: pages.second.id, answer_value: "Yes", goto_page_id: pages.third.id)
+      end
+
       # Provide a route that matches the stale condition's key, but is now a "default" route.
       let(:routes) do
         [
+          # Route for the first page, which is default so conditions are removed
           build(:route_input, :default, page: pages.first, answer_value: "Yes"),
+          # Two routes for the second page, which should not be removed
+          build(:route_input, page: pages.second, goto: pages.third.id, answer_value: "Yes"),
+          # This is default but has no conditions to remove
+          build(:route_input, :default, page: pages.second, answer_value: "No"),
         ]
       end
 
       it "destroys the condition that is now a default route" do
         expect { service.sync_conditions_from_routes }.to change(Condition, :count).by(-1)
         expect(Condition.exists?(stale_condition.id)).to be false
+      end
+
+      it "does not destroy other page's conditions with the same answer value" do
+        service.sync_conditions_from_routes
+        expect(Condition.exists?(healthy_condition.id)).to be true
       end
     end
 


### PR DESCRIPTION
When creating a new set of routes for a form using the Routes::SyncService, a bug occurs when two conditions for different questions share the same answer value. For example, two selection option questions might both have Yes and No as their selection options, so conditions based on either of those questions would have identical-seeming answer values.

The check to see whether a condition can be deleted because it is stale (i.e. it points to the next question, so doesn't need to exist as a condition) was using the answer values from every condition for the form to identify stale conditions by routing_page_id and answer_value.

This meant that conditions which had a routing_page_id matching a route in the list of default_routes, and an answer_value matching an answer_value in any other route in the entire form's default_routes would be considered to be stale, and destroyed.

This change makes it so that stale conditions are identified using the list of default_routes, but only using the answer_value based on the specific default route's, rather than across every default route.


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
