### PR TITLE
Backward route validate

### DIFF
--- a/app/components/page_list_component/error_summary/view.rb
+++ b/app/components/page_list_component/error_summary/view.rb
@@ -10,6 +10,10 @@ module PageListComponent
         "condition_#{number}"
       end
 
+      def self.page_error_id(page)
+        "page-#{page.id}"
+      end
+
       def self.generate_error_message(error_name, condition:, page:)
         # TODO: route_number is hardcoded as 1 here because we know there can be only two conditions. It will need to change in future
         # https://trello.com/c/BfkZEIgM/3446-set-route-count-dynamically-instead-of-hard-coding-it
@@ -22,6 +26,18 @@ module PageListComponent
         defaults.prepend(:"any_other_answer_route.#{error_name}") if condition.secondary_skip?
 
         I18n.t(defaults.first, default: defaults.drop(1), scope:, **interpolation_variables)
+      end
+
+      def self.multiple_branch_error_message(page)
+        page_errors = page.routing_conditions.filter(&:warning_goto_page_before_routing_page)
+
+        return if page_errors.blank?
+
+        if Forms::RoutesInput.route_with_selection_options?(page)
+          I18n.t("errors.routes.page_list.cannot_route_backwards_from_selection_page", question_number: page.position, count: page_errors.count)
+        else
+          I18n.t("errors.routes.page_list.cannot_route_backwards_from_generic_page", question_number: page.position)
+        end
       end
 
       def error_object(error_name:, condition:, page:)

--- a/app/components/page_list_component/error_summary/view.rb
+++ b/app/components/page_list_component/error_summary/view.rb
@@ -48,15 +48,28 @@ module PageListComponent
       end
 
       def errors_for_summary
