### PR TITLE
Warn delete options multiple branches

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -23,4 +23,37 @@ module PagesHelper
   def draft_question_selection_options(draft_question)
     draft_question.answer_settings[:selection_options]
   end
+
+  # option_indexes is either :number or :answer_value
+  def selection_options_in_routes_banner(draft_question, selection_options, include_none_of_the_above, option_indexes: :number)
+    return unless draft_question.form&.group&.multiple_branches_enabled?
+
+    answer_values_from_options = selection_options.pluck(:value) + [Condition::NONE_OF_THE_ABOVE]
+    options_in_routes = draft_question.form.conditions.where(routing_page_id: draft_question.page_id, answer_value: answer_values_from_options).select(:answer_value)
+
+    return if options_in_routes.empty?
+
+    edit_routes_link = govuk_link_to("View your question routes", routes_path(draft_question.form_id))
+
+    if options_in_routes.count == 1 && options_in_routes.first.answer_value == Condition::NONE_OF_THE_ABOVE
+      return { heading: "There is a route from ‘None of the above’", text: "If you remove ‘None of the above’, the route will be deleted. #{edit_routes_link}" }
+    end
+
+    if options_in_routes.count == 1 && option_indexes == :number
+      option_index = selection_options.index { |option| option[:value] == options_in_routes.first.answer_value } + 1
+      return { heading: "There is a route from option #{option_index}", text: "If you remove or change option #{option_index}, the route will be deleted. #{edit_routes_link}" }
+    end
+
+    if options_in_routes.count == 1 && option_indexes == :answer_value
+      option_index = options_in_routes.first.answer_value
+      return { heading: "There is a route from ‘#{option_index}’", text: "If you remove or change this option, the route will be deleted. #{edit_routes_link}" }
+    end
+
+    total_selection_options_count = selection_options.length + (include_none_of_the_above ? 1 : 0)
+    if options_in_routes.count == total_selection_options_count
+      return { heading: "There are routes from these options", text: "If you remove or change an option with a route, the route will be deleted. #{edit_routes_link}" }
+    end
+
+    { heading: "There are routes from some of these options", text: "If you remove or change an option with a route, the route will be deleted. #{edit_routes_link}" }
+  end
 end

--- a/app/input_objects/pages/question_input.rb
+++ b/app/input_objects/pages/question_input.rb
@@ -61,7 +61,10 @@ class Pages::QuestionInput < BaseInput
 
     page.assign_attributes(**attrs)
 
-    page.save_and_update_form
+    ActiveRecord::Base.transaction do
+      remove_conditions_without_valid_answer_values(page) if draft_question.form&.group&.multiple_branches_enabled?
+      page.save_and_update_form
+    end
   end
 
   def update_draft_question!
@@ -132,5 +135,14 @@ private
     end
 
     answer_settings_cloned
+  end
+
+  def remove_conditions_without_valid_answer_values(page)
+    return unless Forms::RoutesInput.route_with_selection_options?(page)
+
+    valid_answer_values = page.answer_settings[:selection_options].map { it[:value] }
+    valid_answer_values << Condition::NONE_OF_THE_ABOVE if page.is_optional
+
+    page.routing_conditions.where.not(answer_value: valid_answer_values).destroy_all
   end
 end

--- a/app/input_objects/pages/selection/base_options_input.rb
+++ b/app/input_objects/pages/selection/base_options_input.rb
@@ -35,8 +35,6 @@ class Pages::Selection::BaseOptionsInput < BaseInput
     only_one_option? ? MAXIMUM_CHOOSE_ONLY_ONE_OPTION : MAXIMUM_CHOOSE_MORE_THAN_ONE_OPTION
   end
 
-private
-
   def selected_none_of_the_above_option(draft_question)
     return nil if draft_question.is_optional.nil?
     return "no" unless draft_question.is_optional
@@ -44,6 +42,8 @@ private
 
     "yes"
   end
+
+private
 
   def maximum_error_type
     only_one_option? ? :maximum_choose_only_one_option : :maximum_choose_more_than_one_option

