### PR TITLE
Sort organisations by first agreement date

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -42,6 +42,8 @@ private
       scope.order_by_user_count
     when "forms"
       scope.order_by_form_count
+    when "agreement_date"
+      scope.order_by_first_agreement_date
     else
       scope.order(:name)
     end

--- a/app/input_objects/organisations/filter_input.rb
+++ b/app/input_objects/organisations/filter_input.rb
@@ -11,6 +11,7 @@ module Organisations
         OpenStruct.new(label: I18n.t("organisations.index.filter.sort.name"), value: "name"),
         OpenStruct.new(label: I18n.t("organisations.index.filter.sort.users"), value: "users"),
         OpenStruct.new(label: I18n.t("organisations.index.filter.sort.forms"), value: "forms"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.sort.agreement_date"), value: "agreement_date"),
       ]
     end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -39,6 +39,11 @@ class Organisation < ApplicationRecord
       .order(:name)
   }
 
+  scope :order_by_first_agreement_date, lambda {
+    order(Arel.sql("(SELECT MIN(created_at) FROM mou_signatures WHERE mou_signatures.organisation_id = organisations.id) DESC NULLS LAST"))
+      .order(:name)
+  }
+
   def name_with_abbreviation
     if abbreviation.present? && abbreviation != name
       "#{name} (#{abbreviation})"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1484,6 +1484,7 @@ en:
           hint: Enter name or abbreviation
           label: Name
         sort:
+          agreement_date: Date first agreement signed (newest first)
           forms: Forms (most first)
           hint: Choose how to order the list
           label: Sort by

--- a/spec/input_objects/organisations/filter_input_spec.rb
+++ b/spec/input_objects/organisations/filter_input_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Organisations::FilterInput, type: :model do
         OpenStruct.new(label: I18n.t("organisations.index.filter.sort.name"), value: "name"),
         OpenStruct.new(label: I18n.t("organisations.index.filter.sort.users"), value: "users"),
         OpenStruct.new(label: I18n.t("organisations.index.filter.sort.forms"), value: "forms"),
+        OpenStruct.new(label: I18n.t("organisations.index.filter.sort.agreement_date"), value: "agreement_date"),
       ])
     end
   end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -101,6 +101,35 @@ RSpec.describe Organisation, type: :model do
         expect(described_class.by_agreement_type("malicious")).to contain_exactly(organisation_with_crown_mou, organisation_with_non_crown_agreement, organisation_without_agreement)
       end
     end
+
+    describe ".order_by_first_agreement_date" do
+      let!(:organisation_signed_last_week) { create :organisation, slug: "org-signed-last-week" }
+      let!(:organisation_signed_last_year) { create :organisation, slug: "org-signed-last-year" }
+      let!(:organisation_without_agreement) { create :organisation, slug: "org-without-agreement" }
+
+      before do
+        create :mou_signature_for_organisation, organisation: organisation_signed_last_week, created_at: 1.week.ago
+        create :mou_signature_for_organisation, organisation: organisation_signed_last_year, agreement_type: :non_crown, created_at: 1.year.ago
+      end
+
+      it "orders organisations by first agreement signed, newest first, without an agreement last" do
+        expect(described_class.order_by_first_agreement_date).to eq [
+          organisation_signed_last_week,
+          organisation_signed_last_year,
+          organisation_without_agreement,
+        ]
+      end
+
+      it "uses the earliest signature when an organisation has more than one" do
+        create :mou_signature_for_organisation, organisation: organisation_signed_last_year, created_at: 1.day.ago
+
+        expect(described_class.order_by_first_agreement_date).to eq [
+          organisation_signed_last_week,
+          organisation_signed_last_year,
+          organisation_without_agreement,
+        ]
+      end
+    end
   end
 
   describe "#name_with_abbreviation" do

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -132,6 +132,17 @@ RSpec.describe OrganisationsController, type: :request do
         expect(organisation_row_order(response).first).to eq(organisation_n.name_with_abbreviation)
       end
 
+      it "sorts by first agreement signed date descending, organisations without an agreement last" do
+        create :mou_signature_for_organisation, organisation: organisation_n, created_at: 1.year.ago
+        create :mou_signature_for_organisation, organisation: organisation_z, created_at: 1.week.ago
+
+        get path, params: { filter: { sort: "agreement_date" } }
+
+        rows = organisation_row_order(response)
+        expect(rows.index(organisation_z.name_with_abbreviation)).to be < rows.index(organisation_n.name_with_abbreviation)
+        expect(rows.index(organisation_n.name_with_abbreviation)).to be < rows.index(organisation_a.name_with_abbreviation)
+      end
+
       it "falls back to name for an unknown sort option" do
         get path, params: { filter: { sort: "malicious" } }
 

--- a/spec/views/organisations/index.html.erb_spec.rb
+++ b/spec/views/organisations/index.html.erb_spec.rb
@@ -61,6 +61,7 @@ describe "organisations/index.html.erb" do
       I18n.t("organisations.index.filter.sort.name"),
       I18n.t("organisations.index.filter.sort.users"),
       I18n.t("organisations.index.filter.sort.forms"),
+      I18n.t("organisations.index.filter.sort.agreement_date"),
     ])
   end
 


### PR DESCRIPTION
The organisations list can be sorted by name, user count and form count, but there is no way to order it by when organisations signed up, so recently onboarded organisations are hard to spot.

This adds a sort option that orders organisations by the date their first MOU or non-crown agreement was signed, newest first. Organisations that have not signed an agreement are placed at the bottom of the list.

This is used to help us identify organisation that have recently signed.

<img width="1026" height="1197" alt="image" src="https://github.com/user-attachments/assets/151323aa-3099-451f-b89a-4a9812018dae" />
