### PR TITLE
Check move policy when group organisation changes

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -82,6 +82,8 @@ class GroupsController < WebController
 
     @group.assign_attributes(group_params)
 
+    authorize @group, :move? if @group.organisation_id_changed?
+
     if @group.active?
       success_message = t("groups.success_messages.update") if @group.changed.include?("name")
       success_message = t("groups.success_messages.move", org_name: @group.organisation.name) if @group.changed.include?("organisation_id")

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -377,6 +377,51 @@ RSpec.describe "/groups", type: :request do
         expect(response).to have_http_status :not_found
       end
     end
+
+    context "when the parameters include a different organisation_id" do
+      let(:other_organisation) { create :organisation, slug: "other-org" }
+
+      context "when user is a group admin of the group" do
+        let(:role) { :group_admin }
+
+        it "is forbidden" do
+          patch group_url(member_group), params: { group: { organisation_id: other_organisation.id } }
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it "does not change the group's organisation" do
+          expect {
+            patch group_url(member_group), params: { group: { organisation_id: other_organisation.id } }
+          }.not_to(change { member_group.reload.organisation_id })
+        end
+      end
+
+      context "when user is an organisation admin for the group's organisation" do
+        let(:current_user) { organisation_admin_user }
+
+        it "is forbidden" do
+          patch group_url(member_group), params: { group: { organisation_id: other_organisation.id } }
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it "does not change the group's organisation" do
+          expect {
+            patch group_url(member_group), params: { group: { organisation_id: other_organisation.id } }
+          }.not_to(change { member_group.reload.organisation_id })
+        end
+      end
+
+      context "when user is a super admin" do
+        before do
+          login_as_super_admin_user
+        end
+
+        it "moves the group to the other organisation" do
+          patch group_url(member_group), params: { group: { organisation_id: other_organisation.id } }
+          expect(member_group.reload.organisation_id).to eq(other_organisation.id)
+        end
+      end
+    end
   end
 
   describe "GET /move" do


### PR DESCRIPTION
### What problem does this pull request solve?

Only super admins are supposed to be able to move a group to a different organisation. There is a dedicated "move group" page for this, and it is only shown to super admins.

However, the endpoint that actually saves the change is the ordinary group update endpoint (`PATCH /groups/:id`), and it accepted an `organisation_id` parameter from anyone allowed to edit the group. The edit form doesn't include that field, but nothing stopped a group admin or organisation admin from adding it to the request themselves. Doing so would move their group into any other organisation, skipping the super-admin-only check entirely.

The update action now checks the `move?` policy whenever a request would change a group's organisation:

- Super admins can still move groups exactly as before.
- Anyone else who sends an `organisation_id` gets a 403 Forbidden response

You might expect the fix to be removing `organisation_id` from the permitted parameters. We can't do that, because the super admin move page submits its form to this same update action. Instead, the parameter stays permitted and the organisation change itself is now guarded by the `move?` policy.