### PR TITLE
Let super admins enable group feature flags

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -108,19 +108,17 @@ class GroupsController < WebController
   # GET /groups/1/feature-flags
   def feature_flags
     authorize @group, :manage_feature_flags?
+
+    @feature_flags_input = Groups::FeatureFlagsInput.new(group: @group).assign_group_values
   end
 
   # POST /groups/1/feature-flags
   def update_feature_flags
     authorize @group, :manage_feature_flags?
 
-    # Feature flags can only be switched on, never off. Enabling a feature can change
-    # a group's forms or data in ways that would need to be manually reversed before
-    # it is safe to disable, so we only ever turn flags on here.
-    flags_to_enable = feature_flag_params.select { |_attr, value| ActiveModel::Type::Boolean.new.cast(value) }
-    @group.assign_attributes(flags_to_enable.transform_values { true })
+    @feature_flags_input = Groups::FeatureFlagsInput.new(feature_flags_input_params)
 
-    if @group.save
+    if @feature_flags_input.submit
       redirect_to @group, success: t("groups.success_messages.feature_flags"), status: :see_other
     else
       render :feature_flags, status: :unprocessable_content
@@ -223,8 +221,10 @@ private
     params.require(:group).permit(:name, :organisation_id)
   end
 
-  def feature_flag_params
-    params.require(:group).permit(*Group.feature_flag_attributes)
+  def feature_flags_input_params
+    # When every flag is already enabled the form has no enabled inputs, so the
+    # input params may be missing entirely.
+    params.fetch(:groups_feature_flags_input, {}).permit(*Group.feature_flag_attributes).merge(group: @group)
   end
 
   def confirm_upgrade_input_params

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -105,6 +105,28 @@ class GroupsController < WebController
     render :move
   end
 
+  # GET /groups/1/feature-flags
+  def feature_flags
+    authorize @group, :manage_feature_flags?
+  end
+
+  # POST /groups/1/feature-flags
+  def update_feature_flags
+    authorize @group, :manage_feature_flags?
+
+    # Feature flags can only be switched on, never off. Enabling a feature can change
+    # a group's forms or data in ways that would need to be manually reversed before
+    # it is safe to disable, so we only ever turn flags on here.
+    flags_to_enable = feature_flag_params.select { |_attr, value| ActiveModel::Type::Boolean.new.cast(value) }
+    @group.assign_attributes(flags_to_enable.transform_values { true })
+
+    if @group.save
+      redirect_to @group, success: t("groups.success_messages.feature_flags"), status: :see_other
+    else
+      render :feature_flags, status: :unprocessable_content
+    end
+  end
+
   # GET /groups/1/delete
   def delete
     authorize @group
@@ -199,6 +221,10 @@ private
   # Only allow a list of trusted parameters through.
   def group_params
     params.require(:group).permit(:name, :organisation_id)
+  end
+
+  def feature_flag_params
+    params.require(:group).permit(*Group.feature_flag_attributes)
   end
 
   def confirm_upgrade_input_params

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -119,7 +119,8 @@ class GroupsController < WebController
     @feature_flags_input = Groups::FeatureFlagsInput.new(feature_flags_input_params)
 
     if @feature_flags_input.submit
-      redirect_to @group, success: t("groups.success_messages.feature_flags"), status: :see_other
+      success_message = t("groups.success_messages.feature_flags") if @feature_flags_input.flags_changed?
+      redirect_to @group, success: success_message, status: :see_other
     else
       render :feature_flags, status: :unprocessable_content
     end