--- a/app/input_objects/pages/selection/base_options_input.rb
+++ b/app/input_objects/pages/selection/base_options_input.rb
@@ -10,7 +10,6 @@ class Pages::Selection::BaseOptionsInput < BaseInput
   def submit
     return false if invalid?
 
-    is_optional = include_none_of_the_above != "no"
     draft_question.assign_attributes(answer_settings:, is_optional:)
 
     success = draft_question.save!
@@ -43,6 +42,14 @@ class Pages::Selection::BaseOptionsInput < BaseInput
     "yes"
   end
 
+  def is_optional
+    include_none_of_the_above != "no"
+  end
+
+  def selection_options_with_value
+    selection_options.map { |option| { name: option[:name], value: option[:name] } }
+  end
+
 private
 
   def maximum_error_type
@@ -71,9 +78,5 @@ private
       options_count: selection_options.length,
       only_one_option: only_one_option?,
     )
-  end
-
-  def selection_options_with_value
-    selection_options.map { |option| { name: option[:name], value: option[:name] } }
   end
 end

--- a/app/views/pages/selection/bulk_options.html.erb
+++ b/app/views/pages/selection/bulk_options.html.erb
@@ -6,6 +6,16 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [current_form, @bulk_options_input], url: @bulk_options_path do |f| %>
       <%= f.govuk_error_summary %>
+
+      <% banner_content = selection_options_in_routes_banner(@draft_question, @bulk_options_input.selection_options_with_value, @bulk_options_input.is_optional, option_indexes: :answer_value) %>
+
+      <% if banner_content %>
+        <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+          <% banner.with_heading(text: banner_content[:heading]) %>
+          <p> <%= banner_content[:text].html_safe %> </p>
+        <% end %>
+      <% end %>
+
       <span class="govuk-caption-l"><%= t("pages.question") %> <%= current_form.page_number(@page) %></span>
       <h1 class="govuk-heading-l"><%= t("page_titles.bulk_options") %></h1>
 

--- a/app/views/pages/selection/options.html.erb
+++ b/app/views/pages/selection/options.html.erb
@@ -7,6 +7,15 @@
     <%= form_with model: [current_form, @selection_options_input], url: @selection_options_path do |f| %>
       <%= f.govuk_error_summary %>
 
+      <% banner_content = selection_options_in_routes_banner(@selection_options_input.draft_question, @selection_options_input.selection_options_with_value, @selection_options_input.is_optional) %>
+
+      <% if banner_content %>
+        <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
+          <% banner.with_heading(text: banner_content[:heading]) %>
+          <p> <%= banner_content[:text].html_safe %> </p>
+        <% end %>
+      <% end %>
+
       <%#
         Browsers use the first submit button in a form when the enter key is pressed, so we have to put this hidden button here,
         otherwise pressing the enter key will delete the first item in the list instead of submnitting the form.

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -87,4 +87,97 @@ RSpec.describe PagesHelper, type: :helper do
       end
     end
   end
