### PR TITLE
Add custom brand task list item for a form

### DIFF
--- a/app/controllers/forms/brand_controller.rb
+++ b/app/controllers/forms/brand_controller.rb
@@ -1,12 +1,13 @@
 module Forms
   class BrandController < FormsController
+    before_action :check_user_has_permission
+    before_action :check_feature_flag
+
     def new
-      authorize current_form, :can_view_form?
       @brand_input = BrandInput.new(form: current_form).assign_form_values
     end
 
     def create
-      authorize current_form, :can_view_form?
       @brand_input = BrandInput.new(brand_input_params)
       previous_brand_id = current_form.brand_id
 
@@ -19,6 +20,14 @@ module Forms
     end
 
   private
+
+    def check_user_has_permission
+      authorize current_form, :can_view_form?
+    end
+
+    def check_feature_flag
+      raise NotFoundError unless FeatureService.new(group: current_form.group).enabled?(:custom_branding)
+    end
 
     def brand_input_params
       params.require(:forms_brand_input).permit(:brand_id).merge(form: current_form)

--- a/app/controllers/forms/brand_controller.rb
+++ b/app/controllers/forms/brand_controller.rb
@@ -1,0 +1,34 @@
+module Forms
+  class BrandController < FormsController
+    def new
+      authorize current_form, :can_view_form?
+      @brand_input = BrandInput.new(form: current_form).assign_form_values
+    end
+
+    def create
+      authorize current_form, :can_view_form?
+      @brand_input = BrandInput.new(brand_input_params)
+      previous_brand_id = current_form.brand_id
+
+      if @brand_input.submit
+        success_message = success_message(previous_brand_id, @brand_input.form.brand_id)
+        redirect_to form_path(@brand_input.form.id), success: success_message
+      else
+        render :new, status: :unprocessable_content
+      end
+    end
+
+  private
+
+    def brand_input_params
+      params.require(:forms_brand_input).permit(:brand_id).merge(form: current_form)
+    end
+
+    def success_message(previous_brand_id, new_brand_id)
+      return t("banner.success.form.brand_saved") if new_brand_id.present? && new_brand_id != previous_brand_id
+      return t("banner.success.form.brand_removed") if new_brand_id.blank? && previous_brand_id.present?
+
+      nil
+    end
+  end
+end

--- a/app/input_objects/forms/brand_input.rb
+++ b/app/input_objects/forms/brand_input.rb
@@ -1,0 +1,34 @@
+class Forms::BrandInput < BaseInput
+  BrandOption = Struct.new(:id, :name)
+
+  attr_accessor :form, :brand_id
+
+  validates :brand_id, inclusion: { in: ->(_input) { Forms::BrandInput.allowed_brand_ids } }, allow_blank: true
+
+  class << self
+    def brands
+      Settings.branding.available_brands
+    end
+
+    def allowed_brand_ids
+      brands.map(&:id)
+    end
+  end
+
+  def brand_options
+    default_option = BrandOption.new("", I18n.t("helpers.label.forms_brand_input.brand_id.options.default"))
+    [default_option] + self.class.brands.map { |brand| BrandOption.new(brand.id, brand.name) }
+  end
+
+  def submit
+    return false if invalid?
+
+    form.brand_id = brand_id.presence
+    form.save_draft!
+  end
+
+  def assign_form_values
+    self.brand_id = form.brand_id.to_s
+    self
+  end
+end

--- a/app/models/form_document/content.rb
+++ b/app/models/form_document/content.rb
@@ -16,6 +16,7 @@ class FormDocument::Content
   attribute :start_page, :integer
   attribute :updated_at, :datetime
   attribute :payment_url, :string
