### PR TITLE
Improve factories

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -159,6 +159,6 @@ private
   end
 
   def requires_organisation?
-    organisation_id_was.present? || role_changed?(to: :organisation_admin)
+    organisation.blank? && (organisation_id_was.present? || role_changed?(to: :organisation_admin))
   end
 end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -61,7 +61,7 @@ FactoryBot.define do
       end
 
       pages do
-        Array.new(pages_count) { association(:page) }
+        Array.new(pages_count) { build(:page, form: nil) }
       end
 
       after(:build) do |form|
@@ -80,7 +80,7 @@ FactoryBot.define do
 
     trait :with_text_page do
       pages do
-        Array.new(1) { association(:page, answer_type: "text", answer_settings: { input_type: %w[single_line long_text].sample }) }
+        Array.new(1) { build(:page, answer_type: "text", answer_settings: { input_type: %w[single_line long_text].sample }, form: nil) }
       end
 
       question_section_completed { true }
@@ -148,7 +148,7 @@ FactoryBot.define do
       end
 
       pages do
-        Array.new(pages_count) { association(:page, :with_selection_settings) }
+        Array.new(pages_count) { build(:page, :with_selection_settings, form: nil) }
       end
 
       after(:build) do |form|

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -29,11 +29,11 @@ FactoryBot.define do
 
     trait :with_group do
       transient do
-        group { nil }
+        group { association :group }
       end
 
       after(:build) do |form, evaluator|
-        g = evaluator.group || FactoryBot.create(:group)
+        g = evaluator.group
         form.instance_variable_set(:@associated_group, g)
         form.define_singleton_method(:group) { g }
       end

--- a/spec/factories/models/groups.rb
+++ b/spec/factories/models/groups.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :group do
     sequence(:name) { |n| "Group #{n}" }
-    organisation { association :organisation, id: 1, slug: "test-org" }
+    organisation { association :organisation, slug: "test-org" }
     creator { association :user, organisation: }
     status { :trial }
     external_id { SecureRandom.base58(8) }
 
     trait :org_has_org_admin do
-      organisation { association :organisation, :with_org_admin, id: 1, slug: "test-org" }
+      organisation { association :organisation, :with_org_admin, slug: "test-org" }
     end
   end
 end

--- a/spec/factories/models/groups.rb
+++ b/spec/factories/models/groups.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :group do
     sequence(:name) { |n| "Group #{n}" }
-    organisation { association :organisation, slug: "test-org" }
+    organisation { association :organisation }
     creator { association :user, organisation: }
     status { :trial }
     external_id { SecureRandom.base58(8) }
 
     trait :org_has_org_admin do
-      organisation { association :organisation, :with_org_admin, slug: "test-org" }
+      organisation { association :organisation, :with_org_admin }
     end
   end
 end

--- a/spec/factories/models/memberships.rb
+++ b/spec/factories/models/memberships.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :membership do
-    user
-    group
-    added_by { association :user }
+    user { build :user }
+    group { build :group, organisation: user&.organisation }
+    added_by { build :user, organisation: user&.organisation }
     role { :editor }
   end
 end

--- a/spec/factories/models/mou_signatures.rb
+++ b/spec/factories/models/mou_signatures.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :mou_signature do
-    user { create(:user) }
+    user { build(:user) }
     organisation { user.organisation }
     agreement_type { :crown }
     created_at { Time.zone.now }
 
     factory :mou_signature_for_organisation do
       organisation
-      user { create(:user, organisation:) }
+      user { build(:user, organisation:) }
     end
   end
 end

--- a/spec/factories/models/organisation_domains.rb
+++ b/spec/factories/models/organisation_domains.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :organisation_domain do
-    organisation { association :organisation, slug: "test-org" }
+    organisation { association :organisation }
     domain { Faker::Internet.domain_name }
   end
 end

--- a/spec/factories/models/organisation_domains.rb
+++ b/spec/factories/models/organisation_domains.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :organisation_domain do
-    organisation { association :organisation, id: 1, slug: "test-org" }
+    organisation { association :organisation, slug: "test-org" }
     domain { Faker::Internet.domain_name }
   end
 end

