### PR TITLE
Speed up test suite with test-prof profiling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,6 +135,9 @@ group :test do
   # Enable running the specs in parallel (and optionally with Spring)
   gem "parallel_rspec"
   gem "spring-prspec"
+
+  # Profiling tools for finding slow tests and factories
+  gem "test-prof", "~> 1.6"
 end
 
 gem "mobility", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -720,6 +720,7 @@ GEM
       spring (>= 0.9.1)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-prof (1.6.1)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -828,6 +829,7 @@ DEPENDENCIES
   simplecov (~> 0.22.0)
   spring-commands-rspec
   spring-prspec
+  test-prof (~> 1.6)
   tzinfo
   tzinfo-data
   uri-idna
@@ -1081,6 +1083,7 @@ CHECKSUMS
   spring-commands-rspec (1.0.4) sha256=6202e54fa4767452e3641461a83347645af478bf45dddcca9737b43af0dd1a2c
   spring-prspec (1.0.0) sha256=2933669caa026e94de5a7bd288f74775298892549fd068b4129d798a3008478f
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
+  test-prof (1.6.1) sha256=0332d9c39a7c118ed942b2db582f055d9f24964d150004ec6b964d2fa262499e
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -59,8 +59,9 @@ class Page < ApplicationRecord
       form.save_question_changes!
 
       if answer_type_changed_from_selection_only_one_option || answer_settings_changed_from_only_one_option
-        exit_pages.destroy_all
+        # conditions reference exit pages, so they must be destroyed first
         check_conditions.destroy_all
+        exit_pages.destroy_all
       end
     end
 

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe PageListComponent::View, type: :component do
     end
 
     context "when the form has multiple pages" do
-      let(:form) { create :form, :with_pages }
+      let_it_be(:form) { create :form, :with_pages }
       let(:first_page) { form.pages.first }
       let(:second_page) { form.pages.second }
 
@@ -79,7 +79,7 @@ RSpec.describe PageListComponent::View, type: :component do
       end
 
       context "when the form has conditions" do
-        let(:form) { create :form, :ready_for_routing }
+        let_it_be(:form) { create :form, :ready_for_routing }
         let(:edit_condition_path) { "/forms/0/pages/1/conditions/1" }
 
         context "when the page has a single condition" do
@@ -144,7 +144,7 @@ RSpec.describe PageListComponent::View, type: :component do
       end
 
       context "when the form has a valid branch route" do
-        let(:form) { create :form, :ready_for_routing }
+        let_it_be(:form) { create :form, :ready_for_routing }
         let!(:secondary_skip_condition) { create :condition, routing_page_id: pages.second.id, check_page_id: pages.first.id, answer_value: nil, goto_page_id: pages.fourth.id }
 
         before do
@@ -164,7 +164,7 @@ RSpec.describe PageListComponent::View, type: :component do
       end
 
       context "when the form has a branch route with an error" do
-        let(:form) { create :form, :ready_for_routing }
+        let_it_be(:form) { create :form, :ready_for_routing }
 
         before do
           create :condition, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1", goto_page_id: pages.third.id
@@ -183,7 +183,7 @@ RSpec.describe PageListComponent::View, type: :component do
   end
 
   describe "rendering component with multiple branches feature", :feature_multiple_branches do
-    let(:form) { create :form, :ready_for_routing }
+    let_it_be(:form) { create :form, :ready_for_routing }
     let(:first_page) { form.pages.first }
     let(:third_page) { form.pages.third }
     let(:fourth_page) { form.pages.fourth }
@@ -288,7 +288,7 @@ RSpec.describe PageListComponent::View, type: :component do
   end
 
   describe "class methods", feature_multiple_branches: false do
-    let(:form) { create :form, :with_pages }
+    let_it_be(:form) { create :form, :with_pages }
 
     describe "show_up_button" do
       it "returns false when index is 0" do

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -12,9 +12,7 @@ FactoryBot.define do
     exit_page_heading { nil }
     exit_page_markdown { nil }
 