+  attribute :brand_id, :string
   attribute :support_url, :string
   attribute :support_email, :string
   attribute :support_phone, :string

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -64,6 +64,7 @@ private
   def create_form_optional_subsection
     rows = [
       { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.payment_link"), path: payment_link_path(@form.id), status: @task_statuses[:payment_link_status] },
+      { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.brand"), path: brand_path(@form.id), status: @task_statuses[:brand_status] },
     ]
     if FeatureService.new(group: @form.group).enabled?(:send_filler_answers)
       rows << { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.copy_of_answers"), path: copy_of_answers_path(@form.id), status: @task_statuses[:copy_of_answers_status] }
@@ -289,6 +290,7 @@ private
 
   def remove_optional_statuses(statuses)
     statuses.delete(:payment_link_status)
+    statuses.delete(:brand_status)
     statuses.delete(:copy_of_answers_status)
     statuses.delete(:submission_attachments_status)
     statuses.delete(:batch_submissions_status)

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -64,8 +64,10 @@ private
   def create_form_optional_subsection
     rows = [
       { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.payment_link"), path: payment_link_path(@form.id), status: @task_statuses[:payment_link_status] },
-      { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.brand"), path: brand_path(@form.id), status: @task_statuses[:brand_status] },
     ]
+    if FeatureService.new(group: @form.group).enabled?(:custom_branding)
+      rows << { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.brand"), path: brand_path(@form.id), status: @task_statuses[:brand_status] }
+    end
     if FeatureService.new(group: @form.group).enabled?(:send_filler_answers)
       rows << { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.copy_of_answers"), path: copy_of_answers_path(@form.id), status: @task_statuses[:copy_of_answers_status] }
     end

--- a/app/services/task_status_service.rb
+++ b/app/services/task_status_service.rb
@@ -29,6 +29,7 @@ class TaskStatusService
       declaration_status:,
       what_happens_next_status:,
       payment_link_status:,
+      brand_status:,
       copy_of_answers_status:,
       privacy_policy_status:,
       support_contact_details_status:,
@@ -85,6 +86,12 @@ private
 
   def payment_link_status
     return :completed if @form.payment_url.present?
+
+    :optional
+  end
+
+  def brand_status
+    return :completed if @form.brand_id.present?
 
     :optional
   end

--- a/app/views/forms/brand/new.html.erb
+++ b/app/views/forms/brand/new.html.erb
@@ -1,0 +1,25 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.brand'), @brand_input.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(form_path, t("back_link.form_create")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with(model: @brand_input, url: brand_path) do |f| %>
+      <% if @brand_input&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <span class="govuk-caption-l"><%= @brand_input.form.name %></span>
+      <h1 class="govuk-heading-l">
+        <%= t('brand_input.heading') %>
+      </h1>
+
+      <%= t('brand_input.body_html') %>
+
+      <%= f.govuk_collection_radio_buttons :brand_id,
+                                           @brand_input.brand_options, :id, :name,
+                                           legend: { text: t('brand_input.heading'), hidden: true } %>
+      <%= f.govuk_submit t('save_and_continue') %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -539,6 +539,7 @@ en:
         other: Optional tasks
     task_list_create:
       create_form_optional_subsection:
+        brand: Choose a brand for your form
         copy_of_answers: Give people the option to ask for a copy of their answers
         payment_link: Add a link to a payment page on GOV.UK Pay
       create_form_section:
@@ -587,6 +588,7 @@ en:
         title: Create a Welsh version of your form (optional)
     task_list_edit:
       create_form_optional_subsection:
+        brand: Choose a brand for your form
         copy_of_answers: Give people the option to ask for a copy of their answers
         payment_link: Add a link to a payment page on GOV.UK Pay
       create_form_section:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,8 @@ en:
           daily_enabled: You’ll get a daily batch of form submissions
           disabled: You will not get a daily or weekly batch of form submissions
           weekly_enabled: You’ll get a weekly batch of form submissions
+        brand_removed: Your form will use the default GOV.UK brand
+        brand_saved: Your form’s brand has been saved
         change_name: Your form name has been saved
         copied: Your form has been copied
         copy_of_answers_disabled: People will not have the option to ask for a copy of their answers
@@ -273,6 +275,12 @@ en:
       route_updated: Question %{question_number}’s route has been updated
       secondary_skip_created: Route for any other answer has been added
       title: Success
+  brand_input:
+    body_html: |
+      <p>You can choose a brand to change how your form looks to people filling it in, for example, the logo and colours.</p>
+
+      <p>If you do not choose a brand, your form will use the default GOV.UK brand.</p>
+    heading: Choose a brand for your form
   bulk_options:
     hint: Enter each option on a new line
     label: Enter the options for your list
@@ -1590,6 +1598,7 @@ en:
     archive_form_confirm: Archive this form
     archive_form_confirmation: Your form has been archived
     archive_welsh_confirm: Archive the Welsh version of this form
+    brand: Choose a brand for your form
     bulk_options: Enter your list’s options into a text box
     change_name: Name your form
     change_order_pages_added_error: Sorry, we could not save the new question order

--- a/config/locales/input_objects/brand.yml
+++ b/config/locales/input_objects/brand.yml
@@ -1,0 +1,15 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        forms/brand_input:
+          attributes:
+            brand_id:
+              inclusion: Select a brand
+  helpers:
+    label:
+      forms_brand_input:
+        brand_id:
+          options:
+            default: GOV.UK (default)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,8 @@ Rails.application.routes.draw do
     post "/declaration-preview" => "forms/declaration#render_preview", as: :declaration_render_preview
     get "/payment-link" => "forms/payment_link#new", as: :payment_link
     post "/payment-link" => "forms/payment_link#create", as: :payment_link_create
+    get "/brand" => "forms/brand#new", as: :brand
+    post "/brand" => "forms/brand#create", as: :brand_create
     get "/share-preview" => "forms/share_preview#new", as: :share_preview
     post "/share-preview" => "forms/share_preview#create", as: :share_preview_create
     get "/welsh-translation" => "forms/welsh_translation#new", as: :welsh_translation

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,15 @@ features:
   send_filler_answers:
     enabled_by_group: true
 
+# Brands that a form can be styled with in forms-runner. A form with no
+# brand_id uses the default GOV.UK branding.
+branding:
+  available_brands:
+    - id: cheshire-east
+      name: Cheshire East Council
+    - id: south-gloucestershire
+      name: South Gloucestershire Council
+
 forms_api:
   # Authentication key to authenticate with forms-api
   auth_key: development_key

--- a/db/migrate/20260707195648_add_brand_id_to_forms.rb
+++ b/db/migrate/20260707195648_add_brand_id_to_forms.rb
@@ -1,0 +1,5 @@
+class AddBrandIdToForms < ActiveRecord::Migration[8.1]
+  def change
+    add_column :forms, :brand_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -138,6 +138,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_131956) do
 
   create_table "forms", force: :cascade do |t|
     t.text "available_languages", default: ["en"], null: false, array: true
+    t.string "brand_id"
     t.integer "copied_from_id"
     t.datetime "created_at", null: false
     t.bigint "creator_id"

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -21,6 +21,11 @@ FactoryBot.define do
     send_daily_submission_batch { false }
     send_weekly_submission_batch { false }
     send_copy_of_answers { "disabled" }
+    brand_id { nil }
+
+    trait :with_brand do
+      brand_id { Settings.branding.available_brands.first.id }
+    end
 
     trait :with_group do
       transient do

--- a/spec/input_objects/forms/brand_input_spec.rb
+++ b/spec/input_objects/forms/brand_input_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe Forms::BrandInput, type: :model do
+  let(:form) do
+    create(:form, :live)
+  end
+
+  describe "validations" do
+    context "when given a blank brand_id" do
+      it "validates successfully" do
+        brand_input = described_class.new(form:, brand_id: "")
+
+        expect(brand_input).to be_valid
+      end
+    end
+
+    context "when given a brand_id from the configured list" do
+      it "validates successfully" do
+        brand_input = described_class.new(form:, brand_id: Settings.branding.available_brands.first.id)
+
+        expect(brand_input).to be_valid
+      end
+    end
+
+    context "when given a brand_id that is not in the configured list" do
+      it "returns a validation error" do
+        brand_input = described_class.new(form:, brand_id: "not-a-brand")
+
+        brand_input.validate(:brand_id)
+
+        expect(brand_input.errors.full_messages_for(:brand_id)).to include(
+          "Brand Select a brand",
+        )
+      end
+    end
+  end
+
+  describe "#brand_options" do
+    it "starts with the GOV.UK default option followed by the configured brands" do
+      brand_input = described_class.new(form:)
+
+      expect(brand_input.brand_options.first).to have_attributes(id: "", name: "GOV.UK (default)")
+      expect(brand_input.brand_options.drop(1).map(&:id)).to eq(Settings.branding.available_brands.map(&:id))
+    end
+  end
+
+  describe "#submit" do
+    context "when given a brand_id" do
+      it "saves the brand_id to the form" do
+        brand_input = described_class.new(form:, brand_id: "cheshire-east")
+
+        expect(brand_input.submit).to be true
+        expect(form.reload.brand_id).to eq "cheshire-east"
+      end
+    end
+
+    context "when given a blank brand_id" do
+      it "clears the brand_id on the form" do
+        form.update!(brand_id: "cheshire-east")
+        brand_input = described_class.new(form:, brand_id: "")
+
+        expect(brand_input.submit).to be true
+        expect(form.reload.brand_id).to be_nil
+      end
+    end
+
+    context "when the input is invalid" do
+      it "does not save and returns false" do
+        brand_input = described_class.new(form:, brand_id: "not-a-brand")
+
+        expect(brand_input.submit).to be false
+        expect(form.reload.brand_id).to be_nil
+      end
+    end
+  end
+
+  describe "#assign_form_values" do
+    context "when the form has a brand" do
+      it "assigns the form's brand_id" do
+        form.update!(brand_id: "cheshire-east")
+        brand_input = described_class.new(form:).assign_form_values
+
+        expect(brand_input.brand_id).to eq "cheshire-east"
+      end
+    end
+
+    context "when the form has no brand" do
+      it "assigns an empty string so the default option is preselected" do
+        brand_input = described_class.new(form:).assign_form_values
+
+        expect(brand_input.brand_id).to eq ""
+      end
+    end
+  end
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1013,6 +1013,7 @@ RSpec.describe Form, type: :model do
         confirm_submission_email_status: :completed,
         privacy_policy_status: :completed,
         payment_link_status: :optional,
+        brand_status: :optional,
         copy_of_answers_status: :optional,
         submission_attachments_status: :optional,
         batch_submissions_status: :optional,

--- a/spec/requests/forms/brand_controller_spec.rb
+++ b/spec/requests/forms/brand_controller_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Forms::BrandController, type: :request do
   let(:form) { create(:form, :live, brand_id: "south-gloucestershire") }
   let(:brand_id) { "cheshire-east" }
 
-  let(:group) { create(:group, organisation: standard_user.organisation) }
+  let(:group) { create(:group, organisation: standard_user.organisation, custom_branding_enabled:) }
+  let(:custom_branding_enabled) { true }
 
   before do
     Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
@@ -19,10 +20,31 @@ RSpec.describe Forms::BrandController, type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(I18n.t("brand_input.heading"))
     end
+
+    context "when the custom_branding feature is disabled" do
+      let(:custom_branding_enabled) { false }
+
+      it "returns 404" do
+        get(brand_path(form_id: form.id))
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "#create" do
     let(:params) { { forms_brand_input: { brand_id: } } }
+
+    context "when the custom_branding feature is disabled" do
+      let(:custom_branding_enabled) { false }
+
+      it "returns 404 and does not update the form" do
+        expect {
+          post(brand_path(form_id: form.id), params:)
+        }.not_to(change { form.reload.brand_id })
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
 
     context "when the brand is changed" do
       it "updates the form" do

--- a/spec/requests/forms/brand_controller_spec.rb
+++ b/spec/requests/forms/brand_controller_spec.rb
@@ -1,0 +1,110 @@
+require "rails_helper"
+
+RSpec.describe Forms::BrandController, type: :request do
+  let(:form) { create(:form, :live, brand_id: "south-gloucestershire") }
+  let(:brand_id) { "cheshire-east" }
+
+  let(:group) { create(:group, organisation: standard_user.organisation) }
+
+  before do
+    Membership.create!(group_id: group.id, user: standard_user, added_by: standard_user)
+    GroupForm.create!(form_id: form.id, group_id: group.id)
+
+    login_as_standard_user
+  end
+
+  describe "#new" do
+    it "renders the brand page" do
+      get(brand_path(form_id: form.id))
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(I18n.t("brand_input.heading"))
+    end
+  end
+
+  describe "#create" do
+    let(:params) { { forms_brand_input: { brand_id: } } }
+
+    context "when the brand is changed" do
+      it "updates the form" do
+        expect {
+          post(brand_path(form_id: form.id), params:)
+        }.to change { form.reload.brand_id }.to(brand_id)
+      end
+
+      it "redirects you to the form overview page" do
+        post(brand_path(form_id: form.id), params:)
+        expect(response).to redirect_to(form_path(form.id))
+      end
+
+      it "displays a flash message that the brand has been saved" do
+        post(brand_path(form_id: form.id), params:)
+        expect(flash[:success]).to eq(I18n.t("banner.success.form.brand_saved"))
+      end
+    end
+
+    context "when a brand is added" do
+      let(:form) { create(:form, :live, brand_id: nil) }
+
+      before do
+        post(brand_path(form_id: form.id), params:)
+      end
+
+      it "displays a flash message that the brand has been saved" do
+        expect(flash[:success]).to eq(I18n.t("banner.success.form.brand_saved"))
+      end
+    end
+
+    context "when the brand is removed" do
+      let(:brand_id) { "" }
+
+      it "clears the brand_id on the form" do
+        expect {
+          post(brand_path(form_id: form.id), params:)
+        }.to change { form.reload.brand_id }.to(nil)
+      end
+
+      it "displays a flash message that the form will use the GOV.UK branding" do
+        post(brand_path(form_id: form.id), params:)
+        expect(flash[:success]).to eq(I18n.t("banner.success.form.brand_removed"))
+      end
+    end
+
+    context "when the brand is unchanged" do
+      let(:form) { create(:form, :live, brand_id:) }
+
+      before do
+        post(brand_path(form_id: form.id), params:)
+      end
+
+      it "does not display a flash message" do
+        expect(flash[:success]).to be_nil
+      end
+    end
+
+    context "when the brand was not previously set and no brand is chosen" do
+      let(:form) { create(:form, :live, brand_id: nil) }
+      let(:brand_id) { "" }
+
+      before do
+        post(brand_path(form_id: form.id), params:)
+      end
+
+      it "does not display a flash message" do
+        expect(flash[:success]).to be_nil
+      end
+    end
+
+    context "when the brand is not in the configured list" do
+      let(:brand_id) { "not-a-brand" }
+
+      it "does not update the form and re-renders the page with an error" do
+        expect {
+          post(brand_path(form_id: form.id), params:)
+        }.not_to(change { form.reload.brand_id })
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include(I18n.t("activemodel.errors.models.forms/brand_input.attributes.brand_id.inclusion"))
+      end
+    end
+  end
+end

--- a/spec/services/form_task_list_service_spec.rb
+++ b/spec/services/form_task_list_service_spec.rb
@@ -156,10 +156,15 @@ describe FormTaskListService do
         expect(section_rows.first[:path]).to eq "/forms/#{form.id}/payment-link"
       end
 
+      it "has link to brand settings" do
+        expect(section_rows[1][:task_name]).to eq "Choose a brand for your form"
+        expect(section_rows[1][:path]).to eq "/forms/#{form.id}/brand"
+      end
+
       context "when the send_filler_answers feature is enabled" do
         it "has link to copy of answers settings" do
-          expect(section_rows[1][:task_name]).to eq "Give people the option to ask for a copy of their answers"
-          expect(section_rows[1][:path]).to eq "/forms/#{form.id}/copy-of-answers"
+          expect(section_rows[2][:task_name]).to eq "Give people the option to ask for a copy of their answers"
+          expect(section_rows[2][:path]).to eq "/forms/#{form.id}/copy-of-answers"
         end
       end
 
@@ -167,7 +172,7 @@ describe FormTaskListService do
         let(:send_filler_answers_enabled) { false }
 
         it "does not have link to copy of answers settings" do
-          expect(section_rows.count).to eq 1
+          expect(section_rows.count).to eq 2
         end
       end
     end
@@ -634,6 +639,7 @@ describe FormTaskListService do
           I18n.t("forms.task_list_edit.create_form_section.declaration"),
           I18n.t("forms.task_list_edit.create_form_section.what_happens_next"),
           I18n.t("forms.task_list_edit.create_form_optional_subsection.payment_link"),
+          I18n.t("forms.task_list_edit.create_form_optional_subsection.brand"),
           I18n.t("forms.task_list_edit.create_form_optional_subsection.copy_of_answers"),
           I18n.t("forms.task_list_edit.how_you_get_completed_forms_section.email"),
           I18n.t("forms.task_list_edit.how_you_get_completed_forms_section.confirm_email"),

--- a/spec/services/form_task_list_service_spec.rb
+++ b/spec/services/form_task_list_service_spec.rb
@@ -6,9 +6,10 @@ describe FormTaskListService do
   let(:organisation) { build :organisation, :with_signed_mou, id: 1 }
   let(:form) { create(:form, :new_form, pages:) }
   let(:pages) { [] }
-  let(:group) { create(:group, name: "Group 1", organisation:, status: group_status, send_filler_answers_enabled:) }
+  let(:group) { create(:group, name: "Group 1", organisation:, status: group_status, send_filler_answers_enabled:, custom_branding_enabled:) }
   let(:group_status) { :trial }
   let(:send_filler_answers_enabled) { true }
+  let(:custom_branding_enabled) { true }
 
   let(:can_view_form) { true }
   let(:can_make_form_live) { false }
@@ -156,9 +157,19 @@ describe FormTaskListService do
         expect(section_rows.first[:path]).to eq "/forms/#{form.id}/payment-link"
       end
 
-      it "has link to brand settings" do
-        expect(section_rows[1][:task_name]).to eq "Choose a brand for your form"
-        expect(section_rows[1][:path]).to eq "/forms/#{form.id}/brand"
+      context "when the custom_branding feature is enabled" do
+        it "has link to brand settings" do
+          expect(section_rows[1][:task_name]).to eq "Choose a brand for your form"
+          expect(section_rows[1][:path]).to eq "/forms/#{form.id}/brand"
+        end
+      end
+
+      context "when the custom_branding feature is disabled" do
+        let(:custom_branding_enabled) { false }
+
+        it "does not have link to brand settings" do
+          expect(section_rows.map { |row| row[:path] }).not_to include("/forms/#{form.id}/brand")
+        end
       end
 
       context "when the send_filler_answers feature is enabled" do

--- a/spec/services/task_status_service_spec.rb
+++ b/spec/services/task_status_service_spec.rb
@@ -118,6 +118,24 @@ describe TaskStatusService do
       end
     end
 
+    describe "brand status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form, :with_group, group:) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.all_task_statuses[:brand_status]).to eq :optional
+        end
+      end
+
+      context "with a form with a brand" do
+        let(:form) { build(:form, :new_form, :with_group, :with_brand, group:) }
+
+        it "returns the completed status" do
+          expect(task_status_service.all_task_statuses[:brand_status]).to eq :completed
+        end
+      end
+    end
+
     describe "copy of answers status" do
       context "with a new form" do
         let(:form) { build(:form, :new_form, :with_group, group:) }
@@ -668,6 +686,7 @@ describe TaskStatusService do
         declaration_status: :completed,
         what_happens_next_status: :completed,
         payment_link_status: :optional,
+        brand_status: :optional,
         copy_of_answers_status: :optional,
         privacy_policy_status: :completed,
         support_contact_details_status: :completed,


### PR DESCRIPTION
This adds an optional "Brand" task so creators can associate their form with a brand, which forms-runner then uses to style the live form. A form with no brand continues to use the default GOV.UK branding, so existing forms are unaffected.

This adds a "brand_id" attribute to the form document, which can be used by forms-runner.

Brands are defined in configuration (config/settings.yml), the initial list is Cheshire East Council and South Gloucestershire Council.

The feature is behind the custom_branding feature flag, so has to be enabled per group. Otherwise the task list item is hidden and the brand configuration pages are inaccessible.