--- a/spec/factories/models/organisations.rb
+++ b/spec/factories/models/organisations.rb
@@ -1,14 +1,10 @@
 FactoryBot.define do
   factory :organisation do
     govuk_content_id { nil }
-    slug { "test-org" }
+    sequence(:slug) { |n| "test-org-#{n}" }
     name { slug.titleize }
     abbreviation { name.split.collect(&:chr).join }
     internal { false }
-
-    initialize_with do
-      Organisation.create_with(govuk_content_id:, name:).find_or_initialize_by(slug:)
-    end
 
     trait :with_signed_mou do
       after(:build) do |organisation|

--- a/spec/factories/models/organisations.rb
+++ b/spec/factories/models/organisations.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
     trait :with_signed_mou do
       after(:build) do |organisation|
-        organisation.mou_signatures << (create :mou_signature_for_organisation, organisation:)
+        organisation.mou_signatures << build(:mou_signature_for_organisation, organisation:)
       end
     end
 
@@ -16,7 +16,7 @@ FactoryBot.define do
       with_signed_mou
 
       after(:build) do |organisation|
-        organisation.users << create(:organisation_admin_user, organisation:)
+        organisation.users << build(:organisation_admin_user, organisation:)
       end
     end
   end

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -26,10 +26,10 @@ FactoryBot.define do
       org_has_signed_mou
     end
 
-    organisation { association :organisation, id: 1, slug: "test-org" }
+    organisation { association :organisation, slug: "test-org" }
 
     trait :org_has_signed_mou do
-      organisation { association :organisation, :with_signed_mou, id: 1, slug: "test-org" }
+      organisation { association :organisation, :with_signed_mou, slug: "test-org" }
     end
 
     after(:build) do |user|

--- a/spec/factories/models/users.rb
+++ b/spec/factories/models/users.rb
@@ -26,10 +26,10 @@ FactoryBot.define do
       org_has_signed_mou
     end
 
-    organisation { association :organisation, slug: "test-org" }
+    organisation { association :organisation }
 
     trait :org_has_signed_mou do
-      organisation { association :organisation, :with_signed_mou, slug: "test-org" }
+      organisation { association :organisation, :with_signed_mou }
     end
 
     after(:build) do |user|

--- a/spec/features/form/create_or_edit_a_form_spec.rb
+++ b/spec/features/form/create_or_edit_a_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "Create or edit a form", type: :feature do
   let(:form) { create :form, name: "Apply for a juggling license", created_at: "2024-10-08T07:31:15.762Z" }
-  let(:group) { create :group, name: "Group 1" }
+  let(:group) { create :group, name: "Group 1", organisation: standard_user.organisation }
 
   before do
     login_as_standard_user

--- a/spec/features/mou/upgrade_user_changes_mou_spec.rb
+++ b/spec/features/mou/upgrade_user_changes_mou_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Assign an organisation to a user with a signed MOU", type: :feature do
   let(:user) { create :user, name: "Test User", organisation: nil }
   let!(:mou_signature) { create(:mou_signature, user:, organisation: nil, created_at: Time.zone.parse("September 1, 2023")) }
-  let(:organisation) { create :organisation }
+  let(:organisation) { test_org }
 
   it "a logged in user can sign an MOU" do
     login_as_super_admin_user

--- a/spec/input_objects/forms/group_select_spec.rb
+++ b/spec/input_objects/forms/group_select_spec.rb
@@ -31,17 +31,12 @@ RSpec.describe Forms::GroupSelect, type: :model do
       end
 
       context "when the organisation admin user is logged in" do
-        let(:org_admin) { build(:organisation_admin_user) }
-
-        it "returns only groups in the user's organisation" do
-          create_list(:group, 3) do |g|
-            g.organisation = group.organisation
-            g.save!
-          end
-          create(:group, organisation: build(:organisation)) # Group 5
+        it "returns only groups in the current group's organisation" do
+          create_list(:group, 3, organisation: group.organisation)
+          create(:group, organisation: build(:organisation)) # Group in a different organisation
 
           expect(group_select.groups).not_to include(group)