-        @form.conditions.map { |condition|
-          condition.validation_errors.map do |error|
-            error_object(
-              error_name: error.name,
-              page: condition.check_page,
-              condition: condition,
+        if FeatureService.new(group: @form.group).enabled?(:multiple_branches)
+          @form.pages.map { |page|
+            error_message = self.class.multiple_branch_error_message(page)
+
+            next if error_message.blank?
+
+            OpenStruct.new(
+              message: error_message,
+              link: "##{self.class.page_error_id(page)}",
             )
-          end
-        }.flatten
+          }.compact
+        else
+          @form.conditions.map { |condition|
+            condition.validation_errors.map do |error|
+              error_object(
+                error_name: error.name,
+                page: condition.check_page,
+                condition: condition,
+              )
+            end
+          }.flatten
+        end
       end
     end
   end

--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -33,11 +33,21 @@
           </div>
 
           <% if FeatureService.new(group: @form.group).enabled?(:multiple_branches) && page.routing_conditions.present? %>
-            <div class="govuk-summary-list__row">
+            <% error_message = PageListComponent::ErrorSummary::View.multiple_branch_error_message(page) %>
+            <div id="<%= PageListComponent::ErrorSummary::View.page_error_id(page) %>" class="govuk-summary-list__row app-page-list__row <%= class_names( "govuk-form-group--error": error_message.present?) %>">
               <dt class="govuk-summary-list__key app-page-list__key">
                 <%= t("page_conditions.condition_list_key", count: page.routing_conditions.count, question_number: page.position) %>
               </dt>
               <dd class="govuk-summary-list__value">
+
+              <% if error_message.present? %>
+                <ul class="govuk-list govuk-!-margin-0">
+                  <li class="app-page_list__route-text--error">
+                    <%= error_message %>
+                  </li>
+                </ul>
+              <% end %>
+
                 <% if page.routing_conditions.first.answer_value.present? %>
                   <% answer_value_groups(page).each do |_, group| %>
                     <p><%= condition_group_description(group) %></p>

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -5,6 +5,7 @@ class RoutesController < FormsController
   def show
     authorize current_form, :can_view_form?
     @routes_input = Forms::RoutesInput.new(form: form_with_pages_and_conditions).assign_form_values
+    @routes_input.validate
   end
 
   def create

--- a/app/input_objects/forms/route_input.rb
+++ b/app/input_objects/forms/route_input.rb
@@ -11,6 +11,8 @@ class Forms::RouteInput < BaseInput
 
   attr_accessor :page, :goto_page, :goto_options, :label
 
+  validate :route_is_not_backwards
+
   def goes_to_default_next_page?
     goto == DEFAULT_VALUE
   end
@@ -26,6 +28,29 @@ class Forms::RouteInput < BaseInput
       nil
     else
       { goto_page_id: goto, skip_to_end: false, check_page_id: page.id }
+    end
+  end
+
+private
+
+  def route_is_not_backwards
+    return if skippable_for_backwards_validation?
+
+    return if goto_page.position > page.position
+
+    errors.add(:goto, error_message_for_backwards_route)
+  end
+
+  def skippable_for_backwards_validation?
+    goes_to_default_next_page? || goes_to_end_of_form? || goto_page.nil?
+  end
+
+  def error_message_for_backwards_route
+    if Forms::RoutesInput.route_with_selection_options?(page)
+      option_index = page.answer_settings.selection_options.find_index { |option| option["value"] == answer_value }
+      I18n.t("errors.routes.cannot_route_backwards_from_selection_page", question_number: page.position, option_number: option_index + 1)
+    else
+      I18n.t("errors.routes.cannot_route_backwards_from_generic_page", question_number: page.position)
     end
   end
 end

--- a/app/input_objects/forms/route_input.rb
+++ b/app/input_objects/forms/route_input.rb
@@ -9,7 +9,7 @@ class Forms::RouteInput < BaseInput
   attribute :goto
   attribute :answer_value
 
-  attr_accessor :page, :goto_options, :label
+  attr_accessor :page, :goto_page, :goto_options, :label
 
   def goes_to_default_next_page?
     goto == DEFAULT_VALUE

--- a/app/input_objects/forms/routes_input.rb
+++ b/app/input_objects/forms/routes_input.rb
@@ -5,6 +5,10 @@ class Forms::RoutesInput < BaseInput
     page.answer_settings["selection_options"].length > 10
   end
 
+  def self.route_with_selection_options?(page)
+    page.answer_type == "selection" && page.answer_settings.only_one_option == "true" && !Forms::RoutesInput.too_many_selection_options?(page)
+  end
+
   def initialize(attributes = {})
     @form = attributes.delete(:form)
     super

--- a/app/input_objects/forms/routes_input.rb
+++ b/app/input_objects/forms/routes_input.rb
@@ -40,9 +40,12 @@ class Forms::RoutesInput < BaseInput
       page = pages_by_id[route_attrs["page_id"].to_i]
       next unless page # Skip if page not found or doesn't belong to form
 
+      goto_page = pages_by_id[route_attrs["goto"].to_i]
+
       Forms::RouteInput.new(
         route_attrs.symbolize_keys.merge(
           page:,
+          goto_page:,
           goto_options: route_build_service.options_for_goto_page(page, route_attrs["goto"]),
         ),
       )

--- a/app/input_objects/forms/routes_input.rb
+++ b/app/input_objects/forms/routes_input.rb
@@ -1,5 +1,9 @@
 class Forms::RoutesInput < BaseInput
+  include ActionView::Helpers::FormTagHelper
+
   attr_accessor :form, :routes
+
+  validate :routes_are_valid
 
   def self.too_many_selection_options?(page)
     page.answer_settings["selection_options"].length > 10
@@ -15,8 +19,6 @@ class Forms::RoutesInput < BaseInput
   end
 
   def submit
-    # TODO: Add validations - this is here so we don't forget it but the model
-    # can't be invalid yet
     return false if invalid?
 
     Routes::SyncService.new(form:, routes:).sync_conditions_from_routes
@@ -50,5 +52,20 @@ class Forms::RoutesInput < BaseInput
         ),
       )
     }.compact
+  end
+
+  def routes_are_valid
+    return if routes.nil?
+
+    routes.each.with_index do |route, index|
+      next if route.valid?
+
+      route.errors.each do |error|
+        attribute_key = "routes_attributes[#{index}][#{error.attribute}]"
+        error_field_id = field_id(:forms_routes_input_routes_attributes, error.attribute, index: index)
+
+        errors.add(attribute_key, error.message, url: "##{error_field_id}")
+      end
+    end
   end
 end

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -17,9 +17,7 @@ class Routes::BuildService
     end
 
     form.pages.flat_map do |page|
