### PR TITLE
Add organisations interface for super admins

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -10,7 +10,7 @@ class OrganisationsController < WebController
 
     organisation_ids = @organisations.map(&:id)
     @user_counts = User.where(organisation_id: organisation_ids).group(:organisation_id).count
-    @group_counts = Group.where(organisation_id: organisation_ids).reorder(nil).group(:organisation_id).count
+    @form_counts = GroupForm.joins(:group).where(groups: { organisation_id: organisation_ids }).reorder(nil).group("groups.organisation_id").count
     @organisation_ids_with_mou = MouSignature.where(organisation_id: organisation_ids).distinct.pluck(:organisation_id).to_set
   end
 

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -6,7 +6,9 @@ class OrganisationsController < WebController
   def index
     authorize Organisation, :can_view_organisations?
 
-    @pagy, @organisations = pagy(Organisation.order(:name), limit: 50)
+    @filter_input = Organisations::FilterInput.new(filter_params)
+
+    @pagy, @organisations = pagy(filtered_organisations, limit: 50)
 
     organisation_ids = @organisations.map(&:id)
     @user_counts = User.where(organisation_id: organisation_ids).group(:organisation_id).count
@@ -18,5 +20,18 @@ class OrganisationsController < WebController
     authorize Organisation, :can_view_organisations?
 
     @organisation = Organisation.includes(:organisation_domains, mou_signatures: :user).find(params[:id])
+  end
+
+private
+
+  def filtered_organisations
+    Organisation
+      .by_name(filter_params[:name])
+      .by_mou_signed(filter_params[:mou_signed])
+      .order(:name)
+  end
+
+  def filter_params
+    params[:filter]&.permit(:name, :mou_signed) || {}
   end
 end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,0 +1,22 @@
+class OrganisationsController < WebController
+  include Pagy::Backend
+
+  after_action :verify_authorized
+
+  def index
+    authorize Organisation, :can_view_organisations?
+
+    @pagy, @organisations = pagy(Organisation.order(:name), limit: 50)
+
+    organisation_ids = @organisations.map(&:id)
+    @user_counts = User.where(organisation_id: organisation_ids).group(:organisation_id).count
+    @group_counts = Group.where(organisation_id: organisation_ids).reorder(nil).group(:organisation_id).count
+    @organisation_ids_with_mou = MouSignature.where(organisation_id: organisation_ids).distinct.pluck(:organisation_id).to_set
+  end
+
+  def show
+    authorize Organisation, :can_view_organisations?
+
+    @organisation = Organisation.includes(:organisation_domains, mou_signatures: :user).find(params[:id])
+  end
+end

--- a/app/input_objects/organisations/filter_input.rb
+++ b/app/input_objects/organisations/filter_input.rb
@@ -1,0 +1,17 @@
+module Organisations
+  class FilterInput < BaseInput
+    attr_accessor :name, :mou_signed
+
+    def has_filters?
+      [name, mou_signed].any?(&:present?)
+    end
+
+    def mou_signed_options
+      [
+        OpenStruct.new(label: I18n.t("organisations.index.filter.mou_signed.any")),
+        OpenStruct.new(label: I18n.t("organisations.boolean.true"), value: "true"),
+        OpenStruct.new(label: I18n.t("organisations.boolean.false"), value: "false"),
+      ]
+    end
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,6 +2,7 @@ class Organisation < ApplicationRecord
   has_paper_trail
 
   has_many :groups
+  has_many :group_forms, through: :groups
   has_many :users
 
   has_many :mou_signatures

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -11,6 +11,22 @@ class Organisation < ApplicationRecord
   scope :not_closed, -> { where(closed: false) }
   scope :with_users, -> { joins(:users).distinct.order(:name) }
 
+  scope :by_name, lambda { |name|
+    if name.present?
+      where("lower(name) LIKE :search OR lower(abbreviation) LIKE :search",
+            search: "%#{sanitize_sql_like(name.downcase)}%")
+    end
+  }
+
+  scope :by_mou_signed, lambda { |mou_signed|
+    case mou_signed
+    when "true"
+      joins(:mou_signatures).distinct
+    when "false"
+      where.missing(:mou_signatures)
+    end
+  }
+
   def name_with_abbreviation
     if abbreviation.present? && abbreviation != name
       "#{name} (#{abbreviation})"

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -1,0 +1,5 @@
+class OrganisationPolicy < ApplicationPolicy
+  def can_view_organisations?
+    user.super_admin?
+  end
+end

--- a/app/services/navigation_items_service.rb
+++ b/app/services/navigation_items_service.rb
@@ -24,6 +24,7 @@ class NavigationItemsService
       your_groups_navigation_item,
       mou_navigation_item,
       users_navigation_item,
+      organisations_navigation_item,
       reports_navigation_item,
       support_navigation_item,
       profile_navigation_item,
@@ -51,6 +52,12 @@ private
     return nil unless should_show_user_profile_link?
 
     NavigationItem.new(text: I18n.t("header.users"), href: users_path, active: false)
+  end
+
+  def organisations_navigation_item
+    return nil unless should_show_organisations_link?
+
+    NavigationItem.new(text: I18n.t("header.organisations"), href: organisations_path, active: false)
   end
 
   def reports_navigation_item
@@ -101,6 +108,10 @@ private
 
   def should_show_mous_link?
     Pundit.policy(user, :mou_signature).can_manage_mous?
+  end
+
+  def should_show_organisations_link?
+    Pundit.policy(user, :organisation).can_view_organisations?
   end
 
   def should_show_reports_link?

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -2,6 +2,38 @@
 
 <h1 class="govuk-heading-l"><%= t("page_titles.organisations") %></h1>
 