-          expect(group_select.groups.count).to eq(4)
+          expect(group_select.groups.count).to eq(3)
         end
       end
 

--- a/spec/integration/create_a_form_prevent_double_click_spec.rb
+++ b/spec/integration/create_a_form_prevent_double_click_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Create a form", type: :feature do
   let(:unwanted_form) { create :form, name: "Test form", created_at: form.created_at + 0.1 }
 
   let(:group) do
-    group = create :group, name: "Test group", creator: user
+    group = create :group, name: "Test group", creator: user, organisation: user.organisation
     create :membership, group:, user:, added_by: user
     group
   end

--- a/spec/integration/organisation_factory_spec.rb
+++ b/spec/integration/organisation_factory_spec.rb
@@ -1,13 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "organisation factory" do
-  it "does not duplicate organisations with same slug" do
-    org1 = create :organisation, slug: "org-slug"
-    org2 = create :organisation, slug: "org-slug"
-
-    expect(org1.id).to eq org2.id
-  end
-
   it "does not persist the organisation" do
     org = build :organisation
 

--- a/spec/lib/tasks/users.rake_spec.rb
+++ b/spec/lib/tasks/users.rake_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "users.rake", type: :task do
       let(:user_in_group) { users.fifth }
 
       before do
-        group = create :group, creator: users.first
+        group = create :group, creator: users.first, organisation: user_in_group.organisation
         create :membership, group:, user: user_in_group, added_by: users.first
       end
 
@@ -181,7 +181,7 @@ RSpec.describe "users.rake", type: :task do
       end
 
       let(:user_in_group) { users.fifth }
-      let(:group_with_user) { create :group, creator: users.first }
+      let(:group_with_user) { create :group, creator: users.first, organisation: user_in_group.organisation }
 
       before do
         create :membership, group: group_with_user, user: user_in_group, added_by: users.first

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -126,9 +126,10 @@ RSpec.describe Group, type: :model do
 
   describe "associations" do
     it "destroys associated memberships" do
-      group = create :group
-      user = create :user
-      added_by = create :user
+      organisation = create :organisation
+      group = create :group, organisation: organisation
+      user = create :user, organisation: organisation
+      added_by = create :user, organisation: organisation
       create(:membership, group:, user:, added_by:)
 
       expect { group.destroy }.to change(Membership, :count).by(-1)
@@ -151,11 +152,12 @@ RSpec.describe Group, type: :model do
     describe "#memberships" do
       describe "#ordered" do
         it "orders the membership records by name of the associated user" do
-          group = create :group
+          organisation = create :organisation
+          group = create :group, organisation: organisation
           users = [
-            create(:user, name: "Barbara User"),
-            create(:user, name: "Alfred User"),
-            create(:user, name: "Charlie User"),
+            create(:user, name: "Barbara User", organisation: organisation),
+            create(:user, name: "Alfred User", organisation: organisation),
+            create(:user, name: "Charlie User", organisation: organisation),
           ]
 
           users.each do |user|
@@ -260,9 +262,10 @@ RSpec.describe Group, type: :model do
   describe "scopes" do
     describe ".for_user" do
       it "returns groups that the user is a member of" do
-        user = create :user
-        group1 = create :group
-        group2 = create :group
+        organisation = create :organisation
+        user = create :user, organisation: organisation
+        group1 = create :group, organisation: organisation
+        group2 = create :group, organisation: organisation
         create :group
         create :membership, user:, group: group1
         create :membership, user:, group: group2
@@ -278,8 +281,9 @@ RSpec.describe Group, type: :model do
       end
 
       it "does not return groups that the user is not a member of" do
-        user = create :user
-        group1 = create :group
+        organisation = create :organisation
+        user = create :user, organisation: organisation
+        group1 = create :group, organisation: organisation
         create :group
         create :group
         create :membership, user:, group: group1

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -35,16 +35,18 @@ RSpec.describe Membership, type: :model do
   end
 
   it "is invalid if the user is already a member of the group" do
-    user = create :user
-    group = create :group
+    organisation = create :organisation
+    user = create :user, organisation: organisation
+    group = create :group, organisation: organisation
     create(:membership, user:, group:)
     membership = build(:membership, user:, group:)
     expect(membership).not_to be_valid
   end
 
   it "raises a DB error if the user is already a member of the group" do
