### PR TITLE
Add super admin area for viewing brands

### DIFF
--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -1,0 +1,15 @@
+class BrandsController < WebController
+  after_action :verify_authorized
+
+  def index
+    authorize Brand, :can_view_brands?
+
+    @brands = Brand.order(:name).load
+  end
+
+  def show
+    authorize Brand, :can_view_brands?
+
+    @brand = Brand.find(params[:id])
+  end
+end

--- a/app/policies/brand_policy.rb
+++ b/app/policies/brand_policy.rb
@@ -1,0 +1,5 @@
+class BrandPolicy < ApplicationPolicy
+  def can_view_brands?
+    user.super_admin?
+  end
+end

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -66,7 +66,7 @@ private
       { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.payment_link"), path: payment_link_path(@form.id), status: @task_statuses[:payment_link_status] },
     ]
     if FeatureService.new(group: @form.group).enabled?(:custom_branding)
-      rows << { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.brand"), path: brand_path(@form.id), status: @task_statuses[:brand_status] }
+      rows << { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.brand"), path: form_brand_path(@form.id), status: @task_statuses[:brand_status] }
     end
     if FeatureService.new(group: @form.group).enabled?(:send_filler_answers)
       rows << { task_name: I18n.t("forms.task_list_#{create_or_edit}.create_form_optional_subsection.copy_of_answers"), path: copy_of_answers_path(@form.id), status: @task_statuses[:copy_of_answers_status] }

--- a/app/services/navigation_items_service.rb
+++ b/app/services/navigation_items_service.rb
@@ -25,6 +25,7 @@ class NavigationItemsService
       mou_navigation_item,
       users_navigation_item,
       organisations_navigation_item,
+      brands_navigation_item,
       reports_navigation_item,
       support_navigation_item,
       profile_navigation_item,
@@ -58,6 +59,12 @@ private
     return nil unless should_show_organisations_link?
 
     NavigationItem.new(text: I18n.t("header.organisations"), href: organisations_path, active: false)
+  end
+
+  def brands_navigation_item
+    return nil unless should_show_brands_link?
+
+    NavigationItem.new(text: I18n.t("header.brands"), href: brands_path, active: false)
   end
 
   def reports_navigation_item
@@ -102,6 +109,10 @@ private
 
   def should_show_organisations_link?
     Pundit.policy(user, :organisation).can_view_organisations?
+  end
+
+  def should_show_brands_link?
+    Pundit.policy(user, :brand).can_view_brands?
   end
 
   def should_show_reports_link?

--- a/app/views/brands/index.html.erb
+++ b/app/views/brands/index.html.erb
@@ -1,0 +1,29 @@
+<% set_page_title(t("page_titles.brands")) %>
+
+<h1 class="govuk-heading-l"><%= t("page_titles.brands") %></h1>
+
+<% if @brands.any? %>
+  <%= render ScrollingWrapperComponent::View.new(aria_label: t("brands.index.table_caption")) do %>
+    <%= govuk_table do |table| %>
+      <%= table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(header: true, text: t("brands.index.table_headings.name"))
+          row.with_cell(header: true, text: t("brands.index.table_headings.slug"))
+        end
+      end %>
+
+      <%= table.with_body do |body|
+        @brands.each do |brand|
+          body.with_row do |row|
+            row.with_cell do
+              govuk_link_to(brand.name, brand_path(brand))
+            end
+            row.with_cell(text: brand.slug)
+          end
+        end
+      end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <p class="govuk-body"><%= t("brands.index.no_results") %></p>
+<% end %>

--- a/app/views/brands/show.html.erb
+++ b/app/views/brands/show.html.erb
@@ -1,0 +1,20 @@
+<% set_page_title(@brand.name) %>
+<% content_for :back_link, govuk_back_link_to(brands_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= @brand.name %></h1>
+
+    <%= govuk_summary_list(actions: false) do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { t('brands.show.summary.slug') }
+        row.with_value { @brand.slug }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { t('brands.show.summary.created_at') }
+        row.with_value { l(@brand.created_at.to_date, format: :long) }
+      end
+    end %>
+  </div>
+</div>

--- a/app/views/forms/brand/new.html.erb
+++ b/app/views/forms/brand/new.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= form_with(model: @brand_input, url: brand_path) do |f| %>
+    <%= form_with(model: @brand_input, url: form_brand_path) do |f| %>
       <% if @brand_input&.errors.any? %>
         <%= f.govuk_error_summary %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,6 +281,17 @@ en:
 
       <p>If you do not choose a brand, your form will use the default GOV.UK brand.</p>
     heading: Choose a brand for your form
+  brands:
+    index:
+      no_results: No brands found.
+      table_caption: Brands
+      table_headings:
+        name: Name
+        slug: Slug
+    show:
+      summary:
+        created_at: Created
+        slug: Slug
   bulk_options:
     hint: Enter each option on a new line
     label: Enter the options for your list
@@ -928,6 +939,7 @@ en:
         Guidance will be displayed at the top of the page, above your question.
       </p>
   header:
+    brands: Brands
     mous: MOUs
     organisations: Organisations
     product_name: Forms
@@ -1619,6 +1631,7 @@ en:
     archive_form_confirmation: Your form has been archived
     archive_welsh_confirm: Archive the Welsh version of this form
     brand: Choose a brand for your form
+    brands: Brands
     bulk_options: Enter your list’s options into a text box
     change_name: Name your form
     change_order_pages_added_error: Sorry, we could not save the new question order

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,6 +219,8 @@ Rails.application.routes.draw do
 
   resources :organisations, only: %i[index show]
 
+  resources :brands, only: %i[index show]
+
   resource :mou_signature, only: %i[new show create], path: "/memorandum-of-understanding", defaults: { agreement_type: :crown }, as: :mou_signature do
     get "/signed", to: "mou_signatures#confirmation", as: :confirmation
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,8 +71,8 @@ Rails.application.routes.draw do
     post "/declaration-preview" => "forms/declaration#render_preview", as: :declaration_render_preview
     get "/payment-link" => "forms/payment_link#new", as: :payment_link
     post "/payment-link" => "forms/payment_link#create", as: :payment_link_create
-    get "/brand" => "forms/brand#new", as: :brand
-    post "/brand" => "forms/brand#create", as: :brand_create
+    get "/brand" => "forms/brand#new", as: :form_brand
+    post "/brand" => "forms/brand#create", as: :form_brand_create
     get "/share-preview" => "forms/share_preview#new", as: :share_preview
     post "/share-preview" => "forms/share_preview#create", as: :share_preview_create
     get "/welsh-translation" => "forms/welsh_translation#new", as: :welsh_translation

--- a/spec/policies/brand_policy_spec.rb
+++ b/spec/policies/brand_policy_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe BrandPolicy do
+  subject(:policy) { described_class.new(user, :brand) }
+
+  let(:user) { build :super_admin_user }
+
+  context "with super admin" do
+    it { is_expected.to permit_actions(%i[can_view_brands]) }
+  end
+
+  (User.roles.keys - %w[super_admin]).each do |role|
+    context "with #{role}" do
+      let(:user) { build :user, role: }
+
+      it { is_expected.to forbid_actions(%i[can_view_brands]) }
+    end
+  end
+end

--- a/spec/requests/brands_controller_spec.rb
+++ b/spec/requests/brands_controller_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe BrandsController, type: :request do
+  shared_examples "unauthorized user is forbidden" do
+    context "when the user is not a super admin" do
+      before do
+        login_as_standard_user
+
+        get path
+      end
+
+      it "returns http code 403 and renders forbidden" do
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+  end
+
+  describe "#index" do
+    let(:path) { brands_path }
+
+    let!(:brand) { create :brand, slug: "cheshire-east", name: "Cheshire East Council" }
+    let!(:other_brand) { create :brand, slug: "south-gloucestershire", name: "South Gloucestershire Council" }
+
+    include_examples "unauthorized user is forbidden"
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get path
+      end
+
+      it "returns http code 200 and renders the index view" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template("brands/index")
+      end
+
+      it "lists all brands with their slugs" do
+        expect(response.body).to include(brand.name)
+        expect(response.body).to include(brand.slug)
+        expect(response.body).to include(other_brand.name)
+        expect(response.body).to include(other_brand.slug)
+      end
+
+      it "links each brand to its show page" do
+        page = Capybara.string(response.body)
+        expect(page).to have_link(brand.name, href: brand_path(brand))
+      end
+    end
+  end
+
+  describe "#show" do
+    let(:brand) { create :brand, slug: "cheshire-east", name: "Cheshire East Council" }
+    let(:path) { brand_path(brand) }
+
+    include_examples "unauthorized user is forbidden"
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get path
+      end
+
+      it "returns http code 200 and renders the show view" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template("brands/show")
+      end
+
+      it "shows the brand's properties" do
+        expect(response.body).to include(brand.name)
+        expect(response.body).to include(brand.slug)
+      end
+    end
+  end
+end

--- a/spec/requests/forms/brand_controller_spec.rb
+++ b/spec/requests/forms/brand_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Forms::BrandController, type: :request do
 
   describe "#new" do
     it "renders the brand page" do
-      get(brand_path(form_id: form.id))
+      get(form_brand_path(form_id: form.id))
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(I18n.t("brand_input.heading"))
     end
@@ -25,7 +25,7 @@ RSpec.describe Forms::BrandController, type: :request do
       let(:custom_branding_enabled) { false }
 
       it "returns 404" do
-        get(brand_path(form_id: form.id))
+        get(form_brand_path(form_id: form.id))
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe Forms::BrandController, type: :request do
 
       it "returns 404 and does not update the form" do
         expect {
-          post(brand_path(form_id: form.id), params:)
+          post(form_brand_path(form_id: form.id), params:)
         }.not_to(change { form.reload.brand_id })
 
         expect(response).to have_http_status(:not_found)
@@ -49,17 +49,17 @@ RSpec.describe Forms::BrandController, type: :request do
     context "when the brand is changed" do
       it "updates the form" do
         expect {
-          post(brand_path(form_id: form.id), params:)
+          post(form_brand_path(form_id: form.id), params:)
         }.to change { form.reload.brand_id }.to(brand_id)
       end
 
       it "redirects you to the form overview page" do
-        post(brand_path(form_id: form.id), params:)
+        post(form_brand_path(form_id: form.id), params:)
         expect(response).to redirect_to(form_path(form.id))
       end
 
       it "displays a flash message that the brand has been saved" do
-        post(brand_path(form_id: form.id), params:)
+        post(form_brand_path(form_id: form.id), params:)
         expect(flash[:success]).to eq(I18n.t("banner.success.form.brand_saved"))
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe Forms::BrandController, type: :request do
       let(:form) { create(:form, :live, brand_id: nil) }
 
       before do
-        post(brand_path(form_id: form.id), params:)
+        post(form_brand_path(form_id: form.id), params:)
       end
 
       it "displays a flash message that the brand has been saved" do
@@ -81,12 +81,12 @@ RSpec.describe Forms::BrandController, type: :request do
 
       it "clears the brand_id on the form" do
         expect {
-          post(brand_path(form_id: form.id), params:)
+          post(form_brand_path(form_id: form.id), params:)
         }.to change { form.reload.brand_id }.to(nil)
       end
 
       it "displays a flash message that the form will use the GOV.UK branding" do
-        post(brand_path(form_id: form.id), params:)
+        post(form_brand_path(form_id: form.id), params:)
         expect(flash[:success]).to eq(I18n.t("banner.success.form.brand_removed"))
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe Forms::BrandController, type: :request do
       let(:form) { create(:form, :live, brand_id:) }
 
       before do
-        post(brand_path(form_id: form.id), params:)
+        post(form_brand_path(form_id: form.id), params:)
       end
 
       it "does not display a flash message" do
@@ -108,7 +108,7 @@ RSpec.describe Forms::BrandController, type: :request do
       let(:brand_id) { "" }
 
       before do
-        post(brand_path(form_id: form.id), params:)
+        post(form_brand_path(form_id: form.id), params:)
       end
 
       it "does not display a flash message" do
@@ -121,7 +121,7 @@ RSpec.describe Forms::BrandController, type: :request do
 
       it "does not update the form and re-renders the page with an error" do
         expect {
-          post(brand_path(form_id: form.id), params:)
+          post(form_brand_path(form_id: form.id), params:)
         }.not_to(change { form.reload.brand_id })
 
         expect(response).to have_http_status(:unprocessable_content)

--- a/spec/services/navigation_items_service_spec.rb
+++ b/spec/services/navigation_items_service_spec.rb
@@ -22,12 +22,14 @@ describe NavigationItemsService do
       let(:can_manage_mous) { false }
       let(:can_view_reports) { false }
       let(:can_view_organisations) { false }
+      let(:can_view_brands) { false }
 
       before do
         allow(Pundit).to receive(:policy).with(user, :user).and_return(instance_double(UserPolicy, can_manage_user?: can_manage_user))
         allow(Pundit).to receive(:policy).with(user, :mou_signature).and_return(instance_double(MouSignaturePolicy, can_manage_mous?: can_manage_mous))
         allow(Pundit).to receive(:policy).with(user, :report).and_return(instance_double(ReportPolicy, can_view_reports?: can_view_reports))
         allow(Pundit).to receive(:policy).with(user, :organisation).and_return(instance_double(OrganisationPolicy, can_view_organisations?: can_view_organisations))
+        allow(Pundit).to receive(:policy).with(user, :brand).and_return(instance_double(BrandPolicy, can_view_brands?: can_view_brands))
         allow(Settings.forms_product_page).to receive(:support_url).and_return(support_url)
       end
 
@@ -61,6 +63,21 @@ describe NavigationItemsService do
       context "when user cannot view organisations" do
         it "does not include organisations in navigation items" do
           expect(service.navigation_items).not_to(be_any { |item| item.text == I18n.t("header.organisations") })
+        end
+      end
+
+      context "when user can view brands" do
+        let(:can_view_brands) { true }
+
+        it "includes brands in navigation items" do
+          brands_item = NavigationItemsService::NavigationItem.new(text: I18n.t("header.brands"), href: brands_path, active: false)
+          expect(service.navigation_items).to include(brands_item)
+        end
+      end
+
+      context "when user cannot view brands" do
+        it "does not include brands in navigation items" do
+          expect(service.navigation_items).not_to(be_any { |item| item.text == I18n.t("header.brands") })
         end
       end
 


### PR DESCRIPTION
Brands are now stored in the database, but there is no way to see which brands exist without querying the database directly.

This adds a brands section for super admins with a page listing all brands and a page showing the properties of a brand, following the same patterns as the organisations section. A link to the brands page is added to the navigation for users who are allowed to view brands. Pages for creating and editing brands will be added later.

The existing route for choosing a brand for a form was named `brand`, which takes the route helper names a brands resource would use. Its helpers are renamed to `form_brand` and `form_brand_create` to free up the resourceful names for the new admin area.

<img width="1026" height="470" alt="image" src="https://github.com/user-attachments/assets/55950783-ee43-49da-918b-21759c9b5774" />
<img width="1014" height="459" alt="image" src="https://github.com/user-attachments/assets/7fc077dd-909c-4ed4-807d-4a1bd4774e1f" />
