### PR TITLE
Tidy up can_add_more_options

### DIFF
--- a/app/input_objects/pages/selection/options_input.rb
+++ b/app/input_objects/pages/selection/options_input.rb
@@ -23,7 +23,7 @@ class Pages::Selection::OptionsInput < Pages::Selection::BaseOptionsInput
     selection_options.map { |option| OpenStruct.new(name: option[:name]) }
   end
 
-  def can_add_more_options
+  def can_add_more_options?
     selection_options.count < maximum_options
   end
 

--- a/app/views/pages/selection/options.html.erb
+++ b/app/views/pages/selection/options.html.erb
@@ -50,7 +50,7 @@
       <% end %>
 
       <div class="govuk-!-margin-bottom-8">
-        <% if @selection_options_input.can_add_more_options %>
+        <% if @selection_options_input.can_add_more_options? %>
           <div class="govuk-button-group">
             <%= f.govuk_submit t("selection_options.add_another"), name: :add_another, secondary: true %>
             <%= govuk_link_to t("selection_options.enter_all_options_into_textbox"), @bulk_options_url %>

--- a/spec/input_objects/pages/selection/options_input_spec.rb
+++ b/spec/input_objects/pages/selection/options_input_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Pages::Selection::OptionsInput do
       context "and there are fewer than 3000 options" do
         let(:selection_options) { (1..2999).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
 
-        it "returns false" do
+        it "returns true" do
           expect(input.can_add_more_options?).to be true
         end
       end

--- a/spec/input_objects/pages/selection/options_input_spec.rb
+++ b/spec/input_objects/pages/selection/options_input_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Pages::Selection::OptionsInput do
 
   it_behaves_like "base selection options input"
 
-  describe "#can_add_more_options" do
+  describe "#can_add_more_options?" do
     context "when only_one_option is true for the draft_question" do
       let(:only_one_option) { "true" }
 
@@ -237,7 +237,7 @@ RSpec.describe Pages::Selection::OptionsInput do
         let(:selection_options) { (1..3000).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
 
         it "returns false" do
-          expect(input.can_add_more_options).to be false
+          expect(input.can_add_more_options?).to be false
         end
       end
 
@@ -245,7 +245,7 @@ RSpec.describe Pages::Selection::OptionsInput do
         let(:selection_options) { (1..2999).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
 
         it "returns false" do
-          expect(input.can_add_more_options).to be true
+          expect(input.can_add_more_options?).to be true
         end
       end
     end
@@ -257,7 +257,7 @@ RSpec.describe Pages::Selection::OptionsInput do
         let(:selection_options) { (1..30).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
 
         it "returns false" do
-          expect(input.can_add_more_options).to be false
+          expect(input.can_add_more_options?).to be false
         end
       end
 
@@ -265,7 +265,7 @@ RSpec.describe Pages::Selection::OptionsInput do
         let(:selection_options) { (1..29).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
 
         it "returns true" do
-          expect(input.can_add_more_options).to be true
+          expect(input.can_add_more_options?).to be true
         end
       end
     end

--- a/spec/views/pages/selection/options.html.erb_spec.rb
+++ b/spec/views/pages/selection/options.html.erb_spec.rb
@@ -18,7 +18,7 @@ describe "pages/selection/options.html.erb", type: :view do
   before do
     # # mock the form.page_number method
     allow(form).to receive(:page_number).and_return(page_number)
-    allow(selection_options_input).to receive(:can_add_more_options).and_return(can_add_more_options)
+    allow(selection_options_input).to receive(:can_add_more_options?).and_return(can_add_more_options)
 
     # # mock the path helper
     without_partial_double_verification do

--- a/spec/views/pages/selection/options.html.erb_spec.rb
+++ b/spec/views/pages/selection/options.html.erb_spec.rb
@@ -99,19 +99,17 @@ describe "pages/selection/options.html.erb", type: :view do
         expect(rendered).to have_link("enter all the options into one text box", href: bulk_options_url)
       end
 
-      context "when there are fewer than 30 options" do
-        let(:selection_options) { (1..29).to_a.map { |i| OpenStruct.new(name: i.to_s) } }
-
+      context "when can add more options" do
         it "has an add another button" do
           expect(rendered).to have_button(I18n.t("selection_options.add_another"))
         end
 
-        it "has inset text stating you cannot add more options" do
+        it "does not have inset text stating you cannot add more options" do
           expect(rendered).not_to have_css(".govuk-inset-text", text: "You cannot add any more options as you have reached the maximum of 30 options.")
         end
       end
 
-      context "when there are 30 options" do
+      context "when cannot add more options" do
         let(:can_add_more_options) { false }
 
         it "does not have an add another button" do


### PR DESCRIPTION
### What problem does this pull request solve?

Follow-up tidy-ups to #2932:

- Renames `can_add_more_options` to `can_add_more_options?`, matching the predicate naming convention used by the other boolean methods on the selection options input objects.
- Fixes spec descriptions that did not match their assertions (an example saying "returns false" while expecting true, and one saying "has inset text" while asserting the opposite).
- Renames the choose-more-than-one-option view spec contexts to describe the stubbed `can_add_more_options?` value rather than option counts, matching the choose-only-one-option contexts, and removes a now-redundant 29-option setup.

### Things to consider when reviewing

- No behaviour change; the rename is mechanical and the rest is spec-only.