-    user = create :user
-    group = create :group
+    organisation = create :organisation
+    user = create :user, organisation: organisation
+    group = create :group, organisation: organisation
     create(:membership, user:, group:)
     membership = build(:membership, user:, group:)
     expect { membership.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -9,19 +9,6 @@ RSpec.describe Organisation, type: :model do
     }.to raise_error ActiveRecord::RecordNotUnique
   end
 
-  describe "factory" do
-    it "does not create organisation if already exists" do
-      existing_organisation = create(:organisation, slug: "duplicate-org")
-      new_organisation = nil
-
-      expect {
-        new_organisation = create(:organisation, slug: "duplicate-org")
-      }.not_to raise_error
-
-      expect(new_organisation).to eq(existing_organisation)
-    end
-  end
-
   describe "versioning", :versioning do
     it "enables paper trail" do
       expect(described_class.new).to be_versioned

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -424,7 +424,7 @@ describe User, type: :model do
       context "and the user's organisation is not the same as given" do
         it "returns false" do
           user = create(:organisation_admin_user)
-          other_org = build(:organisation, id: 2)
+          other_org = build(:organisation)
 
           expect(user.is_organisations_admin?(other_org)).to be(false)
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,6 +58,16 @@ describe User, type: :model do
       end
     end
 
+    context "when reassigning to a new, unsaved organisation" do
+      let(:user) { create(:user, organisation: create(:organisation)) }
+
+      it "is valid even though the new organisation is not yet persisted" do
+        user.organisation = build(:organisation)
+
+        expect(user).to be_valid
+      end
+    end
+
     context "when updating name" do
       let(:user) { create :user, :with_no_name }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -128,7 +128,7 @@ describe User, type: :model do
   describe "associations" do
     it "destroys associated memberships" do
       user = create(:user)
-      group = create(:group)
+      group = create(:group, organisation: user.organisation)
 
       membership = create(:membership, user:, group:)
       user.destroy!
@@ -364,7 +364,7 @@ describe User, type: :model do
 
     it "returns false when user had an organisation" do
       user = create(:user)
-      user.update!(organisation: build(:organisation))
+      user.update!(organisation: create(:organisation))
       expect(user).not_to be_given_organisation
     end
   end
@@ -380,9 +380,9 @@ describe User, type: :model do
 
     context "when the user is an organisation admin" do
       it "returns true" do
-        user = create(:organisation_admin_user)
+        user = create(:organisation_admin_user, organisation: create(:organisation, :with_signed_mou))
 
-        expect(user.can_administer_org?(organisation)).to be(true)
+        expect(user.can_administer_org?(user.organisation)).to be(true)
       end
     end
 

--- a/spec/policies/form_policy_spec.rb
+++ b/spec/policies/form_policy_spec.rb
@@ -184,13 +184,13 @@ describe FormPolicy do
     end
 
     context "when the user is a super admin" do
-      let(:user) { build :super_admin_user }
+      let(:user) { build :super_admin_user, organisation: }
 
       it { is_expected.to permit_action(:can_administer_group) }
     end
 
     context "when the user is an organisation admin" do
-      let(:user) { build :organisation_admin_user }
+      let(:user) { build :organisation_admin_user, organisation: }
 
       it { is_expected.to permit_action(:can_administer_group) }
     end

--- a/spec/requests/api/form_documents_controller_spec.rb
+++ b/spec/requests/api/form_documents_controller_spec.rb
@@ -155,12 +155,12 @@ RSpec.describe Api::FormDocumentsController, type: :request do
     context "when the form exists" do
       let(:form) { create(:form) }
       let(:group) { create(:group, organisation: test_org) }
-      let(:group_admin) { create(:user) }
+      let(:group_admin) { create(:user, organisation: test_org) }
 
       before do
         organisation_admin_user
         create(:membership, user: group_admin, group:, role: :group_admin)
-        create(:membership, user: create(:user), group:, role: :editor)
+        create(:membership, user: create(:user, organisation: test_org), group:, role: :editor)
 
         group.group_forms.create!(form_id: form.id)
       end

