### PR TITLE
Add pages for creating and editing brands

### DIFF
--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -1,4 +1,5 @@
 class BrandsController < WebController
+  before_action :set_brand, only: %i[show edit update]
   after_action :verify_authorized
 
   def index
@@ -9,8 +10,6 @@ class BrandsController < WebController
 
   def show
     authorize Brand, :can_view_brands?
-
-    @brand = Brand.find(params[:id])
   end
 
   def new
@@ -33,14 +32,10 @@ class BrandsController < WebController
 
   def edit
     authorize Brand, :can_edit_brands?
-
-    @brand = Brand.find(params[:id])
   end
 
   def update
     authorize Brand, :can_edit_brands?
-
-    @brand = Brand.find(params[:id])
 
     if @brand.update(update_brand_params)
       redirect_to @brand, success: t("brands.success_messages.update"), status: :see_other
@@ -50,6 +45,10 @@ class BrandsController < WebController
   end
 
 private
+
+  def set_brand
+    @brand = Brand.find(params[:id])
+  end
 
   def brand_params
     params.require(:brand).permit(:name, :slug)

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -12,4 +12,28 @@ class BrandsController < WebController
 
     @brand = Brand.find(params[:id])
   end
+
+  def new
+    authorize Brand, :can_edit_brands?
+
+    @brand = Brand.new
+  end
+
+  def create
+    authorize Brand, :can_edit_brands?
+
+    @brand = Brand.new(brand_params)
+
+    if @brand.save
+      redirect_to @brand, success: t("brands.success_messages.create")
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+private
+
+  def brand_params
+    params.require(:brand).permit(:name, :slug)
+  end
 end

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -31,9 +31,31 @@ class BrandsController < WebController
     end
   end
 
+  def edit
+    authorize Brand, :can_edit_brands?
+
+    @brand = Brand.find(params[:id])
+  end
+
+  def update
+    authorize Brand, :can_edit_brands?
+
+    @brand = Brand.find(params[:id])
+
+    if @brand.update(update_brand_params)
+      redirect_to @brand, success: t("brands.success_messages.update"), status: :see_other
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
 private
 
   def brand_params
     params.require(:brand).permit(:name, :slug)
+  end
+
+  def update_brand_params
+    params.require(:brand).permit(:name)
   end
 end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,4 +1,4 @@
 class Brand < ApplicationRecord
-  validates :slug, presence: true, uniqueness: true
+  validates :slug, presence: true, uniqueness: true, format: { with: /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/, allow_blank: true }
   validates :name, presence: true
 end

--- a/app/policies/brand_policy.rb
+++ b/app/policies/brand_policy.rb
@@ -2,4 +2,8 @@ class BrandPolicy < ApplicationPolicy
   def can_view_brands?
     user.super_admin?
   end
+
+  def can_edit_brands?
+    user.super_admin?
+  end
 end

