### PR TITLE
Add Brand model

### DIFF
--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,0 +1,4 @@
+class Brand < ApplicationRecord
+  validates :slug, presence: true, uniqueness: true
+  validates :name, presence: true
+end

--- a/db/migrate/20260710080000_create_brands.rb
+++ b/db/migrate/20260710080000_create_brands.rb
@@ -1,0 +1,12 @@
+class CreateBrands < ActiveRecord::Migration[8.1]
+  def change
+    create_table :brands do |t|
+      t.string :slug, null: false
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :brands, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_08_131956) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_10_080000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "brands", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_brands_on_slug", unique: true
+  end
 
   create_table "condition_translations", force: :cascade do |t|
     t.bigint "condition_id", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,11 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
+if (HostingEnvironment.local_development? || HostingEnvironment.review?) && Brand.none?
+  Brand.create!(slug: "cheshire-east", name: "Cheshire East Council")
+  Brand.create!(slug: "south-gloucestershire", name: "South Gloucestershire Council")
+end
+
 if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User.none?
 
   gds = Organisation.find_or_create_by!(

--- a/spec/factories/models/brands.rb
+++ b/spec/factories/models/brands.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :brand do
+    sequence(:slug) { |n| "brand-#{n}" }
+    name { slug.titleize }
+  end
+end

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe Brand, type: :model do
+  subject(:brand) { build :brand }
+
+  it "is invalid without a slug" do
+    brand.slug = nil
+    expect(brand).to be_invalid
+    expect(brand.errors).to be_of_kind(:slug, :blank)
+  end
+
+  it "is invalid without a name" do
+    brand.name = nil
+    expect(brand).to be_invalid
+    expect(brand.errors).to be_of_kind(:name, :blank)
+  end
+
+  it "is invalid with a duplicate slug" do
+    create(:brand, slug: "duplicate-brand")
+    brand.slug = "duplicate-brand"
+    expect(brand).to be_invalid
+    expect(brand.errors).to be_of_kind(:slug, :taken)
+  end
+
+  it "is an error to insert a brand with an existing slug" do
+    existing_brand = create(:brand)
+
+    expect {
+      described_class.insert!({ slug: existing_brand.slug, name: existing_brand.name, created_at: Time.zone.now, updated_at: Time.zone.now })
+    }.to raise_error ActiveRecord::RecordNotUnique
+  end
+end


### PR DESCRIPTION
Brands are currently configured in application code, so changing them requires a deployment.

This adds a Brand model with a name and unique slug, and seeds example brands in local development and review environments. Slug uniqueness is enforced with a database index as well as a model validation.

This lays the groundwork for moving brand configuration into the database — in later work we can add an admin UI for managing brands and an API to serve the configuration to forms-runner.

Will remove brand config from Setting YAML - once the existing brands are created in prod.