-      if page.answer_type == "selection" &&
-          page.answer_settings.only_one_option == "true" &&
-          !Forms::RoutesInput.too_many_selection_options?(page)
+      if Forms::RoutesInput.route_with_selection_options?(page)
         build_routes_for_selection_page(page, conditions_by_key)
       else
         build_route_for_generic_page(page, conditions_by_key)

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -73,6 +73,7 @@ private
         page:,
         answer_value:,
         goto: goto_value_for(condition),
+        goto_page: condition&.goto_page,
         goto_options: options_for_goto_page(page, condition&.goto_page_id),
         label: { text: "Option #{index}: #{answer_value_label}" },
       )
@@ -89,6 +90,7 @@ private
         page_id: page.id,
         page:,
         goto: goto_value_for(condition),
+        goto_page: condition&.goto_page,
         goto_options: options_for_goto_page(page, condition&.goto_page_id),
         label: { text: "Go to", hidden: true },
       ),

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -4,9 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% unless FeatureService.new(group: current_form.group).enabled?(:multiple_branches) %>
-      <%= render PageListComponent::ErrorSummary::View.new(current_form) %>
-    <% end %>
+    <%= render PageListComponent::ErrorSummary::View.new(current_form) %>
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       <span class="govuk-caption-l"><%= current_form.name %></span><span class="govuk-visually-hidden"> - </span>

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -33,7 +33,7 @@
                           route_form.hidden_field(:id) +
                             route_form.hidden_field(:page_id) +
                             route_form.hidden_field(:answer_value) +
-                            route_form.govuk_select(:goto, options_for_select(route_form.object.goto_options, route_form.object.goto), label: route_form.object.label)
+                            route_form.govuk_select(:goto, options_for_select(route_form.object.goto_options, route_form.object.goto), label: route_form.object.label, id: route_form.field_id(:goto))
                         end %>
                       </li>
                     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,6 +365,9 @@ en:
       goto_page_doesnt_exist: The question you’re taking the person to no longer exists - edit question %{question_number}’s route
       route_number_for_any_other_answer: for any other answer
     prefix: 'Error:'
+    routes:
+      cannot_route_backwards_from_generic_page: The route from question %{question_number} cannot go to a previous question - edit this route
+      cannot_route_backwards_from_selection_page: The route from question %{question_number}, option %{option_number}, cannot go to a previous question - edit this route
   exit_page:
     no_content_added_html: "<p>No content added</p>"
   feedback_link:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,6 +368,11 @@ en:
     routes:
       cannot_route_backwards_from_generic_page: The route from question %{question_number} cannot go to a previous question - edit this route
       cannot_route_backwards_from_selection_page: The route from question %{question_number}, option %{option_number}, cannot go to a previous question - edit this route
+      page_list:
+        cannot_route_backwards_from_generic_page: The route from question %{question_number} cannot go to a previous question - edit this route
+        cannot_route_backwards_from_selection_page:
+          one: A route from question %{question_number} is going to a previous question - edit this route
+          other: Routes from question %{question_number} are going to a previous question - edit this question’s routes
   exit_page:
     no_content_added_html: "<p>No content added</p>"
   feedback_link:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -367,7 +367,7 @@ en:
     prefix: 'Error:'
     routes:
       cannot_route_backwards_from_generic_page: The route from question %{question_number} cannot go to a previous question - edit this route
-      cannot_route_backwards_from_selection_page: The route from question %{question_number}, option %{option_number}, cannot go to a previous question - edit this route
+      cannot_route_backwards_from_selection_page: The route from question %{question_number}, option %{option_number} cannot go to a previous question - edit this route
       page_list:
         cannot_route_backwards_from_generic_page: The route from question %{question_number} cannot go to a previous question - edit this route
         cannot_route_backwards_from_selection_page:

