### PR TITLE
Only allow moving forms to groups in the same organisation

### DIFF
--- a/app/controllers/group_forms_controller.rb
+++ b/app/controllers/group_forms_controller.rb
@@ -42,9 +42,10 @@ class GroupFormsController < WebController
     @group_select = Forms::GroupSelect.new(group_select_params.merge(form: @form))
 
     if @group_select.valid?
-      receiving_group = Group.find_by(external_id: @group_select.group)
+      # The receiving group must be one the user could have selected: in the
+      # same organisation as the current group, and active if the form is live
+      receiving_group = Forms::GroupSelect.new(group: @group, form: @form).groups.find_by(external_id: @group_select.group)
 
-      # In case the receiving group is deleted since the form was loaded
       if receiving_group
         GroupFormsService.new(group: receiving_group, form: @form, current_user: @current_user, old_group: @group).move_form_to(receiving_group)
         success_message = t(".success", form_name: @form.name, receiving_group_name: receiving_group.name)

--- a/spec/requests/group_forms_controller_spec.rb
+++ b/spec/requests/group_forms_controller_spec.rb
@@ -96,6 +96,44 @@ RSpec.describe "/groups/:group_id/forms", type: :request do
           expect(response).to have_http_status :unprocessable_content
         end
       end
+
+      context "when the target group belongs to another organisation" do
+        let(:other_organisation) { create(:organisation, slug: "other-org") }
+        let(:other_org_group) { create(:group, organisation: other_organisation) }
+
+        it "does not move the form" do
+          expect {
+            patch group_form_url(group, id: form.id), params: { forms_group_select: { group: other_org_group.external_id } }
+          }.not_to(change { GroupForm.find_by(form_id: form.id).group })
+        end
+
+        it "renders a response with 422 status" do
+          patch group_form_url(group, id: form.id), params: { forms_group_select: { group: other_org_group.external_id } }
+
+          expect(response).to have_http_status :unprocessable_content
+        end
+      end
+
+      context "when the form is live and the target group is not active" do
+        let(:live_form) { create :form, :live, id: 2 }
+        let(:trial_group) { create(:group, organisation: organisation_admin_user.organisation, status: :trial) }
+
+        before do
+          group.group_forms.create!(form_id: live_form.id)
+        end
+
+        it "does not move the form" do
+          expect {
+            patch group_form_url(group, id: live_form.id), params: { forms_group_select: { group: trial_group.external_id } }
+          }.not_to(change { GroupForm.find_by(form_id: live_form.id).group })
+        end
+
+        it "renders a response with 422 status" do
+          patch group_form_url(group, id: live_form.id), params: { forms_group_select: { group: trial_group.external_id } }
+
+          expect(response).to have_http_status :unprocessable_content
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

The move form page only offers groups from the form's own organisation as targets. The server doesn't enforce this,  when the request comes in, it looks up the target group by `external_id` across all organisations. This meant a request with any valid group ID would be accepted, even one for a group in a different organisation.

The target group is now resolved from the same list of groups that the page offers in the UI. That list only contains groups in the current organisation, and only active groups when the form is live. Any other target is rejected and the page is re-rendered with the existing "group no longer available" error.

### Things to consider when reviewing

- No new error path was added: an out-of-scope group ID falls into the existing branch that previously only handled a group being deleted after the page was loaded.
- The scoped lookup also enforces two rules on the server that the UI already implied: the target can't be the group the form is already in, and live forms can only move to active groups.
- New request specs cover a target group in another organisation and an inactive target for a live form, checking that the form stays in its group and the response is 422.