+
+  describe "#selection_options_in_routes_banner" do
+    let(:form) { create :form, :with_group, :ready_for_routing, group: create(:group, multiple_branches_enabled:) }
+    let(:multiple_branches_enabled) { true }
+    let(:draft_question) { build :selection_draft_question, form_id: form.id, page_id: form.pages.first.id }
+    let(:selection_options_with_value) { (1..3).to_a.map { |i| { name: i.to_s } } }
+    let(:include_none_of_the_above) { false }
+
+    context "when draft_question has no answer_settings" do
+      it "returns nil" do
+        expect(helper.selection_options_in_routes_banner(draft_question, selection_options_with_value, include_none_of_the_above)).to be_nil
+      end
+    end
+
+    context "when multiple_branches_enabled is false" do
+      let(:selection_options_with_value) { [{ name: "Option 1", value: "Option 1" }] }
+      let(:multiple_branches_enabled) { false }
+
+      before do
+        create(:condition, answer_value: "Option 1", routing_page_id: form.pages.first.id)
+      end
+
+      it "returns nil" do
+        expect(helper.selection_options_in_routes_banner(draft_question, selection_options_with_value, include_none_of_the_above)).to be_nil
+      end
+    end
+
+    context "when a single option is used in a condition" do
+      let(:selection_options_with_value) { [{ name: "Option 1", value: "Option 1" }] }
+
+      before do
+        create(:condition, answer_value: "Option 1", routing_page_id: form.pages.first.id)
+      end
+
+      it "returns a banner with the correct text" do
+        result = helper.selection_options_in_routes_banner(draft_question, selection_options_with_value, include_none_of_the_above)
+        expect(result[:heading]).to eq("There is a route from option 1")
+        expect(result[:text]).to eq("If you remove or change option 1, the route will be deleted. <a class=\"govuk-link\" href=\"/forms/#{form.id}/routes\">View your question routes</a>")
+      end
+
+      it "retuns the correct text when using :answer_value option index" do
+        result = helper.selection_options_in_routes_banner(draft_question, selection_options_with_value, include_none_of_the_above, option_indexes: :answer_value)
+        expect(result[:heading]).to eq("There is a route from ‘Option 1’")
+        expect(result[:text]).to eq("If you remove or change this option, the route will be deleted. <a class=\"govuk-link\" href=\"/forms/#{form.id}/routes\">View your question routes</a>")
+        # "If you remove or change option this option, the route will be deleted. <a class=\"govuk-link\" href=\"/forms/34362/routes\">View your question routes</a>
+      end
+    end
+
+    context "when there is a single option which is none of the above" do
+      let(:selection_options) { [] }
+      let(:include_none_of_the_above) { true }
+
+      before do
+        create(:condition, answer_value: Condition::NONE_OF_THE_ABOVE, routing_page_id: form.pages.first.id)
+      end
+
+      it "returns a banner with the correct text" do
+        result = helper.selection_options_in_routes_banner(draft_question, selection_options, include_none_of_the_above)
+        expect(result[:heading]).to eq("There is a route from ‘None of the above’")
+        expect(result[:text]).to eq("If you remove ‘None of the above’, the route will be deleted. <a class=\"govuk-link\" href=\"/forms/#{form.id}/routes\">View your question routes</a>")
+      end
+    end
+
+    context "when all options are in conditions" do
+      let(:selection_options_with_value) { [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }] }
+
+      before do
+        create(:condition, answer_value: "Option 1", routing_page_id: form.pages.first.id)
+        create(:condition, answer_value: "Option 2", routing_page_id: form.pages.first.id)
+      end
+
+      it "returns a banner with the correct text" do
+        result = helper.selection_options_in_routes_banner(draft_question, selection_options_with_value, include_none_of_the_above)
+        expect(result[:heading]).to eq("There are routes from these options")
+        expect(result[:text]).to eq("If you remove or change an option with a route, the route will be deleted. <a class=\"govuk-link\" href=\"/forms/#{form.id}/routes\">View your question routes</a>")
+      end
+    end
+
+    context "when some options are in conditions" do
+      let(:selection_options_with_value) { [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }, { name: "Option 3", value: "Option 3" }] }
+
+      before do
+        create(:condition, answer_value: "Option 1", routing_page_id: form.pages.first.id)
+        create(:condition, answer_value: "Option 3", routing_page_id: form.pages.first.id)
+      end
+
+      it "returns a banner with the correct text" do
+        result = helper.selection_options_in_routes_banner(draft_question, selection_options_with_value, include_none_of_the_above)
+        expect(result[:heading]).to eq("There are routes from some of these options")
+        expect(result[:text]).to eq("If you remove or change an option with a route, the route will be deleted. <a class=\"govuk-link\" href=\"/forms/#{form.id}/routes\">View your question routes</a>")
+      end
+    end
+  end
 end

--- a/spec/input_objects/pages/question_input_spec.rb
+++ b/spec/input_objects/pages/question_input_spec.rb
@@ -475,6 +475,66 @@ RSpec.describe Pages::QuestionInput, type: :model do
         end
       end
     end