--- a/app/input_objects/groups/feature_flags_input.rb
+++ b/app/input_objects/groups/feature_flags_input.rb
@@ -1,0 +1,44 @@
+module Groups
+  class FeatureFlagsInput < BaseInput
+    attr_accessor :group
+
+    def initialize(attributes = {})
+      # The flag attributes depend on the app settings and the groups schema, so
+      # they cannot be defined when the class is loaded.
+      Group.feature_flag_attributes.each do |flag|
+        singleton_class.attr_accessor(flag)
+      end
+
+      super
+    end
+
+    def assign_group_values
+      Group.feature_flag_attributes.each do |flag|
+        public_send(:"#{flag}=", group[flag])
+      end
+      self
+    end
+
+    def submit
+      return false if invalid?
+
+      # Feature flags can only be switched on, never off. Enabling a feature can change
+      # a group's forms or data in ways that would need to be manually reversed before
+      # it is safe to disable, so we only ever turn flags on here.
+      group.assign_attributes(flags_to_enable.index_with(true))
+
+      return true if group.save
+
+      errors.merge!(group.errors)
+      false
+    end
+
+  private
+
+    def flags_to_enable
+      Group.feature_flag_attributes.select do |flag|
+        ActiveModel::Type::Boolean.new.cast(public_send(flag))
+      end
+    end
+  end
+end

--- a/app/input_objects/groups/feature_flags_input.rb
+++ b/app/input_objects/groups/feature_flags_input.rb
@@ -26,11 +26,16 @@ module Groups
       # a group's forms or data in ways that would need to be manually reversed before
       # it is safe to disable, so we only ever turn flags on here.
       group.assign_attributes(flags_to_enable.index_with(true))
+      @flags_changed = group.changed?
 
       return true if group.save
 
       errors.merge!(group.errors)
       false
+    end
+
+    def flags_changed?
+      @flags_changed
     end
 
   private

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -30,6 +30,18 @@ class Group < ApplicationRecord
 
   enum :status, { trial: "trial", active: "active", upgrade_requested: "upgrade_requested" }, validate: true
 
+  # Feature flag columns that super admins can toggle per group. Derived from the
+  # features in settings.yml marked `enabled_by_group: true` that also have a matching
+  # `*_enabled` column (features without a column, e.g. exit_pages, are skipped).
+  def self.feature_flag_attributes
+    return [] if Settings.features.blank?
+
+    Settings.features.filter_map do |name, config|
+      column = "#{name}_enabled"
+      column if config.respond_to?(:enabled_by_group) && config.enabled_by_group && has_attribute?(column)
+    end
+  end
+
   def to_param
     external_id
   end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -19,6 +19,10 @@ class GroupPolicy < ApplicationPolicy
     user.super_admin?
   end
 
+  def manage_feature_flags?
+    user.super_admin?
+  end
+
   def delete?
     organisation_admin_or_super_admin?
   end

--- a/app/views/groups/feature_flags.html.erb
+++ b/app/views/groups/feature_flags.html.erb
@@ -1,10 +1,10 @@
-<% set_page_title(title_with_error_prefix(t(".title"), @group.errors.any?)) %>
+<% set_page_title(title_with_error_prefix(t(".title"), @feature_flags_input.errors.any?)) %>
 <% content_for :back_link, govuk_back_link_to(@group, t("back_link.group", group_name: @group.name)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @group, url: feature_flags_group_path(@group), method: :post) do |f| %>
-      <% if @group.errors.any? %>
+    <%= form_with(model: @feature_flags_input, url: feature_flags_group_path(@group)) do |f| %>
+      <% if @feature_flags_input.errors.any? %>
         <%= f.govuk_error_summary %>
       <% end %>
 