+<div class="app-filter govuk-grid-row">
+  <%= form_with(model: @filter_input, scope: :filter, url: organisations_path, method: 'get', local: true, class: 'govuk-clearfix') do |f| %>
+    <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-padding-right-3">
+      <div class="govuk-grid-column-one-third">
+        <%= f.govuk_text_field :name,
+          label: { text: t('organisations.index.filter.name.label'), size: 's' },
+          hint: { text: t('organisations.index.filter.name.hint') } %>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= f.govuk_collection_select :mou_signed,
+          @filter_input.mou_signed_options,
+          :value,
+          :label,
+          class: ["govuk-!-width-full"],
+          label: { text: t('organisations.index.filter.mou_signed.label'), size: 's' },
+          hint: { text: t('organisations.index.filter.mou_signed.hint') } %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-padding-right-3">
+      <div class="govuk-grid-column-one-third">
+        <div class="govuk-button-group">
+          <%= f.govuk_submit(t("organisations.index.filter.submit")) %>
+          <% if @filter_input.has_filters? %>
+            <%= govuk_link_to t('organisations.index.filter.clear_filter'), organisations_path, no_visited_state: true %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+
 <% if @organisations.any? %>
   <p class="govuk-body">
     <% if @pagy.pages > 1 %>
@@ -38,4 +70,6 @@
   <% end %>
 
   <%= govuk_pagination(pagy: @pagy) %>
+<% else %>
+  <p class="govuk-body"><%= t("organisations.index.no_results") %></p>
 <% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,0 +1,43 @@
+<% set_page_title(t("page_titles.organisations")) %>
+
+<h1 class="govuk-heading-l"><%= t("page_titles.organisations") %></h1>
+
+<% if @organisations.any? %>
+  <%= govuk_pagination(pagy: @pagy) %>
+
+  <%= render ScrollingWrapperComponent::View.new(aria_label: t("organisations.index.table_caption")) do |table| %>
+    <%= govuk_table do |table| %>
+      <%= table.with_caption(size: 'm', text: t("organisations.index.table_caption")) %>
+
+      <%= table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(header: true, text: t("organisations.index.table_headings.name"))
+          row.with_cell(header: true, text: t("organisations.index.table_headings.slug"))
+          row.with_cell(header: true, text: t("organisations.index.table_headings.internal"))
+          row.with_cell(header: true, text: t("organisations.index.table_headings.closed"))
+          row.with_cell(header: true, text: t("organisations.index.table_headings.users"))
+          row.with_cell(header: true, text: t("organisations.index.table_headings.groups"))
+          row.with_cell(header: true, text: t("organisations.index.table_headings.mou_signed"))
+        end
+      end %>
+
+      <%= table.with_body do |body|
+        @organisations.each do |organisation|
+          body.with_row do |row|
+            row.with_cell do
+              govuk_link_to(organisation.name_with_abbreviation, organisation_path(organisation))
+            end
+            row.with_cell(text: organisation.slug)
+            row.with_cell(text: t("organisations.boolean.#{organisation.internal}"))
+            row.with_cell(text: t("organisations.boolean.#{organisation.closed}"))
+            row.with_cell(text: @user_counts.fetch(organisation.id, 0).to_s)
+            row.with_cell(text: @group_counts.fetch(organisation.id, 0).to_s)
+            row.with_cell(text: t("organisations.boolean.#{@organisation_ids_with_mou.include?(organisation.id)}"))
+          end
+        end
+      end %>
+    <% end %>
+  <% end %>
+
+  <%= govuk_pagination(pagy: @pagy) %>
+<% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -3,6 +3,14 @@
 <h1 class="govuk-heading-l"><%= t("page_titles.organisations") %></h1>
 
 <% if @organisations.any? %>
+  <p class="govuk-body">
+    <% if @pagy.pages > 1 %>
+      <%= t("organisations.index.showing_count", from: @pagy.from, to: @pagy.to, count: @pagy.count) %>
+    <% else %>
+      <%= t("organisations.index.organisation_count", count: @pagy.count) %>
+    <% end %>
+  </p>
+
   <%= render ScrollingWrapperComponent::View.new(aria_label: t("organisations.index.table_caption")) do |table| %>
     <%= govuk_table do |table| %>
       <%= table.with_head do |head|

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -12,11 +12,8 @@
       <%= table.with_head do |head|
         head.with_row do |row|
           row.with_cell(header: true, text: t("organisations.index.table_headings.name"))
-          row.with_cell(header: true, text: t("organisations.index.table_headings.slug"))
-          row.with_cell(header: true, text: t("organisations.index.table_headings.internal"))
-          row.with_cell(header: true, text: t("organisations.index.table_headings.closed"))
           row.with_cell(header: true, text: t("organisations.index.table_headings.users"))
-          row.with_cell(header: true, text: t("organisations.index.table_headings.groups"))
+          row.with_cell(header: true, text: t("organisations.index.table_headings.forms"))
           row.with_cell(header: true, text: t("organisations.index.table_headings.mou_signed"))
         end
       end %>
@@ -27,11 +24,8 @@
             row.with_cell do
               govuk_link_to(organisation.name_with_abbreviation, organisation_path(organisation))
             end
-            row.with_cell(text: organisation.slug)
-            row.with_cell(text: t("organisations.boolean.#{organisation.internal}"))
-            row.with_cell(text: t("organisations.boolean.#{organisation.closed}"))
             row.with_cell(text: @user_counts.fetch(organisation.id, 0).to_s)
-            row.with_cell(text: @group_counts.fetch(organisation.id, 0).to_s)
+            row.with_cell(text: @form_counts.fetch(organisation.id, 0).to_s)
             row.with_cell(text: t("organisations.boolean.#{@organisation_ids_with_mou.include?(organisation.id)}"))
           end
         end

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -3,12 +3,8 @@
 <h1 class="govuk-heading-l"><%= t("page_titles.organisations") %></h1>
 
 <% if @organisations.any? %>
-  <%= govuk_pagination(pagy: @pagy) %>
-
   <%= render ScrollingWrapperComponent::View.new(aria_label: t("organisations.index.table_caption")) do |table| %>
     <%= govuk_table do |table| %>