-    # Define the association but we want to set it to nil by default
-    association :exit_page
-    exit_page_id { nil }
+    exit_page { nil }
 
     trait :with_exit_page do
       goto_page { nil }

--- a/spec/factories/models/memberships.rb
+++ b/spec/factories/models/memberships.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :membership do
-    user { build :user }
-    group { build :group, organisation: user&.organisation }
-    added_by { build :user, organisation: user&.organisation }
+    user { association :user }
+    group { association :group, organisation: user&.organisation, creator: user }
+    added_by { association :user, organisation: user&.organisation }
     role { :editor }
   end
 end

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe AuthenticationController, type: :request do
         expect(controller_spy).not_to have_received(:redirect_to_sign_in)
 
         # wait for the auth_valid_for time to pass
-        sleep(1)
+        travel 2.seconds
 
         get root_path
 

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe ReportsController, type: :request do
 
   shared_examples "unauthorized user is forbidden" do
     context "when the user is not a super admin" do
+      # the request is forbidden before any report data is read
+      let(:forms) { [] }
+
       before do
         login_as_standard_user
 
@@ -26,6 +29,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#index" do
     let(:path) { reports_path }
+    let(:forms) { [] }
 
     include_examples "unauthorized user is forbidden"
 
@@ -430,6 +434,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#add_another_answer" do
     let(:path) { report_add_another_answer_path }
+    let(:forms) { [] }
     let(:report_data) do
       OpenStruct.new(
         count: 3,
@@ -796,6 +801,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#contact_for_research" do
     let(:path) { report_contact_for_research_path }
+    let(:forms) { [] }
 
     include_examples "unauthorized user is forbidden"
 
@@ -815,6 +821,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#users_per_organisation" do
     let(:path) { report_users_per_organisation_path }
+    let(:forms) { [] }
 
     include_examples "unauthorized user is forbidden"
 
@@ -835,6 +842,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#organisation_domains" do
     let(:path) { report_organisation_domains_path }
+    let(:forms) { [] }
 
     include_examples "unauthorized user is forbidden"
 

--- a/spec/services/reports/feature_report_service_spec.rb
+++ b/spec/services/reports/feature_report_service_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe Reports::FeatureReportService do
           })
     end
   end
-  let(:group) { create(:group) }
+  let_it_be(:group) { create(:group) }
 
-  let(:form_with_all_answer_types) do
+  let_it_be(:form_with_all_answer_types) do
     create(:form, :live,
            :with_support,
            submission_type: "email",
@@ -41,7 +41,7 @@ RSpec.describe Reports::FeatureReportService do
              create(:page, :with_single_line_text_settings, is_repeatable: true),
            ])
   end
-  let(:form_with_a_few_answer_types) do
+  let_it_be(:form_with_a_few_answer_types) do
     create(:form,
            :live,
            submission_type: "email",
@@ -53,7 +53,7 @@ RSpec.describe Reports::FeatureReportService do
              *create_list(:page, 3, answer_type: "name"),
            ])
   end
-  let(:branch_route_form) do
+  let_it_be(:branch_route_form) do
     form = create(:form, :live, :ready_for_routing, submission_type: "s3", submission_format: %w[csv])
     create(:condition, :with_exit_page, routing_page_id: form.pages[0].id, check_page_id: form.pages[0].id, answer_value: "Option 1")
     create(:condition, routing_page_id: form.pages[1].id, check_page_id: form.pages[1].id, answer_value: "Option 1", goto_page_id: form.pages[3].id)
@@ -61,18 +61,18 @@ RSpec.describe Reports::FeatureReportService do
     form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
-  let(:basic_route_form) do
+  let_it_be(:basic_route_form) do
     form = create(:form, :live, :ready_for_routing)
     create(:condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, answer_value: "Option 1", skip_to_end: true)
     form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
-  let(:copied_form) do
+  let_it_be(:copied_form) do
     original_form = create(:form, :live, pages: [])
     form = create(:form, :live, copied_from_id: original_form.id, pages: [])
     form
   end