--- a/spec/requests/forms/unarchive_controller_spec.rb
+++ b/spec/requests/forms/unarchive_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Forms::UnarchiveController, type: :request do
     end
 
     context "when current user does not belong to the forms group" do
-      let(:user) { build :user }
+      let(:user) { build :user, organisation: standard_user.organisation }
 
       it "is forbidden" do
         expect(response).to have_http_status(:forbidden)
@@ -119,7 +119,7 @@ RSpec.describe Forms::UnarchiveController, type: :request do
     end
 
     context "when current user does not belong to the forms group" do
-      let(:user) { build :user }
+      let(:user) { build :user, organisation: standard_user.organisation }
 
       it "is forbidden" do
         post(unarchive_create_path(form_id: form.id), params: form_params)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "/groups", type: :request do
       end
     end
 
-    let(:other_org) { create :organisation, id: 2, slug: "other-org" }
+    let(:other_org) { create :organisation, slug: "other-org" }
     let!(:other_org_trial_groups) { create_list :group, 3, organisation: other_org, status: :trial }
 
     context "when the user is not a super-admin" do
@@ -128,7 +128,7 @@ RSpec.describe "/groups", type: :request do
         let!(:other_org_active_groups) { create_list :group, 3, :active, organisation: other_org }
         let!(:other_org_upgrade_requested_groups) { create_list :group, 3, :upgrade_requested, organisation: other_org }
 
-        it "shows groups for organisation in query", :flaky do
+        it "shows groups for organisation in query" do
           get groups_url, params: { search: { organisation_id: other_org.id } }
           expect(assigns(:trial_groups)).to match_array(other_org_trial_groups)
           expect(assigns(:active_groups)).to match_array(other_org_active_groups)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe "/groups", type: :request do
   end
 
   describe "GET /delete" do
-    let!(:group) { create :group }
+    let!(:group) { create :group, organisation: test_org }
 
     context "when user is a super admin" do
       before do
@@ -598,7 +598,7 @@ RSpec.describe "/groups", type: :request do
   end
 
   describe "DELETE /destroy" do
-    let!(:group) { create :group, name: "Test Group" }
+    let!(:group) { create :group, name: "Test Group", organisation: test_org }
 
     context "when user is a super admin" do
       before do

--- a/spec/requests/memberships_controller_spec.rb
+++ b/spec/requests/memberships_controller_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe "/memberships", type: :request do
-  let(:user) { create(:user) }
-  let(:group) { create(:group) }
+  let(:user) { create(:user, organisation: standard_user.organisation) }
+  let(:group) { create(:group, organisation: standard_user.organisation) }
   let(:logged_in_user_role) { :group_admin }
 
   before do

--- a/spec/requests/routes_controller_spec.rb
+++ b/spec/requests/routes_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe RoutesController, type: :request do
   let(:form) { create(:form, :with_group, group:) }
   let(:membership) { create :membership, group:, user: standard_user }
-  let(:group) { create(:group, multiple_branches_enabled: true) }
+  let(:group) { create(:group, multiple_branches_enabled: true, organisation: standard_user.organisation) }
 
   before do
     membership
@@ -31,7 +31,7 @@ RSpec.describe RoutesController, type: :request do
     end
 
     context "when the multiple_branches feature is not enabled" do
-      let(:group) { create(:group, multiple_branches_enabled: false) }
+      let(:group) { create(:group, multiple_branches_enabled: false, organisation: standard_user.organisation) }
 
       it "returns a 404" do
         get routes_path(form.id)
@@ -89,7 +89,7 @@ RSpec.describe RoutesController, type: :request do
     end
 
     context "when the multiple_branches feature is not enabled" do
-      let(:group) { create(:group, multiple_branches_enabled: false) }
+      let(:group) { create(:group, multiple_branches_enabled: false, organisation: standard_user.organisation) }
 
       it "returns a 404" do
         post routes_path(form.id), params: valid_params

--- a/spec/services/group_service_spec.rb
+++ b/spec/services/group_service_spec.rb
@@ -5,16 +5,17 @@ RSpec.describe GroupService do
     described_class.new(group:, current_user:, host:)
   end
 
