### PR TITLE
Update warnings when deleting route questions

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,7 +18,14 @@ class PagesController < FormsController
 
     @page_goto_conditions = page.goto_conditions
 
-    if page.routing_conditions.any? && page.routing_conditions.first.secondary_skip?
+    if FeatureService.new(group: current_form.group).enabled?(:multiple_branches)
+      @page_conditions = page.routing_conditions
+      @routing = @page_conditions + @page_goto_conditions
+      if @routing.present?
+        @routing_banner_heading = routing_banner_heading(@page_conditions, @page_goto_conditions)
+        @routing_banner_html = routing_banner_html(@page_conditions, @page_goto_conditions)
+      end
+    elsif page.routing_conditions.any? && page.routing_conditions.first.secondary_skip?
       @routing = :start_of_secondary_skip_route
 
       # route page is condition check page
@@ -39,7 +46,6 @@ class PagesController < FormsController
       # route page is condition routing page
       @route_page = @page_goto_conditions.first.routing_page
     end
-
     @delete_confirmation_input = Pages::DeleteConfirmationInput.new
 
     render locals: { current_form: }
@@ -181,5 +187,25 @@ private
     end
 
     CurrentLoggingAttributes.validation_errors = errors.map { |error| "PageList: #{error}" } if errors.any?
+  end
+
+  def routing_banner_heading(page_conditions, goto_conditions)
+    if page_conditions.present? && goto_conditions.present?
+      t("pages.delete.routing_and_goto_heading", question_number: page.position)
+    elsif page_conditions.present?
+      t("pages.delete.routing_heading", question_number: page.position, count: page_conditions.count)
+    elsif goto_conditions.present?
+      t("pages.delete.goto_heading", question_number: page.position, count: goto_conditions.count)
+    end
+  end
+
+  def routing_banner_html(page_conditions, goto_conditions)
+    if page_conditions.present? && goto_conditions.present?
+      t("pages.delete.routing_and_goto_html", routes_href: routes_path(current_form.id))
+    elsif page_conditions.present?
+      t("pages.delete.routing_html", question_number: page.position, count: page_conditions.count, routes_href: routes_path(current_form.id))
+    elsif goto_conditions.present?
+      t("pages.delete.goto_html", question_number: page.position, count: goto_conditions.count, routes_href: routes_path(current_form.id))
+    end
   end
 end

--- a/app/views/pages/delete.html.erb
+++ b/app/views/pages/delete.html.erb
@@ -5,16 +5,26 @@
   <div class="govuk-grid-column-two-thirds">
 
     <% unless @delete_confirmation_input.errors.any? %>
-      <% if @routing.present? %>
-        <%= govuk_notification_banner(title_text: "Important") do |banner|
-          banner.with_heading(text: t(".notification_banner.#{@routing}.heading_text", question_number: @page.position), tag: :h3)
+      <% if FeatureService.new(group: current_form.group).enabled?(:multiple_branches) %>
+        <% if @routing.present? %>
+          <%= govuk_notification_banner(title_text: "Important") do |banner|
+            banner.with_heading(text: @routing_banner_heading, tag: :h3)
+            
+            @routing_banner_html
+          end %>
+        <% end %>
+      <% else %>
+        <% if @routing.present? %>
+          <%= govuk_notification_banner(title_text: "Important") do |banner|
+            banner.with_heading(text: t(".notification_banner.#{@routing}.heading_text", question_number: @page.position), tag: :h3)
 
-          t(
-            ".notification_banner.#{@routing}.html",
-            route_page_question_number: @route_page.position,
-            show_routes_href: show_routes_path(current_form.id, @route_page.id),
-          )
-        end %>
+            t(
+              ".notification_banner.#{@routing}.html",
+              route_page_question_number: @route_page.position,
+              show_routes_href: show_routes_path(current_form.id, @route_page.id),
+            )
+          end %>
+        <% end %>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1640,6 +1640,18 @@ en:
         back_link: Back to question %{question_number}’s routes
       hint_html: "<p>You can skip people who select one specific answer to question %{question_number} to a later question or page. People who select any other answer will continue to question %{continue_to_question_number}.<p>"
     delete:
+      goto_heading:
+        one: There’s a route to question %{question_number}
+        other: There are routes to question %{question_number}
+      goto_html:
+        one: |
+          <p class="govuk-body">
+            If you delete this question, the route to it will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
+          </p>
+        other: |
+          <p class="govuk-body">
+            If you delete this question, the routes to it will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
+          </p>
       notification_banner:
         end_of_route:
           heading_text: Question %{question_number} is at the end of a route
@@ -1669,6 +1681,23 @@ en:
               <a class="govuk-notification-banner__link" href="%{show_routes_href}">Question %{route_page_question_number}’s route</a>
               starts at this question. If you delete this question, the route from it will also be deleted.
             </p>
+      routing_and_goto_heading: There are routes to and from question %{question_number}
+      routing_and_goto_html: |
+        <p class="govuk-body">
+          If you delete this question, its routes will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
+        </p>
+      routing_heading:
+        one: Question %{question_number} has a route
+        other: Question %{question_number} has routes
+      routing_html:
+        one: |
+          <p class="govuk-body">
+            If you delete this question, its route will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
+          </p>
+        other: |
+          <p class="govuk-body">
+            If you delete this question, its routes will also be deleted. <a class="govuk-notification-banner__link" href="%{routes_href}">View your question routes</a>
+          </p>
       title: Are you sure you want to delete this question?
     delete_question: Delete question
     destroy:

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -248,6 +248,118 @@ RSpec.describe PagesController, type: :request do
           end
         end
       end
+
+      context "when the multiple_branches feature is enabled", :feature_multiple_branches do
+        let(:form) { create(:form, :ready_for_routing) }
+        let(:pages) { form.pages }
+        let(:page) { pages.first }
+
+        context "when page to delete has no routes" do
+          it "does not render a warning" do
+            get delete_page_path(form_id: form.id, page_id: page.id)
+
+            expect(response.body).not_to include "Important"
+          end
+        end
+
+        context "when page to delete is the start of one route" do
+          let(:page) { pages.first }
+
+          before do
+            create(:condition, routing_page_id: page.id, answer_value: "Red", goto_page_id: pages.last.id)
+          end
+
+          it "renders a warning about deleting this page" do
+            get delete_page_path(form_id: form.id, page_id: page.id)
+
+            assert_select(".govuk-notification-banner", count: 1) do
+              assert_select "*", "Important"
+              assert_select "h3", "Question #{page.position} has a route"
+              assert_select "p.govuk-body", /If you delete this question, its route will also be deleted/
+              assert_select "p.govuk-body a", "View your question routes"
+            end
+          end
+        end
+
+        context "when page to delete is the start of mulltiple routes" do
+          let(:page) { pages.first }
+
+          before do
+            create(:condition, routing_page_id: page.id, answer_value: "Red", goto_page_id: pages.last.id)
+            create(:condition, routing_page_id: page.id, answer_value: "Blue", goto_page_id: pages.last.id)
+          end
+
+          it "renders a warning about deleting this page" do
+            get delete_page_path(form_id: form.id, page_id: page.id)
+
+            assert_select(".govuk-notification-banner", count: 1) do
+              assert_select "*", "Important"
+              assert_select "h3", "Question #{page.position} has routes"
+              assert_select "p.govuk-body", /If you delete this question, its routes will also be deleted/
+              assert_select "p.govuk-body a", "View your question routes"
+            end
+          end
+        end
+
+        context "when page to delete is the end of a route" do
+          let(:page) { pages.last }
+
+          before do
+            create(:condition, routing_page_id: pages.first.id, answer_value: "Red", goto_page_id: page.id)
+          end
+
+          it "renders a warning about deleting this page" do
+            get delete_page_path(form_id: form.id, page_id: page.id)
+
+            assert_select(".govuk-notification-banner", count: 1) do
+              assert_select "*", "Important"
+              assert_select "h3", "There’s a route to question #{page.position}"
+              assert_select "p.govuk-body", /If you delete this question, the route to it will also be deleted./
+              assert_select "p.govuk-body a", "View your question routes"
+            end
+          end
+        end
+
+        context "when page to delete is the end of multiple routes" do
+          let(:page) { pages.last }
+
+          before do
+            create(:condition, routing_page_id: pages.first.id, answer_value: "Red", goto_page_id: page.id)
+            create(:condition, routing_page_id: pages.first.id, answer_value: "Blue", goto_page_id: page.id)
+          end
+
+          it "renders a warning about deleting this page" do
+            get delete_page_path(form_id: form.id, page_id: page.id)
+
+            assert_select(".govuk-notification-banner", count: 1) do
+              assert_select "*", "Important"
+              assert_select "h3", "There are routes to question #{page.position}"
+              assert_select "p.govuk-body", /If you delete this question, the routes to it will also be deleted./
+              assert_select "p.govuk-body a", "View your question routes"
+            end
+          end
+        end
+
+        context "when page to delete is the start and end of multiple routes" do
+          let(:page) { pages.third }
+
+          before do
+            create(:condition, routing_page_id: pages.first.id, answer_value: "Red", goto_page_id: page.id)
+            create(:condition, routing_page_id: page.id, answer_value: "Blue", goto_page_id: pages.last.id)
+          end
+
+          it "renders a warning about deleting this page" do
+            get delete_page_path(form_id: form.id, page_id: page.id)
+
+            assert_select(".govuk-notification-banner", count: 1) do
+              assert_select "*", "Important"
+              assert_select "h3", "There are routes to and from question #{page.position}"
+              assert_select "p.govuk-body", /If you delete this question, its routes will also be deleted./
+              assert_select "p.govuk-body a", "View your question routes"
+            end
+          end
+        end
+      end
     end
   end
 

