### PR TITLE
Add column sorting to organisations list

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -25,13 +25,25 @@ class OrganisationsController < WebController
 private
 
   def filtered_organisations
-    Organisation
+    scope = Organisation
       .by_name(filter_params[:name])
       .by_mou_signed(filter_params[:mou_signed])
-      .order(:name)
+
+    apply_sort(scope)
+  end
+
+  def apply_sort(scope)
+    case filter_params[:sort]
+    when "users"
+      scope.order_by_user_count
+    when "forms"
+      scope.order_by_form_count
+    else
+      scope.order(:name)
+    end
   end
 
   def filter_params
-    params[:filter]&.permit(:name, :mou_signed) || {}
+    params[:filter]&.permit(:name, :mou_signed, :sort) || {}
   end
 end

--- a/app/input_objects/organisations/filter_input.rb
+++ b/app/input_objects/organisations/filter_input.rb
@@ -1,9 +1,17 @@
 module Organisations
   class FilterInput < BaseInput
-    attr_accessor :name, :mou_signed
+    attr_accessor :name, :mou_signed, :sort
 
     def has_filters?
       [name, mou_signed].any?(&:present?)
+    end
+
+    def sort_options
+      [
+        OpenStruct.new(label: I18n.t("organisations.index.filter.sort.name"), value: "name"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.sort.users"), value: "users"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.sort.forms"), value: "forms"),
+      ]
     end
 
     def mou_signed_options

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -21,10 +21,20 @@ class Organisation < ApplicationRecord
   scope :by_mou_signed, lambda { |mou_signed|
     case mou_signed
     when "true"
-      joins(:mou_signatures).distinct
+      where(id: MouSignature.select(:organisation_id))
     when "false"
       where.missing(:mou_signatures)
     end
+  }
+
+  scope :order_by_user_count, lambda {
+    order(Arel.sql("(SELECT COUNT(*) FROM users WHERE users.organisation_id = organisations.id) DESC"))
+      .order(:name)
+  }
+
+  scope :order_by_form_count, lambda {
+    order(Arel.sql("(SELECT COUNT(*) FROM groups_form_ids INNER JOIN groups ON groups.id = groups_form_ids.group_id WHERE groups.organisation_id = organisations.id) DESC"))
+      .order(:name)
   }
 
   def name_with_abbreviation

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -19,6 +19,15 @@
           label: { text: t('organisations.index.filter.mou_signed.label'), size: 's' },
           hint: { text: t('organisations.index.filter.mou_signed.hint') } %>
       </div>
+      <div class="govuk-grid-column-one-third">
+        <%= f.govuk_collection_select :sort,
+          @filter_input.sort_options,
+          :value,
+          :label,
+          class: ["govuk-!-width-full"],
+          label: { text: t('organisations.index.filter.sort.label'), size: 's' },
+          hint: { text: t('organisations.index.filter.sort.hint') } %>
+      </div>
     </div>
 
     <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-padding-right-3">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1467,11 +1467,17 @@ en:
         clear_filter: Clear filter
         mou_signed:
           any: All organisations
-          hint: Filter by whether an MOU or agreement has been agreed
+          hint: Select MOU or agreement status
           label: MOU signed
         name:
-          hint: Enter full or partial name or abbreviation
+          hint: Enter name or abbreviation
           label: Name
+        sort:
+          forms: Forms (most first)
+          hint: Choose how to order the list
+          label: Sort by
+          name: Name (A to Z)
+          users: Users (most first)
         submit: Filter
       no_results: No organisations found.
       organisation_count:

--- a/spec/input_objects/organisations/filter_input_spec.rb
+++ b/spec/input_objects/organisations/filter_input_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Organisations::FilterInput, type: :model do
     end
   end
 
+  describe "#sort_options" do
+    it "returns the correct options" do
+      expect(described_class.new.sort_options).to eq([
+        OpenStruct.new(label: I18n.t("organisations.index.filter.sort.name"), value: "name"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.sort.users"), value: "users"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.sort.forms"), value: "forms"),
+      ])
+    end
+  end
+
   describe "#mou_signed_options" do
     it "returns the correct options" do
       expect(described_class.new.mou_signed_options).to eq([

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -80,6 +80,60 @@ RSpec.describe OrganisationsController, type: :request do
         expect(response.body).not_to include(organisation_with_mou.name)
       end
     end
+
+    context "when sorting" do
+      let!(:organisation_a) { create :organisation, name: "Alpha department", slug: "alpha-department" }
+      let!(:organisation_z) { create :organisation, name: "Zulu department", slug: "zulu-department", closed: true }
+
+      def organisation_row_order(response)
+        page = Capybara.string(response.body)
+        page.all("tbody tr td:first-child").map(&:text).map(&:strip)
+      end
+
+      before do
+        login_as_super_admin_user
+
+        create_list :user, 2, organisation: organisation_a
+        create :user, organisation: organisation_z
+
+        group = create :group, organisation: organisation_z
+        create :form, :with_group, group:
+      end
+
+      it "sorts by name ascending by default" do
+        get path
+
+        expect(organisation_row_order(response).first).to eq(organisation_a.name_with_abbreviation)
+      end
+
+      it "sorts by user count descending" do
+        get path, params: { filter: { sort: "users" } }
+
+        expect(organisation_row_order(response).first).to eq(organisation_a.name_with_abbreviation)
+      end
+
+      it "sorts by form count descending" do
+        get path, params: { filter: { sort: "forms" } }
+
+        expect(organisation_row_order(response).first).to eq(organisation_z.name_with_abbreviation)
+      end
+
+      it "falls back to name for an unknown sort option" do
+        get path, params: { filter: { sort: "malicious" } }
+
+        expect(organisation_row_order(response).first).to eq(organisation_a.name_with_abbreviation)
+      end
+
+      it "sorts while filtering by MOU signed at the same time" do
+        organisation_with_mou = create :organisation, :with_signed_mou, name: "Mike department", slug: "mike-department"
+
+        get path, params: { filter: { mou_signed: "true", sort: "users" } }
+
+        expect(response).to have_http_status(:ok)
+        expect(organisation_row_order(response)).to include(organisation_with_mou.name_with_abbreviation)
+        expect(organisation_row_order(response)).not_to include(organisation_a.name_with_abbreviation, organisation_z.name_with_abbreviation)
+      end
+    end
   end
 
   describe "#show" do

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -55,6 +55,14 @@ describe "organisations/index.html.erb" do
     expect(rendered).to have_css(".app-scrolling-wrapper > table")
   end
 
+  it "contains a sort select in the filter bar" do
+    expect(rendered).to have_select("filter[sort]", options: [
+      I18n.t("organisations.index.filter.sort.name"),
+      I18n.t("organisations.index.filter.sort.users"),
+      I18n.t("organisations.index.filter.sort.forms"),
+    ])
+  end
+
   it "links each organisation name to its show page" do
     expect(rendered).to have_link(organisation.name_with_abbreviation, href: organisation_path(organisation))
     expect(rendered).to have_link(closed_organisation.name_with_abbreviation, href: organisation_path(closed_organisation))


### PR DESCRIPTION
Adds a "Sort by" select to the filter bar on the organisations list, letting you order by:

- **Name (A to Z)** — the default
- **Users (most first)**
- **Forms (most first)**

The select lives in the existing filter form, so choosing an order submits alongside any active name/MOU filters.

<img width="1009" height="887" alt="image" src="https://github.com/user-attachments/assets/a5979b6d-568d-4c07-a052-fad41a741d70" />