### PR TITLE
Fix none of the above route backwards

### DIFF
--- a/app/input_objects/forms/route_input.rb
+++ b/app/input_objects/forms/route_input.rb
@@ -9,7 +9,7 @@ class Forms::RouteInput < BaseInput
   attribute :goto
   attribute :answer_value
 
-  attr_accessor :page, :goto_page, :goto_options, :label
+  attr_accessor :page, :goto_page, :goto_options
 
   validate :route_is_not_backwards
 
@@ -31,6 +31,15 @@ class Forms::RouteInput < BaseInput
     end
   end
 
+  def label
+    if Forms::RoutesInput.route_with_selection_options?(page)
+      answer_value_label = answer_value == Condition::NONE_OF_THE_ABOVE ? I18n.t("page_conditions.none_of_the_above") : answer_value
+      return { text: "If option #{option_index} (#{answer_value_label}), go to:" }
+    end
+
+    { text: "After question #{page.position}, go to:" }
+  end
+
 private
 
   def route_is_not_backwards
@@ -38,7 +47,7 @@ private
 
     return if goto_page.position > page.position
 
-    errors.add(:goto, error_message_for_backwards_route)
+    errors.add(:goto, :backwards_route, message: error_message_for_backwards_route)
   end
 
   def skippable_for_backwards_validation?
@@ -47,10 +56,17 @@ private
 
   def error_message_for_backwards_route
     if Forms::RoutesInput.route_with_selection_options?(page)
-      option_index = page.answer_settings.selection_options.find_index { |option| option["value"] == answer_value }
-      I18n.t("errors.routes.cannot_route_backwards_from_selection_page", question_number: page.position, option_number: option_index + 1)
+      I18n.t("errors.routes.cannot_route_backwards_from_selection_page", question_number: page.position, option_number: option_index)
     else
       I18n.t("errors.routes.cannot_route_backwards_from_generic_page", question_number: page.position)
+    end
+  end
+
+  def option_index
+    if answer_value == Condition::NONE_OF_THE_ABOVE
+      page.answer_settings.selection_options.length + 1
+    else
+      page.answer_settings.selection_options.find_index { |option| option["value"] == answer_value } + 1
     end
   end
 end

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -57,7 +57,7 @@ class Routes::BuildService
 private
 
   def build_routes_for_selection_page(page, conditions_by_key)
-    options = page.answer_settings&.selection_options || []
+    options = page.answer_settings&.selection_options&.dup || []
 
     options << NONE_OF_THE_ABOVE_OPTION if page.is_optional
 

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -61,9 +61,8 @@ private
 
     options << NONE_OF_THE_ABOVE_OPTION if page.is_optional
 
-    options.map.with_index(1) do |option, index|
+    options.map do |option|
       answer_value = option["value"]
-      answer_value_label = answer_value == NONE_OF_THE_ABOVE_OPTION[:value] ? I18n.t("page_conditions.none_of_the_above") : option["name"]
       key = [page.id, answer_value]
       condition = conditions_by_key[key]
 
@@ -75,7 +74,6 @@ private
         goto: goto_value_for(condition),
         goto_page: condition&.goto_page,
         goto_options: options_for_goto_page(page, condition&.goto_page_id),
-        label: { text: "If option #{index} (#{answer_value_label}), go to:" },
       )
     end
   end
@@ -92,7 +90,6 @@ private
         goto: goto_value_for(condition),
         goto_page: condition&.goto_page,
         goto_options: options_for_goto_page(page, condition&.goto_page_id),
-        label: { text: "After question #{page.position}, go to:" },
       ),
     ]
   end