-  let(:group) { create :group }
-  let(:current_user) { create :user }
+  let(:organisation) { create :organisation }
+  let(:group) { create :group, organisation: }
+  let(:current_user) { create :user, organisation: }
   let(:host) { "example.net" }
 
   describe "#upgrade_group" do
-    let(:first_group_admin_user) { create :user }
-    let(:second_group_admin_user) { create :user }
-    let(:editor_user) { create :user }
+    let(:first_group_admin_user) { create :user, organisation: }
+    let(:second_group_admin_user) { create :user, organisation: }
+    let(:editor_user) { create :user, organisation: }
     let(:group) do
-      create(:group).tap do |group|
+      create(:group, organisation:).tap do |group|
         create(:membership, user: first_group_admin_user, group:, role: :group_admin)
         create(:membership, user: second_group_admin_user, group:, role: :group_admin)
         create(:membership, user: editor_user, group:, role: :editor)
@@ -63,11 +64,11 @@ RSpec.describe GroupService do
   end
 
   describe "#reject_upgrade" do
-    let(:first_group_admin_user) { create :user }
-    let(:second_group_admin_user) { create :user }
-    let(:editor_user) { create :user }
+    let(:first_group_admin_user) { create :user, organisation: }
+    let(:second_group_admin_user) { create :user, organisation: }
+    let(:editor_user) { create :user, organisation: }
     let(:group) do
-      create(:group, status: :upgrade_requested).tap do |group|
+      create(:group, status: :upgrade_requested, organisation:).tap do |group|
         create(:membership, user: first_group_admin_user, group:, role: :group_admin)
         create(:membership, user: second_group_admin_user, group:, role: :group_admin)
         create(:membership, user: editor_user, group:, role: :editor)
@@ -119,11 +120,12 @@ RSpec.describe GroupService do
   end
 
   describe "#request_upgrade" do
-    let!(:first_organisation_admin_user) { create :organisation_admin_user }
-    let!(:second_organisation_admin_user) { create :organisation_admin_user }
-    let(:editor_user) { create :user }
+    let(:organisation) { create :organisation, :with_signed_mou }
+    let!(:first_organisation_admin_user) { create :organisation_admin_user, organisation: }
+    let!(:second_organisation_admin_user) { create :organisation_admin_user, organisation: }
+    let(:editor_user) { create :user, organisation: }
     let(:group) do
-      create(:group).tap do |group|
+      create(:group, organisation:).tap do |group|
         create(:membership, user: editor_user, group:, role: :editor)
         create(:membership, user: current_user, group:, role: :group_admin)
       end

--- a/spec/services/mailchimp/list_sync_service_spec.rb
+++ b/spec/services/mailchimp/list_sync_service_spec.rb
@@ -22,8 +22,11 @@ RSpec.describe Mailchimp::ListSyncService do
     let(:mou_signer_and_organisation_admin_with_access) { users_with_access.third }
 
     before do
+      signed_mou_org = create(:organisation)
+      signed_mou_org_user = create(:user, organisation: signed_mou_org, has_access: false)
+      create(:mou_signature, organisation: signed_mou_org, user: signed_mou_org_user)
       users_with_access.each do |email|
-        create :user, email:, has_access: true
+        create :user, email:, has_access: true, organisation: signed_mou_org
       end
 
       users_without_access.each do |email|
@@ -69,17 +72,19 @@ RSpec.describe Mailchimp::ListSyncService do
   end
 
   describe "#mou_signers" do
