### PR TITLE
Update labels and option text on new routes page

### DIFF
--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -76,7 +76,7 @@ private
         answer_value:,
         goto: goto_value_for(condition),
         goto_options: options_for_goto_page(page, condition&.goto_page_id),
-        label: { text: "Option #{index}: #{answer_value_label}" },
+        label: { text: "If option #{index} (#{answer_value_label}), go to:" },
       )
     end
   end
@@ -92,7 +92,7 @@ private
         page:,
         goto: goto_value_for(condition),
         goto_options: options_for_goto_page(page, condition&.goto_page_id),
-        label: { text: "Go to", hidden: true },
+        label: { text: "After question #{page.position}, go to:" },
       ),
     ]
   end

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -45,7 +45,7 @@ class Routes::BuildService
       if drop
         if value == next_page_id
           drop = false
-          ["Go to question #{page.position.next}", Forms::RouteInput::DEFAULT_VALUE]
+          ["#{page.position.next}. #{next_page.question_text}", Forms::RouteInput::DEFAULT_VALUE]
         elsif selected && value == selected
           option
         end

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Routes::BuildService do
 
         it "sets the label correctly for a generic page" do
           route_for_page1 = service.build_routes.first
-          expect(route_for_page1.label).to eq({ text: "Go to", hidden: true })
+          expect(route_for_page1.label).to eq({ text: "After question #{pages.first.position}, go to:" })
         end
 
         context "when a condition exists for the generic page" do
@@ -117,10 +117,10 @@ RSpec.describe Routes::BuildService do
           route_for_no = routes_for_page1.find { |r| r.answer_value == "No" }
 
           expect(route_for_yes.goto).to eq(Forms::RouteInput::DEFAULT_VALUE)
-          expect(route_for_yes.label).to eq({ text: "Option 1: Yes" })
+          expect(route_for_yes.label).to eq({ text: "If option 1 (Yes), go to:" })
 
           expect(route_for_no.goto).to eq(Forms::RouteInput::DEFAULT_VALUE)
-          expect(route_for_no.label).to eq({ text: "Option 2: No" })
+          expect(route_for_no.label).to eq({ text: "If option 2 (No), go to:" })
         end
 
         context "when the selection page has more than 10 options" do
@@ -154,7 +154,7 @@ RSpec.describe Routes::BuildService do
 
             none_of_the_above_route = routes_for_page1.find { |r| r.answer_value == "none_of_the_above" }
             expect(none_of_the_above_route).not_to be_nil
-            expect(none_of_the_above_route.label[:text]).to eq("Option 3: None of the above")
+            expect(none_of_the_above_route.label[:text]).to eq("If option 3 (None of the above), go to:")
           end
         end
 
@@ -207,7 +207,7 @@ RSpec.describe Routes::BuildService do
           expect(route_for_page1).to be_a(Forms::RouteInput)
           expect(route_for_page1.page_id).to eq(pages.first.id)
           expect(route_for_page1.answer_value).to be_nil
-          expect(route_for_page1.label).to eq({ text: "Go to", hidden: true })
+          expect(route_for_page1.label).to eq({ text: "After question #{pages.first.position}, go to:" })
         end
       end
     end

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Routes::BuildService do
       options = service.options_for_goto_page(pages.first)
       default_option = options.find { |opt| opt[1] == Forms::RouteInput::DEFAULT_VALUE }
 
-      expect(default_option).to eq(["Go to question 2", Forms::RouteInput::DEFAULT_VALUE])
+      expect(default_option).to eq(["2. #{pages.second.question_text}", Forms::RouteInput::DEFAULT_VALUE])
     end
 
     it "does not include the current page in the options" do
@@ -256,7 +256,7 @@ RSpec.describe Routes::BuildService do
       options = service.options_for_goto_page(pages.second)
 
       expect(options).to eq [
-        ["Go to question 3", Forms::RouteInput::DEFAULT_VALUE],
+        ["3. #{pages.third.question_text}", Forms::RouteInput::DEFAULT_VALUE],
         ["End of the form", "end_of_form"],
       ]
     end
@@ -267,7 +267,7 @@ RSpec.describe Routes::BuildService do
 
         expect(options).to eq [
           ["1. #{pages.first.question_text}", pages.first.id],
-          ["Go to question 3", Forms::RouteInput::DEFAULT_VALUE],
+          ["3. #{pages.third.question_text}", Forms::RouteInput::DEFAULT_VALUE],
           ["End of the form", "end_of_form"],
         ]
       end

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -81,7 +81,7 @@ describe "routes/show.html.erb" do
 
       expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][0][goto]"]') do |field|
         expect(select_options(field)).to eq [
-          ["default", "Go to question 2"],
+          ["default", "2. #{pages.second.question_text}"],
           ["103", "3. #{pages.third.question_text}"],
           ["end_of_form", "End of the form"],
         ]
@@ -89,7 +89,7 @@ describe "routes/show.html.erb" do
 
       expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][1][goto]"]') do |field|
         expect(select_options(field)).to eq [
-          ["default", "Go to question 3"],
+          ["default", "3. #{pages.third.question_text}"],
           ["end_of_form", "End of the form"],
         ]
       end


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/53dcbwCq/3138-update-labels-and-option-text-on-new-routes-page

Updates to the routes page:
 - Default options now use the same text as all other page options
 - Non-selection question dropdowns are labelled, with the visually hidden label removed
 - Selection question dropdown labels use the new text

---

### Before

<img width="734" height="588" alt="image" src="https://github.com/user-attachments/assets/385898cc-2f5d-43bc-b271-a3a37ae49863" />


---
### After

<img width="717" height="601" alt="image" src="https://github.com/user-attachments/assets/6f410981-446e-4654-b49c-6269a4067ed3" />