--- a/app/views/groups/feature_flags.html.erb
+++ b/app/views/groups/feature_flags.html.erb
@@ -1,0 +1,23 @@
+<% set_page_title(title_with_error_prefix(t(".title"), @group.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(@group, t("back_link.group", group_name: @group.name)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @group, url: feature_flags_group_path(@group), method: :post) do |f| %>
+      <% if @group.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <%= f.govuk_check_boxes_fieldset :feature_flags, multiple: false, legend: { text: t(".title"), tag: "h1", size: "l" }, caption: { text: @group.name, size: "l" }, hint: { text: t(".hint") } do %>
+        <% Group.feature_flag_attributes.each do |flag| %>
+          <% already_enabled = @group.public_send(flag) %>
+          <%= f.govuk_check_box flag, "true", "false", multiple: false,
+                checked: already_enabled, disabled: already_enabled,
+                label: { text: t("groups.feature_flags.flags.#{flag}") } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -66,6 +66,7 @@
     <li><%= govuk_link_to(t(".edit_group_name"), edit_group_path(@group)) %></li>
     <li><%= govuk_link_to(t(".edit_group_members"), group_members_path(@group)) %></li>
     <% if policy(@group).move? %><li><%= govuk_link_to(t(".move"), move_group_path(@group)) %></li><% end %>
+    <% if policy(@group).manage_feature_flags? %><li><%= govuk_link_to(t(".feature_flags"), feature_flags_group_path(@group)) %></li><% end %>
   <% else %>
     <li><%= govuk_link_to(t(".review_group_members"), group_members_path(@group)) %></li>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -748,7 +748,7 @@ en:
         custom_branding_enabled: Custom branding
         multiple_branches_enabled: Multiple branches
         send_filler_answers_enabled: Send a copy of completed answers to form fillers
-      hint: You can turn a feature flag on, but not off. A feature can change how a form or group works, which might take extra steps to reverse. Contact the team if you need to switch a feature off.
+      hint: You can turn a feature flag on, but not off. A feature can change how a form or group works, which might take extra steps to reverse. Ask a developer if you need to switch a feature off.
       title: Feature flags
     form_table_caption: Forms in ‘%{group_name}’
     group_list:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -746,7 +746,7 @@ en:
     feature_flags:
       flags:
         custom_branding_enabled: Custom branding
-        multiple_branches_enabled: Multiple branches and skip conditions
+        multiple_branches_enabled: Multiple branches
         send_filler_answers_enabled: Send a copy of completed answers to form fillers
       hint: You can turn a feature flag on, but not off. A feature can change how a form or group works, which might take extra steps to reverse. Contact the team if you need to switch a feature off.
       title: Feature flags

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -743,6 +743,13 @@ en:
       success: The group, ‘%{group_name}’, has been deleted
     edit:
       title: Change the name of this group
+    feature_flags:
+      flags:
+        custom_branding_enabled: Custom branding
+        multiple_branches_enabled: Multiple branches and skip conditions
+        send_filler_answers_enabled: Send a copy of completed answers to form fillers
+      hint: You can turn a feature flag on, but not off. A feature can change how a form or group works, which might take extra steps to reverse. Contact the team if you need to switch a feature off.
+      title: Feature flags
     form_table_caption: Forms in ‘%{group_name}’
     group_list:
       created_by: Created by
@@ -856,6 +863,7 @@ en:
         title: Managing this group
       edit_group_members: Edit members of this group
       edit_group_name: Change the name of this group
+      feature_flags: Manage feature flags for this group
       move: Move this group to another organisation
       review_group_members: View members of this group
       trial_banner:
@@ -886,6 +894,7 @@ en:
       trial: Trial group
       upgrade_requested: Trial group
     success_messages:
+      feature_flags: This group’s feature flags have been updated
       move: Group’s organisation has changed to %{org_name}
       update: The name of this group has been changed
       upgrade: This group is now active

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,6 +240,9 @@ Rails.application.routes.draw do
       get "delete", to: "groups#delete"
       get "move", to: "groups#move"
 
+      get "feature-flags", to: "groups#feature_flags"
+      post "feature-flags", to: "groups#update_feature_flags"
+
       get "upgrade", to: "groups#confirm_upgrade"
       post "upgrade", to: "groups#upgrade"
 

--- a/spec/input_objects/groups/feature_flags_input_spec.rb
+++ b/spec/input_objects/groups/feature_flags_input_spec.rb
@@ -35,4 +35,22 @@ RSpec.describe Groups::FeatureFlagsInput, type: :model do
       expect(group.reload[feature_flag]).to be(true)
     end
   end
+
+  describe "#flags_changed?" do
+    it "is true when submitting enabled a flag" do
+      input = described_class.new({ group:, feature_flag => "true" })
+      input.submit
+
+      expect(input.flags_changed?).to be(true)
+    end
+
+    it "is false when submitting made no changes" do
+      group.update!(feature_flag => true)
+
+      input = described_class.new({ group:, feature_flag => "true" })
+      input.submit
+
+      expect(input.flags_changed?).to be(false)
+    end
+  end
 end

--- a/spec/input_objects/groups/feature_flags_input_spec.rb
+++ b/spec/input_objects/groups/feature_flags_input_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Groups::FeatureFlagsInput, type: :model do
+  let(:feature_flag) { Group.feature_flag_attributes.first }
+  let(:group) { create :group, feature_flag => false }
+
+  before do
+    skip "no group feature flags are configured" if Group.feature_flag_attributes.empty?
+  end
+
+  describe "#assign_group_values" do
+    it "copies the group's flag values onto the input" do
+      group.update!(feature_flag => true)
+
+      input = described_class.new(group:).assign_group_values
+
+      expect(input.public_send(feature_flag)).to be(true)
+    end
+  end
+
+  describe "#submit" do
+    it "enables a flag submitted as true" do
+      input = described_class.new({ group:, feature_flag => "true" })
+
+      expect(input.submit).to be(true)
+      expect(group.reload[feature_flag]).to be(true)
+    end
+
+    it "does not turn a flag off when submitted as false" do
+      group.update!(feature_flag => true)
+
+      input = described_class.new({ group:, feature_flag => "false" })
+
+      expect(input.submit).to be(true)
+      expect(group.reload[feature_flag]).to be(true)
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -64,6 +64,42 @@ RSpec.describe Group, type: :model do
     end
   end
 
+  describe ".feature_flag_attributes" do
+    let(:features) do
+      Config::Options.new(
+        some_group_feature: Config::Options.new(enabled_by_group: true),
+        feature_without_column: Config::Options.new(enabled_by_group: true),
+        global_feature: Config::Options.new(enabled: true),
+      )
+    end
+
+    before do
+      allow(Settings).to receive(:features).and_return(features)
+      allow(described_class).to receive(:has_attribute?).and_call_original
+      allow(described_class).to receive(:has_attribute?).with("some_group_feature_enabled").and_return(true)
+    end
+
+    it "includes the column for each enabled_by_group feature with a matching column" do
+      expect(described_class.feature_flag_attributes).to include("some_group_feature_enabled")
+    end
+
+    it "excludes enabled_by_group features that have no matching column" do
+      expect(described_class.feature_flag_attributes).not_to include("feature_without_column_enabled")
+    end
+
+    it "excludes features that are not enabled_by_group" do
+      expect(described_class.feature_flag_attributes).not_to include("global_feature_enabled")
+    end
+
+    context "when no features are configured" do
+      let(:features) { nil }
+
+      it "returns an empty array" do
+        expect(described_class.feature_flag_attributes).to eq([])
+      end
+    end
+  end
+
   describe "before_create" do
     it "sets the external_id" do
       group = create :group

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe GroupPolicy do
       expect(GroupPolicy::Scope.new(user, Group).resolve).to eq(Group.all)
     end
 
+    it "permits manage_feature_flags" do
+      expect(policy).to permit_action(:manage_feature_flags)
+    end
+
     context "when the group has status upgrade_requested" do
       let(:group) { build :group, status: :upgrade_requested }
 
@@ -41,8 +45,8 @@ RSpec.describe GroupPolicy do
     let(:organisation) { group.organisation }
 
     context "and in the same organisation as the group" do
-      it "forbids only request_upgrade, review_upgrade and move" do
-        expect(policy).to forbid_only_actions(%i[request_upgrade review_upgrade move])
+      it "forbids only request_upgrade, review_upgrade, move and manage_feature_flags" do
+        expect(policy).to forbid_only_actions(%i[request_upgrade review_upgrade move manage_feature_flags])
       end
     end
 
@@ -92,7 +96,7 @@ RSpec.describe GroupPolicy do
       end
 
       it "forbids upgrade, add_group_admin, review_upgrade, delete and destroy" do
-        expect(policy).to forbid_only_actions(%i[upgrade add_group_admin review_upgrade delete destroy move])
+        expect(policy).to forbid_only_actions(%i[upgrade add_group_admin review_upgrade delete destroy move manage_feature_flags])
       end
 
       context "when the group status is active" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -484,7 +484,7 @@ RSpec.describe "/groups", type: :request do
 
     context "when user is not a super admin" do
       it "is forbidden and does not change the flag" do
-        post feature_flags_group_path(group), params: { group: { feature_flag => "true" } }
+        post feature_flags_group_path(group), params: { groups_feature_flags_input: { feature_flag => "true" } }
 
         expect(response).to have_http_status(:forbidden)
         expect(group.reload[feature_flag]).to be(false)
@@ -497,7 +497,7 @@ RSpec.describe "/groups", type: :request do
       end
 
       it "enables a feature flag and redirects to the group" do
-        post feature_flags_group_path(group), params: { group: { feature_flag => "true" } }
+        post feature_flags_group_path(group), params: { groups_feature_flags_input: { feature_flag => "true" } }
 
         expect(group.reload[feature_flag]).to be(true)
         expect(FeatureService.new(group:).enabled?(feature_name)).to be(true)
@@ -507,10 +507,16 @@ RSpec.describe "/groups", type: :request do
       it "does not turn an enabled feature flag off" do
         group.update!(feature_flag => true)
 
-        post feature_flags_group_path(group), params: { group: { feature_flag => "false" } }
+        post feature_flags_group_path(group), params: { groups_feature_flags_input: { feature_flag => "false" } }
 
         expect(group.reload[feature_flag]).to be(true)
         expect(FeatureService.new(group:).enabled?(feature_name)).to be(true)
+      end
+
+      it "redirects without error when no params are submitted" do
+        post feature_flags_group_path(group)
+
+        expect(response).to redirect_to(group_path(group))
       end
 
       it "leaves an enabled flag on while enabling another" do
@@ -519,7 +525,7 @@ RSpec.describe "/groups", type: :request do
         other_feature_flag = Group.feature_flag_attributes.second
         group.update!(feature_flag => true)
 
-        post feature_flags_group_path(group), params: { group: { feature_flag => "false", other_feature_flag => "true" } }
+        post feature_flags_group_path(group), params: { groups_feature_flags_input: { feature_flag => "false", other_feature_flag => "true" } }
 
         group.reload
         expect(group[feature_flag]).to be(true)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -502,6 +502,7 @@ RSpec.describe "/groups", type: :request do
         expect(group.reload[feature_flag]).to be(true)
         expect(FeatureService.new(group:).enabled?(feature_name)).to be(true)
         expect(response).to redirect_to(group_path(group))
+        expect(flash[:success]).to eq(I18n.t("groups.success_messages.feature_flags"))
       end
 
       it "does not turn an enabled feature flag off" do
@@ -513,10 +514,18 @@ RSpec.describe "/groups", type: :request do
         expect(FeatureService.new(group:).enabled?(feature_name)).to be(true)
       end
 
+      it "does not show a success message when no flags have changed" do
+        post feature_flags_group_path(group), params: { groups_feature_flags_input: { feature_flag => "false" } }
+
+        expect(response).to redirect_to(group_path(group))
+        expect(flash[:success]).to be_nil
+      end
+
       it "redirects without error when no params are submitted" do
         post feature_flags_group_path(group)
 
         expect(response).to redirect_to(group_path(group))
+        expect(flash[:success]).to be_nil
       end
 
       it "leaves an enabled flag on while enabling another" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -448,6 +448,86 @@ RSpec.describe "/groups", type: :request do
     end
   end
 
+  describe "GET /feature-flags" do
+    let(:group) { create(:group) }
+
+    context "when user is not a super admin" do
+      it "is forbidden" do
+        get feature_flags_group_path(group)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when user is a super admin" do
+      before do
+        login_as_super_admin_user
+      end
+
+      it "is allowed" do
+        get feature_flags_group_path(group)
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:feature_flags)
+      end
+    end
+  end
+
+  describe "POST /feature-flags" do
+    let(:feature_flag) { Group.feature_flag_attributes.first }
+    let(:feature_name) { feature_flag.delete_suffix("_enabled") }
+    let(:group) { create(:group, feature_flag => false) }
+
+    before do
+      skip "no group feature flags are configured" if Group.feature_flag_attributes.empty?
+    end
+
+    context "when user is not a super admin" do
+      it "is forbidden and does not change the flag" do
+        post feature_flags_group_path(group), params: { group: { feature_flag => "true" } }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(group.reload[feature_flag]).to be(false)
+      end
+    end
+
+    context "when user is a super admin" do
+      before do
+        login_as_super_admin_user
+      end
+
+      it "enables a feature flag and redirects to the group" do
+        post feature_flags_group_path(group), params: { group: { feature_flag => "true" } }
+
+        expect(group.reload[feature_flag]).to be(true)
+        expect(FeatureService.new(group:).enabled?(feature_name)).to be(true)
+        expect(response).to redirect_to(group_path(group))
+      end
+
+      it "does not turn an enabled feature flag off" do
+        group.update!(feature_flag => true)
+
+        post feature_flags_group_path(group), params: { group: { feature_flag => "false" } }
+
+        expect(group.reload[feature_flag]).to be(true)
+        expect(FeatureService.new(group:).enabled?(feature_name)).to be(true)
+      end
+
+      it "leaves an enabled flag on while enabling another" do
+        skip "fewer than two group feature flags are configured" if Group.feature_flag_attributes.size < 2
+
+        other_feature_flag = Group.feature_flag_attributes.second
+        group.update!(feature_flag => true)
+
+        post feature_flags_group_path(group), params: { group: { feature_flag => "false", other_feature_flag => "true" } }
+
+        group.reload
+        expect(group[feature_flag]).to be(true)
+        expect(group[other_feature_flag]).to be(true)
+      end
+    end
+  end
+
   describe "GET /delete" do
     let!(:group) { create :group }
 

--- a/spec/views/groups/feature_flags.html.erb_spec.rb
+++ b/spec/views/groups/feature_flags.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "groups/feature_flags", type: :view do
     skip "no group feature flags are configured" if Group.feature_flag_attributes.empty?
 
     assign(:group, group)
+    assign(:feature_flags_input, Groups::FeatureFlagsInput.new(group:).assign_group_values)
     render
   end
 
@@ -21,7 +22,7 @@ RSpec.describe "groups/feature_flags", type: :view do
 
   it "renders the feature flags form posting to the update action" do
     assert_select "form[action=?][method=?]", feature_flags_group_path(group), "post" do
-      assert_select "input[name=?]", "group[#{feature_flag}]"
+      assert_select "input[name=?]", "groups_feature_flags_input[#{feature_flag}]"
     end
   end
 
@@ -45,13 +46,13 @@ RSpec.describe "groups/feature_flags", type: :view do
     end
 
     it "renders the flag as checked and disabled so it cannot be turned off" do
-      assert_select "input[type=checkbox][name=?][checked=checked][disabled=disabled]", "group[#{feature_flag}]"
+      assert_select "input[type=checkbox][name=?][checked=checked][disabled=disabled]", "groups_feature_flags_input[#{feature_flag}]"
     end
 
     it "leaves flags that are off enabled and unchecked" do
       skip "fewer than two group feature flags are configured" if Group.feature_flag_attributes.size < 2
 
-      assert_select "input[type=checkbox][name=?]:not([disabled])", "group[#{other_feature_flag}]"
+      assert_select "input[type=checkbox][name=?]:not([disabled])", "groups_feature_flags_input[#{other_feature_flag}]"
     end
   end
 end

--- a/spec/views/groups/feature_flags.html.erb_spec.rb
+++ b/spec/views/groups/feature_flags.html.erb_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe "groups/feature_flags", type: :view do
+  let(:feature_flag) { Group.feature_flag_attributes.first }
+  let(:other_feature_flag) { Group.feature_flag_attributes.second }
+
+  let(:group) do
+    create :group, name: "Name"
+  end
+
+  before do
+    skip "no group feature flags are configured" if Group.feature_flag_attributes.empty?
+
+    assign(:group, group)
+    render
+  end
+
+  it "contains the page heading" do
+    expect(rendered).to have_css("h1", text: I18n.t("groups.feature_flags.title"))
+  end
+
+  it "renders the feature flags form posting to the update action" do
+    assert_select "form[action=?][method=?]", feature_flags_group_path(group), "post" do
+      assert_select "input[name=?]", "group[#{feature_flag}]"
+    end
+  end
+
+  it "includes a checkbox for each toggleable feature flag" do
+    Group.feature_flag_attributes.each do |flag|
+      expect(rendered).to have_field(I18n.t("groups.feature_flags.flags.#{flag}"))
+    end
+  end
+
+  it "includes the group name as a caption" do
+    expect(rendered).to have_css(".govuk-caption-l", text: group.name)
+  end
+
+  it "explains that flags cannot be turned off" do
+    expect(rendered).to have_text(I18n.t("groups.feature_flags.hint"))
+  end
+
+  context "when a feature flag is already enabled" do
+    let(:group) do
+      create :group, name: "Name", feature_flag => true
+    end
+
+    it "renders the flag as checked and disabled so it cannot be turned off" do
+      assert_select "input[type=checkbox][name=?][checked=checked][disabled=disabled]", "group[#{feature_flag}]"
+    end
+
+    it "leaves flags that are off enabled and unchecked" do
+      skip "fewer than two group feature flags are configured" if Group.feature_flag_attributes.size < 2
+
+      assert_select "input[type=checkbox][name=?]:not([disabled])", "group[#{other_feature_flag}]"
+    end
+  end
+end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "groups/show", type: :view do
   let(:edit?) { true }
   let(:move?) { false }
   let(:delete?) { false }
+  let(:manage_feature_flags?) { false }
   let(:request_upgrade?) { false }
   let(:review_upgrade?) { false }
 
@@ -29,6 +30,7 @@ RSpec.describe "groups/show", type: :view do
                                       edit?: edit?,
                                       delete?: delete?,
                                       move?: move?,
+                                      manage_feature_flags?: manage_feature_flags?,
                                       request_upgrade?: request_upgrade?,
                                       review_upgrade?: review_upgrade?)
 