-      <%= table.with_caption(size: 'm', text: t("organisations.index.table_caption")) %>
-
       <%= table.with_head do |head|
         head.with_row do |row|
           row.with_cell(header: true, text: t("organisations.index.table_headings.name"))

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -7,16 +7,6 @@
 
     <%= govuk_summary_list(actions: false) do |summary_list|
       summary_list.with_row do |row|
-        row.with_key { t('organisations.show.summary.name') }
-        row.with_value { @organisation.name }
-      end
-
-      summary_list.with_row do |row|
-        row.with_key { t('organisations.show.summary.abbreviation') }
-        row.with_value { @organisation.abbreviation.presence || t("organisations.show.not_set") }
-      end
-
-      summary_list.with_row do |row|
         row.with_key { t('organisations.show.summary.slug') }
         row.with_value { @organisation.slug }
       end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -1,0 +1,108 @@
+<% set_page_title(@organisation.name_with_abbreviation) %>
+<% content_for :back_link, govuk_back_link_to(organisations_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= @organisation.name_with_abbreviation %></h1>
+
+    <%= govuk_summary_list(actions: false) do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.name') }
+        row.with_value { @organisation.name }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.abbreviation') }
+        row.with_value { @organisation.abbreviation.presence || t("organisations.show.not_set") }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.slug') }
+        row.with_value { @organisation.slug }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.govuk_content_id') }
+        row.with_value { @organisation.govuk_content_id.presence || t("organisations.show.not_set") }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.internal') }
+        row.with_value { t("organisations.boolean.#{@organisation.internal}") }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.closed') }
+        row.with_value { t("organisations.boolean.#{@organisation.closed}") }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.created_at') }
+        row.with_value { l(@organisation.created_at.to_date, format: :long) }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.users') }
+        row.with_value { @organisation.users.count.to_s }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.groups') }
+        row.with_value { @organisation.groups.count.to_s }
+      end
+    end %>
+
+    <h2 class="govuk-heading-m"><%= t("organisations.show.admin_users.heading") %></h2>
+    <% if @organisation.admin_users.any? %>
+      <ul class="govuk-list">
+        <% @organisation.admin_users.each do |user| %>
+          <li><%= govuk_link_to(user.email, edit_user_path(user)) %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="govuk-body"><%= t("organisations.show.admin_users.none") %></p>
+    <% end %>
+
+    <h2 class="govuk-heading-m"><%= t("organisations.show.mou_signatures.heading") %></h2>
+    <% if @organisation.mou_signatures.any? %>
+      <%= render ScrollingWrapperComponent::View.new(aria_label: t("organisations.show.mou_signatures.heading")) do |table| %>
+        <%= govuk_table do |table| %>
+          <%= table.with_head do |head|
+            head.with_row do |row|
+              row.with_cell(header: true, text: t("mou_signatures.index.table_headings.agreement_type"))
+              row.with_cell(header: true, text: t("mou_signatures.index.table_headings.name"))
+              row.with_cell(header: true, text: t("mou_signatures.index.table_headings.email"))
+              row.with_cell(header: true, text: t("mou_signatures.index.table_headings.agreed_at"))
+            end
+          end %>
+
+          <%= table.with_body do |body|
+            @organisation.mou_signatures.each do |mou_signature|
+              body.with_row do |row|
+                row.with_cell(text: t("mou_signatures.index.agreement_type.#{mou_signature.agreement_type}"))
+                row.with_cell(text: mou_signature.user.name.presence || t("users.index.name_blank"))
+                row.with_cell do
+                  govuk_link_to(mou_signature.user.email, edit_user_path(mou_signature.user))
+                end
+                row.with_cell(text: l(mou_signature.created_at.to_date, format: :long))
+              end
+            end
+          end %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <p class="govuk-body"><%= t("organisations.show.mou_signatures.none") %></p>
+    <% end %>
+
+    <h2 class="govuk-heading-m"><%= t("organisations.show.domains.heading") %></h2>
+    <% if @organisation.organisation_domains.any? %>
+      <ul class="govuk-list">
+        <% @organisation.organisation_domains.each do |organisation_domain| %>
+          <li><%= organisation_domain.domain %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="govuk-body"><%= t("organisations.show.domains.none") %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -37,6 +37,11 @@
       end
 
       summary_list.with_row do |row|
+        row.with_key { t('organisations.show.summary.forms') }
+        row.with_value { @organisation.group_forms.count.to_s }
+      end
+
+      summary_list.with_row do |row|
         row.with_key { t('organisations.show.summary.groups') }
         row.with_value { @organisation.groups.count.to_s }
       end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -92,6 +92,12 @@
       <% end %>
     <% else %>
       <p class="govuk-body"><%= t("organisations.show.mou_signatures.none") %></p>
+
+      <%= t("mou_signatures.index.preamble_html") %>
+
+      <%= t("mou_signatures.index.share_mou_link_html", mou_link: link_to(mou_signature_url, mou_signature_url)) %>
+
+      <%= t("mou_signatures.index.share_non_crown_agreement_link_html", agreement_link: link_to(non_crown_agreement_signature_url, non_crown_agreement_signature_url)) %>
     <% end %>
 
     <h2 class="govuk-heading-m"><%= t("organisations.show.domains.heading") %></h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1453,6 +1453,17 @@ en:
       'false': 'No'
       'true': 'Yes'
     index:
+      filter:
+        clear_filter: Clear filter
+        mou_signed:
+          any: All organisations
+          hint: Filter by whether an MOU or agreement has been agreed
+          label: MOU signed
+        name:
+          hint: Enter full or partial name or abbreviation
+          label: Name
+        submit: Filter
+      no_results: No organisations found.
       organisation_count:
         one: 1 organisation
         other: "%{count} organisations"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -910,6 +910,7 @@ en:
       </p>
   header:
     mous: MOUs
+    organisations: Organisations
     product_name: Forms
     reports: Reports
     sign_out: Sign out

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1447,6 +1447,41 @@ en:
 
       If you pasted the web address, check you copied the entire address.
     title: Page not found
+  organisations:
+    boolean:
+      'false': 'No'
+      'true': 'Yes'
+    index:
+      table_caption: All organisations
+      table_headings:
+        closed: Closed
+        groups: Groups
+        internal: Internal
+        mou_signed: MOU signed
+        name: Name
+        slug: Slug
+        users: Users
+    show:
+      admin_users:
+        heading: Organisation admins
+        none: This organisation does not have any organisation admins.
+      domains:
+        heading: Email domains
+        none: This organisation does not have any email domains.
+      mou_signatures:
+        heading: MOUs and agreements
+        none: No one has agreed an MOU or agreement for this organisation.
+      not_set: Not set
+      summary:
+        abbreviation: Abbreviation
+        closed: Closed
+        created_at: Created
+        govuk_content_id: GOV.UK content ID
+        groups: Number of groups
+        internal: Internal
+        name: Name
+        slug: Slug
+        users: Number of users
   page_conditions:
     condition_answer_value_text: "“%{answer_value}”"
     condition_answer_value_text2: "‘%{answer_value}’"
@@ -1588,6 +1623,7 @@ en:
     non_crown_agreement_confirmation: You’ve agreed to the GOV.UK Forms agreement
     non_crown_agreement_new: GOV.UK Forms agreement
     not_found: Page not found
+    organisations: Organisations
     payment_link: Add a link to a payment page on GOV.UK Pay
     privacy_policy: Provide a link to privacy information for this form
     question_text: What’s your question?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1455,12 +1455,9 @@ en:
     index:
       table_caption: All organisations
       table_headings:
-        closed: Closed
-        groups: Groups
-        internal: Internal
+        forms: Forms
         mou_signed: MOU signed
         name: Name
-        slug: Slug
         users: Users
     show:
       admin_users:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1477,6 +1477,7 @@ en:
       summary:
         closed: Closed
         created_at: Created
+        forms: Number of forms
         govuk_content_id: GOV.UK content ID
         groups: Number of groups
         internal: Internal

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1475,13 +1475,11 @@ en:
         none: No one has agreed an MOU or agreement for this organisation.
       not_set: Not set
       summary:
-        abbreviation: Abbreviation
         closed: Closed
         created_at: Created
         govuk_content_id: GOV.UK content ID
         groups: Number of groups
         internal: Internal
-        name: Name
         slug: Slug
         users: Number of users
   page_conditions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1453,6 +1453,10 @@ en:
       'false': 'No'
       'true': 'Yes'
     index:
+      organisation_count:
+        one: 1 organisation
+        other: "%{count} organisations"
+      showing_count: Showing %{from} to %{to} of %{count} organisations
       table_caption: All organisations
       table_headings:
         forms: Forms

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,6 +214,8 @@ Rails.application.routes.draw do
 
   resources :mou_signatures, only: %i[index], path: "mous"
 
+  resources :organisations, only: %i[index show]
+
   resource :mou_signature, only: %i[new show create], path: "/memorandum-of-understanding", defaults: { agreement_type: :crown }, as: :mou_signature do
     get "/signed", to: "mou_signatures#confirmation", as: :confirmation
   end

--- a/spec/input_objects/organisations/filter_input_spec.rb
+++ b/spec/input_objects/organisations/filter_input_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Organisations::FilterInput, type: :model do
+  describe "#has_filters?" do
+    context "when the name filter is set" do
+      subject(:input) { described_class.new(name: "foo") }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
+    context "when the mou_signed filter is set" do
+      subject(:input) { described_class.new(mou_signed: "true") }
+
+      it "returns true" do
+        expect(input.has_filters?).to be true
+      end
+    end
+
+    context "when no filters are set" do
+      subject(:input) { described_class.new }
+
+      it "returns false" do
+        expect(input.has_filters?).to be false
+      end
+    end
+  end
+
+  describe "#mou_signed_options" do
+    it "returns the correct options" do
+      expect(described_class.new.mou_signed_options).to eq([
+        OpenStruct.new(label: I18n.t("organisations.index.filter.mou_signed.any")),
+        OpenStruct.new(label: I18n.t("organisations.boolean.true"), value: "true"),
+        OpenStruct.new(label: I18n.t("organisations.boolean.false"), value: "false"),
+      ])
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -53,6 +53,41 @@ RSpec.describe Organisation, type: :model do
         expect(described_class.not_closed).to eq [organisation]
       end
     end
+
+    describe ".by_name" do
+      let!(:justice_org) { create :organisation, slug: "ministry-of-justice" }
+      let!(:transport_org) { create :organisation, slug: "department-for-transport" }
+
+      it "matches a partial name, ignoring case" do
+        expect(described_class.by_name("justice")).to contain_exactly(justice_org)
+      end
+
+      it "matches the abbreviation, ignoring case" do
+        expect(described_class.by_name("dft")).to contain_exactly(transport_org)
+      end
+
+      it "returns all organisations when the name is blank" do
+        expect(described_class.by_name(nil)).to contain_exactly(justice_org, transport_org)
+        expect(described_class.by_name("")).to contain_exactly(justice_org, transport_org)
+      end
+    end
+
+    describe ".by_mou_signed" do
+      let!(:organisation_with_mou) { create :organisation, :with_signed_mou, slug: "org-with-mou" }
+      let!(:organisation_without_mou) { create :organisation, slug: "org-without-mou" }
+
+      it "returns organisations with a signed MOU when true" do
+        expect(described_class.by_mou_signed("true")).to contain_exactly(organisation_with_mou)
+      end
+
+      it "returns organisations without a signed MOU when false" do
+        expect(described_class.by_mou_signed("false")).to contain_exactly(organisation_without_mou)
+      end
+
+      it "returns all organisations when blank" do
+        expect(described_class.by_mou_signed(nil)).to contain_exactly(organisation_with_mou, organisation_without_mou)
+      end
+    end
   end
 
   describe "#name_with_abbreviation" do

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe OrganisationPolicy do
+  subject(:policy) { described_class.new(user, :organisation) }
+
+  let(:user) { build :super_admin_user }
+
+  context "with super admin" do
+    it { is_expected.to permit_actions(%i[can_view_organisations]) }
+  end
+
+  (User.roles.keys - %w[super_admin]).each do |role|
+    context "with #{role}" do
+      let(:user) { build :user, role: }
+
+      it { is_expected.to forbid_actions(%i[can_view_organisations]) }
+    end
+  end
+end

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -51,6 +51,35 @@ RSpec.describe OrganisationsController, type: :request do
         expect(page).to have_xpath "//tbody/tr[1]/td[3]", text: "0"
       end
     end
+
+    context "when filtering" do
+      let!(:organisation_with_mou) { create :organisation, :with_signed_mou, slug: "department-with-mou" }
+
+      before do
+        login_as_super_admin_user
+      end
+
+      it "filters organisations by name" do
+        get path, params: { filter: { name: "closed" } }
+
+        expect(response.body).to include(closed_organisation.name)
+        expect(response.body).not_to include(organisation.name)
+      end
+
+      it "filters organisations by whether an MOU is signed" do
+        get path, params: { filter: { mou_signed: "true" } }
+
+        expect(response.body).to include(organisation_with_mou.name)
+        expect(response.body).not_to include(closed_organisation.name)
+      end
+
+      it "filters organisations without a signed MOU" do
+        get path, params: { filter: { mou_signed: "false" } }
+
+        expect(response.body).to include(closed_organisation.name)
+        expect(response.body).not_to include(organisation_with_mou.name)
+      end
+    end
   end
 
   describe "#show" do

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -22,10 +22,14 @@ RSpec.describe OrganisationsController, type: :request do
     let!(:organisation) { create :organisation, slug: "department-for-testing" }
     let!(:closed_organisation) { create :organisation, slug: "closed-department", closed: true }
 
+    let(:group) { create :group, organisation: }
+
     include_examples "unauthorized user is forbidden"
 
     context "when the user is a super admin" do
       before do
+        create(:form, :with_group, group:)
+
         login_as_super_admin_user
 
         get path
@@ -39,6 +43,12 @@ RSpec.describe OrganisationsController, type: :request do
       it "lists all organisations, including closed ones" do
         expect(response.body).to include(organisation.name)
         expect(response.body).to include(closed_organisation.name)
+      end
+
+      it "shows the number of forms in each organisation" do
+        page = Capybara.string(response.body)
+        expect(page).to have_xpath "//tbody/tr[2]/td[3]", text: "1"
+        expect(page).to have_xpath "//tbody/tr[1]/td[3]", text: "0"
       end
     end
   end

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe OrganisationsController, type: :request do
+  shared_examples "unauthorized user is forbidden" do
+    context "when the user is not a super admin" do
+      before do
+        login_as_standard_user
+
+        get path
+      end
+
+      it "returns http code 403 and renders forbidden" do
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+  end
+
+  describe "#index" do
+    let(:path) { organisations_path }
+
+    let!(:organisation) { create :organisation, slug: "department-for-testing" }
+    let!(:closed_organisation) { create :organisation, slug: "closed-department", closed: true }
+
+    include_examples "unauthorized user is forbidden"
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get path
+      end
+
+      it "returns http code 200 and renders the index view" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template("organisations/index")
+      end
+
+      it "lists all organisations, including closed ones" do
+        expect(response.body).to include(organisation.name)
+        expect(response.body).to include(closed_organisation.name)
+      end
+    end
+  end
+
+  describe "#show" do
+    let(:organisation) { create :organisation, :with_org_admin, slug: "department-for-testing" }
+    let(:path) { organisation_path(organisation) }
+
+    let!(:organisation_domain) { create :organisation_domain, organisation: }
+
+    include_examples "unauthorized user is forbidden"
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get path
+      end
+
+      it "returns http code 200 and renders the show view" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template("organisations/show")
+      end
+
+      it "shows the organisation's configuration" do
+        expect(response.body).to include(organisation.name)
+        expect(response.body).to include(organisation.slug)
+        expect(response.body).to include(organisation.admin_users.first.email)
+        expect(response.body).to include(I18n.t("mou_signatures.index.agreement_type.#{organisation.mou_signatures.first.agreement_type}"))
+        expect(response.body).to include(organisation_domain.domain)
+      end
+    end
+  end
+end

--- a/spec/services/navigation_items_service_spec.rb
+++ b/spec/services/navigation_items_service_spec.rb
@@ -21,11 +21,13 @@ describe NavigationItemsService do
       let(:can_manage_user) { false }
       let(:can_manage_mous) { false }
       let(:can_view_reports) { false }
+      let(:can_view_organisations) { false }
 
       before do
         allow(Pundit).to receive(:policy).with(user, :user).and_return(instance_double(UserPolicy, can_manage_user?: can_manage_user))
         allow(Pundit).to receive(:policy).with(user, :mou_signature).and_return(instance_double(MouSignaturePolicy, can_manage_mous?: can_manage_mous))
         allow(Pundit).to receive(:policy).with(user, :report).and_return(instance_double(ReportPolicy, can_view_reports?: can_view_reports))
+        allow(Pundit).to receive(:policy).with(user, :organisation).and_return(instance_double(OrganisationPolicy, can_view_organisations?: can_view_organisations))
         allow(Settings.forms_product_page).to receive(:support_url).and_return(support_url)
       end
 
@@ -44,6 +46,21 @@ describe NavigationItemsService do
         it "includes mous in navigation items" do
           mous_item = NavigationItemsService::NavigationItem.new(text: I18n.t("header.mous"), href: mou_signatures_path, active: false)
           expect(service.navigation_items).to include(mous_item)
+        end
+      end
+
+      context "when user can view organisations" do
+        let(:can_view_organisations) { true }
+
+        it "includes organisations in navigation items" do
+          organisations_item = NavigationItemsService::NavigationItem.new(text: I18n.t("header.organisations"), href: organisations_path, active: false)
+          expect(service.navigation_items).to include(organisations_item)
+        end
+      end
+
+      context "when user cannot view organisations" do
+        it "does not include organisations in navigation items" do
+          expect(service.navigation_items).not_to(be_any { |item| item.text == I18n.t("header.organisations") })
         end
       end
 

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -5,13 +5,13 @@ describe "organisations/index.html.erb" do
   let(:closed_organisation) { create :organisation, slug: "closed-department", closed: true }
   let(:organisations) { [organisation, closed_organisation] }
   let(:user_counts) { { organisation.id => 3 } }
-  let(:group_counts) { { organisation.id => 2 } }
+  let(:form_counts) { { organisation.id => 2 } }
   let(:organisation_ids_with_mou) { Set.new([organisation.id]) }
 
   before do
     assign(:organisations, organisations)
     assign(:user_counts, user_counts)
-    assign(:group_counts, group_counts)
+    assign(:form_counts, form_counts)
     assign(:organisation_ids_with_mou, organisation_ids_with_mou)
 
     render template: "organisations/index"
@@ -30,23 +30,19 @@ describe "organisations/index.html.erb" do
     expect(rendered).to have_link(closed_organisation.name_with_abbreviation, href: organisation_path(closed_organisation))
   end
 
-  it "contains the organisation slug" do
-    expect(rendered).to have_text(organisation.slug)
+  it "contains the user and form counts" do
+    expect(rendered).to have_xpath "//tbody/tr[1]/td[2]", text: "3"
+    expect(rendered).to have_xpath "//tbody/tr[1]/td[3]", text: "2"
   end
 
-  it "contains the user and group counts" do
-    expect(rendered).to have_xpath "//tbody/tr[1]/td[5]", text: "3"
-    expect(rendered).to have_xpath "//tbody/tr[1]/td[6]", text: "2"
-  end
-
-  it "shows zero counts for organisations without users or groups" do
-    expect(rendered).to have_xpath "//tbody/tr[2]/td[5]", text: "0"
-    expect(rendered).to have_xpath "//tbody/tr[2]/td[6]", text: "0"
+  it "shows zero counts for organisations without users or forms" do
+    expect(rendered).to have_xpath "//tbody/tr[2]/td[2]", text: "0"
+    expect(rendered).to have_xpath "//tbody/tr[2]/td[3]", text: "0"
   end
 
   it "shows whether an MOU has been signed" do
-    expect(rendered).to have_xpath "//tbody/tr[1]/td[7]", text: I18n.t("organisations.boolean.true")
-    expect(rendered).to have_xpath "//tbody/tr[2]/td[7]", text: I18n.t("organisations.boolean.false")
+    expect(rendered).to have_xpath "//tbody/tr[1]/td[4]", text: I18n.t("organisations.boolean.true")
+    expect(rendered).to have_xpath "//tbody/tr[2]/td[4]", text: I18n.t("organisations.boolean.false")
   end
 
   context "when there are no organisations" do

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -7,8 +7,10 @@ describe "organisations/index.html.erb" do
   let(:user_counts) { { organisation.id => 3 } }
   let(:form_counts) { { organisation.id => 2 } }
   let(:organisation_ids_with_mou) { Set.new([organisation.id]) }
+  let(:pagy) { Pagy.new(count: organisations.size, page: 1, limit: 50) }
 
   before do
+    assign(:pagy, pagy)
     assign(:organisations, organisations)
     assign(:user_counts, user_counts)
     assign(:form_counts, form_counts)
@@ -19,6 +21,10 @@ describe "organisations/index.html.erb" do
 
   it "contains page heading" do
     expect(rendered).to have_css("h1.govuk-heading-l", text: I18n.t("page_titles.organisations"))
+  end
+
+  it "contains the total number of organisations" do
+    expect(rendered).to have_css("p", text: "2 organisations")
   end
 
   it "contains a scrollable wrapper with a table in it" do
@@ -43,6 +49,14 @@ describe "organisations/index.html.erb" do
   it "shows whether an MOU has been signed" do
     expect(rendered).to have_xpath "//tbody/tr[1]/td[4]", text: I18n.t("organisations.boolean.true")
     expect(rendered).to have_xpath "//tbody/tr[2]/td[4]", text: I18n.t("organisations.boolean.false")
+  end
+
+  context "when the organisations span multiple pages" do
+    let(:pagy) { Pagy.new(count: 120, page: 1, limit: 50) }
+
+    it "shows how many organisations are on this page out of the total" do
+      expect(rendered).to have_css("p", text: "Showing 1 to 50 of 120 organisations")
+    end
   end
 
   context "when there are no organisations" do

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -8,9 +8,11 @@ describe "organisations/index.html.erb" do
   let(:form_counts) { { organisation.id => 2 } }
   let(:organisation_ids_with_mou) { Set.new([organisation.id]) }
   let(:pagy) { Pagy.new(count: organisations.size, page: 1, limit: 50) }
+  let(:filter_input) { Organisations::FilterInput.new }
 
   before do
     assign(:pagy, pagy)
+    assign(:filter_input, filter_input)
     assign(:organisations, organisations)
     assign(:user_counts, user_counts)
     assign(:form_counts, form_counts)
@@ -25,6 +27,28 @@ describe "organisations/index.html.erb" do
 
   it "contains the total number of organisations" do
     expect(rendered).to have_css("p", text: "2 organisations")
+  end
+
+  it "contains a filter form" do
+    expect(rendered).to have_field("filter[name]")
+    expect(rendered).to have_select("filter[mou_signed]", options: [
+      I18n.t("organisations.index.filter.mou_signed.any"),
+      I18n.t("organisations.boolean.true"),
+      I18n.t("organisations.boolean.false"),
+    ])
+    expect(rendered).to have_button(I18n.t("organisations.index.filter.submit"))
+  end
+
+  it "does not show the clear filter link when no filters are set" do
+    expect(rendered).not_to have_link(I18n.t("organisations.index.filter.clear_filter"))
+  end
+
+  context "when filters are set" do
+    let(:filter_input) { Organisations::FilterInput.new(name: "testing") }
+
+    it "shows a link to clear the filter" do
+      expect(rendered).to have_link(I18n.t("organisations.index.filter.clear_filter"), href: organisations_path)
+    end
   end
 
   it "contains a scrollable wrapper with a table in it" do
@@ -64,6 +88,10 @@ describe "organisations/index.html.erb" do
 
     it "does not show the table" do
       expect(rendered).not_to have_css("table")
+    end
+
+    it "shows a message that no organisations were found" do
+      expect(rendered).to have_text(I18n.t("organisations.index.no_results"))
     end
   end
 end

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+describe "organisations/index.html.erb" do
+  let(:organisation) { create :organisation, slug: "department-for-testing" }
+  let(:closed_organisation) { create :organisation, slug: "closed-department", closed: true }
+  let(:organisations) { [organisation, closed_organisation] }
+  let(:user_counts) { { organisation.id => 3 } }
+  let(:group_counts) { { organisation.id => 2 } }
+  let(:organisation_ids_with_mou) { Set.new([organisation.id]) }
+
+  before do
+    assign(:organisations, organisations)
+    assign(:user_counts, user_counts)
+    assign(:group_counts, group_counts)
+    assign(:organisation_ids_with_mou, organisation_ids_with_mou)
+
+    render template: "organisations/index"
+  end
+
+  it "contains page heading" do
+    expect(rendered).to have_css("h1.govuk-heading-l", text: I18n.t("page_titles.organisations"))
+  end
+
+  it "contains a scrollable wrapper with a table in it" do
+    expect(rendered).to have_css(".app-scrolling-wrapper > table")
+  end
+
+  it "links each organisation name to its show page" do
+    expect(rendered).to have_link(organisation.name_with_abbreviation, href: organisation_path(organisation))
+    expect(rendered).to have_link(closed_organisation.name_with_abbreviation, href: organisation_path(closed_organisation))
+  end
+
+  it "contains the organisation slug" do
+    expect(rendered).to have_text(organisation.slug)
+  end
+
+  it "contains the user and group counts" do
+    expect(rendered).to have_xpath "//tbody/tr[1]/td[5]", text: "3"
+    expect(rendered).to have_xpath "//tbody/tr[1]/td[6]", text: "2"
+  end
+
+  it "shows zero counts for organisations without users or groups" do
+    expect(rendered).to have_xpath "//tbody/tr[2]/td[5]", text: "0"
+    expect(rendered).to have_xpath "//tbody/tr[2]/td[6]", text: "0"
+  end
+
+  it "shows whether an MOU has been signed" do
+    expect(rendered).to have_xpath "//tbody/tr[1]/td[7]", text: I18n.t("organisations.boolean.true")
+    expect(rendered).to have_xpath "//tbody/tr[2]/td[7]", text: I18n.t("organisations.boolean.false")
+  end
+
+  context "when there are no organisations" do
+    let(:organisations) { [] }
+
+    it "does not show the table" do
+      expect(rendered).not_to have_css("table")
+    end
+  end
+end

--- a/spec/views/organisations/show.html.erb_spec.rb
+++ b/spec/views/organisations/show.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe "organisations/show.html.erb" do
 
   before do
     organisation_domains
+    create(:form, :with_group, group: create(:group, organisation:))
 
     assign(:organisation, organisation)
 
@@ -19,6 +20,15 @@ describe "organisations/show.html.erb" do
   it "contains a summary of the organisation's details" do
     expect(rendered).to have_css(".govuk-summary-list__key", text: I18n.t("organisations.show.summary.slug"))
     expect(rendered).to have_css(".govuk-summary-list__value", text: organisation.slug)
+  end
+
+  it "shows the number of forms between the user and group counts" do
+    users_index = rendered.index(I18n.t("organisations.show.summary.users"))
+    forms_index = rendered.index(I18n.t("organisations.show.summary.forms"))
+    groups_index = rendered.index(I18n.t("organisations.show.summary.groups"))
+
+    expect(forms_index).to be_between(users_index, groups_index)
+    expect(rendered).to have_css(".govuk-summary-list__row", text: /#{I18n.t('organisations.show.summary.forms')}\s*1/)
   end
 
   it "shows whether the organisation is internal or closed" do

--- a/spec/views/organisations/show.html.erb_spec.rb
+++ b/spec/views/organisations/show.html.erb_spec.rb
@@ -44,6 +44,10 @@ describe "organisations/show.html.erb" do
     expect(rendered).to have_text("testing.gov.uk")
   end
 
+  it "does not show the MOU guidance" do
+    expect(rendered).not_to have_text("Someone from each organisation needs to agree")
+  end
+
   context "when the organisation has no admins, MOU signatures or domains" do
     let(:organisation) { create :organisation, slug: "empty-department", abbreviation: nil }
     let(:organisation_domains) { [] }
@@ -52,6 +56,12 @@ describe "organisations/show.html.erb" do
       expect(rendered).to have_text(I18n.t("organisations.show.admin_users.none"))
       expect(rendered).to have_text(I18n.t("organisations.show.mou_signatures.none"))
       expect(rendered).to have_text(I18n.t("organisations.show.domains.none"))
+    end
+
+    it "shows the MOU guidance with links to the agreements" do
+      expect(rendered).to have_text("Someone from each organisation needs to agree")
+      expect(rendered).to have_link(mou_signature_url, href: mou_signature_url)
+      expect(rendered).to have_link(non_crown_agreement_signature_url, href: non_crown_agreement_signature_url)
     end
 
     it "shows a fallback for the blank abbreviation" do

--- a/spec/views/organisations/show.html.erb_spec.rb
+++ b/spec/views/organisations/show.html.erb_spec.rb
@@ -17,10 +17,8 @@ describe "organisations/show.html.erb" do
   end
 
   it "contains a summary of the organisation's details" do
-    expect(rendered).to have_css(".govuk-summary-list__key", text: I18n.t("organisations.show.summary.name"))
-    expect(rendered).to have_css(".govuk-summary-list__value", text: organisation.name)
+    expect(rendered).to have_css(".govuk-summary-list__key", text: I18n.t("organisations.show.summary.slug"))
     expect(rendered).to have_css(".govuk-summary-list__value", text: organisation.slug)
-    expect(rendered).to have_css(".govuk-summary-list__value", text: organisation.abbreviation)
   end
 
   it "shows whether the organisation is internal or closed" do
@@ -49,7 +47,7 @@ describe "organisations/show.html.erb" do
   end
 
   context "when the organisation has no admins, MOU signatures or domains" do
-    let(:organisation) { create :organisation, slug: "empty-department", abbreviation: nil }
+    let(:organisation) { create :organisation, slug: "empty-department" }
     let(:organisation_domains) { [] }
 
     it "shows a message for each empty section" do
@@ -64,7 +62,7 @@ describe "organisations/show.html.erb" do
       expect(rendered).to have_link(non_crown_agreement_signature_url, href: non_crown_agreement_signature_url)
     end
 
-    it "shows a fallback for the blank abbreviation" do
+    it "shows a fallback for the blank GOV.UK content ID" do
       expect(rendered).to have_css(".govuk-summary-list__value", text: I18n.t("organisations.show.not_set"))
     end
   end

--- a/spec/views/organisations/show.html.erb_spec.rb
+++ b/spec/views/organisations/show.html.erb_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe "organisations/show.html.erb" do
+  let(:organisation) { create :organisation, :with_org_admin, slug: "department-for-testing" }
+  let(:organisation_domains) { [create(:organisation_domain, organisation:, domain: "testing.gov.uk")] }
+
+  before do
+    organisation_domains
+
+    assign(:organisation, organisation)
+
+    render template: "organisations/show"
+  end
+
+  it "contains page heading" do
+    expect(rendered).to have_css("h1.govuk-heading-l", text: organisation.name_with_abbreviation)
+  end
+
+  it "contains a summary of the organisation's details" do
+    expect(rendered).to have_css(".govuk-summary-list__key", text: I18n.t("organisations.show.summary.name"))
+    expect(rendered).to have_css(".govuk-summary-list__value", text: organisation.name)
+    expect(rendered).to have_css(".govuk-summary-list__value", text: organisation.slug)
+    expect(rendered).to have_css(".govuk-summary-list__value", text: organisation.abbreviation)
+  end
+
+  it "shows whether the organisation is internal or closed" do
+    expect(rendered).to have_css(".govuk-summary-list__key", text: I18n.t("organisations.show.summary.internal"))
+    expect(rendered).to have_css(".govuk-summary-list__key", text: I18n.t("organisations.show.summary.closed"))
+  end
+
+  it "lists the organisation admins with links to their edit pages" do
+    admin_user = organisation.admin_users.first
+    expect(rendered).to have_link(admin_user.email, href: edit_user_path(admin_user))
+  end
+
+  it "lists the MOU signatures" do
+    mou_signature = organisation.mou_signatures.first
+    expect(rendered).to have_text(I18n.t("mou_signatures.index.agreement_type.#{mou_signature.agreement_type}"))
+    expect(rendered).to have_link(mou_signature.user.email, href: edit_user_path(mou_signature.user))
+    expect(rendered).to have_text(I18n.l(mou_signature.created_at.to_date, format: :long))
+  end
+
+  it "lists the organisation's email domains" do
+    expect(rendered).to have_text("testing.gov.uk")
+  end
+
+  context "when the organisation has no admins, MOU signatures or domains" do
+    let(:organisation) { create :organisation, slug: "empty-department", abbreviation: nil }
+    let(:organisation_domains) { [] }
+
+    it "shows a message for each empty section" do
+      expect(rendered).to have_text(I18n.t("organisations.show.admin_users.none"))
+      expect(rendered).to have_text(I18n.t("organisations.show.mou_signatures.none"))
+      expect(rendered).to have_text(I18n.t("organisations.show.domains.none"))
+    end
+
+    it "shows a fallback for the blank abbreviation" do
+      expect(rendered).to have_css(".govuk-summary-list__value", text: I18n.t("organisations.show.not_set"))
+    end
+  end
+end


### PR DESCRIPTION
Super admin users have no single place to see all the organisations in GOV.UK Forms and check how each one is configured. Organisation data is currently spread across the reports section, which does not show MOU signatures, email domains or organisation admins together.

This adds a read-only organisations section for super admins:

- An index page listing every organisation, including closed ones, showing each organisation's name, number of users, number of forms and whether an MOU has been signed. The list is paginated with 50 organisations per page.
- A show page for each organisation summarising its details, organisation admins, agreed MOUs and email domains.
- An organisations link in the header navigation, shown only to users the organisation policy allows to view organisations.

This also give us a foundation to build edit interfaces to some of the organisation attributes, for example domains and branding. That lets the whole team administrate, rather than just developers running rake tasks.

Access is limited to super admins.

<img width="1016" height="875" alt="image" src="https://github.com/user-attachments/assets/faca1513-a23e-43ea-a195-52aa3e82b4a3" />

<img width="1041" height="1130" alt="image" src="https://github.com/user-attachments/assets/49a5d4e7-7625-4de2-b88a-a7b471bd61e7" />
