### PR TITLE
Add organisation_domains table

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,6 +5,7 @@ class Organisation < ApplicationRecord
   has_many :users
 
   has_many :mou_signatures
+  has_many :organisation_domains, dependent: :destroy
 
   scope :not_closed, -> { where(closed: false) }
   scope :with_users, -> { joins(:users).distinct.order(:name) }

--- a/app/models/organisation_domain.rb
+++ b/app/models/organisation_domain.rb
@@ -3,6 +3,7 @@ class OrganisationDomain < ApplicationRecord
 
   validates :domain, presence: true
   validates :domain, uniqueness: { scope: :organisation_id, case_sensitive: false }
+  validates :domain, domain: true
 
   before_validation -> { self.domain = domain&.downcase&.strip }
 end

--- a/app/models/organisation_domain.rb
+++ b/app/models/organisation_domain.rb
@@ -1,0 +1,8 @@
+class OrganisationDomain < ApplicationRecord
+  belongs_to :organisation
+
+  validates :domain, presence: true
+  validates :domain, uniqueness: { scope: :organisation_id, case_sensitive: false }
+
+  before_validation -> { self.domain = domain&.downcase&.strip }
+end

--- a/app/validators/domain_validator.rb
+++ b/app/validators/domain_validator.rb
@@ -1,0 +1,11 @@
+class DomainValidator < ActiveModel::EachValidator
+  REGEX = /\A([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}\Z/i
+
+  def validate_each(record, attribute, value)
+    return true if value.blank?
+
+    unless value.match?(/\A[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,}\z/i)
+      record.errors.add(attribute, :invalid_domain)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,12 @@ en:
             agreed:
               crown: You must agree to the memorandum of understanding
               non_crown: You must agree to the agreement to continue
+        organisation_domain:
+          attributes:
+            domain:
+              blank: Enter a domain name
+              invalid_domain: Enter a domain name in the correct format, like subdomain.gov.uk
+              taken: This domain name is already in use
         page:
           attributes:
             hint_text:

--- a/db/migrate/20260626145112_create_organisation_domains.rb
+++ b/db/migrate/20260626145112_create_organisation_domains.rb
@@ -1,0 +1,12 @@
+class CreateOrganisationDomains < ActiveRecord::Migration[8.1]
+  def change
+    create_table :organisation_domains do |t|
+      t.references :organisation, null: false, foreign_key: true
+      t.string :domain, null: false
+      t.timestamps
+    end
+
+    add_index :organisation_domains, %i[organisation_id domain], unique: true, name: "index_organisation_domains_unique"
+    add_index :organisation_domains, :domain
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_112508) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_145112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -199,6 +199,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_112508) do
     t.index ["user_id"], name: "index_mou_signatures_on_user_id_unique_without_organisation_id", unique: true, where: "(organisation_id IS NULL)", comment: "Users can only sign a single MOU without an organisation"
   end
 
+  create_table "organisation_domains", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "domain", null: false
+    t.bigint "organisation_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["domain"], name: "index_organisation_domains_on_domain"
+    t.index ["organisation_id", "domain"], name: "index_organisation_domains_unique", unique: true
+    t.index ["organisation_id"], name: "index_organisation_domains_on_organisation_id"
+  end
+
   create_table "organisations", force: :cascade do |t|
     t.string "abbreviation"
     t.boolean "closed", default: false
@@ -297,6 +307,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_112508) do
   add_foreign_key "memberships", "users", column: "added_by_id"
   add_foreign_key "mou_signatures", "organisations"
   add_foreign_key "mou_signatures", "users"
+  add_foreign_key "organisation_domains", "organisations"
   add_foreign_key "page_translations", "pages"
   add_foreign_key "pages", "forms"
   add_foreign_key "users", "organisations"

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -87,6 +87,62 @@ namespace :organisations do
       change_organisation_internal_status(**args, status: false, task:, dry_run: true)
     end
   end
