### PR TITLE
Allow all Welsh government, Scottish government, and MOD subdomains in email validation

### DIFF
--- a/app/validators/allowed_email_domain_validator.rb
+++ b/app/validators/allowed_email_domain_validator.rb
@@ -1,7 +1,13 @@
 class AllowedEmailDomainValidator < ActiveModel::EachValidator
+  ALLOWED_SUBDOMAIN_REGEXES = [/\.gov\.uk\z/i,
+                               /\.gov\.scot\z/i,
+                               /\.gov\.wales\z/i,
+                               /\.mod\.uk\z/i].freeze
+
   def validate_each(record, attribute, value)
     if value.present?
-      return if value =~ /\.gov\.uk\z/i
+
+      return if ALLOWED_SUBDOMAIN_REGEXES.any? { it.match?(value) }
 
       # TODO: we might not want to check against current user domain
       # when we have a proper allow list?

--- a/spec/validator/allowed_email_domain_validator_spec.rb
+++ b/spec/validator/allowed_email_domain_validator_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe AllowedEmailDomainValidator do
     expect(model).to be_valid
   end
 
+  it "validates email with .gov.scot" do
+    model.email = "test.gov.scot"
+    expect(model).to be_valid
+  end
+
+  it "validates email with .gov.wales" do
+    model.email = "test.gov.wales"
+    expect(model).to be_valid
+  end
+
+  it "validates email with .mod.uk" do
+    model.email = "test.mod.uk"
+    expect(model).to be_valid
+  end
+
   it "does not validate any non-govuk email" do
     model.email = "test@example.com"
     expect(model).to be_invalid


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->Mitigates https://trello.com/c/NQj6zljA/3449-make-email-domain-validation-check-against-allowed-domains-rather-than-just-govuk-and-the-users-current-domain

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
In our domain allowlist, we include a number of non .gov.uk email domains. Most of these match the entire domain - e.g. `@hs2.org.uk` - but a small number allow any subdomains - e.g. `.gov.scot`.

In this validator we allow any `.gov.uk `email address, as well as any domain that matches the current user's domain, which we implemented to avoid duplicating the entire allowlist in this app. However, this sometimes causes issues when editors from a parent organisation attempt to use an email address from one of their suborganisations.

This commit explicitly allows any subdomain of the `.gov.scot`,`.gov.wales`, and `.mod.uk` domains on the logic that:
- they are likely to account for a lot of the parent/child organisation mismatches that cause validation issues
- they allow us to significantly increase the number of valid emails without having to duplicate the whole allowlist here.

This should mitigate the domain mismatch validation issue until we have a permanent fix in place.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