+
+    context "when there are conditions which no longer have answer_values" do
+      let(:draft_question) { build :selection_draft_question, form_id: form.id }
+      let(:answer_settings) { { only_one_option: "true", selection_options: [{ name: "Option 1", value: "Option 1" }, { name: "Not option 2", value: "Not option 2" }] } }
+
+      let!(:keep_condition) { create(:condition, answer_value: "Option 1", routing_page_id: page.id) }
+      let!(:remove_condition) { create(:condition, answer_value: "Option 2", routing_page_id: page.id) }
+
+      context "when the form has multiple branches enabled" do
+        let(:form) { create :form, :with_group, group: create(:group, multiple_branches_enabled: true) }
+
+        it "removes the conditions" do
+          expect { question_input.update_page(page) }.to change { page.routing_conditions.count }.from(2).to(1)
+          expect(Condition.exists?(keep_condition.id)).to be true
+          expect(Condition.exists?(remove_condition.id)).to be false
+        end
+      end
+
+      context "when the form has multiple branches disabled" do
+        let(:form) { create :form, :with_group, group: create(:group, multiple_branches_enabled: false) }
+
+        it "does not remove the conditions" do
+          expect { question_input.update_page(page) }.not_to change { page.routing_conditions.count }.from(2)
+        end
+      end
+    end
+
+    context "when there are conditions based on the none of the above option" do
+      # The draft question before we update it
+      # It's optional so there is a none of the above option
+      let(:draft_question) { build :selection_draft_question, form_id: form.id, is_optional: true }
+
+      # The settings we are saving to the page
+      let(:answer_settings) { { only_one_option: "true", selection_options: [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }] } }
+
+      # Is optional is a string here because it comes from the form
+      # We set it to false, simulating remove the none of the above option
+      let(:is_optional) { "false" }
+
+      let!(:none_of_the_above_condition) { create(:condition, answer_value: Condition::NONE_OF_THE_ABOVE, routing_page_id: page.id) }
+      let!(:other_condition) { create(:condition, answer_value: "Option 2", routing_page_id: page.id) }
+
+      context "when the form has multiple branches enabled" do
+        let(:form) { create :form, :with_group, group: create(:group, multiple_branches_enabled: true) }
+
+        it "removes the none of the above condition" do
+          expect { question_input.update_page(page) }.to change { page.routing_conditions.count }.from(2).to(1)
+          expect(Condition.exists?(none_of_the_above_condition.id)).to be false
+          expect(Condition.exists?(other_condition.id)).to be true
+        end
+      end
+
+      context "when the form has multiple branches disabled" do
+        let(:form) { create :form, :with_group, group: create(:group, multiple_branches_enabled: false) }
+
+        it "does not remove the none of the above condition" do
+          expect { question_input.update_page(page) }.not_to change { page.routing_conditions.count }.from(2)
+        end
+      end
+    end
   end
 
   describe "#update_draft_question!" do

--- a/spec/views/pages/selection/bulk_options.html.erb_spec.rb
+++ b/spec/views/pages/selection/bulk_options.html.erb_spec.rb
@@ -2,14 +2,15 @@ require "rails_helper"
 
 describe "pages/selection/bulk_options.html.erb", type: :view do
   let(:form) { create :form }
-  let(:page) { create :page, :with_selection_settings, answer_settings: }
-  let(:bulk_options_input) { build :bulk_options_input, draft_question: page, include_none_of_the_above: }
+  let(:draft_question) { build :draft_question, answer_type: "selection", answer_settings: }
+  let(:bulk_options_input) { build :bulk_options_input, draft_question:, include_none_of_the_above: }
   let(:include_none_of_the_above) { "yes" }
   let(:answer_settings) { DataStruct.new(only_one_option:, selection_options:) }
   let(:only_one_option) { "true" }
   let(:selection_options) { [] }
   let(:page_number) { 1 }
   let(:back_link_url) { "/a-back-link-url" }
+  let(:banner_content) { nil }
 
   before do
     form.reload
@@ -20,12 +21,14 @@ describe "pages/selection/bulk_options.html.erb", type: :view do
     # # mock the path helper
     without_partial_double_verification do
       allow(view).to receive_messages(form_pages_path: "/type-of-answer", current_form: form)