+
+  namespace :domains do
+    desc "Add domains to an organisation"
+    task :add, %i[organisation_slug domains] => :environment do |_task, args|
+      organisation_slug = args[:organisation_slug]
+      domains = args.to_a[1..]
+
+      usage_message = "usage: rake organisations:domains:add[<organisation_slug>, <domain1>, <domain2>, ...]".freeze
+      abort usage_message if organisation_slug.blank? || domains.blank?
+
+      organisation = Organisation.find_by(slug: organisation_slug)
+      abort "Organisation with slug #{organisation_slug} does not exist" if organisation.nil?
+
+      domains.each do |domain|
+        Rails.logger.info("Adding domain: #{domain}")
+        organisation.organisation_domains.create!(domain: domain)
+      end
+    end
+
+    desc "Remove domains from an organisation"
+    task :remove, %i[organisation_slug domains] => :environment do |_task, args|
+      organisation_slug = args[:organisation_slug]
+      domains = args.to_a[1..]
+
+      usage_message = "usage: rake organisations:domains:remove[<organisation_slug>, <domain1>, <domain2>, ...]".freeze
+      abort usage_message if organisation_slug.blank? || domains.blank?
+
+      organisation = Organisation.find_by(slug: organisation_slug)
+      abort "Organisation with slug #{organisation_slug} does not exist" if organisation.nil?
+
+      domains.each do |domain|
+        organisation.organisation_domains.find_by!(domain: domain).destroy!
+        Rails.logger.info("Removed domain: #{domain}")
+      rescue ActiveRecord::RecordNotFound
+        Rails.logger.info("Domain #{domain} not found for organisation with slug #{organisation_slug}")
+      end
+    end
+
+    desc "List domains associated with an organisation"
+    task :list, %i[organisation_slug] => :environment do |_task, args|
+      organisation_slug = args[:organisation_slug]
+
+      usage_message = "usage: rake organisations:domains:list[<organisation_slug>]".freeze
+      abort usage_message if organisation_slug.blank?
+
+      organisation = Organisation.find_by(slug: organisation_slug)
+      abort "Organisation with slug #{organisation_slug} does not exist" if organisation.nil?
+
+      domains = organisation.organisation_domains.pluck(:domain).join(", ")
+      if domains.present?
+        Rails.logger.info "Domains for organisation with slug '#{organisation_slug}': #{domains}"
+      else
+        Rails.logger.info "Organisation with slug '#{organisation_slug}' has no domains"
+      end
+    end
+  end
 end
 
 def run_organisation_fetch(dry_run:)

--- a/spec/factories/models/organisation_domains.rb
+++ b/spec/factories/models/organisation_domains.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :organisation_domain do
+    organisation { association :organisation, id: 1, slug: "test-org" }
+    domain { Faker::Internet.domain_name }
+  end
+end

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -262,4 +262,106 @@ RSpec.describe "organisations.rake", type: :task do
         .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
     end
   end
+
+  describe "organisations:domains:add" do
+    subject(:task) do
+      Rake::Task["organisations:domains:add"]
+    end
+
+    let!(:organisation) { create :organisation, slug: "test-org" }
+
+    it "adds domains to an organisation" do
+      expect(Rails.logger).to receive(:info).with("Adding domain: example.gov.uk")
+      expect(Rails.logger).to receive(:info).with("Adding domain: example.org")
+
+      expect {
+        task.invoke("test-org", "example.gov.uk", "example.org")
+      }.to change { organisation.reload.organisation_domains.pluck(:domain) }
+        .from([])
+        .to(match_array(%w[example.gov.uk example.org]))
+    end
+
+    it "raises an error when a domain is invalid" do
+      expect {
+        task.invoke("test-org", "not a domain")
+      }.to raise_error(ActiveRecord::RecordInvalid, /Enter a domain name in the correct format, like subdomain\.gov\.uk/)
+
+      expect(organisation.reload.organisation_domains).to be_empty
+    end
+
+    it "aborts when the organisation slug does not exist" do
+      expect { task.invoke("missing-org", "example.gov.uk") }
+        .to output(/Organisation with slug missing-org does not exist/).to_stderr
+        .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+  end
+
+  describe "organisations:domains:remove" do
+    subject(:task) do
+      Rake::Task["organisations:domains:remove"]
+    end
+
+    let!(:organisation) { create :organisation, slug: "test-org" }
+
+    before do
+      create :organisation_domain, organisation:, domain: "example.gov.uk"
+      create :organisation_domain, organisation:, domain: "example.org"
+    end
+
+    it "removes domains from an organisation" do
+      expect(Rails.logger).to receive(:info).with("Removed domain: example.gov.uk")
+
+      expect {
+        task.invoke("test-org", "example.gov.uk")
+      }.to change { organisation.reload.organisation_domains.pluck(:domain) }
+        .from(%w[example.gov.uk example.org])
+        .to(%w[example.org])
+    end
+
+    it "logs and continues when a domain does not exist" do
+      expect(Rails.logger).to receive(:info).with("Domain missing.gov.uk not found for organisation with slug test-org").ordered
+      expect(Rails.logger).to receive(:info).with("Removed domain: example.gov.uk").ordered
+
+      expect {
+        task.invoke("test-org", "missing.gov.uk", "example.gov.uk")
+      }.to change { organisation.reload.organisation_domains.pluck(:domain) }
+        .from(%w[example.gov.uk example.org])
+        .to(%w[example.org])
+    end
+
+    it "aborts when the organisation slug does not exist" do
+      expect { task.invoke("missing-org", "example.gov.uk") }
+        .to output(/Organisation with slug missing-org does not exist/).to_stderr
+        .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+  end
+
+  describe "organisations:domains:list" do
+    subject(:task) do
+      Rake::Task["organisations:domains:list"]
+    end
+
+    let!(:organisation) { create :organisation, slug: "test-org" }
+
+    it "logs the organisation domains" do
+      create :organisation_domain, organisation:, domain: "example.gov.uk"
+      create :organisation_domain, organisation:, domain: "example.org"
+
+      expect(Rails.logger).to receive(:info).with("Domains for organisation with slug 'test-org': example.gov.uk, example.org")
+
+      task.invoke("test-org")
+    end
+
+    it "logs when the organisation has no domains" do
+      expect(Rails.logger).to receive(:info).with("Organisation with slug 'test-org' has no domains")
+
+      task.invoke("test-org")
+    end
+
+    it "aborts when the organisation slug does not exist" do
+      expect { task.invoke("missing-org") }
+        .to output(/Organisation with slug missing-org does not exist/).to_stderr
+        .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+  end
 end