--- a/spec/input_objects/forms/route_input_spec.rb
+++ b/spec/input_objects/forms/route_input_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Forms::RouteInput, type: :model do
   let(:attributes) do
     {
       id: 1,
-      page_id: 2,
+      page_id: page.id,
       goto: goto_page.id,
       answer_value: "Yes",
       page: page,
@@ -27,15 +27,10 @@ RSpec.describe Forms::RouteInput, type: :model do
   describe "attributes" do
     it "can be initialized with a hash of attributes" do
       expect(route_input.id).to eq(1)
-      expect(route_input.page_id).to eq(2)
+      expect(route_input.page_id).to eq(page.id)
       expect(route_input.goto).to eq(goto_page.id)
       expect(route_input.answer_value).to eq("Yes")
       expect(route_input.page).to eq(page)
-    end
-
-    it "allows access to other accessors like label" do
-      route_input.label = "Go to next page"
-      expect(route_input.label).to eq("Go to next page")
     end
   end
 
@@ -101,6 +96,43 @@ RSpec.describe Forms::RouteInput, type: :model do
       expect(route_input.condition_attributes).to eq(
         { goto_page_id: 123, skip_to_end: false, check_page_id: page.id },
       )
+    end
+  end
+
+  describe "#label" do
+    context "when the route is to the next page" do
+      it "returns the correct label" do
+        expect(route_input.label).to eq({ text: "After question 1, go to:" })
+      end
+    end
+
+    context "when the route is for a generic page" do
+      let(:middle_page) { build_stubbed(:page, position: 2) }
+      let(:goto_page) { build_stubbed(:page, position: 3) }
+
+      it "sets the label correctly for a generic page" do
+        expect(route_input.label).to eq({ text: "After question 1, go to:" })
+      end
+    end
+
+    context "when the route is for a selection page" do
+      let(:page) { build_stubbed(:page, :with_selection_settings, position: 1) }
+      let(:goto_page) { build_stubbed(:page, position: 2) }
+      let(:attributes) { super().merge(answer_value: "Option 1") }
+
+      it "sets the label correctly for a selection page" do
+        expect(route_input.label).to eq({ text: "If option 1 (Option 1), go to:" })
+      end
+    end
+
+    context "when the route is for a selection page with a none of the above option" do
+      let(:page) { build_stubbed(:page, :with_selection_settings, position: 1) }
+      let(:goto_page) { build_stubbed(:page, position: 2) }
+      let(:attributes) { super().merge(answer_value: Condition::NONE_OF_THE_ABOVE) }
+
+      it "sets the label correctly for a selection page with a none of the above option" do
+        expect(route_input.label).to eq({ text: "If option 3 (None of the above), go to:" })
+      end
     end
   end
 

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -36,11 +36,6 @@ RSpec.describe Routes::BuildService do
           expect(route_for_page1.goto).to eq(Forms::RouteInput::DEFAULT_VALUE)
         end
 
-        it "sets the label correctly for a generic page" do
-          route_for_page1 = service.build_routes.first
-          expect(route_for_page1.label).to eq({ text: "After question #{pages.first.position}, go to:" })
-        end
-
         context "when a condition exists for the generic page" do
           let!(:conditions) do
             [
@@ -109,18 +104,6 @@ RSpec.describe Routes::BuildService do
 
           expect(route_for_yes).not_to be_nil
           expect(route_for_no).not_to be_nil
-        end
-
-        it "sets the correct goto value and label for each option route" do
-          routes_for_page1 = service.build_routes.select { |r| r.page_id == pages.first.id }
-          route_for_yes = routes_for_page1.find { |r| r.answer_value == "Yes" }
-          route_for_no = routes_for_page1.find { |r| r.answer_value == "No" }
-
-          expect(route_for_yes.goto).to eq(Forms::RouteInput::DEFAULT_VALUE)
-          expect(route_for_yes.label).to eq({ text: "If option 1 (Yes), go to:" })
-
-          expect(route_for_no.goto).to eq(Forms::RouteInput::DEFAULT_VALUE)
-          expect(route_for_no.label).to eq({ text: "If option 2 (No), go to:" })
         end
 
         context "when the selection page has more than 10 options" do


### PR DESCRIPTION
### Fix route labels and validation errors for none of the above

This PR fixes a couple of related bugs for displaying routes:
- Route labels aren't shown when the page is rendered for a validation error
- An [exception is thrown](https://govuk-forms.sentry.io/issues/7552115510/?environment=aws-dev&project=6576190&query=is%3Aunresolved&referrer=issue-stream) when there are backward routes for a none of the above option
- The code for routes accidentally changes the selection options for a question with none of the above

It moves the label code from the build service into the route itself and stops the aliasing issue which meant the answer_settings for a page were being modified.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