+      allow(view).to receive(:selection_options_in_routes_banner).and_return(banner_content)
     end
 
     # # setup instance variables
     @bulk_options_input = bulk_options_input
     @bulk_options_path = selection_bulk_options_create_path(form.id)
     @back_link_url = back_link_url
+    @draft_question = draft_question
   end
 
   context "when there are no errors" do
@@ -138,6 +141,23 @@ describe "pages/selection/bulk_options.html.erb", type: :view do
           expect(rendered).to have_unchecked_field("pages_selection_bulk_options_input[include_none_of_the_above]", with: "no")
           expect(rendered).to have_unchecked_field("pages_selection_bulk_options_input[include_none_of_the_above]", with: "yes")
           expect(rendered).to have_unchecked_field("pages_selection_bulk_options_input[include_none_of_the_above]", with: "yes_with_question")
+        end
+      end
+    end
+
+    context "when is selection_options_in_routes_banner returns a banner shows it" do
+      let(:banner_content) { nil }
+
+      it "doesn't render the banner" do
+        expect(rendered).not_to have_css(".govuk-notification-banner")
+      end
+
+      context "when there is a single option which is none of the above" do
+        let(:banner_content) { { heading: "There is a route from ‘None of the above’", text: "If you remove ‘None of the above’, the route will be deleted. View your question routes" } }
+
+        it "renders the banner" do
+          expect(rendered).to have_css(".govuk-notification-banner")
+          expect(rendered).to have_css(".govuk-notification-banner__heading", text: "There is a route from ‘None of the above’")
         end
       end
     end

--- a/spec/views/pages/selection/options.html.erb_spec.rb
+++ b/spec/views/pages/selection/options.html.erb_spec.rb
@@ -11,6 +11,7 @@ describe "pages/selection/options.html.erb", type: :view do
   let(:include_none_of_the_above) { "yes" }
   let(:only_one_option) { "true" }
   let(:draft_question) { build :draft_question, answer_type: "selection", answer_settings: { only_one_option: } }
+  let(:banner_content) { nil }
 
   before do
     # # mock the form.page_number method
@@ -19,6 +20,7 @@ describe "pages/selection/options.html.erb", type: :view do
     # # mock the path helper
     without_partial_double_verification do
       allow(view).to receive_messages(form_pages_path: "/pages", current_form: form)
+      allow(view).to receive(:selection_options_in_routes_banner).and_return(banner_content)
     end
 
     # # setup instance variables
@@ -167,6 +169,23 @@ describe "pages/selection/options.html.erb", type: :view do
         expect(rendered).to have_unchecked_field("pages_selection_options_input[include_none_of_the_above]", with: "no")
         expect(rendered).to have_unchecked_field("pages_selection_options_input[include_none_of_the_above]", with: "yes")
         expect(rendered).to have_unchecked_field("pages_selection_options_input[include_none_of_the_above]", with: "yes_with_question")
+      end
+    end
+
+    context "when is selection_options_in_routes_banner returns a banner shows it" do
+      let(:banner_content) { nil }
+
+      it "doesn't render the banner" do
+        expect(rendered).not_to have_css(".govuk-notification-banner")
+      end
+
+      context "when there is a single option which is none of the above" do
+        let(:banner_content) { { heading: "There is a route from ‘None of the above’", text: "If you remove ‘None of the above’, the route will be deleted. View your question routes" } }
+
+        it "renders the banner" do
+          expect(rendered).to have_css(".govuk-notification-banner")
+          expect(rendered).to have_css(".govuk-notification-banner__heading", text: "There is a route from ‘None of the above’")
+        end
       end
     end
   end


### PR DESCRIPTION
### Delete conditions which reference options which don't exist and add banner to options page about routes

Trello card: https://trello.com/c/vaePaWB5/3141-delete-routes-when-changing-selection-options-makes-it-invalid-when-multiple-branches-is-enabled

This PR adds a banner to the selection options page to warn the user that options are being used in routes. The banner changes the wording based on how many options are involved in routes and whether the "none of the above" is activated for the page.

When options are changed or removed, it removes any conditions which have answer_values which no longer have matching options.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
