### PR TITLE
Ensure conditions match question type

### DIFF
--- a/app/input_objects/pages/question_input.rb
+++ b/app/input_objects/pages/question_input.rb
@@ -62,7 +62,10 @@ class Pages::QuestionInput < BaseInput
     page.assign_attributes(**attrs)
 
     ActiveRecord::Base.transaction do
-      remove_conditions_without_valid_answer_values(page) if draft_question.form&.group&.multiple_branches_enabled?
+      if draft_question.form&.group&.multiple_branches_enabled?
+        remove_conditions_without_valid_answer_values(page)
+        ensure_conditions_match_question_type(page)
+      end
       page.save_and_update_form
     end
   end
@@ -144,5 +147,38 @@ private
     valid_answer_values << Condition::NONE_OF_THE_ABOVE if page.is_optional
 
     page.routing_conditions.where.not(answer_value: valid_answer_values).destroy_all
+  end
+
+  def ensure_conditions_match_question_type(page)
+    if Forms::RoutesInput.route_with_selection_options?(page)
+      generic_condition = page.routing_conditions.where(answer_value: nil)&.first
+
+      return if generic_condition.nil?
+
+      attributes = if generic_condition.skip_to_end?
+                     {
+                       goto_page_id: nil,
+                       skip_to_end: true,
+                       check_page_id: page.id,
+                     }
+                   else
+                     {
+                       goto_page_id: generic_condition.goto_page_id,
+                       skip_to_end: false,
+                       check_page_id: page.id,
+                     }
+                   end
+
+      options = page.answer_settings[:selection_options].map { |option| option["value"] }
+      options << Condition::NONE_OF_THE_ABOVE if page.is_optional
+
+      options.each do |option|
+        condition_for_option = Condition.find_or_initialize_by(routing_page_id: page.id, answer_value: option)
+        condition_for_option.assign_attributes(attributes)
+        condition_for_option.save!
+      end
+
+      generic_condition.destroy!
+    end
   end
 end

--- a/app/input_objects/pages/selection/type_input.rb
+++ b/app/input_objects/pages/selection/type_input.rb
@@ -24,4 +24,12 @@ class Pages::Selection::TypeInput < BaseInput
     selection_options = draft_question&.answer_settings&.[](:selection_options)
     selection_options.present? && selection_options.length > 30
   end
+
+  def show_routing_warning?
+    return true unless FeatureService.new(group: draft_question.form&.group).enabled?(:multiple_branches)
+
+    return false if draft_question.page.nil?
+
+    draft_question.page.answer_type == "selection" && draft_question.page.answer_settings.only_one_option == "true"
+  end
 end

--- a/app/models/draft_question.rb
+++ b/app/models/draft_question.rb
@@ -1,5 +1,6 @@
 class DraftQuestion < ApplicationRecord
   belongs_to :user
+  belongs_to :page, optional: true
 
   validates :form_id, presence: true
 

--- a/app/views/pages/selection/type.html.erb
+++ b/app/views/pages/selection/type.html.erb
@@ -10,7 +10,7 @@
           <% banner.with_heading(text: t("selection_type.routing_and_reduce_your_options_combined_warning.heading"), tag: "h3") %>
           <p><%= t("selection_type.routing_and_reduce_your_options_combined_warning.body", pages_link_url: form_pages_path(current_form.id)) %></p>
         <% end %>
-      <% else %>
+      <% elsif @selection_type_input.show_routing_warning? %>
         <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
           <% banner.with_heading(text: t("selection_type.routing_warning")) %>
         <% end %>

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @page.present? && @page.routing_conditions.any?  %>
+    <% if !current_form&.group&.multiple_branches_enabled? && @page.present? && @page.routing_conditions.any?  %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("type_of_answer.routing_warning_about_change_answer_type_heading"), tag: "h3") %>
         <%= t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(current_form.id)) %>

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if !current_form&.group&.multiple_branches_enabled? && @page.present? && @page.routing_conditions.any?  %>
+    <% if !FeatureService.new(group: current_form&.group).enabled?(:multiple_branches) && @page.present? && @page.routing_conditions.any?  %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
         <% banner.with_heading(text: t("type_of_answer.routing_warning_about_change_answer_type_heading"), tag: "h3") %>
         <%= t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(current_form.id)) %>

--- a/spec/input_objects/pages/question_input_spec.rb
+++ b/spec/input_objects/pages/question_input_spec.rb
@@ -535,6 +535,58 @@ RSpec.describe Pages::QuestionInput, type: :model do
         end
       end
     end
+
+    context "when the original question is being changed to a selection question and has a condition" do
+      let(:answer_type) { "selection" }
+      let(:answer_settings) { { only_one_option: "true", selection_options: [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }] } }
+      let!(:condition) { create(:condition, routing_page_id: page.id) }
+
+      context "when the form has multiple branches enabled" do
+        let(:form) { create :form, :with_group, group: create(:group, multiple_branches_enabled: true) }
+
+        it "creates a condition for each option" do
+          expect { question_input.update_page(page) }.to change { page.routing_conditions.count }.from(1).to(2)
+
+          expect(Condition.where(answer_value: "Option 1", routing_page_id: page.id).exists?).to be true
+          expect(Condition.where(answer_value: "Option 2", routing_page_id: page.id).exists?).to be true
+
+          expect(Condition.exists?(condition.id)).to be false
+        end
+
+        context "when the question is optional" do
+          let(:is_optional) { "true" }
+
+          it "creates a condition for each option and none of the above" do
+            expect { question_input.update_page(page) }.to change { page.routing_conditions.count }.from(1).to(3)
+
+            expect(Condition.where(answer_value: Condition::NONE_OF_THE_ABOVE).exists?).to be true
+
+            expect(Condition.exists?(condition.id)).to be false
+          end
+        end
+
+        context "when the original condition skips to the end of the form" do
+          let!(:condition) { create(:condition, routing_page: page, skip_to_end: true) }
+
+          it "creates a condition for each option which skips to the end" do
+            expect { question_input.update_page(page) }.to change { page.routing_conditions.count }.from(1).to(2)
+
+            expect(Condition.where(answer_value: "Option 1", routing_page_id: page.id, skip_to_end: true, goto_page_id: nil).exists?).to be true
+
+            expect(Condition.exists?(condition.id)).to be false
+          end
+        end
+      end
+
+      context "when the form does not have multiple branches enabled" do
+        let(:form) { create :form, :with_group, group: create(:group, multiple_branches_enabled: false) }
+
+        it "does not create a condition for each option or remove the original condition" do
+          expect { question_input.update_page(page) }.not_to change { page.routing_conditions.count }.from(1)
+          expect(Condition.exists?(condition.id)).to be true
+        end
+      end
+    end
   end
 
   describe "#update_draft_question!" do

