### PR TITLE
Show result counts on the users list page

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -72,6 +72,14 @@
     <p><%= govuk_link_to t('users.index.download_all'), download_users_path, no_visited_state: true %></p>
   <% end %>
 
+  <p class="govuk-body">
+    <% if @pagy.pages > 1 %>
+      <%= t("users.index.showing_count", from: @pagy.from, to: @pagy.to, count: @pagy.count) %>
+    <% else %>
+      <%= t("users.index.user_count", count: @pagy.count) %>
+    <% end %>
+  </p>
+
   <%= govuk_pagination(pagy: @pagy) %>
 
   <%= render ScrollingWrapperComponent::View.new(aria_label: t("users.index.wrapper_aria_label")) do |table| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2348,6 +2348,7 @@ en:
         submit: Filter
       name_blank: No name set
       organisation_blank: No organisation set
+      showing_count: Showing %{from} to %{to} of %{count} users
       table_headings:
         access: Access
         act_as_user: Act as user
@@ -2357,6 +2358,9 @@ en:
         role: Role
         signon_organisation: Signon organisation slug
       title: Users
+      user_count:
+        one: Showing 1 user
+        other: Showing %{count} users
       wrapper_aria_label: Users
     roles:
       all: All roles

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -9,6 +9,7 @@ describe "users/index.html.erb" do
   end
   let(:filter_input) { Users::FilterInput.new }
   let(:filtered_download_path) { Faker::Internet.url }
+  let(:pagy) { Pagy.new(count: users.size, page: 1, limit: 50) }
 
   before do
     allow(Settings).to receive(:act_as_user_enabled).and_return(act_as_user_enabled)
@@ -20,6 +21,7 @@ describe "users/index.html.erb" do
     assign(:users, users)
     assign(:filter_input, filter_input)
     assign(:filtered_download_path, filtered_download_path)
+    assign(:pagy, pagy)
     render template: "users/index"
   end
 
@@ -29,6 +31,18 @@ describe "users/index.html.erb" do
 
   it "contains a scrollable wrapper with a table in it" do
     expect(rendered).to have_css(".app-scrolling-wrapper > table")
+  end
+
+  it "contains the total number of users" do
+    expect(rendered).to have_css("p", text: "Showing 3 users")
+  end
+
+  context "when the users span multiple pages" do
+    let(:pagy) { Pagy.new(count: 120, page: 1, limit: 50) }
+
+    it "shows how many users are on this page out of the total" do
+      expect(rendered).to have_css("p", text: "Showing 1 to 50 of 120 users")
+    end
   end
 
   it "contains the user's name" do


### PR DESCRIPTION
This adds a count above the table matching the one on the organisations list: "Showing x to y of n users" when the results span multiple pages, or just the total number of users when they fit on one page. (Same as organisation page)

Helpful to see total number of users, and number of users when filtered.