--- a/spec/components/page_list_component/error_summary/error_summary_component_preview.rb
+++ b/spec/components/page_list_component/error_summary/error_summary_component_preview.rb
@@ -2,7 +2,7 @@ class PageListComponent::ErrorSummary::ErrorSummaryComponentPreview < ViewCompon
   include FactoryBot::Syntax::Methods
 
   def default
-    form = build(:form, id: 1, pages: [])
+    form = build(:form, :with_group, id: 1, pages: [])
 
     render(PageListComponent::ErrorSummary::View.new(form))
   end
@@ -13,7 +13,7 @@ class PageListComponent::ErrorSummary::ErrorSummaryComponentPreview < ViewCompon
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions:),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: []),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    form = build(:form, id: 0, pages:)
+    form = build(:form, :with_group, id: 0, pages:)
 
     # We need to build the records rather than create them so that we don't save them to the database when we view the
     # preview. However, this means that the associations aren't available so we need to manually set the associations
@@ -35,7 +35,7 @@ class PageListComponent::ErrorSummary::ErrorSummaryComponentPreview < ViewCompon
     pages = [(build :page, id: 1, position: 1, question_text: "Enter your name", routing_conditions: routing_conditions_page_1),
              (build :page, id: 2, position: 2, question_text: "What is your pet's phone number?", routing_conditions: routing_conditions_page_2),
              (build :page, id: 3, position: 3, question_text: "How many pets do you own?", routing_conditions: [])]
-    form = build(:form, id: 0, pages:)
+    form = build(:form, :with_group, id: 0, pages:)
 
     # We need to build the records rather than create them so that we don't save them to the database when we view the
     # preview. However, this means that the associations aren't available so we need to manually set the associations

--- a/spec/components/page_list_component/error_summary/view_spec.rb
+++ b/spec/components/page_list_component/error_summary/view_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PageListComponent::ErrorSummary::View, type: :component do
   let(:pages) { form.reload.pages }
   let(:error_summary_component) { described_class.new(form) }
 
-  describe "rendering component" do
+  describe "rendering component", feature_multiple_branches: false do
     context "when there are no pages" do
       it "is blank" do
         render_inline(error_summary_component)
@@ -138,11 +138,34 @@ RSpec.describe PageListComponent::ErrorSummary::View, type: :component do
     end
 
     describe "#errors_for_summary" do
-      it "returns all of the routing errors for a form with their respective positions and links" do
-        expect(error_summary_component.errors_for_summary).to eq [
-          OpenStruct.new(message: I18n.t("errors.page_conditions.answer_value_doesnt_exist", question_number: pages.first.position, route_number: 1), link: "#condition_#{condition_with_answer_value_missing.id}"),
-          OpenStruct.new(message: I18n.t("errors.page_conditions.goto_page_doesnt_exist", question_number: pages.second.position, route_number: 1), link: "#condition_#{condition_with_goto_page_missing.id}"),
-        ]
+      context "when the multiple_branches feature is disabled", feature_multiple_branches: false do
+        it "returns all of the routing errors for a form with their respective positions and links" do
+          expect(error_summary_component.errors_for_summary).to eq [
+            OpenStruct.new(message: I18n.t("errors.page_conditions.answer_value_doesnt_exist", question_number: pages.first.position, route_number: 1), link: "#condition_#{condition_with_answer_value_missing.id}"),
+            OpenStruct.new(message: I18n.t("errors.page_conditions.goto_page_doesnt_exist", question_number: pages.second.position, route_number: 1), link: "#condition_#{condition_with_goto_page_missing.id}"),
+          ]
+        end
+      end
+
+      context "when the multiple_branches feature is enabled", :feature_multiple_branches do
+        it "returns an empty array" do
+          expect(error_summary_component.errors_for_summary).to eq []
+        end
+
+        context "when there is a backward route" do
+          let(:expected_page_field_id) { "page-#{form.pages.second.id}" }
+
+          before do
+            create :condition, routing_page_id: form.pages.second.id, check_page_id: form.pages.second.id, goto_page_id: form.pages.first.id
+            form.pages.second.reload
+          end
+
+          it "returns only the backward route error" do
+            expect(error_summary_component.errors_for_summary).to eq [
+              OpenStruct.new(message: "A route from question 2 is going to a previous question - edit this route", link: "##{expected_page_field_id}"),
+            ]
+          end
+        end
       end
     end
   end