--- a/spec/models/organisation_domain_spec.rb
+++ b/spec/models/organisation_domain_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe OrganisationDomain do
+  describe "validations" do
+    it "has a valid factory" do
+      expect(build(:organisation_domain)).to be_valid
+    end
+
+    it "is invalid without an organisation" do
+      organisation_domain = described_class.new(domain: "example.gov.uk")
+      expect(organisation_domain).not_to be_valid
+    end
+
+    it "is invalid without a domain" do
+      organisation_domain = described_class.new(organisation: create(:organisation))
+      expect(organisation_domain).not_to be_valid
+    end
+
+    it "is invalid when the domain already exists for the organisation" do
+      organisation = create(:organisation)
+      described_class.create!(organisation: organisation, domain: "example.gov.uk")
+      duplicate_domain = described_class.new(organisation: organisation, domain: "example.gov.uk")
+      expect(duplicate_domain).not_to be_valid
+    end
+
+    it_behaves_like "a domain validator" do
+      let(:model) { described_class.new(organisation: create(:organisation)) }
+      let(:attribute) { :domain }
+    end
+  end
+end

--- a/spec/support/shared_examples/domain_validation.rb
+++ b/spec/support/shared_examples/domain_validation.rb
@@ -1,0 +1,26 @@
+RSpec.shared_examples "a domain validator" do
+  context "with a valid domain" do
+    %w[example.com sub.example.gov.wales EXAMPLE.COM a-b.example].each do |domain|
+      context "when domain is '#{domain}'" do
+        it "is valid" do
+          model.send("#{attribute}=", domain)
+
+          expect(model).to be_valid
+        end
+      end
+    end
+  end
+
+  context "with invalid domain" do
+    %w[http://example.com ex_ample.com example..com -example.com example-.com @example.com .example.com].each do |domain|
+      context "when domain is '#{domain}'" do
+        it "is invalid" do
+          model.send("#{attribute}=", domain)
+
+          expect(model).to be_invalid
+          expect(model.errors.details[:domain].first[:error]).to eq(:invalid_domain)
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/domain_validator_spec.rb
+++ b/spec/validators/domain_validator_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+class DomainModel
+  include ActiveModel::Validations
+  attr_accessor :domain
+
+  validates :domain, domain: true
+end
+
+RSpec.describe DomainValidator, type: :validator do
+  context "when value is blank" do
+    it "is valid" do
+      model = DomainModel.new
+      expect(model).to be_valid
+    end
+  end
+
+  it_behaves_like "a domain validator" do
+    let(:model) { DomainModel.new }
+    let(:attribute) { :domain }
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/lIDJ2j9T/3176-store-email-domains-per-organisation-in-forms-admin

Add `organisation_domains` table so we can store the email domains associated with each organisation. Add rake tasks to add/remove/list domains for an organisation.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