-    let(:user_with_access_and_mou) { create(:user, email: "mou_user@example.com") }
-    let(:user_with_access_admin) { create(:user, email: "admin_user@example.com") }
-    let(:user_without_access) { create(:user, email: "inactive_user@example.com", has_access: false) }
-    let(:user_access_and_admin_with_mou) { create(:user, email: "admin_mou_user@example.com") }
-
+    let(:signed_mou_org) { create(:organisation) }
+    let(:user_with_access_and_mou) { create(:user, email: "mou_user@example.com", organisation: signed_mou_org) }
+    let(:user_with_access_admin) { create(:user, email: "admin_user@example.com", organisation: signed_mou_org) }
+    let(:user_without_access) { create(:user, email: "inactive_user@example.com", has_access: false, organisation: signed_mou_org) }
+    let(:user_access_and_admin_with_mou) { create(:user, email: "admin_mou_user@example.com", organisation: signed_mou_org) }
     let(:non_crown_org) { create(:organisation, id: 2, slug: "non-crown-org") }
     let(:user_that_signed_non_crown_agreement) { create(:user, organisation: non_crown_org) }
     let(:not_org_admin_that_signed_non_crown_agreement) { create(:user, organisation: non_crown_org) }
     let(:org_admin_for_non_crown_org) { create(:user, organisation: non_crown_org) }
+    let!(:signed_mou_org_user) { create(:user, organisation: signed_mou_org, has_access: false) }
 
     before do
+      create(:mou_signature, organisation: signed_mou_org, user: signed_mou_org_user)
       create(:mou_signature, user: user_with_access_and_mou)
       create(:mou_signature, user: user_access_and_admin_with_mou)
       create(:mou_signature, agreement_type: :non_crown, user: user_that_signed_non_crown_agreement)

--- a/spec/services/mailchimp/list_sync_service_spec.rb
+++ b/spec/services/mailchimp/list_sync_service_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Mailchimp::ListSyncService do
     let(:user_with_access_admin) { create(:user, email: "admin_user@example.com", organisation: signed_mou_org) }
     let(:user_without_access) { create(:user, email: "inactive_user@example.com", has_access: false, organisation: signed_mou_org) }
     let(:user_access_and_admin_with_mou) { create(:user, email: "admin_mou_user@example.com", organisation: signed_mou_org) }
-    let(:non_crown_org) { create(:organisation, id: 2, slug: "non-crown-org") }
+    let(:non_crown_org) { create(:organisation, slug: "non-crown-org") }
     let(:user_that_signed_non_crown_agreement) { create(:user, organisation: non_crown_org) }
     let(:not_org_admin_that_signed_non_crown_agreement) { create(:user, organisation: non_crown_org) }
     let(:org_admin_for_non_crown_org) { create(:user, organisation: non_crown_org) }

--- a/spec/services/reports/organisations_report_service_spec.rb
+++ b/spec/services/reports/organisations_report_service_spec.rb
@@ -19,13 +19,12 @@ describe Reports::OrganisationsReportService do
 
     context "with organisations" do
       it "returns the correct rows" do
