### PR TITLE
Add unique index to delivery_configurations and add DeliveryConfigurations for seeds

### DIFF
--- a/db/migrate/20260716171610_add_unique_index_to_delivery_configurations.rb
+++ b/db/migrate/20260716171610_add_unique_index_to_delivery_configurations.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToDeliveryConfigurations < ActiveRecord::Migration[8.1]
+  def change
+    add_index :delivery_configurations, %i[form_id delivery_method delivery_schedule], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_15_095436) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_16_171610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_095436) do
     t.bigint "form_id", null: false
     t.string "formats", default: [], null: false, array: true
     t.datetime "updated_at", null: false
+    t.index ["form_id", "delivery_method", "delivery_schedule"], name: "idx_on_form_id_delivery_method_delivery_schedule_be17307eef", unique: true
     t.index ["form_id"], name: "index_delivery_configurations_on_form_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -228,6 +228,13 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     support_phone: "08000800",
     what_happens_next_markdown: "Test",
     share_preview_completed: true,
+    delivery_configurations: [
+      DeliveryConfiguration.create(
+        delivery_method: :email,
+        delivery_schedule: :immediate,
+        formats: [],
+      ),
+    ],
   )
   all_question_types_form.set_task_status_service(TaskStatusService.new(form: all_question_types_form, current_user: craig))
   all_question_types_form.make_live!
@@ -258,6 +265,13 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     s3_bucket_region: "eu-west-2",
     s3_bucket_name: "govuk-forms-submissions-to-s3-test",
     s3_bucket_aws_account_id: "711966560482",
+    delivery_configurations: [
+      DeliveryConfiguration.create(
+        delivery_method: :s3,
+        delivery_schedule: :immediate,
+        formats: [],
+      ),
+    ],
   )
   e2e_s3_forms.set_task_status_service(TaskStatusService.new(form: e2e_s3_forms, current_user: craig))
   e2e_s3_forms.make_live!
@@ -333,6 +347,13 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     support_phone: "08000800",
     what_happens_next_markdown: "Test",
     share_preview_completed: true,
+    delivery_configurations: [
+      DeliveryConfiguration.create(
+        delivery_method: :email,
+        delivery_schedule: :immediate,
+        formats: [],
+      ),
+    ],
   )
   Condition.create!(
     check_page: branch_route_form.pages.second,
@@ -406,6 +427,13 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     support_phone: "08000800",
     what_happens_next_markdown: "Test",
     share_preview_completed: true,
+    delivery_configurations: [
+      DeliveryConfiguration.create(
+        delivery_method: :email,
+        delivery_schedule: :immediate,
+        formats: [],
+      ),
+    ],
   )
   none_of_the_above_form.set_task_status_service(TaskStatusService.new(form: none_of_the_above_form, current_user: craig))
   none_of_the_above_form.make_live!
@@ -475,6 +503,13 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     share_preview_completed: true,
     available_languages: %w[en cy],
     welsh_completed: true,
+    delivery_configurations: [
+      DeliveryConfiguration.create(
+        delivery_method: :email,
+        delivery_schedule: :immediate,
+        formats: [],
+      ),
+    ],
   )
 
   welsh_form.set_task_status_service(TaskStatusService.new(form: welsh_form, current_user: craig))
@@ -544,6 +579,13 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     support_phone: "08000800",
     what_happens_next_markdown: "Test",
     share_preview_completed: true,
+    delivery_configurations: [
+      DeliveryConfiguration.create(
+        delivery_method: :email,
+        delivery_schedule: :immediate,
+        formats: [],
+      ),
+    ],
   )
   Condition.create!(
     check_page: multiple_branch_form.pages[0],
@@ -613,6 +655,13 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     what_happens_next_markdown: "Test",
     share_preview_completed: true,
     send_copy_of_answers: "enabled",
+    delivery_configurations: [
+      DeliveryConfiguration.create(
+        delivery_method: :email,
+        delivery_schedule: :immediate,
+        formats: [],
+      ),
+    ],
   )
   copy_of_answers_form.set_task_status_service(TaskStatusService.new(form: multiple_branch_form, current_user: craig))
   copy_of_answers_form.make_live!


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WMnjLlJV/

There can only be one delivery configuration per form with the same delivery_method and delivery_schedule. Add a unique index to enforce this at the database level.

Also add DeliveryConfigurations for the seed forms.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