--- a/spec/views/pages/delete.html.erb_spec.rb
+++ b/spec/views/pages/delete.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "pages/delete" do
+RSpec.describe "pages/delete", feature_multiple_branches: false do
   let(:delete_confirmation_input) { Forms::DeleteConfirmationInput.new }
   let(:current_form) { create :form }
   let(:page) { create :page, form: current_form }
@@ -192,6 +192,40 @@ RSpec.describe "pages/delete" do
 
       it "does not render the notification banner" do
         expect(rendered).not_to have_css ".govuk-notification-banner"
+      end
+    end
+  end
+
+  context "when multiple_branches is enabled", :feature_multiple_branches do
+    context "when page to delete is not associated with any routes" do
+      before do
+        assign(:routing, [])
+      end
+
+      it "does not render a notification banner" do
+        expect(rendered).not_to have_css ".govuk-notification-banner"
+      end
+    end
+
+    context "when the page to delete is associated with a route" do
+      before do
+        assign(:routing, ["a route"])
+        assign(:routing_banner_heading, "Question 1 has a route")
+        assign(:routing_banner_html, "<p class=\"govuk-body\">If you delete this question, its route will also be deleted.</p>".html_safe)
+
+        render locals: { current_form: }
+      end
+
+      it "renders a notification banner" do
+        expect(rendered).to have_css ".govuk-notification-banner"
+      end
+
+      describe "notification banner" do
+        subject(:banner) { rendered.html.at_css(".govuk-notification-banner") }
+
+        it { is_expected.to have_text "Important" }
+        it { is_expected.to have_css "h3.govuk-notification-banner__heading", text: "Question 1 has a route", count: 1 }
+        it { is_expected.to have_css "p.govuk-body", text: "If you delete this question, its route will also be deleted." }
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/NL0r23hr/3142-update-warnings-when-deleting-a-question-at-the-start-or-end-of-a-route-if-multiple-branches-is-enabled

The warning notification when deleting a page will reflect the routing situation around the page - if there are one or more routes to or from the page, the banner will describe this accordingly.

<img width="697" height="580" alt="image" src="https://github.com/user-attachments/assets/536540d2-a0d2-4279-a81c-9b5fbc1aa312" />


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