--- a/spec/components/page_list_component/error_summary/view_spec.rb
+++ b/spec/components/page_list_component/error_summary/view_spec.rb
@@ -146,4 +146,50 @@ RSpec.describe PageListComponent::ErrorSummary::View, type: :component do
       end
     end
   end
+
+  describe "multiple branch errors" do
+    let(:form) { create :form, :ready_for_routing }
+
+    describe "multiple_branch_error_message" do
+      it "returns nil when the page has no errors" do
+        expect(described_class.multiple_branch_error_message(form.pages.first)).to be_nil
+      end
+
+      context "when the page is a generic page with a backward route" do
+        before do
+          create :condition, routing_page_id: form.pages.second.id, check_page_id: form.pages.second.id, goto_page_id: form.pages.first.id
+          form.pages.second.reload
+        end
+
+        it "returns the correct error message" do
+          expect(described_class.multiple_branch_error_message(form.pages.second)).to eq "A route from question 2 is going to a previous question - edit this route"
+        end
+      end
+
+      context "when the page is a selection page with a single backward route" do
+        before do
+          form.pages << (create :page, :with_selection_settings, form: form, position: 2)
+          create :condition, routing_page_id: form.pages.last.id, check_page_id: form.pages.last.id, goto_page_id: form.pages.first.id, answer_value: "Option 1"
+          form.pages.last.reload
+        end
+
+        it "returns the correct error message" do
+          expect(described_class.multiple_branch_error_message(form.pages.last)).to eq "A route from question 2 is going to a previous question - edit this route"
+        end
+      end
+
+      context "when the page is a selection page with multiple backward routes" do
+        before do
+          form.pages << (create :page, :with_selection_settings, form: form, position: 2)
+          create :condition, routing_page_id: form.pages.last.id, check_page_id: form.pages.last.id, goto_page_id: form.pages.first.id, answer_value: "Option 1"
+          create :condition, routing_page_id: form.pages.last.id, check_page_id: form.pages.last.id, goto_page_id: form.pages.first.id, answer_value: "Option 2"
+          form.pages.last.reload
+        end
+
+        it "returns the correct error message" do
+          expect(described_class.multiple_branch_error_message(form.pages.last)).to eq "Routes from question 2 are going to a previous question - edit this question’s routes"
+        end
+      end
+    end
+  end
 end

--- a/spec/factories/input_objects/forms/route_input.rb
+++ b/spec/factories/input_objects/forms/route_input.rb
@@ -2,23 +2,27 @@ FactoryBot.define do
   factory :route_input, class: "Forms::RouteInput" do
     transient do
       page { association :page }
+      goto_page { association :page }
     end
 
     # Assign attributes based on the transient page object.
     page_id { page.id }
     answer_value { "Yes" }
-    goto { build_stubbed(:page).id }
+    goto { goto_page.id }
 
     after(:build) do |route_input, evaluator|
       route_input.page = evaluator.page
+      route_input.goto_page = evaluator.goto_page
     end
 
     trait :default do
       goto { Forms::RouteInput::DEFAULT_VALUE }
+      goto_page { nil }
     end
 
     trait :check_your_answers do
       goto { Forms::RouteInput::END_OF_FORM_VALUE }
+      goto_page { nil }
     end
   end
 end

--- a/spec/input_objects/forms/route_input_spec.rb
+++ b/spec/input_objects/forms/route_input_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Forms::RouteInput, type: :model do
   let(:check_your_answers_value) { described_class::END_OF_FORM_VALUE }
   let(:default_value) { described_class::DEFAULT_VALUE }
 
