### PR TITLE
Add rake task to populate domains from existing users

### DIFF
--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -142,6 +142,22 @@ namespace :organisations do
         Rails.logger.info "Organisation with slug '#{organisation_slug}' has no domains"
       end
     end
+
+    desc "Populate organisation domains using the email addresses of existing users"
+    task populate_from_users: :environment do
+      Organisation.includes(:users, :organisation_domains).find_each do |organisation|
+        next if organisation.users.empty?
+
+        users = organisation.users.to_a
+        domains = domains_for_users(users).uniq
+
+        domains.each do |domain|
+          organisation.organisation_domains.find_or_create_by!(domain: domain)
+        end
+
+        Rails.logger.info("Added domains for #{organisation.name}: #{domains.join(', ')}")
+      end
+    end
   end
 end
 
@@ -214,5 +230,16 @@ def change_organisation_internal_status(task:, organisation_slug: nil, status: n
     organisation.save!
 
     Rails.logger.info("#{task.name}: Made organisation '#{organisation.name}' #{status_string}")
+  end
+end
+
+def domains_for_users(users)
+  users.filter_map do |user|
+    next if user.email.blank?
+
+    email_domain = user.email.split("@").last&.downcase&.strip
+    next if email_domain.blank? || !user.email.include?("@")
+
+    email_domain
   end
 end

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -364,4 +364,29 @@ RSpec.describe "organisations.rake", type: :task do
         .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
     end
   end
+
+  describe "organisations:domains:populate_from_users" do
+    subject(:task) do
+      Rake::Task["organisations:domains:populate_from_users"]
+    end
+
+    it "creates one domain per unique user email domain for each organisation" do
+      first_organisation = create :organisation, name: "Department for Testing", slug: "dft"
+      second_organisation = create :organisation, name: "Department for Experiments", slug: "dfe"
+
+      create :user, organisation: first_organisation, email: "alice@example.gov.uk"
+      create :user, organisation: first_organisation, email: "bob@example.gov.uk"
+      create :user, organisation: first_organisation, email: "carol@example.org"
+
+      create :user, organisation: second_organisation, email: "dana@service.gov.uk"
+
+      expect(Rails.logger).to receive(:info).with("Added domains for Department for Testing: example.gov.uk, example.org")
+      expect(Rails.logger).to receive(:info).with("Added domains for Department for Experiments: service.gov.uk")
+
+      task.invoke
+
+      expect(first_organisation.reload.organisation_domains.pluck(:domain)).to match_array(%w[example.gov.uk example.org])
+      expect(second_organisation.reload.organisation_domains.pluck(:domain)).to match_array(%w[service.gov.uk])
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/CELIu9oE

This rake tasks looks at existing users per organisation and adds an OrganisationDomain per unique email domain. This is intended to be run as a one-off task to populate the OrganisationDomain table with existing data. We'll review this data after we've run the task and remove any domains we don't think should be associated with organisations.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
