### PR TITLE
Fix slow options spec

### DIFF
--- a/app/input_objects/pages/selection/options_input.rb
+++ b/app/input_objects/pages/selection/options_input.rb
@@ -23,6 +23,10 @@ class Pages::Selection::OptionsInput < Pages::Selection::BaseOptionsInput
     selection_options.map { |option| OpenStruct.new(name: option[:name]) }
   end
 
+  def can_add_more_options
+    selection_options.count < maximum_options
+  end
+
 private
 
   def validate_selection_options

--- a/app/views/pages/selection/options.html.erb
+++ b/app/views/pages/selection/options.html.erb
@@ -50,7 +50,7 @@
       <% end %>
 
       <div class="govuk-!-margin-bottom-8">
-        <% if @selection_options_input.selection_options_form_objects.length < @selection_options_input.maximum_options %>
+        <% if @selection_options_input.can_add_more_options %>
           <div class="govuk-button-group">
             <%= f.govuk_submit t("selection_options.add_another"), name: :add_another, secondary: true %>
             <%= govuk_link_to t("selection_options.enter_all_options_into_textbox"), @bulk_options_url %>

--- a/spec/input_objects/pages/selection/options_input_spec.rb
+++ b/spec/input_objects/pages/selection/options_input_spec.rb
@@ -228,4 +228,46 @@ RSpec.describe Pages::Selection::OptionsInput do
   end
 
   it_behaves_like "base selection options input"
+
+  describe "#can_add_more_options" do
+    context "when only_one_option is true for the draft_question" do
+      let(:only_one_option) { "true" }
+
+      context "and there are 3000 options" do
+        let(:selection_options) { (1..3000).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
+
+        it "returns false" do
+          expect(input.can_add_more_options).to be false
+        end
+      end
+
+      context "and there are fewer than 3000 options" do
+        let(:selection_options) { (1..2999).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
+
+        it "returns false" do
+          expect(input.can_add_more_options).to be true
+        end
+      end
+    end
+
+    context "when only_one_option is false for the draft_question" do
+      let(:only_one_option) { "false" }
+
+      context "and there are 30 options" do
+        let(:selection_options) { (1..30).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
+
+        it "returns false" do
+          expect(input.can_add_more_options).to be false
+        end
+      end
+
+      context "and there are fewer than 30 options" do
+        let(:selection_options) { (1..29).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
+
+        it "returns true" do
+          expect(input.can_add_more_options).to be true
+        end
+      end
+    end
+  end
 end

--- a/spec/views/pages/selection/options.html.erb_spec.rb
+++ b/spec/views/pages/selection/options.html.erb_spec.rb
@@ -12,10 +12,13 @@ describe "pages/selection/options.html.erb", type: :view do
   let(:only_one_option) { "true" }
   let(:draft_question) { build :draft_question, answer_type: "selection", answer_settings: { only_one_option: } }
   let(:banner_content) { nil }
+  let(:can_add_more_options) { true }
+  let(:selection_options_input) { Pages::Selection::OptionsInput.new(selection_options:, include_none_of_the_above:, draft_question:) }
 
   before do
     # # mock the form.page_number method
     allow(form).to receive(:page_number).and_return(page_number)
+    allow(selection_options_input).to receive(:can_add_more_options).and_return(can_add_more_options)
 
     # # mock the path helper
     without_partial_double_verification do
@@ -28,7 +31,7 @@ describe "pages/selection/options.html.erb", type: :view do
     assign(:selection_options_path, selection_options_path)
     assign(:back_link_url, back_link_url)
     assign(:bulk_options_url, bulk_options_url)
-    assign(:selection_options_input, Pages::Selection::OptionsInput.new(selection_options:, include_none_of_the_above:, draft_question:))
+    assign(:selection_options_input, selection_options_input)
 
     render(template: "pages/selection/options")
   end
@@ -62,9 +65,7 @@ describe "pages/selection/options.html.erb", type: :view do
         expect(rendered).not_to have_text("You can add up to")
       end
 
-      context "when there are fewer than 3000 options" do
-        let(:selection_options) { (1..2999).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
-
+      context "when can add more options" do
         it "has an add another button" do
           expect(rendered).to have_button(I18n.t("selection_options.add_another"))
         end
@@ -74,8 +75,8 @@ describe "pages/selection/options.html.erb", type: :view do
         end
       end
 
-      context "when there are 3000 options" do
-        let(:selection_options) { (1..3000).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
+      context "when cannot add more options" do
+        let(:can_add_more_options) { false }
 
         it "does not have an add another button" do
           expect(rendered).not_to have_button(I18n.t("selection_options.add_another"))
@@ -111,7 +112,7 @@ describe "pages/selection/options.html.erb", type: :view do
       end
 
       context "when there are 30 options" do
-        let(:selection_options) { (1..30).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
+        let(:can_add_more_options) { false }
 
         it "does not have an add another button" do
           expect(rendered).not_to have_button(I18n.t("selection_options.add_another"))


### PR DESCRIPTION
### Rewrite very slow test

Trello card: https://trello.com/c/L37Bdby6/260-improve-the-tests-in-forms-admin

The view which let's users add options to a selection question contains a test to check how many options have been added. It uses it to decide whether to show the add button or a message explaining the limit has been reached.

The spec for this view took about 20s to run. It rendered pages with 3000 options, the maximum for single choice questions several times and checked the output to confirm the button was present.

I think there is a few ways to change this to make the test faster. I've gone for making the view simpler and moving the responsibility for checking the limit into the input object. This allows us to quickly test the behaviour in the input object and mock the object in the view test to check the correct values are displayed.

This cuts the test time to a second or so.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
