### PR TITLE
Remove order of routing conditions in live view

### DIFF
--- a/app/services/step_summary_card_service.rb
+++ b/app/services/step_summary_card_service.rb
@@ -199,8 +199,7 @@ private
     if @step.routing_conditions.length == 1
       print_route(@step.routing_conditions.first)
     else
-      ordered_conditions = ordered_routing_conditions(@step.routing_conditions)
-      html_ordered_list(ordered_conditions.map { |condition| print_route(condition) })
+      html_ordered_list(@step.routing_conditions.map { |condition| print_route(condition) })
     end
   end
 
@@ -296,10 +295,5 @@ private
       sorted_condition_group = condition_group.in_order_of(:answer_value, answer_order, filter: false)
       [goto_page_position, sorted_condition_group]
     }.sort_by { |goto_page_position, _| goto_page_position || Float::INFINITY }
-  end
-
-  def ordered_routing_conditions(conditions)
-    answer_order = @step.answer_settings.selection_options.map(&:value) || []
-    conditions.sort_by { |condition| answer_order.index(condition.answer_value) || Float::INFINITY }
   end
 end

--- a/spec/services/step_summary_card_service_spec.rb
+++ b/spec/services/step_summary_card_service_spec.rb
@@ -337,7 +337,7 @@ describe StepSummaryCardService do
           form.reload.make_live!
         end
 
-        it "returns the correct options" do
+        it "returns the correct options", :flaky do
           first_condition_text = I18n.t("page_conditions.condition_compact_html", answer_value: "Option 1", goto_page_question_number: first_goto_page.position, goto_page_question_text: first_goto_page.question_text)
           second_condition_text = I18n.t("page_conditions.condition_compact_html", answer_value: "Option 2", goto_page_question_number: second_goto_page.position, goto_page_question_text: second_goto_page.question_text)
 


### PR DESCRIPTION
I tried to fix a flaky test be making the live view order the routing conditions under a question. I used the same logic we use to order conditions for multiple branches.

This broke the live question view for forms with multiple secondary skips on the same page. These pages have multiple routing conditions but the page won't have selection options, which caused multiple errors in the alerts channel.

This commit abandons the change, reverting to how the file was before I made the change. It also marks the test as flaky once again.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