--- a/spec/input_objects/pages/selection/type_input_spec.rb
+++ b/spec/input_objects/pages/selection/type_input_spec.rb
@@ -111,4 +111,49 @@ RSpec.describe Pages::Selection::TypeInput do
       end
     end
   end
+
+  describe "show_routing_warning?" do
+    let(:draft_question) { build :draft_question, form_id: form.id, page: }
+    let(:page) { build(:page) }
+
+    context "when multiple branches is disabled", feature_multiple_branches: false do
+      it "returns true" do
+        expect(input.show_routing_warning?).to be true
+      end
+    end
+
+    context "when multiple branches is enabled", :feature_multiple_branches do
+      context "when the page is nil" do
+        let(:page) { nil }
+
+        it "returns false" do
+          expect(input.show_routing_warning?).to be false
+        end
+      end
+
+      context "when the page is not a selection question" do
+        let(:page) { build(:page, answer_type: "text") }
+
+        it "returns false" do
+          expect(input.show_routing_warning?).to be false
+        end
+      end
+
+      context "when the selection type is only one option" do
+        let(:page) { build(:page, :selection_with_radios) }
+
+        it "returns false" do
+          expect(input.show_routing_warning?).to be true
+        end
+      end
+
+      context "when the selection type is multiple options" do
+        let(:page) { build(:page, :selection_with_checkboxes) }
+
+        it "returns true" do
+          expect(input.show_routing_warning?).to be false
+        end
+      end
+    end
+  end
 end

--- a/spec/views/pages/selection/type.html.erb_spec.rb
+++ b/spec/views/pages/selection/type.html.erb_spec.rb
@@ -81,15 +81,26 @@ describe "pages/selection/type.html.erb", type: :view do
 
         context "when a routing condition is set" do
           let(:routing_conditions) { [build(:condition)] }
+          let(:show_routing_warning) { true }
 
           context "when the options will not need to be reduced" do
             before do
-              allow(selection_type_input).to receive(:need_to_reduce_options?).and_return false
+              allow(selection_type_input).to receive_messages(need_to_reduce_options?: false, show_routing_warning?: show_routing_warning)
               render(template: "pages/selection/type")
             end
 
-            it "displays a warning about routes being deleted" do
-              expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_warning"))
+            context "when show_routing_warning returns true" do
+              it "displays a warning about routes being deleted" do
+                expect(rendered).to have_selector(".govuk-notification-banner__content", text: I18n.t("selection_type.routing_warning"))
+              end
+            end
+
+            context "when show_routing_warning returns false" do
+              let(:show_routing_warning) { false }
+
+              it "does not display a warning about routes being deleted" do
+                expect(rendered).not_to have_selector(".govuk-notification-banner__content")
+              end
             end
           end
 

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -77,6 +77,15 @@ describe "pages/type_of_answer.html.erb", type: :view do
                         .text(normalize_ws: true))
     end
 
+    context "when multiple branches are enabled" do
+      let(:form) { create(:form, :with_group, group:) }
+      let(:group) { create(:group, multiple_branches_enabled: true) }
+
+      it "does not display a warning about routes being deleted if answer type changes" do
+        expect(rendered).not_to have_selector(".govuk-notification-banner__content")
+      end
+    end
+
     context "when no routing conditions set" do
       let(:routing_conditions) { [] }
 

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "pages/type_of_answer.html.erb", type: :view do
-  let(:form) { create :form }
+  let(:form) { create :form, :with_group }
   let(:type_of_answer_input) { build :type_of_answer_input }
   let(:page) { OpenStruct.new(routing_conditions: [], answer_type: "number") }
   let(:question_number) { 1 }
@@ -77,10 +77,7 @@ describe "pages/type_of_answer.html.erb", type: :view do
                         .text(normalize_ws: true))
     end
 
-    context "when multiple branches are enabled" do
-      let(:form) { create(:form, :with_group, group:) }
-      let(:group) { create(:group, multiple_branches_enabled: true) }
-
+    context "when multiple branches are enabled", :feature_multiple_branches do
       it "does not display a warning about routes being deleted if answer type changes" do
         expect(rendered).not_to have_selector(".govuk-notification-banner__content")
       end


### PR DESCRIPTION
### Make conditions match the question type, if changed

Trello card: https://trello.com/c/lDyxaMH5/3145-if-a-question-with-an-unconditional-route-is-changed-to-a-select-one-list-question-set-all-the-options-to-go-to-the-same-target

When a question is changed to selection type which supports routing from multiple options, we need to make sure the conditions are updated to match.

This commit adds a new method which is called when a question is changed. It updates conditions to based on the selection options for the new question.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