--- a/app/views/brands/edit.html.erb
+++ b/app/views/brands/edit.html.erb
@@ -1,0 +1,21 @@
+<% set_page_title(title_with_error_prefix(t(".title"), @brand.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(brand_path(@brand)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @brand) do |f| %>
+      <% if @brand.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @brand.name %></span>
+        <%= t(".title") %>
+      </h1>
+
+      <%= f.govuk_text_field :name, label: { size: 'm' } %>
+
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/brands/index.html.erb
+++ b/app/views/brands/index.html.erb
@@ -27,3 +27,7 @@
 <% else %>
   <p class="govuk-body"><%= t("brands.index.no_results") %></p>
 <% end %>
+
+<% if policy(Brand).can_edit_brands? %>
+  <%= govuk_button_link_to t("brands.index.create_brand"), new_brand_path, class: "govuk-!-margin-top-3" %>
+<% end %>

--- a/app/views/brands/new.html.erb
+++ b/app/views/brands/new.html.erb
@@ -1,0 +1,20 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.brand_new"), @brand.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(brands_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @brand) do |f| %>
+      <% if @brand.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l"><%= t("page_titles.brand_new") %></h1>
+
+      <%= f.govuk_text_field :name, label: { size: 'm' } %>
+
+      <%= f.govuk_text_field :slug, label: { size: 'm' } %>
+
+      <%= f.govuk_submit t("save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/brands/show.html.erb
+++ b/app/views/brands/show.html.erb
@@ -16,5 +16,11 @@
         row.with_value { l(@brand.created_at.to_date, format: :long) }
       end
     end %>
+
+    <% if policy(Brand).can_edit_brands? %>
+      <p class="govuk-body">
+        <%= govuk_link_to t("brands.show.edit_brand"), edit_brand_path(@brand) %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,7 +151,8 @@ en:
         brand:
           attributes:
             slug:
-              invalid: Enter a slug in the correct format, like example-council
+              invalid: Slug must only include lowercase letters a to z, numbers and hyphens
+              taken: There is already a brand with this slug
         draft_question:
           attributes:
             hint_text:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,6 +282,8 @@ en:
       <p>If you do not choose a brand, your form will use the default GOV.UK brand.</p>
     heading: Choose a brand for your form
   brands:
+    edit:
+      title: Edit brand
     index:
       create_brand: Create a brand
       no_results: No brands found.
@@ -290,11 +292,13 @@ en:
         name: Name
         slug: Slug
     show:
+      edit_brand: Edit this brand
       summary:
         created_at: Created
         slug: Slug
     success_messages:
       create: The brand has been created
+      update: The brand has been updated
   bulk_options:
     hint: Enter each option on a new line
     label: Enter the options for your list

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,10 @@ en:
   activerecord:
     errors:
       models:
+        brand:
+          attributes:
+            slug:
+              invalid: Enter a slug in the correct format, like example-council
         draft_question:
           attributes:
             hint_text:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -283,6 +283,7 @@ en:
     heading: Choose a brand for your form
   brands:
     index:
+      create_brand: Create a brand
       no_results: No brands found.
       table_caption: Brands
       table_headings:
@@ -292,6 +293,8 @@ en:
       summary:
         created_at: Created
         slug: Slug
+    success_messages:
+      create: The brand has been created
   bulk_options:
     hint: Enter each option on a new line
     label: Enter the options for your list
@@ -1632,6 +1635,7 @@ en:
     archive_form_confirmation: Your form has been archived
     archive_welsh_confirm: Archive the Welsh version of this form
     brand: Choose a brand for your form
+    brand_new: Create a brand
     brands: Brands
     bulk_options: Enter your list’s options into a text box
     change_name: Name your form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,7 +219,7 @@ Rails.application.routes.draw do
 
   resources :organisations, only: %i[index show]
 
-  resources :brands, only: %i[index show]
+  resources :brands, only: %i[index show new create]
 
   resource :mou_signature, only: %i[new show create], path: "/memorandum-of-understanding", defaults: { agreement_type: :crown }, as: :mou_signature do
     get "/signed", to: "mou_signatures#confirmation", as: :confirmation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,7 +219,7 @@ Rails.application.routes.draw do
 
   resources :organisations, only: %i[index show]
 
-  resources :brands, only: %i[index show new create]
+  resources :brands, only: %i[index show new create edit update]
 
   resource :mou_signature, only: %i[new show create], path: "/memorandum-of-understanding", defaults: { agreement_type: :crown }, as: :mou_signature do
     get "/signed", to: "mou_signatures#confirmation", as: :confirmation

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe Brand, type: :model do
     expect(brand.errors).to be_of_kind(:name, :blank)
   end
 
+  it "is invalid when the slug is not kebab-case" do
+    ["Testshire", "testshire council", "testshire_council", " testshire", "testshire-"].each do |slug|
+      brand.slug = slug
+      expect(brand).to be_invalid
+      expect(brand.errors).to be_of_kind(:slug, :invalid)
+    end
+  end
+
+  it "is valid with a kebab-case slug" do
+    brand.slug = "testshire-east-2"
+    expect(brand).to be_valid
+  end
+
   it "is invalid with a duplicate slug" do
     create(:brand, slug: "duplicate-brand")
     brand.slug = "duplicate-brand"

--- a/spec/policies/brand_policy_spec.rb
+++ b/spec/policies/brand_policy_spec.rb
@@ -6,14 +6,14 @@ describe BrandPolicy do
   let(:user) { build :super_admin_user }
 
   context "with super admin" do
-    it { is_expected.to permit_actions(%i[can_view_brands]) }
+    it { is_expected.to permit_actions(%i[can_view_brands can_edit_brands]) }
   end
 
   (User.roles.keys - %w[super_admin]).each do |role|
     context "with #{role}" do
       let(:user) { build :user, role: }
 
-      it { is_expected.to forbid_actions(%i[can_view_brands]) }
+      it { is_expected.to forbid_actions(%i[can_view_brands can_edit_brands]) }
     end
   end
 end

--- a/spec/requests/brands_controller_spec.rb
+++ b/spec/requests/brands_controller_spec.rb
@@ -149,4 +149,77 @@ RSpec.describe BrandsController, type: :request do
       end
     end
   end
+
+  describe "#edit" do
+    let(:brand) { create :brand, slug: "testshire", name: "Testshire Council" }
+    let(:path) { edit_brand_path(brand) }
+
+    include_examples "unauthorized user is forbidden"
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get path
+      end
+
+      it "returns http code 200 and renders the edit view" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template("brands/edit")
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:brand) { create :brand, slug: "testshire", name: "Testshire Council" }
+    let(:path) { brand_path(brand) }
+    let(:params) { { brand: { name: "Greater Testshire Council", slug: "greater-testshire" } } }
+
+    context "when the user is not a super admin" do
+      before do
+        login_as_standard_user
+      end
+
+      it "returns http code 403 and does not change the brand" do
+        expect {
+          put path, params: params
+        }.not_to(change { brand.reload.attributes })
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+      end
+
+      it "updates the brand's name but not its slug" do
+        put path, params: params
+
+        expect(brand.reload).to have_attributes(name: "Greater Testshire Council", slug: "testshire")
+      end
+
+      it "redirects to the brand page with a success message" do
+        put path, params: params
+
+        expect(response).to redirect_to(brand_path(brand))
+        expect(flash[:success]).to eq(I18n.t("brands.success_messages.update"))
+      end
+
+      context "when the brand is invalid" do
+        let(:params) { { brand: { name: "" } } }
+
+        it "does not change the brand and re-renders the edit view" do
+          expect {
+            put path, params: params
+          }.not_to(change { brand.reload.attributes })
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response).to render_template("brands/edit")
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/brands_controller_spec.rb
+++ b/spec/requests/brands_controller_spec.rb
@@ -74,4 +74,79 @@ RSpec.describe BrandsController, type: :request do
       end
     end
   end
+
+  describe "#new" do
+    let(:path) { new_brand_path }
+
+    include_examples "unauthorized user is forbidden"
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+
+        get path
+      end
+
+      it "returns http code 200 and renders the new view" do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template("brands/new")
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:path) { brands_path }
+    let(:params) { { brand: { name: "Cheshire East Council", slug: "cheshire-east" } } }
+
+    context "when the user is not a super admin" do
+      before do
+        login_as_standard_user
+      end
+
+      it "returns http code 403 and does not create a brand" do
+        expect {
+          post path, params: params
+        }.not_to change(Brand, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when the user is a super admin" do
+      before do
+        login_as_super_admin_user
+      end
+
+      it "creates a brand with the given name and slug" do
+        expect {
+          post path, params: params
+        }.to change(Brand, :count).by(1)
+
+        brand = Brand.last
+        expect(brand.name).to eq("Cheshire East Council")
+        expect(brand.slug).to eq("cheshire-east")
+      end
+
+      it "redirects to the brand page with a success message" do
+        post path, params: params
+
+        expect(response).to redirect_to(brand_path(Brand.last))
+        expect(flash[:success]).to eq(I18n.t("brands.success_messages.create"))
+      end
+
+      context "when the brand is invalid" do
+        let(:params) { { brand: { name: "", slug: "cheshire-east" } } }
+
+        it "does not create a brand and re-renders the new view" do
+          expect {
+            post path, params: params
+          }.not_to change(Brand, :count)
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response).to render_template("brands/new")
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/brands_controller_spec.rb
+++ b/spec/requests/brands_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe BrandsController, type: :request do
   describe "#index" do
     let(:path) { brands_path }
 