@@ -71,6 +73,22 @@ RSpec.describe "groups/show", type: :view do
 
     it "has a link to move the group" do
       expect(rendered).to have_link("Move this group to another organisation")
+    end
+  end
+
+  context "when the user has permission to manage feature flags" do
+    let(:manage_feature_flags?) { true }
+
+    it "has a link to manage feature flags" do
+      expect(rendered).to have_link("Manage feature flags for this group", href: feature_flags_group_path(group))
+    end
+  end
+
+  context "when the user does not have permission to manage feature flags" do
+    let(:manage_feature_flags?) { false }
+
+    it "does not have a link to manage feature flags" do
+      expect(rendered).not_to have_link("Manage feature flags for this group")
     end
   end
 


### PR DESCRIPTION
Some features are rolled out per group through boolean columns on the groups table, but the only way to set those columns was a rake task that had to be run by an engineer. There was also no easy way to see which flags were already enabled for a group.

This adds a page, linked from the group page for super admins, that shows a checkbox for each group feature flag and saves the selection. The flags are derived from the features in settings.yml marked `enabled_by_group` that have a matching column on the groups table, so new flags show up without further changes.

Flags can only be switched on: a feature can change a form or group in ways that need manual work to undo, so flags that are already on are shown disabled and are never written back off.

<img width="1009" height="934" alt="image" src="https://github.com/user-attachments/assets/bd1ef988-c979-421c-984f-b8767906764f" />

<img width="989" height="605" alt="image" src="https://github.com/user-attachments/assets/7bc64058-3783-4072-bf46-985d357c43c2" />
