### PR TITLE
Show and filter organisations by agreement type

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -13,7 +13,11 @@ class OrganisationsController < WebController
     organisation_ids = @organisations.map(&:id)
     @user_counts = User.where(organisation_id: organisation_ids).group(:organisation_id).count
     @form_counts = GroupForm.joins(:group).where(groups: { organisation_id: organisation_ids }).reorder(nil).group("groups.organisation_id").count
-    @organisation_ids_with_mou = MouSignature.where(organisation_id: organisation_ids).distinct.pluck(:organisation_id).to_set
+    @agreement_types = MouSignature.where(organisation_id: organisation_ids)
+                                   .distinct
+                                   .pluck(:organisation_id, :agreement_type)
+                                   .group_by(&:first)
+                                   .transform_values { |pairs| pairs.map(&:last).sort }
   end
 
   def show

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -31,7 +31,7 @@ private
   def filtered_organisations
     scope = Organisation
       .by_name(filter_params[:name])
-      .by_mou_signed(filter_params[:mou_signed])
+      .by_agreement_type(filter_params[:agreement_type])
 
     apply_sort(scope)
   end
@@ -48,6 +48,6 @@ private
   end
 
   def filter_params
-    params[:filter]&.permit(:name, :mou_signed, :sort) || {}
+    params[:filter]&.permit(:name, :agreement_type, :sort) || {}
   end
 end

--- a/app/input_objects/organisations/filter_input.rb
+++ b/app/input_objects/organisations/filter_input.rb
@@ -1,9 +1,9 @@
 module Organisations
   class FilterInput < BaseInput
-    attr_accessor :name, :mou_signed, :sort
+    attr_accessor :name, :agreement_type, :sort
 
     def has_filters?
-      [name, mou_signed].any?(&:present?)
+      [name, agreement_type].any?(&:present?)
     end
 
     def sort_options
@@ -14,11 +14,12 @@ module Organisations
       ]
     end
 