-  let(:page) { build_stubbed(:page) }
-  let(:goto_page) { build_stubbed(:page) }
+  let(:page) { build_stubbed(:page, position: 1) }
+  let(:goto_page) { build_stubbed(:page, position: 2) }
 
   let(:attributes) do
     {
@@ -101,6 +101,52 @@ RSpec.describe Forms::RouteInput, type: :model do
       expect(route_input.condition_attributes).to eq(
         { goto_page_id: 123, skip_to_end: false, check_page_id: page.id },
       )
+    end
+  end
+
+  describe "#route_is_not_backwards" do
+    context "when the route is not backwards" do
+      let(:page) { build_stubbed(:page, position: 1) }
+      let(:goto_page) { build_stubbed(:page, position: 2) }
+
+      it "does not add an error" do
+        expect(route_input).to be_valid
+      end
+    end
+
+    context "when the route is backwards" do
+      let(:page) { build_stubbed(:page, position: 2) }
+      let(:goto_page) { build_stubbed(:page, position: 1) }
+
+      it "adds the correct error" do
+        expect(route_input).to be_invalid
+        expect(route_input.errors[:goto]).to eq(["The route from question 2 cannot go to a previous question - edit this route"])
+      end
+
+      context "when the route is for a selection question" do
+        let(:page) { build_stubbed(:page, :with_selection_settings, position: 2) }
+        let(:attributes) { super().merge(answer_value: "Option 1") }
+
+        it "adds the correct error" do
+          expect(route_input).to be_invalid
+          expect(route_input.errors[:goto]).to eq(["The route from question 2, option 1, cannot go to a previous question - edit this route"])
+        end
+      end
+
+      it "doesn't add an error for a default route" do
+        route_input.goto = default_value
+        expect(route_input).to be_valid
+      end
+
+      it "doesn't add an error for an end of form route" do
+        route_input.goto = check_your_answers_value
+        expect(route_input).to be_valid
+      end
+
+      it "doesn't add an error when not goto_page is set" do
+        route_input.goto_page = nil
+        expect(route_input).to be_valid
+      end
     end
   end
 end

--- a/spec/input_objects/forms/route_input_spec.rb
+++ b/spec/input_objects/forms/route_input_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Forms::RouteInput, type: :model do
 
         it "adds the correct error" do
           expect(route_input).to be_invalid
-          expect(route_input.errors[:goto]).to eq(["The route from question 2, option 1, cannot go to a previous question - edit this route"])
+          expect(route_input.errors[:goto]).to eq(["The route from question 2, option 1 cannot go to a previous question - edit this route"])
         end
       end
 

--- a/spec/input_objects/forms/route_input_spec.rb
+++ b/spec/input_objects/forms/route_input_spec.rb
@@ -7,14 +7,16 @@ RSpec.describe Forms::RouteInput, type: :model do
   let(:default_value) { described_class::DEFAULT_VALUE }
 
   let(:page) { build_stubbed(:page) }
+  let(:goto_page) { build_stubbed(:page) }
 
   let(:attributes) do
     {
       id: 1,
       page_id: 2,
-      goto: 3,
+      goto: goto_page.id,
       answer_value: "Yes",
       page: page,
+      goto_page: goto_page,
     }
   end
 
@@ -26,7 +28,7 @@ RSpec.describe Forms::RouteInput, type: :model do
     it "can be initialized with a hash of attributes" do
       expect(route_input.id).to eq(1)
       expect(route_input.page_id).to eq(2)
-      expect(route_input.goto).to eq(3)
+      expect(route_input.goto).to eq(goto_page.id)
       expect(route_input.answer_value).to eq("Yes")
       expect(route_input.page).to eq(page)
     end

--- a/spec/input_objects/forms/routes_input_spec.rb
+++ b/spec/input_objects/forms/routes_input_spec.rb
@@ -151,4 +151,38 @@ RSpec.describe Forms::RoutesInput do
       end
     end
   end
+
+  describe "#route_with_selection_options" do
+    context "when given a page with less than 10 selection options, only one option" do
+      let(:page) { build(:page, :with_selection_settings) }
+
+      it "returns true" do
+        expect(described_class.route_with_selection_options?(page)).to be true
+      end
+    end
+
+    context "when given a page with more than 10 selection options, only one option" do
+      let(:page) { build(:page, :with_selection_settings, selection_options: (1..11).to_a.map { |i| { name: i.to_s, value: i.to_s } }) }
+
+      it "returns false" do
+        expect(described_class.route_with_selection_options?(page)).to be false
+      end
+    end
+
+    context "when given a selection page with checkboxes" do
+      let(:page) { build(:page, :selection_with_checkboxes) }
+
+      it "returns false" do
+        expect(described_class.route_with_selection_options?(page)).to be false
+      end
+    end
+
+    context "when given a page which isn't a selection type" do
+      let(:page) { build(:page, :with_text_settings) }
+
+      it "returns false" do
+        expect(described_class.route_with_selection_options?(page)).to be false
+      end
+    end
+  end
 end

--- a/spec/input_objects/forms/routes_input_spec.rb
+++ b/spec/input_objects/forms/routes_input_spec.rb
@@ -89,12 +89,14 @@ RSpec.describe Forms::RoutesInput do
 
         expect(Forms::RouteInput).to have_received(:new).with(
           page_id: pages.first.id.to_s,
+          goto_page: pages.second,
           goto: pages.second.id.to_s,
           page: pages.first,
           goto_options:,
         )
         expect(Forms::RouteInput).to have_received(:new).with(
           page_id: pages.second.id.to_s,
+          goto_page: nil,
           goto: "1",
           page: pages.second,
           goto_options:,
@@ -124,6 +126,7 @@ RSpec.describe Forms::RoutesInput do
         expect(Forms::RouteInput).to have_received(:new).with(
           page_id: pages.first.id.to_s,
           page: pages.first,
+          goto_page: nil,
           goto_options:,
         )
       end

--- a/spec/input_objects/forms/routes_input_spec.rb
+++ b/spec/input_objects/forms/routes_input_spec.rb
@@ -188,4 +188,58 @@ RSpec.describe Forms::RoutesInput do
       end
     end
   end
+
+  describe "#routes_are_valid" do
+    before do
+      routes_input.routes = routes
+      routes_input.validate
+    end
+
+    context "when routes are valid" do
+      let(:routes) { build_list(:route_input, 2) }
+
+      it "is valid" do
+        expect(routes_input).to be_valid
+      end
+    end
+
+    context "when there are no routes" do
+      let(:routes) { [] }
+
+      it "is valid" do
+        expect(routes_input).to be_valid
+      end
+    end
+
+    context "when a route is invalid" do
+      let(:routes) do
+        [
+          instance_double(
+            Forms::RouteInput,
+            valid?: false,
+            errors: [instance_double(ActiveModel::Error, attribute: :goto, message: "a mock error")],
+          ),
+        ]
+      end
+
+      it "makes the parent object invalid" do
+        expect(routes_input).to be_invalid
+      end
+
+      it "copies the error from the route" do
+        expected_key = "routes_attributes[0][goto]".to_sym
+        expect(routes_input.errors).to have_key(expected_key)
+        expect(routes_input.errors.messages[expected_key]).to include("a mock error")
+      end
+
+      it "adds the URL" do
+        expected_key = "routes_attributes[0][goto]".to_sym
+        expected_url = "#forms_routes_input_routes_attributes_0_goto"
+
+        error_detail = routes_input.errors.details[expected_key].first
+        expect(error_detail).to have_key(:url)
+        expect(error_detail[:url]).to eq(expected_url)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Add validations to the routes page for backwards routes

Trello card: https://trello.com/c/mwYaCg6h/3137-show-errors-for-backwards-routes-when-multiple-branches-are-enabled

This PR adds backward route validation to the multiple branches routes and page list.

In the routes code, we use new validation. In the page list, we use the Conditions. I think in the long term, the validation should all happen in the routes input which should be used in the page list too. While the feature is still in development, I think using the condition code for now makes sense.

## The routes view:

<img width="814" height="2005" alt="image" src="https://github.com/user-attachments/assets/f95de227-b1d6-476b-bc8d-c88e6e5dd364" />


## The page list view:

<img width="703" height="2837" alt="image" src="https://github.com/user-attachments/assets/ea7517bc-21fd-4fac-b8af-b7098853ab26" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