-        create(:organisation, name: "Ministry of tests", slug: "ministry-of-tests", organisation_domains: [
-          create(:organisation_domain, domain: "ministry-of-tests.gov.uk"),
-          create(:organisation_domain, domain: "mot.gov.uk"),
-        ])
-        create(:organisation, name: "Department of juggling", slug: "department-of-juggling", organisation_domains: [
-          create(:organisation_domain, domain: "juggling.gov.uk"),
-        ])
+        create(:organisation, name: "Test Org", slug: "test-org")
+        ministry_org = create(:organisation, name: "Ministry of tests", slug: "ministry-of-tests")
+        create(:organisation_domain, domain: "ministry-of-tests.gov.uk", organisation: ministry_org)
+        create(:organisation_domain, domain: "mot.gov.uk", organisation: ministry_org)
+        juggling_org = create(:organisation, name: "Department of juggling", slug: "department-of-juggling")
+        create(:organisation_domain, domain: "juggling.gov.uk", organisation: juggling_org)
 
         expect(service.organisation_domains_report[:rows]).to contain_exactly(
           [{ text: "Test Org" }, { text: "test-org" }, { text: "" }],

--- a/spec/support/authentication_feature_helpers.rb
+++ b/spec/support/authentication_feature_helpers.rb
@@ -13,7 +13,7 @@ module AuthenticationFeatureHelpers
   end
 
   def test_org
-    @test_org ||= FactoryBot.create(:organisation, :with_signed_mou, id: 1, slug: "test-org")
+    @test_org ||= FactoryBot.create(:organisation, :with_signed_mou, slug: "test-org")
   end
 
   def super_admin_user

--- a/spec/views/account/organisations/edit.html.erb_spec.rb
+++ b/spec/views/account/organisations/edit.html.erb_spec.rb
@@ -65,9 +65,7 @@ describe "account/organisations/edit.html.erb" do
 
   context "when there are closed organisations" do
     before do
-      create(:organisation, slug: "test-org")
       create(:organisation, slug: "closed-org", closed: true)
-      create(:organisation, slug: "department-for-testing", name: "Department for Testing")
 
       render
     end

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "groups/index", type: :view do
   end
 
   context "when the user is a super admin" do
-    let(:current_user) { build :super_admin_user }
+    let(:current_user) { create :super_admin_user }
     let(:search_input) { OrganisationSearchInput.new({ organisation_id: current_user.organisation_id }) }
     let(:organisation) { current_user.organisation }
 

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "groups/show", type: :view do
   let(:current_user) { create :user, :org_has_signed_mou }
   let(:forms) { [] }
-  let(:group) { create :group, name: "My Group" }
+  let(:group) { create :group, name: "My Group", organisation: current_user.organisation }
 
   let(:form_list_presenter) { FormListPresenter.call(forms:, group:) }
 
@@ -150,7 +150,7 @@ RSpec.describe "groups/show", type: :view do
   end
 
   context "when the group is a trial group" do
-    let(:group) { create :group, :trial, name: "trial group" }
+    let(:group) { create :group, :trial, name: "trial group", organisation: current_user.organisation }
 
     it "renders the status of the group" do
       expect(rendered).to have_css ".govuk-caption-l", text: t("groups.status_caption.trial")
@@ -354,7 +354,7 @@ RSpec.describe "groups/show", type: :view do
   end
 
   context "when the group has an upgrade requested" do
-    let(:group) { create :group, :upgrade_requested }
+    let(:group) { create :group, :upgrade_requested, organisation: current_user.organisation }
 
     it "have the caption trial group" do
       expect(rendered).to have_css ".govuk-caption-l", text: "Trial group"
@@ -370,7 +370,7 @@ RSpec.describe "groups/show", type: :view do
   end
 
   context "when the group is an active group" do
-    let(:group) { create :group, :active, name: "Active group" }
+    let(:group) { create :group, :active, name: "Active group", organisation: current_user.organisation }
 
     it "renders the status of the group" do
       expect(rendered).to have_css ".govuk-caption-l", text: t("groups.status_caption.active")

--- a/spec/views/mou_signatures/index.html.erb_spec.rb
+++ b/spec/views/mou_signatures/index.html.erb_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "mou_signatures/index.html.erb" do
   let(:mou_signatures) do
     [
-      build(:mou_signature, agreement_type: :crown, created_at: Time.zone.parse("October 12, 2023")),
-      build(:mou_signature, agreement_type: :non_crown, created_at: Time.zone.parse("October 13, 2023")),
+      build(:mou_signature, user: build_stubbed(:user), agreement_type: :crown, created_at: Time.zone.parse("October 12, 2023")),
+      build(:mou_signature, user: build_stubbed(:user), agreement_type: :non_crown, created_at: Time.zone.parse("October 13, 2023")),
     ]
   end
 


### PR DESCRIPTION
### Improvements to our test Factories

Trello card: https://trello.com/c/L37Bdby6/260-improve-the-tests-in-forms-admin

Our FactoryBot tests have become a bit tangled. I'm trying to uncouple them a bit and stop using the database when it's not needed and stop hardcoding database ids, which, I think, causes reliability problems when tests are run in certain orders or at the same time.

This PR tackles some of the issues which stop us using build, which doesn't use the database instead of create. It doesn't switch any tests yet, it's just preparing the groundwork.

One of the biggest issues is how we treat organisations. I've tried to keep the commits small but one commit makes small changes to a lot of specs which relied on orgs being the same.

You can use the rails console to test the factories with `Factorybot.create` or `FactoryBot.build` enabling SQL logging is also useful:

```
ActiveRecord::Base.logger = Logger.new(STDOUT)
ActiveRecord::LogSubscriber.attach_to :active_record
```

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
