### PR TITLE
Add custom branding per-group feature flag

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,7 @@
 # Used to add feature flags in the app to control access to certain features.
 features:
+  custom_branding:
+    enabled_by_group: true
   exit_pages:
     enabled_by_group: true
   multiple_branches:

--- a/db/migrate/20260708131956_add_custom_branding_enabled_to_groups.rb
+++ b/db/migrate/20260708131956_add_custom_branding_enabled_to_groups.rb
@@ -1,0 +1,5 @@
+class AddCustomBrandingEnabledToGroups < ActiveRecord::Migration[8.1]
+  def change
+    add_column :groups, :custom_branding_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_145441) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_08_131956) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -176,6 +176,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_145441) do
   create_table "groups", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "creator_id"
+    t.boolean "custom_branding_enabled", default: false
     t.text "external_id", null: false
     t.boolean "multiple_branches_enabled", default: false
     t.string "name"

--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -48,6 +48,13 @@ namespace :groups do
     abort usage_message if args[:group_id].blank?
     toggle_send_filler_answers_enabled(args[:group_id])
   end
+
+  desc "Toggle custom_branding_enabled for a group"
+  task :toggle_custom_branding_enabled, %i[group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:toggle_custom_branding_enabled[<group_external_id>]".freeze
+    abort usage_message if args[:group_id].blank?
+    toggle_custom_branding_enabled(args[:group_id])
+  end
 end
 
 def run_task(task_name, args, rollback:)
@@ -131,4 +138,13 @@ def toggle_send_filler_answers_enabled(group_id)
   group.save!
 
   Rails.logger.info "send_filler_answers_enabled for #{fmt_group(group)} is now set to #{group.reload.send_filler_answers_enabled}"
+end
+
+def toggle_custom_branding_enabled(group_id)
+  group = Group.find_by!(external_id: group_id)
+
+  group.custom_branding_enabled = !group.custom_branding_enabled
+  group.save!
+
+  Rails.logger.info "custom_branding_enabled for #{fmt_group(group)} is now set to #{group.reload.custom_branding_enabled}"
 end

--- a/spec/lib/tasks/groups.rake_spec.rb
+++ b/spec/lib/tasks/groups.rake_spec.rb
@@ -73,4 +73,30 @@ RSpec.describe "groups.rake", type: :task do
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe "groups:toggle_custom_branding_enabled" do
+    subject(:task) { Rake::Task["groups:toggle_custom_branding_enabled"] }
+
+    it "with correct arguments toggles custom_branding_enabled for the group" do
+      group = create(:group, custom_branding_enabled: false)
+
+      expect {
+        task.invoke(group.external_id)
+      }.to change { group.reload.custom_branding_enabled }.from(false).to(true)
+    end
+
+    it "with no arguments raises an error" do
+      expect {
+        task.invoke
+      }.to raise_error(SystemExit)
+      .and output(/usage/).to_stderr
+    end
+
+    it "with invalid group id raises an error" do
+      invalid_args = %w[some_id_that_does_not_exist]
+      expect {
+        task.invoke(*invalid_args)
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
We're building a custom branding feature that form creators will configure for individual forms via a new task list item on the form edit page. That task needs to be shown only to specific groups while the feature is rolled out.

This adds a `custom_branding` feature flag using the existing `enabled_by_group` pattern: a `custom_branding_enabled` column on groups, a settings entry so `FeatureService` delegates the check to the group, and a rake task to toggle the flag for a group by its external ID:

```
rake groups:toggle_custom_branding_enabled[<group_external_id>]
```

The branding task list item itself will be added separately, gated behind this flag.