### PR TITLE
Update banner notifications when changing a select-one question with routes from answers

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -54,7 +54,7 @@ class Page < ApplicationRecord
 
     save!
     form.save_question_changes!
-    check_conditions.destroy_all if answer_type_changed_from_selection
+    check_conditions.destroy_all if answer_type_changed_from_selection_only_one_option
     check_conditions.destroy_all if answer_settings_changed_from_only_one_option
 
     true
@@ -79,8 +79,8 @@ class Page < ApplicationRecord
     next_page.present?
   end
 
-  def answer_type_changed_from_selection
-    answer_type_previously_was&.to_sym == :selection && answer_type&.to_sym != :selection
+  def answer_type_changed_from_selection_only_one_option
+    answer_type_previously_was&.to_sym == :selection && answer_type&.to_sym != :selection && answer_settings_previously_was.only_one_option == "true"
   end
 
   def answer_settings_changed_from_only_one_option

--- a/app/views/pages/type_of_answer.html.erb
+++ b/app/views/pages/type_of_answer.html.erb
@@ -3,10 +3,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if !FeatureService.new(group: current_form&.group).enabled?(:multiple_branches) && @page.present? && @page.routing_conditions.any?  %>
+    <% if @page.present? && @page.routing_conditions.any? && @page.answer_settings.only_one_option == "true" %>
       <%= govuk_notification_banner(title_text: t("banner.default.title")) do |banner| %>
-        <% banner.with_heading(text: t("type_of_answer.routing_warning_about_change_answer_type_heading"), tag: "h3") %>
-        <%= t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(current_form.id)) %>
+        <% banner.with_heading(text: t("type_of_answer.routing_warning_changing_from_one_option_heading", count: @page.routing_conditions.count), tag: "h3") %>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2168,14 +2168,9 @@ en:
     not_started: Not started
     optional: Optional
   type_of_answer:
-    routing_warning_about_change_answer_type_heading: Your existing route may be deleted
-    routing_warning_about_change_answer_type_html: |
-      <p>
-        Changing the answer type from “Selection from a list of options” to a different answer type means your route will no longer work and will be deleted.
-      </p>
-      <p>
-        If you do not want to lose your route you can cancel this change by using the back button or <a href="%{pages_link_url}">go to your questions</a>.
-      </p>
+    routing_warning_changing_from_one_option_heading:
+      one: If you change the answer type of this question, its route will be deleted
+      other: If you change the answer type of this question, its routes will be deleted
   unarchive:
     new:
       body_html: |

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -521,6 +521,16 @@ RSpec.describe Page, type: :model do
           expect(page.reload.check_conditions).not_to be_empty
         end
       end
+
+      context "when the answer type changes from selection with more than one option" do
+        subject(:page) { create :page, :selection_with_checkboxes, form:, routing_conditions:, check_conditions: }
+
+        it "does not delete any conditions" do
+          page.answer_type = "number"
+          page.save_and_update_form
+          expect(page.reload.check_conditions).not_to be_empty
+        end
+      end
     end
   end
 

--- a/spec/views/pages/type_of_answer.html.erb_spec.rb
+++ b/spec/views/pages/type_of_answer.html.erb_spec.rb
@@ -66,20 +66,25 @@ describe "pages/type_of_answer.html.erb", type: :view do
     expect(rendered).not_to have_selector(".govuk-notification-banner__content")
   end
 
-  context "when editing an existing" do
-    let(:page) { OpenStruct.new(routing_conditions:, answer_type:) }
+  context "when editing an existing select one option question with a route set" do
+    let(:page) { OpenStruct.new(routing_conditions:, answer_type:, answer_settings:) }
+    let(:answer_settings) { OpenStruct.new(only_one_option: "true") }
     let(:answer_type) { "selection" }
     let(:routing_conditions) { [build(:condition)] }
 
     it "displays a warning about routes being deleted if answer type changes" do
-      expect(Capybara.string(rendered.html).find(".govuk-notification-banner__content").text(normalize_ws: true))
-        .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_about_change_answer_type_html", pages_link_url: form_pages_path(form)))
-                        .text(normalize_ws: true))
+      expect(Capybara.string(rendered.html).find(".govuk-notification-banner__heading").text(normalize_ws: true))
+        .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_changing_from_one_option_heading", count: 1))
+          .text(normalize_ws: true))
     end
 
-    context "when multiple branches are enabled", :feature_multiple_branches do
-      it "does not display a warning about routes being deleted if answer type changes" do
-        expect(rendered).not_to have_selector(".govuk-notification-banner__content")
+    context "with multiple routes set" do
+      let(:routing_conditions) { [build(:condition), build(:condition)] }
+
+      it "displays a warning about routes being deleted if answer type changes" do
+        expect(Capybara.string(rendered.html).find(".govuk-notification-banner__heading").text(normalize_ws: true))
+          .to include(Capybara.string(I18n.t("type_of_answer.routing_warning_changing_from_one_option_heading", count: 2))
+            .text(normalize_ws: true))
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/P4dayADV/3143-update-banner-notifications-when-changing-a-select-one-question-with-routes-from-answers

Updates the banner that shows when changing the answer type from a selection question, with only one option. The banner no longer shows if it's a selection question with multiple options. 

The banner says `route` or `routes` depending on the number of routes from that question. 

<img width="738" height="831" alt="image" src="https://github.com/user-attachments/assets/9ef8221d-4c3d-4da1-a53e-ebadc2c68e2c" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
