### PR TITLE
Add rake task to retrieve live and draft for docs

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -174,6 +174,24 @@ namespace :forms do
       Rails.logger.info "Form #{form.id} (\"#{form.name}\") created by #{creator&.name || 'No creator'} with organisation #{creator&.organisation&.name || 'N/A'}"
     end
   end
+
+  desc "Show a form's form_document as JSON"
+  task :show_form_document, %i[form_id tag language] => :environment do |_, args|
+    usage_message = "usage: rake forms:show_form_document[<form_id>, <tag>, <language>]".freeze
+
+    abort usage_message if args[:form_id].blank? || args[:tag].blank?
+    language = args[:language].presence || "en"
+
+    abort "tag must be one of draft, live or archived" unless %w[draft live archived].include?(args[:tag])
+    abort "language must be en or cy" unless %w[en cy].include?(language)
+
+    form = Form.find(args[:form_id])
+
+    form_document = form.form_documents.find_by(tag: args[:tag], language:)
+    abort "#{fmt_form(form)} does not have a #{args[:tag]} #{language} form document" if form_document.blank?
+
+    puts JSON.pretty_generate(form_document.as_json)
+  end
 end
 
 def move_forms(form_ids, group_id)

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -807,4 +807,59 @@ RSpec.describe "forms.rake", type: :task do
       end
     end
   end
+
+  describe "forms:show_form_document" do
+    subject(:task) do
+      Rake::Task["forms:show_form_document"]
+    end
+
+    let(:form) { create(:form) }
+
+    it "prints the requested form document as JSON" do
+      expect { task.invoke(form.id, "draft", "en") }
+        .to output(/"id": #{form.draft_form_document.id}/).to_stdout
+    end
+
+    it "prints the requested English form document when no language is given" do
+      expect { task.invoke(form.id, "draft") }
+        .to output(/"id": #{form.draft_form_document.id}/).to_stdout
+    end
+
+    it "aborts with a usage message when arguments are missing" do
+      expect {
+        task.invoke(form.id)
+      }.to raise_error(SystemExit)
+         .and output(/usage: rake forms:show_form_document\[<form_id>, <tag>, <language>\]/).to_stderr
+    end
+
+    it "aborts when the tag is invalid" do
+      expect {
+        task.invoke(form.id, "invalid", "en")
+      }.to raise_error(SystemExit)
+         .and output(/tag must be one of draft, live or archived/).to_stderr
+    end
+
+    it "aborts when the language is invalid" do
+      expect {
+        task.invoke(form.id, "draft", "invalid")
+      }.to raise_error(SystemExit)
+         .and output(/language must be en or cy/).to_stderr
+    end
+
+    it "aborts when the requested form document is missing" do
+      expect {
+        task.invoke(form.id, "draft", "cy")
+      }.to raise_error(SystemExit)
+         .and output(/form #{form.id} \("#{form.name}"\) does not have a draft cy form document/).to_stderr
+    end
+
+    context "when a form has a Welsh translation" do
+      let(:form) { create(:form, :with_welsh_translation) }
+
+      it "prints the requested form document as JSON" do
+        expect { task.invoke(form.id, "draft", "cy") }
+          .to output(/"id": #{form.draft_welsh_form_document.id}/).to_stdout
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

As part of investigating issues with a draft form document, this task will make it easier to compare the form's current state in the db. I've kept this as a task under the `forms` namespace as it's easy to work out a form's ID, and get the form documents for that form using it. 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