-    let!(:brand) { create :brand, slug: "cheshire-east", name: "Cheshire East Council" }
-    let!(:other_brand) { create :brand, slug: "south-gloucestershire", name: "South Gloucestershire Council" }
+    let!(:brand) { create :brand, slug: "testshire", name: "Testshire Council" }
+    let!(:other_brand) { create :brand, slug: "exampleton", name: "Exampleton Town Council" }
 
     include_examples "unauthorized user is forbidden"
 
@@ -51,7 +51,7 @@ RSpec.describe BrandsController, type: :request do
   end
 
   describe "#show" do
-    let(:brand) { create :brand, slug: "cheshire-east", name: "Cheshire East Council" }
+    let(:brand) { create :brand, slug: "testshire", name: "Testshire Council" }
     let(:path) { brand_path(brand) }
 
     include_examples "unauthorized user is forbidden"
@@ -96,7 +96,7 @@ RSpec.describe BrandsController, type: :request do
 
   describe "#create" do
     let(:path) { brands_path }
-    let(:params) { { brand: { name: "Cheshire East Council", slug: "cheshire-east" } } }
+    let(:params) { { brand: { name: "Testshire Council", slug: "testshire" } } }
 
     context "when the user is not a super admin" do
       before do
@@ -124,8 +124,8 @@ RSpec.describe BrandsController, type: :request do
         }.to change(Brand, :count).by(1)
 
         brand = Brand.last
