### PR TITLE
Add API endpoint for fetching a brand

### DIFF
--- a/app/controllers/api/brands_controller.rb
+++ b/app/controllers/api/brands_controller.rb
@@ -1,0 +1,12 @@
+class Api::BrandsController < ApplicationController
+  def show
+    expires_in 5.minutes, public: true
+    render json: brand.as_json(only: %i[name slug])
+  end
+
+private
+
+  def brand
+    Brand.find_by!(id: params[:brand_id])
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,6 +299,8 @@ Rails.application.routes.draw do
       get "/:tag", to: "api/form_documents#show", as: :form_document, constraints: { tag: /draft|live|archived/ }
       get "/group", to: "api/form_documents#group", as: :form_group
     end
+
+    get "brands/:brand_id", to: "api/brands#show", as: :brand
   end
 
   get "/maintenance" => "errors#maintenance", as: :maintenance_page

--- a/spec/requests/api/brands_controller_spec.rb
+++ b/spec/requests/api/brands_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Api::BrandsController, type: :request do
+  let(:headers) { { "ACCEPT": "application/json" } }
+
+  describe "#show" do
+    context "when the brand exists" do
+      let(:brand) { create :brand, name: "Golden Zephyr", slug: "golden-zephyr" }
+
+      before do
+        get "/api/v2/brands/#{brand.id}", headers:
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the brand configuration" do
+        expect(response.parsed_body).to eq({
+          "name" => "Golden Zephyr",
+          "slug" => "golden-zephyr",
+        })
+      end
+
+      it "sets the response to be cached for 5 minutes" do
+        expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
+      end
+    end
+
+    context "when the brand does not exist" do
+      before do
+        get "/api/v2/brands/0", headers:
+      end
+
+      it "returns http not found" do
+        expect(response).to have_http_status(:not_found)
+        expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?
Forms include a `brand_id` in the form document sent to forms-runner, but there was no way for the runner to fetch the details of the brand it refers to.

This adds a `GET /api/v2/brands/:brand_id` endpoint that returns the brand as a JSON resource. At the moment a brand only has a name and a slug, so that is all the response contains, but future brand configuration such as header colours and logo images can be added to the response as it is built.

This would let us build a UI to configure brands.

The response is served with a `Cache-Control: max-age=300, public` header so it can be cached for 5 minutes. Note that forms-runner's ActiveResource client doesn't honour cache headers by itself, so for the runner to benefit it will need its own client-side caching as part of the work to consume this endpoint.