### PR TITLE
Right-align numeric columns on organisations page

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -48,8 +48,8 @@
       <%= table.with_head do |head|
         head.with_row do |row|
           row.with_cell(header: true, text: t("organisations.index.table_headings.name"))
-          row.with_cell(header: true, text: t("organisations.index.table_headings.users"))
-          row.with_cell(header: true, text: t("organisations.index.table_headings.forms"))
+          row.with_cell(header: true, text: t("organisations.index.table_headings.users"), numeric: true)
+          row.with_cell(header: true, text: t("organisations.index.table_headings.forms"), numeric: true)
           row.with_cell(header: true, text: t("organisations.index.table_headings.mou_signed"))
         end
       end %>
@@ -60,8 +60,8 @@
             row.with_cell do
               govuk_link_to(organisation.name_with_abbreviation, organisation_path(organisation))
             end
-            row.with_cell(text: @user_counts.fetch(organisation.id, 0).to_s)
-            row.with_cell(text: @form_counts.fetch(organisation.id, 0).to_s)
+            row.with_cell(text: @user_counts.fetch(organisation.id, 0).to_s, numeric: true)
+            row.with_cell(text: @form_counts.fetch(organisation.id, 0).to_s, numeric: true)
             row.with_cell(text: t("organisations.boolean.#{@organisation_ids_with_mou.include?(organisation.id)}"))
           end
         end


### PR DESCRIPTION
The users and forms columns on the organisations page contain counts. Marking their cells as numeric right-aligns them in line with the GOV.UK table styling.