-    def mou_signed_options
+    def agreement_type_options
       [
-        OpenStruct.new(label: I18n.t("organisations.index.filter.mou_signed.any")),
-        OpenStruct.new(label: I18n.t("organisations.boolean.true"), value: "true"),
-        OpenStruct.new(label: I18n.t("organisations.boolean.false"), value: "false"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.any")),
+        OpenStruct.new(label: I18n.t("mou_signatures.index.agreement_type.crown"), value: "crown"),
+        OpenStruct.new(label: I18n.t("mou_signatures.index.agreement_type.non_crown"), value: "non_crown"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.none"), value: "none"),
       ]
     end
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -18,11 +18,13 @@ class Organisation < ApplicationRecord
     end
   }
 
-  scope :by_mou_signed, lambda { |mou_signed|
-    case mou_signed
-    when "true"
-      where(id: MouSignature.select(:organisation_id))
-    when "false"
+  scope :by_agreement_type, lambda { |agreement_type|
+    case agreement_type
+    when "crown"
+      where(id: MouSignature.crown.select(:organisation_id))
+    when "non_crown"
+      where(id: MouSignature.non_crown.select(:organisation_id))
+    when "none"
       where.missing(:mou_signatures)
     end
   }

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -59,7 +59,7 @@
           row.with_cell(header: true, text: t("organisations.index.table_headings.name"))
           row.with_cell(header: true, text: t("organisations.index.table_headings.users"), numeric: true)
           row.with_cell(header: true, text: t("organisations.index.table_headings.forms"), numeric: true)
-          row.with_cell(header: true, text: t("organisations.index.table_headings.mou_signed"))
+          row.with_cell(header: true, text: t("organisations.index.table_headings.agreement_type"))
         end
       end %>
 
@@ -71,7 +71,12 @@
             end
             row.with_cell(text: @user_counts.fetch(organisation.id, 0).to_s, numeric: true)
             row.with_cell(text: @form_counts.fetch(organisation.id, 0).to_s, numeric: true)
-            row.with_cell(text: t("organisations.boolean.#{@organisation_ids_with_mou.include?(organisation.id)}"))
+            agreement_types = @agreement_types.fetch(organisation.id, [])
+            if agreement_types.any?
+              row.with_cell(text: agreement_types.map { |agreement_type| t("mou_signatures.index.agreement_type.#{agreement_type}") }.join(", "))
+            else
+              row.with_cell(text: t("organisations.index.agreement_type_none"))
+            end
           end
         end
       end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -11,13 +11,13 @@
           hint: { text: t('organisations.index.filter.name.hint') } %>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= f.govuk_collection_select :mou_signed,
-          @filter_input.mou_signed_options,
+        <%= f.govuk_collection_select :agreement_type,
+          @filter_input.agreement_type_options,
           :value,
           :label,
           class: ["govuk-!-width-full"],
-          label: { text: t('organisations.index.filter.mou_signed.label'), size: 's' },
-          hint: { text: t('organisations.index.filter.mou_signed.hint') } %>
+          label: { text: t('organisations.index.filter.agreement_type.label'), size: 's' },
+          hint: { text: t('organisations.index.filter.agreement_type.hint') } %>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= f.govuk_collection_select :sort,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1474,11 +1474,12 @@ en:
     index:
       agreement_type_none: None
       filter:
-        clear_filter: Clear filter
-        mou_signed:
+        agreement_type:
           any: All organisations
           hint: Select MOU or agreement status
-          label: MOU signed
+          label: Agreement type
+          none: No agreement signed
+        clear_filter: Clear filter
         name:
           hint: Enter name or abbreviation
           label: Name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1472,6 +1472,7 @@ en:
       'false': 'No'
       'true': 'Yes'
     index:
+      agreement_type_none: None
       filter:
         clear_filter: Clear filter
         mou_signed:
@@ -1495,8 +1496,8 @@ en:
       showing_count: Showing %{from} to %{to} of %{count} organisations
       table_caption: All organisations
       table_headings:
+        agreement_type: Agreement type
         forms: Forms
-        mou_signed: MOU signed
         name: Name
         users: Users
     show:

--- a/spec/input_objects/organisations/filter_input_spec.rb
+++ b/spec/input_objects/organisations/filter_input_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Organisations::FilterInput, type: :model do
       end
     end
 
-    context "when the mou_signed filter is set" do
-      subject(:input) { described_class.new(mou_signed: "true") }
+    context "when the agreement_type filter is set" do
+      subject(:input) { described_class.new(agreement_type: "crown") }
 
       it "returns true" do
         expect(input.has_filters?).to be true
@@ -37,12 +37,13 @@ RSpec.describe Organisations::FilterInput, type: :model do
     end
   end
 
-  describe "#mou_signed_options" do
+  describe "#agreement_type_options" do
     it "returns the correct options" do
-      expect(described_class.new.mou_signed_options).to eq([
-        OpenStruct.new(label: I18n.t("organisations.index.filter.mou_signed.any")),
-        OpenStruct.new(label: I18n.t("organisations.boolean.true"), value: "true"),
-        OpenStruct.new(label: I18n.t("organisations.boolean.false"), value: "false"),
+      expect(described_class.new.agreement_type_options).to eq([
+        OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.any")),
+        OpenStruct.new(label: I18n.t("mou_signatures.index.agreement_type.crown"), value: "crown"),
+        OpenStruct.new(label: I18n.t("mou_signatures.index.agreement_type.non_crown"), value: "non_crown"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.none"), value: "none"),
       ])
     end
   end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -72,20 +72,33 @@ RSpec.describe Organisation, type: :model do
       end
     end
 
-    describe ".by_mou_signed" do
-      let!(:organisation_with_mou) { create :organisation, :with_signed_mou, slug: "org-with-mou" }
-      let!(:organisation_without_mou) { create :organisation, slug: "org-without-mou" }
+    describe ".by_agreement_type" do
+      let!(:organisation_with_crown_mou) { create :organisation, :with_signed_mou, slug: "org-with-crown-mou" }
+      let!(:organisation_with_non_crown_agreement) { create :organisation, slug: "org-with-non-crown-agreement" }
+      let!(:organisation_without_agreement) { create :organisation, slug: "org-without-agreement" }
 
-      it "returns organisations with a signed MOU when true" do
-        expect(described_class.by_mou_signed("true")).to contain_exactly(organisation_with_mou)
+      before do
+        create :mou_signature_for_organisation, organisation: organisation_with_non_crown_agreement, agreement_type: :non_crown
       end
 
-      it "returns organisations without a signed MOU when false" do
-        expect(described_class.by_mou_signed("false")).to contain_exactly(organisation_without_mou)
+      it "returns organisations with a Crown MOU when crown" do
+        expect(described_class.by_agreement_type("crown")).to contain_exactly(organisation_with_crown_mou)
+      end
+
+      it "returns organisations with a non-crown agreement when non_crown" do
+        expect(described_class.by_agreement_type("non_crown")).to contain_exactly(organisation_with_non_crown_agreement)
+      end
+
+      it "returns organisations without a signed agreement when none" do
+        expect(described_class.by_agreement_type("none")).to contain_exactly(organisation_without_agreement)
       end
 
       it "returns all organisations when blank" do
-        expect(described_class.by_mou_signed(nil)).to contain_exactly(organisation_with_mou, organisation_without_mou)
+        expect(described_class.by_agreement_type(nil)).to contain_exactly(organisation_with_crown_mou, organisation_with_non_crown_agreement, organisation_without_agreement)
+      end
+
+      it "returns all organisations for an unknown value" do
+        expect(described_class.by_agreement_type("malicious")).to contain_exactly(organisation_with_crown_mou, organisation_with_non_crown_agreement, organisation_without_agreement)
       end
     end
   end

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -53,9 +53,12 @@ RSpec.describe OrganisationsController, type: :request do
     end
 
     context "when filtering" do
-      let!(:organisation_with_mou) { create :organisation, :with_signed_mou, slug: "department-with-mou" }
+      let!(:organisation_with_crown_mou) { create :organisation, :with_signed_mou, slug: "department-with-mou" }
+      let!(:organisation_with_non_crown_agreement) { create :organisation, slug: "department-with-non-crown-agreement" }
 
       before do
+        create :mou_signature_for_organisation, organisation: organisation_with_non_crown_agreement, agreement_type: :non_crown
+
         login_as_super_admin_user
       end
 
@@ -66,18 +69,28 @@ RSpec.describe OrganisationsController, type: :request do
         expect(response.body).not_to include(organisation.name)
       end
 
-      it "filters organisations by whether an MOU is signed" do
-        get path, params: { filter: { mou_signed: "true" } }
+      it "filters organisations with a Crown MOU" do
+        get path, params: { filter: { agreement_type: "crown" } }
 
-        expect(response.body).to include(organisation_with_mou.name)
+        expect(response.body).to include(organisation_with_crown_mou.name)
+        expect(response.body).not_to include(organisation_with_non_crown_agreement.name)
         expect(response.body).not_to include(closed_organisation.name)
       end
 
-      it "filters organisations without a signed MOU" do
-        get path, params: { filter: { mou_signed: "false" } }
+      it "filters organisations with a non-crown agreement" do
+        get path, params: { filter: { agreement_type: "non_crown" } }
+
+        expect(response.body).to include(organisation_with_non_crown_agreement.name)
+        expect(response.body).not_to include(organisation_with_crown_mou.name)
+        expect(response.body).not_to include(closed_organisation.name)
+      end
+
+      it "filters organisations without a signed agreement" do
+        get path, params: { filter: { agreement_type: "none" } }
 
         expect(response.body).to include(closed_organisation.name)
-        expect(response.body).not_to include(organisation_with_mou.name)
+        expect(response.body).not_to include(organisation_with_crown_mou.name)
+        expect(response.body).not_to include(organisation_with_non_crown_agreement.name)
       end
     end
 
@@ -125,10 +138,10 @@ RSpec.describe OrganisationsController, type: :request do
         expect(organisation_row_order(response).first).to eq(organisation_a.name_with_abbreviation)
       end
 
-      it "sorts while filtering by MOU signed at the same time" do
+      it "sorts while filtering by agreement type at the same time" do
         organisation_with_mou = create :organisation, :with_signed_mou, name: "Mike department", slug: "mike-department"
 
-        get path, params: { filter: { mou_signed: "true", sort: "users" } }
+        get path, params: { filter: { agreement_type: "crown", sort: "users" } }
 
         expect(response).to have_http_status(:ok)
         expect(organisation_row_order(response)).to include(organisation_with_mou.name_with_abbreviation)

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -31,10 +31,11 @@ describe "organisations/index.html.erb" do
 
   it "contains a filter form" do
     expect(rendered).to have_field("filter[name]")
-    expect(rendered).to have_select("filter[mou_signed]", options: [
-      I18n.t("organisations.index.filter.mou_signed.any"),
-      I18n.t("organisations.boolean.true"),
-      I18n.t("organisations.boolean.false"),
+    expect(rendered).to have_select("filter[agreement_type]", options: [
+      I18n.t("organisations.index.filter.agreement_type.any"),
+      I18n.t("mou_signatures.index.agreement_type.crown"),
+      I18n.t("mou_signatures.index.agreement_type.non_crown"),
+      I18n.t("organisations.index.filter.agreement_type.none"),
     ])
     expect(rendered).to have_button(I18n.t("organisations.index.filter.submit"))
   end

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe "organisations/index.html.erb" do
   let(:organisations) { [organisation, closed_organisation] }
   let(:user_counts) { { organisation.id => 3 } }
   let(:form_counts) { { organisation.id => 2 } }
-  let(:organisation_ids_with_mou) { Set.new([organisation.id]) }
+  let(:agreement_types) { { organisation.id => %w[crown] } }
   let(:pagy) { Pagy.new(count: organisations.size, page: 1, limit: 50) }
   let(:filter_input) { Organisations::FilterInput.new }
 
@@ -16,7 +16,7 @@ describe "organisations/index.html.erb" do
     assign(:organisations, organisations)
     assign(:user_counts, user_counts)
     assign(:form_counts, form_counts)
-    assign(:organisation_ids_with_mou, organisation_ids_with_mou)
+    assign(:agreement_types, agreement_types)
 
     render template: "organisations/index"
   end
@@ -78,9 +78,17 @@ describe "organisations/index.html.erb" do
     expect(rendered).to have_xpath "//tbody/tr[2]/td[3]", text: "0"
   end
 
-  it "shows whether an MOU has been signed" do
-    expect(rendered).to have_xpath "//tbody/tr[1]/td[4]", text: I18n.t("organisations.boolean.true")
-    expect(rendered).to have_xpath "//tbody/tr[2]/td[4]", text: I18n.t("organisations.boolean.false")
+  it "shows the agreement type for each organisation" do
+    expect(rendered).to have_xpath "//tbody/tr[1]/td[4]", text: I18n.t("mou_signatures.index.agreement_type.crown")
+    expect(rendered).to have_xpath "//tbody/tr[2]/td[4]", text: I18n.t("organisations.index.agreement_type_none")
+  end
+
+  context "when an organisation has both agreement types" do
+    let(:agreement_types) { { organisation.id => %w[crown non_crown] } }
+
+    it "shows both agreement types" do
+      expect(rendered).to have_xpath "//tbody/tr[1]/td[4]", text: "Crown MOU, Non-crown agreement"
+    end
   end
 
   context "when the organisations span multiple pages" do


### PR DESCRIPTION
The organisations list showed a yes/no "MOU signed" column and filter, however want to replicate the information available in the MOUs page.

This replaces the "MOU signed" column with an "Agreement type" column showing which agreements each organisation has signed ("Crown MOU", "Non-crown agreement", or "None"), reusing the existing agreement type translations. The filter is updated to match, offering all organisations, Crown MOU, non-crown agreement, or no agreement signed.

<img width="1012" height="811" alt="image" src="https://github.com/user-attachments/assets/07242046-33fc-4f0f-aa9c-6210eae323dc" />

