### PR TITLE
Replace sleep with time travel in auth spec

### DIFF
--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe AuthenticationController, type: :request do
         expect(controller_spy).not_to have_received(:redirect_to_sign_in)
 
         # wait for the auth_valid_for time to pass
-        sleep(1)
+        travel 2.seconds
 
         get root_path
 


### PR DESCRIPTION
Waiting a real second for the stubbed `auth_valid_for` period to elapse added a second to every suite run; travelling the test clock forward tests the same expiry comparison instantly.