### PR TITLE
Show backwars routing error for final page

### DIFF
--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -28,7 +28,18 @@ class Routes::BuildService
   def options_for_goto_page(page, selected = nil)
     next_page = form.next_page_after(page)
 
-    return [] unless next_page
+    # If there's no next page then it's the last page of the form.
+    # We only need options for this page if there's an error that needs correcting.
+    if next_page.nil?
+      selected_page = if selected && selected != Forms::RouteInput::DEFAULT_VALUE
+                        option_for_select(form.pages.find { |page| page.id == selected })
+                      end
+
+      return [
+        selected_page,
+        [END_OF_FORM_OPTION.first, Forms::RouteInput::DEFAULT_VALUE],
+      ].compact
+    end
 
     # Don't include the current page or pages before in the options,
     # unless the goto page for the existing condition is before the current page,

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -25,7 +25,7 @@
               row.with_value do
                 capture do %>
                 <p> <%= page.question_text %> </p>
-                <% if @routes_input.form.next_page_after(page).present? %>
+                <% if @routes_input.form.next_page_after(page).present? || routes.any?(&:invalid?) %>
                   <ul class="govuk-list">
                     <% routes.each do |route| %>
                       <li>

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -205,8 +205,23 @@ RSpec.describe Routes::BuildService do
       end
     end
 
-    it "returns an empty array if the page has no next page" do
-      expect(service.options_for_goto_page(pages.third)).to be_empty
+    context "when the page has no next page" do
+      it "returns the end of the form option" do
+        expected_options = [["End of the form", "default"]]
+
+        expect(service.options_for_goto_page(pages.third)).to match_array(expected_options)
+      end
+
+      context "when there is a selected page" do
+        it "returns the selected page and end of the form options" do
+          expected_options = [
+            ["1. question 1", pages.first.id],
+            ["End of the form", "default"],
+          ]
+
+          expect(service.options_for_goto_page(pages.third, pages.first.id)).to match_array(expected_options)
+        end
+      end
     end
 
     it "returns a list of all possible goto options" do

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -171,6 +171,43 @@ describe "routes/show.html.erb" do
           end
         end
       end
+
+      context "when the routing page is the final page" do
+        let(:pages) do
+          [
+            build_stubbed(:page, id: 101),
+            build_stubbed(:page, id: 102),
+            build_stubbed(
+              :page,
+              id: 103,
+              routing_conditions: [
+                build_stubbed(
+                  :condition,
+                  routing_page_id: 103,
+                  goto_page_id: 101,
+                  answer_value: nil,
+                ),
+              ],
+            ),
+          ]
+        end
+
+        let(:routes_input) do
+          build(:routes_input, form:).assign_form_values.tap do |routes_input|
+            routes_input.routes.each { |route| allow(route).to receive(:invalid?).and_return(true) }
+          end
+        end
+
+        it "shows the selected goto page for the route" do
+          render_page
+
+          expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][2][goto]"]') do |field|
+            expect(field).to have_selector("option[selected]") do |option|
+              expect(option["value"]).to eq "101"
+            end
+          end
+        end
+      end
     end
 
     context "when a page is a select from a list question" do
@@ -247,7 +284,7 @@ describe "routes/show.html.erb" do
     end
   end
 
-  context "when there are not enoough pages" do
+  context "when there are not enough pages" do
     let(:pages) do
       [
         build_stubbed(:page, id: 101),


### PR DESCRIPTION
When there is a backwards route on the final page of a form, the selection options for routing will be displayed on the routes page, so that it can be corrected.

### What problem does this pull request solve?

https://trello.com/c/OGjKv7oo/3140-show-route-selection-drop-downs-on-the-last-question-if-it-has-any-backwards-routes

When there is backwards routing on the final page of a form (probably because there have been pages moved around) we want to show the selection options for that page on the routes page. Normally, we don't give the options for the final page, as they always lead to the end of the form. 

---

**Multiple selection backwards route**

<img width="595" height="1066" alt="image" src="https://github.com/user-attachments/assets/c5e17eca-2075-4219-8f83-72eda38df56d" />

---

**Unconditional backwards route**

<img width="609" height="1047" alt="image" src="https://github.com/user-attachments/assets/4bb7fdc6-ecfc-4c46-bd6a-aba14c24a9b0" />
 


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