-  let(:form_with_a_welsh_translation) do
+  let_it_be(:form_with_a_welsh_translation) do
     form = create(:form, :live, welsh_completed: true, pages: [])
     form
   end

--- a/spec/services/reports/form_documents_service_spec.rb
+++ b/spec/services/reports/form_documents_service_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Reports::FormDocumentsService do
-  let(:form_with_no_routes) { create(:form, :live) }
-  let(:draft_form) { create(:form) }
-  let(:archived_form) { create(:form, :archived) }
-  let(:live_with_draft_form) { create(:form, :live_with_draft) }
-  let(:archived_with_draft_form) { create(:form, :archived_with_draft) }
-  let(:draft_internal_organisation_form) { create :form }
-  let(:live_internal_organisation_form) { create :form }
-  let(:form_with_welsh_translation) { create :form, welsh_completed: true }
-  let(:branch_route_form) do
+  let_it_be(:form_with_no_routes) { create(:form, :live) }
+  let_it_be(:draft_form) { create(:form) }
+  let_it_be(:archived_form) { create(:form, :archived) }
+  let_it_be(:live_with_draft_form) { create(:form, :live_with_draft) }
+  let_it_be(:archived_with_draft_form) { create(:form, :archived_with_draft) }
+  let_it_be(:draft_internal_organisation_form) { create :form }
+  let_it_be(:live_internal_organisation_form) { create :form }
+  let_it_be(:form_with_welsh_translation) { create :form, welsh_completed: true }
+  let_it_be(:branch_route_form) do
     form = create(:form, :live, :ready_for_routing)
     create(:condition, :with_exit_page, routing_page_id: form.pages[0].id, check_page_id: form.pages[0].id, answer_value: "Option 1")
     create(:condition, routing_page_id: form.pages[1].id, check_page_id: form.pages[1].id, answer_value: "Option 1", goto_page_id: form.pages[3].id)
@@ -18,14 +18,14 @@ RSpec.describe Reports::FormDocumentsService do
     form
   end
 
-  let(:basic_route_form) do
+  let_it_be(:basic_route_form) do
     form = create(:form, :live, :ready_for_routing)
     create(:condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, answer_value: "Option 1", skip_to_end: true)
     form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
 
-  let(:form_with_2_branch_routes) do
+  let_it_be(:form_with_2_branch_routes) do
     form = create(:form, :live, :ready_for_routing, pages_count: 10)
     create(:condition, routing_page_id: form.pages[1].id, check_page_id: form.pages[1].id, answer_value: "Option 1", goto_page_id: form.pages[3].id)
     create(:condition, routing_page_id: form.pages[2].id, check_page_id: form.pages[1].id, answer_value: "Option 2", goto_page_id: form.pages[4].id)
@@ -36,10 +36,10 @@ RSpec.describe Reports::FormDocumentsService do
   end
 
   describe "#form_documents" do
-    let(:organisation) { create :organisation, internal: false, slug: "hm-revenue-customs" }
-    let(:internal_organisation) { create :organisation, internal: true, slug: "internal-org" }
-    let(:group) { create :group, organisation: }
-    let(:internal_group) { create :group, organisation: internal_organisation }
+    let_it_be(:organisation) { create :organisation, internal: false, slug: "hm-revenue-customs" }
+    let_it_be(:internal_organisation) { create :organisation, internal: true, slug: "internal-org" }
+    let_it_be(:group) { create :group, organisation: }
+    let_it_be(:internal_group) { create :group, organisation: internal_organisation }
 
     before do
       group.group_forms.create!(form: form_with_no_routes)

--- a/spec/services/reports/questions_csv_report_service_spec.rb
+++ b/spec/services/reports/questions_csv_report_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Reports::QuestionsCsvReportService do
           })
     end
   end