-        expect(brand.name).to eq("Cheshire East Council")
-        expect(brand.slug).to eq("cheshire-east")
+        expect(brand.name).to eq("Testshire Council")
+        expect(brand.slug).to eq("testshire")
       end
 
       it "redirects to the brand page with a success message" do
@@ -136,7 +136,7 @@ RSpec.describe BrandsController, type: :request do
       end
 
       context "when the brand is invalid" do
-        let(:params) { { brand: { name: "", slug: "cheshire-east" } } }
+        let(:params) { { brand: { name: "", slug: "testshire" } } }
 
         it "does not create a brand and re-renders the new view" do
           expect {

--- a/spec/requests/brands_controller_spec.rb
+++ b/spec/requests/brands_controller_spec.rb
@@ -2,11 +2,13 @@ require "rails_helper"
 
 RSpec.describe BrandsController, type: :request do
   shared_examples "unauthorized user is forbidden" do
+    let(:do_request) { get path }
+
     context "when the user is not a super admin" do
       before do
         login_as_standard_user
 
-        get path
+        do_request
       end
 
       it "returns http code 403 and renders forbidden" do
@@ -98,18 +100,19 @@ RSpec.describe BrandsController, type: :request do
     let(:path) { brands_path }
     let(:params) { { brand: { name: "Testshire Council", slug: "testshire" } } }
 
+    it_behaves_like "unauthorized user is forbidden" do
+      let(:do_request) { post path, params: params }
+    end
+
     context "when the user is not a super admin" do
       before do
         login_as_standard_user
       end
 
-      it "returns http code 403 and does not create a brand" do
+      it "does not create a brand" do
         expect {
           post path, params: params
         }.not_to change(Brand, :count)
-
-        expect(response).to have_http_status(:forbidden)
-        expect(response).to render_template("errors/forbidden")
       end
     end
 
@@ -175,18 +178,19 @@ RSpec.describe BrandsController, type: :request do
     let(:path) { brand_path(brand) }
     let(:params) { { brand: { name: "Greater Testshire Council", slug: "greater-testshire" } } }
 
+    it_behaves_like "unauthorized user is forbidden" do
+      let(:do_request) { put path, params: params }
+    end
+
     context "when the user is not a super admin" do
       before do
         login_as_standard_user
       end
 
-      it "returns http code 403 and does not change the brand" do
+      it "does not change the brand" do
         expect {
           put path, params: params
         }.not_to(change { brand.reload.attributes })
-
-        expect(response).to have_http_status(:forbidden)
-        expect(response).to render_template("errors/forbidden")
       end
     end
 


### PR DESCRIPTION
This PR adds pages for super admins to create a brand and to edit a brands, following the same patterns as the groups section. The brands list page gets a button for creating a brand, and each brand's page gets a link to edit it.

This is a stepping stone towards making branding self service - to start allow management by other's in the team and not just a dev task.

<img width="999" height="540" alt="image" src="https://github.com/user-attachments/assets/46860387-d21d-4d48-936c-0b22901f8f09" />
<img width="999" height="629" alt="image" src="https://github.com/user-attachments/assets/26c4f510-a9cc-4f56-be6a-8a891a86d40d" />
<img width="996" height="529" alt="image" src="https://github.com/user-attachments/assets/9d6fcb1a-99e5-4e2c-93f1-7512d0c628fd" />
<img width="996" height="551" alt="image" src="https://github.com/user-attachments/assets/1d99ee86-ce98-4e1a-849d-94961d4bbcde" />

