### PR TITLE
Add filter option for any signed agreement

### DIFF
--- a/app/input_objects/organisations/filter_input.rb
+++ b/app/input_objects/organisations/filter_input.rb
@@ -19,6 +19,7 @@ module Organisations
         OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.any")),
         OpenStruct.new(label: I18n.t("mou_signatures.index.agreement_type.crown"), value: "crown"),
         OpenStruct.new(label: I18n.t("mou_signatures.index.agreement_type.non_crown"), value: "non_crown"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.signed"), value: "signed"),
         OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.none"), value: "none"),
       ]
     end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -24,6 +24,8 @@ class Organisation < ApplicationRecord
       where(id: MouSignature.crown.select(:organisation_id))
     when "non_crown"
       where(id: MouSignature.non_crown.select(:organisation_id))
+    when "signed"
+      where(id: MouSignature.select(:organisation_id))
     when "none"
       where.missing(:mou_signatures)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1479,6 +1479,7 @@ en:
           hint: Select MOU or agreement status
           label: Agreement type
           none: No agreement signed
+          signed: Any agreement signed
         clear_filter: Clear filter
         name:
           hint: Enter name or abbreviation

--- a/spec/input_objects/organisations/filter_input_spec.rb
+++ b/spec/input_objects/organisations/filter_input_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Organisations::FilterInput, type: :model do
         OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.any")),
         OpenStruct.new(label: I18n.t("mou_signatures.index.agreement_type.crown"), value: "crown"),
         OpenStruct.new(label: I18n.t("mou_signatures.index.agreement_type.non_crown"), value: "non_crown"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.signed"), value: "signed"),
         OpenStruct.new(label: I18n.t("organisations.index.filter.agreement_type.none"), value: "none"),
       ])
     end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe Organisation, type: :model do
         expect(described_class.by_agreement_type("non_crown")).to contain_exactly(organisation_with_non_crown_agreement)
       end
 
+      it "returns organisations with any signed agreement when signed" do
+        expect(described_class.by_agreement_type("signed")).to contain_exactly(organisation_with_crown_mou, organisation_with_non_crown_agreement)
+      end
+
       it "returns organisations without a signed agreement when none" do
         expect(described_class.by_agreement_type("none")).to contain_exactly(organisation_without_agreement)
       end

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -35,6 +35,7 @@ describe "organisations/index.html.erb" do
       I18n.t("organisations.index.filter.agreement_type.any"),
       I18n.t("mou_signatures.index.agreement_type.crown"),
       I18n.t("mou_signatures.index.agreement_type.non_crown"),
+      I18n.t("organisations.index.filter.agreement_type.signed"),
       I18n.t("organisations.index.filter.agreement_type.none"),
     ])
     expect(rendered).to have_button(I18n.t("organisations.index.filter.submit"))


### PR DESCRIPTION
The organisations list can be filtered by Crown MOU, non-crown agreement, or no agreement, but there is no way to see all organisations that have signed either type of agreement in one list.

This adds an 'Any agreement signed' option to the agreement type filter, matching organisations with an MOU signature of either type and excluding those that have not signed anything.

<img width="1067" height="741" alt="image" src="https://github.com/user-attachments/assets/5f253db2-4e91-4c77-9d71-53dc746a109c" />