-  let(:form_with_all_answer_types) do
+  let_it_be(:form_with_all_answer_types) do
     create(:form, :live, :with_support, submission_type: "email", payment_url: "https://www.gov.uk/payments/organisation/service", pages: [
       create(:page, :with_address_settings, is_repeatable: true),
       create(:page, :with_date_settings),
@@ -36,7 +36,7 @@ RSpec.describe Reports::QuestionsCsvReportService do
       create(:page, :with_single_line_text_settings, is_repeatable: true),
     ])
   end
-  let(:branch_route_form) do
+  let_it_be(:branch_route_form) do
     form = create(:form, :live, :ready_for_routing)
     create(:condition, :with_exit_page, routing_page_id: form.pages[0].id, check_page_id: form.pages[0].id, answer_value: "Option 1")
     create(:condition, routing_page_id: form.pages[1].id, check_page_id: form.pages[1].id, answer_value: "Option 1", goto_page_id: form.pages[3].id)
@@ -44,7 +44,7 @@ RSpec.describe Reports::QuestionsCsvReportService do
     form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
-  let(:basic_route_form) do
+  let_it_be(:basic_route_form) do
     form = create(:form, :live, :ready_for_routing)
     create(:condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, answer_value: "Option 1", skip_to_end: true)
     form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))

--- a/spec/support/test_prof.rb
+++ b/spec/support/test_prof.rb
@@ -1,0 +1,13 @@
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
+TestProf::LetItBe.configure do |config|
+  # Refind each record per example so in-memory mutation can't leak between examples
+  config.default_modifiers[:refind] = true
+end
+
+TestProf::FactoryDefault.configure do |config|
+  # Don't substitute the default record when traits or attribute overrides are given
+  config.preserve_traits = true
+  config.preserve_attributes = true
+end


### PR DESCRIPTION
## What

Profiles the RSpec suite with [test-prof](https://test-prof.evilmartians.io/) and fixes the hotspots it found. No parallelisation.

- Add test-prof with `let_it_be` (refind per example) and FactoryDefault config
- Replace a real 1-second `sleep` with `travel` in the authentication request spec
- Stop the membership factory creating a stray third user as group creator (6 → 5 records per membership)
- Stop the condition factory creating an orphaned exit page (+ question page + form) on every `create(:condition)` — 768 wasted exit pages per suite run. The factory's `exit_page_id { nil }` was also silently discarding explicit `exit_page:` overrides, so specs that linked a condition to an exit page never really did
- Fix a latent bug that exposed: `Page#save_and_update_form` destroyed exit pages before the conditions referencing them, which violates the foreign key once conditions genuinely reference exit pages (`app/models/page.rb`)
- Convert read-only fixtures in the hottest profiled specs to `let_it_be`, and stop the reports controller spec creating four live forms for examples that never read them

## Numbers (full suite, feature specs excluded, same machine)

| Metric | Before | After |
|---|---|---|
| Factory records created | 18,243 | 15,109 |
| Time in `factory.create` | 3m 01s | 2m 43s |
| exit_page creates | 768 | 17 |
| condition factory time | 20.3s | 5.5s |
| Reports::FeatureReportService spec | 14.1s (612 creates) | 5.8s (33 creates) |

Worst-offender spec files (per EVENT_PROF):
- feature_report_service_spec: 612 → 33 creates
- reports_controller_spec: 344 → 279 creates
- form_documents_service_spec: 125 → 32 creates
- questions_csv_report_service_spec: 96 → 16 creates
- page_list_component/view_spec: 108 → 74 creates

## Notes

- Local wall-clock timings are noisy because `config/vite.json` sets `autoBuild: true` in test: the first browser-driving spec pays a full vite build when the cache is stale (observed 6–8 minutes in `organisation_autocomplete_spec.rb`; 11 seconds warm). Running `bin/vite build` first avoids this locally; CI already does.
- Converted specs were run with multiple random-order seeds to check for `let_it_be` state leakage.
- Profilers for future use: `FPROF=1`, `EVENT_PROF=factory.create`, `TAG_PROF=type`, `FDOC=1` with any rspec command.