### PR TITLE
Use DeliveryConfigurations instead of old form attributes

### DIFF
--- a/app/controllers/forms/batch_submissions_controller.rb
+++ b/app/controllers/forms/batch_submissions_controller.rb
@@ -10,7 +10,8 @@ module Forms
       @batch_submissions_input = Forms::BatchSubmissionsInput.new(batch_submissions_input_params)
 
       if @batch_submissions_input.submit
-        redirect_to form_path(current_form.id), success: success_message(current_form)
+        success_message = success_message(@batch_submissions_input.batch_frequencies, @batch_submissions_input.delivery_configurations_changed?)
+        redirect_to form_path(current_form.id), success: success_message
       else
         render :new, status: :unprocessable_content
       end
@@ -22,14 +23,16 @@ module Forms
       params.require(:forms_batch_submissions_input).permit(batch_frequencies: []).merge(form: current_form)
     end
 
-    def success_message(form)
-      return nil unless form.send_daily_submission_batch_previously_changed? || form.send_weekly_submission_batch_previously_changed?
+    def success_message(batch_frequencies, delivery_configurations_changed)
+      return nil unless delivery_configurations_changed
 
-      if form.send_daily_submission_batch && form.send_weekly_submission_batch
+      batch_frequencies = Array(batch_frequencies)
+
+      if batch_frequencies.include?("daily") && batch_frequencies.include?("weekly")
         t("banner.success.form.batch_submissions.daily_and_weekly_enabled")
-      elsif form.send_daily_submission_batch
+      elsif batch_frequencies.include?("daily")
         t("banner.success.form.batch_submissions.daily_enabled")
-      elsif form.send_weekly_submission_batch
+      elsif batch_frequencies.include?("weekly")
         t("banner.success.form.batch_submissions.weekly_enabled")
       else
         t("banner.success.form.batch_submissions.disabled")

--- a/app/controllers/forms/submission_attachments_controller.rb
+++ b/app/controllers/forms/submission_attachments_controller.rb
@@ -1,6 +1,6 @@
 module Forms
   class SubmissionAttachmentsController < FormsController
-    before_action :submission_type_email?
+    before_action :has_email_delivery_configuration?
 
     def new
       authorize current_form, :can_view_form?
@@ -24,14 +24,14 @@ module Forms
       params.require(:forms_submission_attachments_input).permit(submission_format: []).merge(form: current_form)
     end
 
-    def submission_type_email?
-      redirect_to error_404_path unless current_form.email?
+    def has_email_delivery_configuration?
+      redirect_to error_404_path if current_form.immediate_email_delivery_configuration.blank?
     end
 
     def success_message(form)
-      return nil unless form.submission_format_previously_changed?
+      return nil unless form.immediate_email_delivery_configuration.formats_previously_changed?
 
-      case form.submission_format
+      case form.immediate_email_delivery_configuration.formats
       when []
         t("banner.success.form.receive_no_attachments")
       when %w[csv]

--- a/app/input_objects/forms/batch_submissions_input.rb
+++ b/app/input_objects/forms/batch_submissions_input.rb
@@ -2,10 +2,8 @@ class Forms::BatchSubmissionsInput < BaseInput
   attr_accessor :form, :batch_frequencies
 
   def submit
+    @delivery_configurations_before = batch_delivery_configuration_snapshot
     selected_frequencies = Array(batch_frequencies)
-
-    form.send_daily_submission_batch = selected_frequencies.include?("daily")
-    form.send_weekly_submission_batch = selected_frequencies.include?("weekly")
 
     %w[daily weekly].each do |frequency|
       if selected_frequencies.include?(frequency)
@@ -19,10 +17,23 @@ class Forms::BatchSubmissionsInput < BaseInput
     form.save_draft!
   end
 
+  def delivery_configurations_changed?
+    @delivery_configurations_before != batch_delivery_configuration_snapshot
+  end
+
   def assign_form_values
     self.batch_frequencies ||= []
-    self.batch_frequencies << "daily" if form.send_daily_submission_batch
-    self.batch_frequencies << "weekly" if form.send_weekly_submission_batch
+    self.batch_frequencies << "daily" if form.delivery_configurations.daily.any?
+    self.batch_frequencies << "weekly" if form.delivery_configurations.weekly.any?
     self
+  end
+
+private
+
+  def batch_delivery_configuration_snapshot
+    form.delivery_configurations
+      .where(delivery_method: "email", delivery_schedule: %w[daily weekly])
+      .pluck(:delivery_method, :delivery_schedule, :formats)
+      .sort
   end
 end

--- a/app/input_objects/forms/submission_attachments_input.rb
+++ b/app/input_objects/forms/submission_attachments_input.rb
@@ -9,11 +9,10 @@ class Forms::SubmissionAttachmentsInput < BaseInput
   def submit
     return false if invalid?
 
-    formats = submission_format.compact_blank
-    form.submission_format = formats
+    delivery_configuration = form.immediate_email_delivery_configuration
+    raise NotFoundError if delivery_configuration.nil?
 
-    delivery_configuration = form.delivery_configurations.where(delivery_method: "email", delivery_schedule: "immediate").first_or_initialize
-    delivery_configuration.formats = formats
+    delivery_configuration.formats = submission_format.compact_blank
     delivery_configuration.save!
     form.delivery_configurations.reload
 
@@ -21,7 +20,7 @@ class Forms::SubmissionAttachmentsInput < BaseInput
   end
 
   def assign_form_values
-    self.submission_format = form.submission_format
+    self.submission_format = form.immediate_email_delivery_configuration&.formats || []
     self
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -18,6 +18,7 @@ class Form < ApplicationRecord
   has_one :draft_form_document, -> { where tag: "draft", language: :en }, class_name: "FormDocument"
   has_many :conditions, through: :pages, source: :routing_conditions
   has_many :delivery_configurations, dependent: :destroy
+  has_one :immediate_email_delivery_configuration, -> { where delivery_method: "email", delivery_schedule: "immediate" }, class_name: "DeliveryConfiguration"
 
   translates :name,
              :privacy_policy_url,

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -244,6 +244,10 @@ class Form < ApplicationRecord
     true
   end
 
+  def only_s3_delivery_enabled?
+    delivery_configurations.immediate.one? && delivery_configurations.immediate.first.delivery_method == "s3"
+  end
+
 private
 
   def set_external_id

--- a/app/models/form_document/content.rb
+++ b/app/models/form_document/content.rb
@@ -34,6 +34,7 @@ class FormDocument::Content
   attribute :send_daily_submission_batch, :boolean
   attribute :send_weekly_submission_batch, :boolean
   attribute :send_copy_of_answers, :string
+  attribute :delivery_configurations, array: true
 
   alias_attribute :id, :form_id
 
@@ -53,5 +54,27 @@ class FormDocument::Content
 
   def has_welsh_translation?
     available_languages.present? && available_languages.include?("cy")
+  end
+
+  def has_email_delivery?
+    email_delivery_configuration.present?
+  end
+
+  def email_delivery_configuration
+    delivery_configurations.find do |delivery_configuration|
+      delivery_configuration["delivery_method"] == "email" && delivery_configuration["delivery_schedule"] == "immediate"
+    end
+  end
+
+  def daily_submission_batch_enabled?
+    delivery_configurations.any? do |delivery_configuration|
+      delivery_configuration["delivery_schedule"] == "daily"
+    end
+  end
+
+  def weekly_submission_batch_enabled?
+    delivery_configurations.any? do |delivery_configuration|
+      delivery_configuration["delivery_schedule"] == "weekly"
+    end
   end
 end

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -97,7 +97,7 @@ private
 
   def how_you_get_completed_forms_optional_subsection
     rows = []
-    rows << submission_attachments_task if @form.email?
+    rows << submission_attachments_task unless @form.only_s3_delivery_enabled?
     rows << batch_submissions_task
 
     return nil if rows.empty?
@@ -115,6 +115,7 @@ private
       task_name: I18n.t("forms.task_list_#{create_or_edit}.how_you_get_completed_forms_section.optional_subsection.submission_attachments"),
       path: submission_attachments_path(@form.id),
       status: @task_statuses[:submission_attachments_status],
+      active: @task_statuses[:submission_attachments_status] != :cannot_start,
     }
   end
 

--- a/app/services/reports/form_documents_service.rb
+++ b/app/services/reports/form_documents_service.rb
@@ -41,23 +41,31 @@ class Reports::FormDocumentsService
     end
 
     def has_csv_submission_email_attachments(form_document)
-      form_document["content"]["submission_type"] == "email" && form_document["content"]["submission_format"].include?("csv")
+      form_document["content"]["delivery_configurations"].any? do |delivery_configuration|
+        delivery_configuration["delivery_method"] == "email" &&
+          delivery_configuration["delivery_schedule"] == "immediate" &&
+          delivery_configuration["formats"].include?("csv")
+      end
     end
 
     def has_json_submission_email_attachments(form_document)
-      form_document["content"]["submission_type"] == "email" && form_document["content"]["submission_format"].include?("json")
+      form_document["content"]["delivery_configurations"].any? do |delivery_configuration|
+        delivery_configuration["delivery_method"] == "email" &&
+          delivery_configuration["delivery_schedule"] == "immediate" &&
+          delivery_configuration["formats"].include?("json")
+      end
     end
 
     def has_daily_submission_csv(form_document)
-      form_document["content"]["send_daily_submission_batch"]
+      form_document["content"]["delivery_configurations"].any? { |c| c["delivery_schedule"] == "daily" }
     end
 
     def has_weekly_submission_csv(form_document)
-      form_document["content"]["send_weekly_submission_batch"]
+      form_document["content"]["delivery_configurations"].any? { |c| c["delivery_schedule"] == "weekly" }
     end
 
     def has_s3_submissions(form_document)
-      form_document["content"]["submission_type"] == "s3"
+      form_document["content"]["delivery_configurations"].any? { |c| c["delivery_method"] == "s3" }
     end
 
     def has_exit_pages?(form_document)

--- a/app/services/reports/forms_csv_report_service.rb
+++ b/app/services/reports/forms_csv_report_service.rb
@@ -25,8 +25,7 @@ class Reports::FormsCsvReportService
     "Support phone",
     "Privacy policy URL",
     "What happens next markdown",
-    "Submission type",
-    "Submission formats",
+    "Delivery methods",
     "Daily submissions CSV enabled",
     "Weekly submissions CSV enabled",
     "Has Welsh translation",
@@ -77,12 +76,19 @@ private
       form["content"]["support_phone"],
       form["content"]["privacy_policy_url"],
       form["content"]["what_happens_next_markdown"],
-      form["content"]["submission_type"],
-      form["content"]["submission_format"]&.sort&.join(" "),
       form["content"]["send_daily_submission_batch"],
       form["content"]["send_weekly_submission_batch"],
+      format_delivery_methods(form),
       Reports::FormDocumentsService.has_welsh_translation(form),
       Reports::FormDocumentsService.copy_of_answers_enabled?(form),
     ]
+  end
+
+  def format_delivery_methods(form)
+    form["content"]["delivery_configurations"].map { |delivery_configuration|
+      next unless delivery_configuration["delivery_schedule"] == "immediate"
+
+      "#{delivery_configuration['delivery_method']}: #{delivery_configuration['formats'].join(', ')}"
+    }.compact.join("\n")
   end
 end

--- a/app/services/reports/forms_csv_report_service.rb
+++ b/app/services/reports/forms_csv_report_service.rb
@@ -76,9 +76,9 @@ private
       form["content"]["support_phone"],
       form["content"]["privacy_policy_url"],
       form["content"]["what_happens_next_markdown"],
-      form["content"]["send_daily_submission_batch"],
-      form["content"]["send_weekly_submission_batch"],
       format_delivery_methods(form),
+      Reports::FormDocumentsService.has_daily_submission_csv(form),
+      Reports::FormDocumentsService.has_weekly_submission_csv(form),
       Reports::FormDocumentsService.has_welsh_translation(form),
       Reports::FormDocumentsService.copy_of_answers_enabled?(form),
     ]

--- a/app/services/task_status_service.rb
+++ b/app/services/task_status_service.rb
@@ -123,13 +123,15 @@ private
   end
 
   def submission_attachments_status
-    return :completed if @form.email? && @form.submission_format.any?
+    email_delivery_configuration = @form.immediate_email_delivery_configuration
+    return :cannot_start if email_delivery_configuration.nil?
+    return :completed if email_delivery_configuration.formats.any?
 
     :optional
   end
 
   def batch_submissions_status
-    return :completed if @form.send_daily_submission_batch || @form.send_weekly_submission_batch
+    return :completed if @form.delivery_configurations.daily.any? || @form.delivery_configurations.weekly.any?
 
     :optional
   end

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -150,18 +150,18 @@
     <h4 class="govuk-heading-s"><%= t('.how_you_get_completed_forms.submission_email') %></h4>
     <p class="govuk-!-text-break-word"><%= form_document.submission_email %></p>
 
-    <% if form_document.submission_type == "email" %>
-      <% submission_format = ["email", *form_document.submission_format].join("_") %>
+    <% if form_document.has_email_delivery? %>
+      <% formats = ["email", *form_document.email_delivery_configuration["formats"]].join("_") %>
       <h4 class="govuk-heading-s"><%= t(".how_you_get_completed_forms.csv_and_json") %></h4>
-      <p><%= t(".how_you_get_completed_forms.submission_format.email.#{submission_format}_html") %></p>
+      <p><%= t(".how_you_get_completed_forms.submission_format.email.#{formats}_html") %></p>
     <% end %>
 
     <h4 class="govuk-heading-s"><%= t(".how_you_get_completed_forms.batch_submissions.title") %></h4>
-    <% if form_document.send_daily_submission_batch && form_document.send_weekly_submission_batch %>
+    <% if form_document.daily_submission_batch_enabled? && form_document.weekly_submission_batch_enabled? %>
       <p><%= t(".how_you_get_completed_forms.batch_submissions.daily_and_weekly_enabled") %></p>
-    <% elsif form_document.send_daily_submission_batch %>
+    <% elsif form_document.daily_submission_batch_enabled? %>
       <p><%= t(".how_you_get_completed_forms.batch_submissions.daily_enabled") %></p>
-    <% elsif form_document.send_weekly_submission_batch %>
+    <% elsif form_document.weekly_submission_batch_enabled? %>
       <p><%= t(".how_you_get_completed_forms.batch_submissions.weekly_enabled") %></p>
     <% else %>
       <p><%= t(".how_you_get_completed_forms.batch_submissions.disabled") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,10 +84,6 @@ en:
             submission_format:
               blank: Sorry, there was a problem. Please try again.
           invalid_submission_format: Sorry, there was a problem. Please try again.
-        forms/submission_type_input:
-          attributes:
-            submission_type:
-              blank: Choose if you want to get completed forms as CSV files
         group_member_input:
           attributes:
             member_email_address:
@@ -1055,9 +1051,6 @@ en:
         submission_format_options:
           csv: Get a CSV file of each completed form
           json: Get a JSON file of each completed form
-      forms_submission_type_input:
-        submission_type_options:
-          email_with_csv: Get CSV files
       group:
         name: Enter a name for your new group
       group_member_input:
@@ -1214,8 +1207,6 @@ en:
         send_copy_of_answers: Do you want to give people the option to get a copy of their answers by email?
       forms_submission_attachments_input:
         submission_format: Do you want to get a CSV or JSON file of each completed form?
-      forms_submission_type_input:
-        submission_type: Do you want to get completed forms as CSV files?
       mou_signature:
         crown_agreed: Do you agree to the MOU?
         non_crown_agreed: Do you agree to the GOV.UK Forms agreement?

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -179,6 +179,16 @@ FactoryBot.define do
       s3_bucket_aws_account_id { "123456789012" }
       s3_bucket_region { "eu-west-1" }
     end
+
+    trait :with_email_delivery do
+      after(:create) do |form|
+        form.delivery_configurations.create!(
+          delivery_method: "email",
+          delivery_schedule: "immediate",
+          formats: [],
+        )
+      end
+    end
   end
 end
 

--- a/spec/input_objects/forms/batch_submissions_input_spec.rb
+++ b/spec/input_objects/forms/batch_submissions_input_spec.rb
@@ -15,11 +15,6 @@ RSpec.describe Forms::BatchSubmissionsInput, type: :model do
 
       before { input.submit }
 
-      it "updates the form flags" do
-        expect(form.reload.send_daily_submission_batch).to be(true)
-        expect(form.reload.send_weekly_submission_batch).to be(true)
-      end
-
       it "creates delivery configurations for both frequencies" do
         expect(form.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to contain_exactly(
           ["email", "daily", %w[csv]], ["email", "weekly", %w[csv]]
@@ -40,22 +35,23 @@ RSpec.describe Forms::BatchSubmissionsInput, type: :model do
           },
         )
       end
+
+      it "reports that the delivery configurations changed" do
+        expect(input.delivery_configurations_changed?).to be(true)
+      end
     end
 
     context "when only daily is selected and both delivery configurations already exist" do
-      let(:form) { create(:form, send_daily_submission_batch: true, send_weekly_submission_batch: true) }
+      let(:form) do
+        create(:form, delivery_configurations: [
+          create(:delivery_configuration, :daily_email),
+          create(:delivery_configuration, :weekly_email),
+        ])
+      end
       let(:batch_frequencies) { %w[daily] }
 
       before do
-        create(:delivery_configuration, :daily_email, form:)
-        create(:delivery_configuration, :weekly_email, form:)
-
         input.submit
-      end
-
-      it "updates the form flags" do
-        expect(form.reload.send_daily_submission_batch).to be(true)
-        expect(form.reload.send_weekly_submission_batch).to be(false)
       end
 
       it "keeps daily and removes weekly delivery configurations" do
@@ -73,22 +69,23 @@ RSpec.describe Forms::BatchSubmissionsInput, type: :model do
           },
         )
       end
+
+      it "reports that the delivery configurations changed" do
+        expect(input.delivery_configurations_changed?).to be(true)
+      end
     end
 
     context "when neither daily or weekly are selected" do
-      let(:form) { create(:form, send_daily_submission_batch: true, send_weekly_submission_batch: true) }
+      let(:form) do
+        create(:form, delivery_configurations: [
+          create(:delivery_configuration, :daily_email),
+          create(:delivery_configuration, :weekly_email),
+        ])
+      end
       let(:batch_frequencies) { [] }
 
       before do
-        create(:delivery_configuration, :daily_email, form:)
-        create(:delivery_configuration, :weekly_email, form:)
-
         input.submit
-      end
-
-      it "clears the form flags" do
-        expect(form.reload.send_daily_submission_batch).to be(false)
-        expect(form.reload.send_weekly_submission_batch).to be(false)
       end
 
       it "removes all batch delivery configurations" do
@@ -98,26 +95,81 @@ RSpec.describe Forms::BatchSubmissionsInput, type: :model do
       it "updates the draft form document" do
         expect(form.draft_form_document.reload.content["delivery_configurations"]).to be_empty
       end
+
+      it "reports that the delivery configurations changed" do
+        expect(input.delivery_configurations_changed?).to be(true)
+      end
+    end
+
+    context "when the selected batch frequencies match the existing delivery configurations" do
+      let(:form) do
+        create(:form, delivery_configurations: [
+          create(:delivery_configuration, :daily_email),
+        ])
+      end
+      let(:batch_frequencies) { %w[daily] }
+
+      before do
+        input.submit
+      end
+
+      it "keeps the batch delivery configurations unchanged" do
+        expect(form.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to contain_exactly(
+          ["email", "daily", %w[csv]],
+        )
+      end
+
+      it "reports that the delivery configurations did not change" do
+        expect(input.delivery_configurations_changed?).to be(false)
+      end
     end
   end
 
   describe "#assign_form_values" do
     subject(:input) { described_class.new(form:) }
 
-    [
-      [true, false, %w[daily]],
-      [false, true, %w[weekly]],
-      [true, true, %w[daily weekly]],
-      [false, false, []],
-    ].each do |send_daily_submission_batch, send_weekly_submission_batch, expected|
-      context "when send_daily_submission_batch is #{send_daily_submission_batch} and send_weekly_submission_batch is #{send_weekly_submission_batch}" do
-        let(:form) { create(:form, send_daily_submission_batch:, send_weekly_submission_batch:) }
+    context "when the form has a daily batch delivery configuration" do
+      let(:form) { create(:form, delivery_configurations: [create(:delivery_configuration, :daily_email)]) }
 
-        it "sets batch_frequencies to #{expected.inspect}" do
-          input.assign_form_values
+      it "sets batch_frequencies to daily" do
+        input.assign_form_values
 
-          expect(input.batch_frequencies).to match_array(expected)
-        end
+        expect(input.batch_frequencies).to match_array(%w[daily])
+      end
+    end
+
+    context "when the form has a weekly batch delivery configuration" do
+      let(:form) { create(:form, delivery_configurations: [create(:delivery_configuration, :weekly_email)]) }
+
+      it "sets batch_frequencies to weekly" do
+        input.assign_form_values
+
+        expect(input.batch_frequencies).to match_array(%w[weekly])
+      end
+    end
+
+    context "when the form has daily and weekly batch delivery configurations" do
+      let(:form) do
+        create(:form, delivery_configurations: [
+          create(:delivery_configuration, :daily_email),
+          create(:delivery_configuration, :weekly_email),
+        ])
+      end
+
+      it "sets batch_frequencies to daily and weekly" do
+        input.assign_form_values
+
+        expect(input.batch_frequencies).to match_array(%w[daily weekly])
+      end
+    end
+
+    context "when the form has no batch delivery configurations" do
+      let(:form) { create(:form) }
+
+      it "sets batch_frequencies to an empty array" do
+        input.assign_form_values
+
+        expect(input.batch_frequencies).to be_empty
       end
     end
   end

--- a/spec/input_objects/forms/submission_attachments_input_spec.rb
+++ b/spec/input_objects/forms/submission_attachments_input_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Forms::SubmissionAttachmentsInput, type: :model do
     context "when given a valid CSV and JSON submission format" do
       let(:submission_format) { %w[csv json] }
 
-      it "validates succesfully" do
+      it "validates successfully" do
         submission_attachments_input = described_class.new(form:, submission_format:)
 
         expect(submission_attachments_input).to be_valid
@@ -17,7 +17,7 @@ RSpec.describe Forms::SubmissionAttachmentsInput, type: :model do
     context "when given a valid no attachments submission format" do
       let(:submission_format) { [""] }
 
-      it "validates succesfully" do
+      it "validates successfully" do
         submission_attachments_input = described_class.new(form:, submission_format:)
 
         expect(submission_attachments_input).to be_valid
@@ -50,92 +50,73 @@ RSpec.describe Forms::SubmissionAttachmentsInput, type: :model do
   describe "#submit" do
     subject(:submission_attachments_input) { described_class.new(form:, submission_format: updated_submission_format) }
 
-    let(:form) { create(:form, submission_format: []) }
+    let(:form) { create(:form) }
 
     context "when valid" do
       let(:updated_submission_format) { %w[csv] }
 
-      it "updates the form's submission_format" do
-        expect {
-          submission_attachments_input.submit
-        }.to change(form, :submission_format).to(updated_submission_format)
+      context "when an immediate email DeliveryConfiguration exists" do
+        let(:immediate_delivery_configuration) { create(:delivery_configuration, form:, formats: %w[csv]) }
+        let(:daily_delivery_configuration) { create(:delivery_configuration, :daily_email, form:, formats: %w[csv]) }
+        let(:updated_submission_format) { %w[csv json] }
+
+        before do
+          immediate_delivery_configuration
+          daily_delivery_configuration
+        end
+
+        it "updates the immediate DeliveryConfiguration formats" do
+          expect {
+            submission_attachments_input.submit
+          }.to change { immediate_delivery_configuration.reload.formats }.from(%w[csv]).to(updated_submission_format)
+
+          expect(form.draft_form_document.reload.content["delivery_configurations"]).to contain_exactly(
+            {
+              "delivery_method" => "email",
+              "delivery_schedule" => "immediate",
+              "formats" => updated_submission_format,
+            },
+            {
+              "delivery_method" => "email",
+              "delivery_schedule" => "daily",
+              "formats" => %w[csv],
+            },
+          )
+        end
+
+        it "does not change the daily DeliveryConfiguration formats" do
+          expect {
+            submission_attachments_input.submit
+          }.not_to(change { daily_delivery_configuration.reload.formats })
+        end
+      end
+
+      context "when an immediate email DeliveryConfiguration does not exist" do
+        let(:s3_delivery_configuration) { create(:delivery_configuration, :s3, form:, formats: %w[csv]) }
+        let(:daily_delivery_configuration) { create(:delivery_configuration, :daily_email, form:, formats: %w[csv]) }
+        let(:updated_submission_format) { %w[csv json] }
+
+        before do
+          s3_delivery_configuration
+          daily_delivery_configuration
+        end
+
+        it "raises an error" do
+          expect {
+            submission_attachments_input.submit
+          }.to raise_error(NotFoundError)
+        end
       end
     end
 
     context "when invalid" do
       let(:updated_submission_format) { %w[banana] }
+      let(:form) { create(:form, delivery_configurations: [create(:delivery_configuration, :immediate_email)]) }
 
-      it "does not update the form's submission_format" do
+      it "does not change the formats" do
         expect {
           submission_attachments_input.submit
-        }.not_to change(form, :submission_format)
-      end
-    end
-
-    context "when an immediate email DeliveryConfiguration exists" do
-      let(:immediate_delivery_configuration) { create(:delivery_configuration, form:, formats: %w[csv]) }
-      let(:daily_delivery_configuration) { create(:delivery_configuration, :daily_email, form:, formats: %w[csv]) }
-      let(:updated_submission_format) { %w[csv json] }
-
-      before do
-        immediate_delivery_configuration
-        daily_delivery_configuration
-      end
-
-      it "updates the immediate DeliveryConfiguration formats" do
-        expect {
-          submission_attachments_input.submit
-        }.to change { immediate_delivery_configuration.reload.formats }.from(%w[csv]).to(updated_submission_format)
-
-        expect(form.draft_form_document.reload.content["delivery_configurations"]).to contain_exactly(
-          {
-            "delivery_method" => "email",
-            "delivery_schedule" => "immediate",
-            "formats" => updated_submission_format,
-          },
-          {
-            "delivery_method" => "email",
-            "delivery_schedule" => "daily",
-            "formats" => %w[csv],
-          },
-        )
-      end
-
-      it "does not change the daily DeliveryConfiguration formats" do
-        expect {
-          submission_attachments_input.submit
-        }.not_to(change { daily_delivery_configuration.reload.formats })
-      end
-    end
-
-    context "when an immediate email DeliveryConfiguration does not exist" do
-      let(:s3_delivery_configuration) { create(:delivery_configuration, :s3, form:, formats: %w[csv]) }
-      let(:daily_delivery_configuration) { create(:delivery_configuration, :daily_email, form:, formats: %w[csv]) }
-      let(:updated_submission_format) { %w[csv json] }
-
-      before do
-        s3_delivery_configuration
-        daily_delivery_configuration
-      end
-
-      it "creates an immediate email DeliveryConfiguration" do
-        expect {
-          submission_attachments_input.submit
-        }.to change(DeliveryConfiguration, :count).by(1)
-
-        expect(form.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to contain_exactly(
-          ["email", "immediate", updated_submission_format],
-          ["email", "daily", %w[csv]],
-          ["s3", "immediate", %w[csv]],
-        )
-
-        expect(form.draft_form_document.reload.content["delivery_configurations"]).to include(
-          {
-            "delivery_method" => "email",
-            "delivery_schedule" => "immediate",
-            "formats" => updated_submission_format,
-          },
-        )
+        }.not_to(change { form.delivery_configurations.first.reload.formats })
       end
     end
   end
@@ -143,8 +124,12 @@ RSpec.describe Forms::SubmissionAttachmentsInput, type: :model do
   describe "#assign_form_values" do
     subject(:submission_attachments_input) { described_class.new(form:) }
 
-    context "when the original form has an empty array submission format" do
-      let(:form) { create(:form, submission_format: []) }
+    context "when the form has no formats" do
+      let(:form) do
+        create(:form, delivery_configurations: [
+          create(:delivery_configuration, :immediate_email, formats: []),
+        ])
+      end
 
       it "sets the submission format value to an empty array" do
         submission_attachments_input.assign_form_values
@@ -153,10 +138,14 @@ RSpec.describe Forms::SubmissionAttachmentsInput, type: :model do
       end
     end
 
-    context "when the original form has a csv and json submission format" do
-      let(:form) { create(:form, submission_format: %w[csv json]) }
+    context "when the form has a csv and json submission format" do
+      let(:form) do
+        create(:form, delivery_configurations: [
+          create(:delivery_configuration, :immediate_email, formats: %w[csv json]),
+        ])
+      end
 
-      it "sets the submission format value to an empty array" do
+      it "sets the submission format value to the correct array" do
         submission_attachments_input.assign_form_values
 
         expect(submission_attachments_input.submission_format).to eq(%w[csv json])

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1015,7 +1015,7 @@ RSpec.describe Form, type: :model do
         payment_link_status: :optional,
         brand_status: :optional,
         copy_of_answers_status: :optional,
-        submission_attachments_status: :optional,
+        submission_attachments_status: :cannot_start,
         batch_submissions_status: :optional,
         support_contact_details_status: :completed,
         welsh_language_status: :optional,

--- a/spec/requests/forms/batch_submissions_controller_spec.rb
+++ b/spec/requests/forms/batch_submissions_controller_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::BatchSubmissionsController, type: :request do
-  let(:form) { create(:form, :live, send_daily_submission_batch:, send_weekly_submission_batch:) }
-  let(:send_daily_submission_batch) { false }
-  let(:send_weekly_submission_batch) { false }
+  let(:form) { create(:form, :live) }
   let(:current_user) { standard_user }
   let(:group) { create(:group, organisation: standard_user.organisation) }
 
@@ -45,8 +43,10 @@ RSpec.describe Forms::BatchSubmissionsController, type: :request do
     end
 
     it "updates the form" do
-      expect(form.reload.send_daily_submission_batch).to be true
-      expect(form.reload.send_weekly_submission_batch).to be true
+      expect(form.reload.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to contain_exactly(
+        ["email", "daily", %w[csv]],
+        ["email", "weekly", %w[csv]],
+      )
     end
 
     it "redirects to the form overview page" do
@@ -78,8 +78,12 @@ RSpec.describe Forms::BatchSubmissionsController, type: :request do
     end
 
     context "when daily and weekly batch checkboxes are unchecked" do
-      let(:send_daily_submission_batch) { true }
-      let(:send_weekly_submission_batch) { true }
+      let(:form) do
+        create(:form, :live, delivery_configurations: [
+          create(:delivery_configuration, :daily_email),
+          create(:delivery_configuration, :weekly_email),
+        ])
+      end
       let(:batch_frequencies) { [] }
 
       it "displays a success flash message indicating that batch emails are disabled" do
@@ -87,8 +91,12 @@ RSpec.describe Forms::BatchSubmissionsController, type: :request do
       end
     end
 
-    context "when the setting is unchanged" do
-      let(:send_daily_submission_batch) { true }
+    context "when the delivery configurations are unchanged" do
+      let(:form) do
+        create(:form, :live, delivery_configurations: [
+          create(:delivery_configuration, :daily_email),
+        ])
+      end
       let(:batch_frequencies) { %w[daily] }
 
       it "does not display a flash message" do

--- a/spec/requests/forms/submission_attachments_controller_spec.rb
+++ b/spec/requests/forms/submission_attachments_controller_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Forms::SubmissionAttachmentsController, type: :request do
-  let(:form) { create(:form, :live, submission_format: original_submission_format) }
+  let(:form) do
+    create(:form, :live, delivery_configurations: [
+      create(:delivery_configuration, :immediate_email, formats: original_submission_format),
+    ])
+  end
   let(:user) { standard_user }
   let(:original_submission_format) { [] }
   let(:group) { create(:group, organisation: user.organisation) }
@@ -25,8 +29,13 @@ RSpec.describe Forms::SubmissionAttachmentsController, type: :request do
       expect(assigns).to include submission_attachments_input: an_instance_of(Forms::SubmissionAttachmentsInput)
     end
 
-    context "when the submission_type is s3" do
-      let(:form) { create(:form, submission_type: "s3") }
+    context "when the form does not have an immediate email delivery configuration" do
+      let(:form) do
+        create(:form, delivery_configurations: [
+          create(:delivery_configuration, :s3),
+          create(:delivery_configuration, :daily_email),
+        ])
+      end
 
       it "returns a 404 page" do
         expect(response).to redirect_to :error_404
@@ -40,10 +49,10 @@ RSpec.describe Forms::SubmissionAttachmentsController, type: :request do
     context "when params are valid" do
       let(:submission_format) { %w[csv json] }
 
-      it "updates the form submission format" do
+      it "updates the submission format for the email delivery method" do
         expect {
           post(submission_attachments_path(form_id: form.id), params:)
-        }.to change { form.reload.submission_format }.to(submission_format)
+        }.to change { form.reload.delivery_configurations.first.formats }.to(submission_format)
       end
 
       it "redirects you to the form overview page" do
@@ -109,7 +118,7 @@ RSpec.describe Forms::SubmissionAttachmentsController, type: :request do
       it "does not update the form" do
         expect {
           post(submission_attachments_path(form_id: form.id), params:)
-        }.not_to(change { form.reload.submission_format })
+        }.not_to(change { form.reload.delivery_configurations.first.formats })
       end
 
       it "re-renders the page with an error" do
@@ -119,8 +128,13 @@ RSpec.describe Forms::SubmissionAttachmentsController, type: :request do
       end
     end
 
-    context "when the submission_type is s3" do
-      let(:form) { create(:form, submission_type: "s3") }
+    context "when the form does not have an immediate email delivery configuration" do
+      let(:form) do
+        create(:form, delivery_configurations: [
+          create(:delivery_configuration, :s3),
+          create(:delivery_configuration, :daily_email),
+        ])
+      end
       let(:submission_format) { %w[csv] }
 
       it "returns a 404 page" do

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe ReportsController, type: :request do
   let(:question_text) { "Question text" }
-  let(:forms) { create_list(:form, 4, :live) }
+  let(:forms) { create_list(:form, 4, :live, :with_email_delivery) }
 
   before do
     group = create :group
@@ -255,7 +255,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#forms_with_csv_submission_email_attachments" do
     let(:path) { report_forms_with_csv_submission_email_attachments_path(tag: :live) }
-    let(:form) { create(:form, :live, submission_type: "email", submission_format: %w[csv]) }
+    let(:form) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: %w[csv])]) }
     let(:forms) { [form] }
 
     include_examples "unauthorized user is forbidden"
@@ -280,7 +280,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#forms_with_json_submission_email_attachments" do
     let(:path) { report_forms_with_json_submission_email_attachments_path(tag: :live) }
-    let(:form) { create(:form, :live, submission_type: "email", submission_format: %w[json]) }
+    let(:form) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: %w[json])]) }
     let(:forms) { [form] }
 
     include_examples "unauthorized user is forbidden"
@@ -305,7 +305,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#forms_with_daily_submission_csv" do
     let(:path) { report_forms_with_daily_submission_csv_path(tag: :live) }
-    let(:form) { create(:form, :live, submission_type: "email", send_daily_submission_batch: true) }
+    let(:form) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :daily_email)]) }
     let(:forms) { [form] }
 
     include_examples "unauthorized user is forbidden"
@@ -330,7 +330,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#forms_with_weekly_submission_csv" do
     let(:path) { report_forms_with_weekly_submission_csv_path(tag: :live) }
-    let(:form) { create(:form, :live, submission_type: "email", send_weekly_submission_batch: true) }
+    let(:form) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :weekly_email)]) }
     let(:forms) { [form] }
 
     include_examples "unauthorized user is forbidden"
@@ -355,7 +355,7 @@ RSpec.describe ReportsController, type: :request do
 
   describe "#forms_with_s3_submissions" do
     let(:path) { report_forms_with_s3_submissions_path(tag: :live) }
-    let(:form) { create(:form, :live, submission_type: "s3", submission_format: %w[json]) }
+    let(:form) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :s3, formats: %w[json])]) }
     let(:forms) { [form] }
 
     include_examples "unauthorized user is forbidden"
@@ -667,7 +667,7 @@ RSpec.describe ReportsController, type: :request do
     end
 
     describe "#forms_with_csv_submission_enabled as csv" do
-      let(:form) { create(:form, :live, submission_type: "email", submission_format: %w[csv]) }
+      let(:form) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: %w[csv])]) }
       let(:forms) { [form, *create_list(:form, 2, :live)] }
       let(:expected_csv_filename) { "live_forms_with_csv_submission_email_attachments_report-2025-05-15 15:31:57 UTC.csv" }
 

--- a/spec/services/form_task_list_service_spec.rb
+++ b/spec/services/form_task_list_service_spec.rb
@@ -299,19 +299,38 @@ describe FormTaskListService do
       let(:section_rows) { section[:rows] }
       let(:all_task_names) { all_sections.flat_map { |section| section[:rows] }.compact.map { |row| row[:task_name] } }
 
-      context "when the submission type is email" do
+      context "when email delivery is configured" do
+        let(:form) { create(:form, :with_email_delivery) }
+
         it "has link to the submission attachments page" do
           expect(section_rows.first[:task_name]).to eq I18n.t("forms.task_list_create.how_you_get_completed_forms_section.optional_subsection.submission_attachments")
           expect(section_rows.first[:path]).to eq "/forms/#{form.id}/submission-attachments"
+          expect(section_rows.first[:active]).to be true
         end
 
         it "has the subsection title 'Optional tasks' as there are multiple tasks" do
           expect(section[:title]).to eq I18n.t("forms.task_list.optional_tasks_title.other")
         end
+
+        it "has link to the batch submissions page" do
+          expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_create.how_you_get_completed_forms_section.optional_subsection.batch_submissions")
+          expect(section_rows.second[:path]).to eq "/forms/#{form.id}/batch-submissions"
+        end
       end
 
-      context "when the submission type is s3" do
-        let(:form) { create(:form, submission_type: "s3") }
+      context "when no delivery methods are configured" do
+        let(:form) { create(:form, delivery_configurations: []) }
+
+        it "has the attachment task with a disabled link and cannot_start status" do
+          expect(section_rows.first[:task_name]).to eq I18n.t("forms.task_list_create.how_you_get_completed_forms_section.optional_subsection.submission_attachments")
+          expect(section_rows.first[:path]).to eq "/forms/#{form.id}/submission-attachments"
+          expect(section_rows.first[:status]).to eq :cannot_start
+          expect(section_rows.first[:active]).to be false
+        end
+      end
+
+      context "when only S3 delivery is enabled" do
+        let(:form) { create(:form, delivery_configurations: [create(:delivery_configuration, :s3)]) }
 
         it "does not have link to the submission attachments page" do
           expect(all_task_names).not_to include I18n.t("forms.task_list_create.how_you_get_completed_forms_section.optional_subsection.submission_attachments")
@@ -320,11 +339,24 @@ describe FormTaskListService do
         it "has the subsection title 'Optional task' as there is only one task" do
           expect(section[:title]).to eq I18n.t("forms.task_list.optional_tasks_title.one")
         end
+
+        it "has link to the batch submissions page" do
+          expect(section_rows.first[:task_name]).to eq I18n.t("forms.task_list_create.how_you_get_completed_forms_section.optional_subsection.batch_submissions")
+          expect(section_rows.first[:path]).to eq "/forms/#{form.id}/batch-submissions"
+        end
       end
 
-      it "has link to the batch submissions page" do
-        expect(section_rows.second[:task_name]).to eq I18n.t("forms.task_list_create.how_you_get_completed_forms_section.optional_subsection.batch_submissions")
-        expect(section_rows.second[:path]).to eq "/forms/#{form.id}/batch-submissions"
+      context "when both email and S3 are enabled" do
+        let(:form) do
+          create(:form, delivery_configurations: [
+            create(:delivery_configuration, :immediate_email),
+            create(:delivery_configuration, :s3),
+          ])
+        end
+
+        it "has link to the submission attachments page" do
+          expect(section_rows.first[:task_name]).to eq I18n.t("forms.task_list_create.how_you_get_completed_forms_section.optional_subsection.submission_attachments")
+        end
       end
     end
 
@@ -626,7 +658,7 @@ describe FormTaskListService do
     end
 
     context "when editing an existing form" do
-      let(:form) { create(:form, :live) }
+      let(:form) { create(:form, :live, :with_email_delivery) }
       let(:can_make_form_live) { true }
 
       it "has the expected section titles" do

--- a/spec/services/reports/feature_report_service_spec.rb
+++ b/spec/services/reports/feature_report_service_spec.rb
@@ -25,8 +25,6 @@ RSpec.describe Reports::FeatureReportService do
   let(:form_with_all_answer_types) do
     create(:form, :live,
            :with_support,
-           submission_type: "email",
-           submission_format: %w[csv],
            payment_url: "https://www.gov.uk/payments/organisation/service",
            send_copy_of_answers: "enabled",
            pages: [
@@ -39,22 +37,28 @@ RSpec.describe Reports::FeatureReportService do
              create(:page, answer_type: "phone_number"),
              create(:page, :with_selection_settings, is_optional: true),
              create(:page, :with_single_line_text_settings, is_repeatable: true),
+           ],
+           delivery_configurations: [
+             create(:delivery_configuration, :immediate_email, formats: %w[csv]),
            ])
   end
   let(:form_with_a_few_answer_types) do
     create(:form,
            :live,
-           submission_type: "email",
-           submission_format: %w[csv json],
-           send_daily_submission_batch: true,
-           send_weekly_submission_batch: true,
            pages: [
              create(:page, answer_type: "email"),
              *create_list(:page, 3, answer_type: "name"),
+           ],
+           delivery_configurations: [
+             create(:delivery_configuration, :immediate_email, formats: %w[csv json]),
+             create(:delivery_configuration, :daily_email),
+             create(:delivery_configuration, :weekly_email),
            ])
   end
   let(:branch_route_form) do
-    form = create(:form, :live, :ready_for_routing, submission_type: "s3", submission_format: %w[csv])
+    form = create(:form, :live, :ready_for_routing, delivery_configurations: [
+      create(:delivery_configuration, :s3, formats: %w[csv]),
+    ])
     create(:condition, :with_exit_page, routing_page_id: form.pages[0].id, check_page_id: form.pages[0].id, answer_value: "Option 1")
     create(:condition, routing_page_id: form.pages[1].id, check_page_id: form.pages[1].id, answer_value: "Option 1", goto_page_id: form.pages[3].id)
     create(:condition, routing_page_id: form.pages[2].id, check_page_id: form.pages[1].id, goto_page_id: form.pages[4].id)
@@ -475,7 +479,7 @@ RSpec.describe Reports::FeatureReportService do
   end
 
   describe "#forms_with_s3_submissions" do
-    it "returns live forms with json enabled" do
+    it "returns live forms with s3 submissions" do
       forms = described_class.new(form_documents).forms_with_s3_submissions
       expect(forms.length).to eq 1
       expect(forms).to match [

--- a/spec/services/reports/form_documents_service_spec.rb
+++ b/spec/services/reports/form_documents_service_spec.rb
@@ -242,37 +242,51 @@ RSpec.describe Reports::FormDocumentsService do
   end
 
   describe ".has_daily_submission_csv" do
-    context "when the form has send_daily_submission_batch enabled" do
-      let(:form_document) { create(:form, :live, send_daily_submission_batch: true).live_form_document }
+    subject(:daily_submission_batch_enabled) do
+      described_class.has_daily_submission_csv(form_document)
+    end
+
+    context "when form has a daily delivery_configuration" do
+      let(:form_document) do
+        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :daily_email)])
+          .live_form_document
+      end
 
       it "returns true" do
-        expect(described_class.has_daily_submission_csv(form_document)).to be true
+        expect(daily_submission_batch_enabled).to be true
       end
     end
 
-    context "when the form has send_daily_submission_batch disabled" do
-      let(:form_document) { create(:form, :live, send_daily_submission_batch: false).live_form_document }
+    context "when form does not have a daily delivery_configuration" do
+      let(:form_document) { create(:form, :live).live_form_document }
 
       it "returns false" do
-        expect(described_class.has_daily_submission_csv(form_document)).to be false
+        expect(daily_submission_batch_enabled).to be false
       end
     end
   end
 
   describe ".has_weekly_submission_csv" do
-    context "when the form has send_weekly_submission_batch enabled" do
-      let(:form_document) { create(:form, :live, send_weekly_submission_batch: true).live_form_document }
+    subject(:weekly_submission_batch_enabled) do
+      described_class.has_weekly_submission_csv(form_document)
+    end
+
+    context "when form has weekly delivery_configuration" do
+      let(:form_document) do
+        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :weekly_email)])
+          .live_form_document
+      end
 
       it "returns true" do
-        expect(described_class.has_weekly_submission_csv(form_document)).to be true
+        expect(weekly_submission_batch_enabled).to be true
       end
     end
 
-    context "when the form has send_weekly_submission_batch disabled" do
-      let(:form_document) { create(:form, :live, send_weekly_submission_batch: false).live_form_document }
+    context "when form does not have a weekly delivery_configuration" do
+      let(:form_document) { create(:form, :live).live_form_document }
 
       it "returns false" do
-        expect(described_class.has_weekly_submission_csv(form_document)).to be false
+        expect(weekly_submission_batch_enabled).to be false
       end
     end
   end

--- a/spec/services/reports/forms_csv_report_service_spec.rb
+++ b/spec/services/reports/forms_csv_report_service_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe Reports::FormsCsvReportService do
     create(:form, :live,
            :with_support,
            :with_welsh_translation,
-           submission_type: "email",
-           submission_format: %w[csv json],
            payment_url: "https://www.gov.uk/payments/organisation/service",
            send_daily_submission_batch: true,
            send_weekly_submission_batch: true,
@@ -41,6 +39,10 @@ RSpec.describe Reports::FormsCsvReportService do
              create(:page, answer_type: "phone_number"),
              create(:page, :with_selection_settings, is_optional: true),
              create(:page, :with_single_line_text_settings, is_repeatable: true),
+           ],
+           delivery_configurations: [
+             create(:delivery_configuration, :immediate_email, formats: %w[csv json]),
+             create(:delivery_configuration, :s3, formats: %w[csv]),
            ])
   end
   let(:forms) { [form, create(:form, :live)] }
@@ -79,8 +81,7 @@ RSpec.describe Reports::FormsCsvReportService do
         form.support_phone,
         form.privacy_policy_url,
         form.what_happens_next_markdown,
-        "email",
-        "csv json",
+        "email: csv, json\ns3: csv",
         "true",
         "true",
         "true",

--- a/spec/services/reports/forms_csv_report_service_spec.rb
+++ b/spec/services/reports/forms_csv_report_service_spec.rb
@@ -27,8 +27,6 @@ RSpec.describe Reports::FormsCsvReportService do
            :with_support,
            :with_welsh_translation,
            payment_url: "https://www.gov.uk/payments/organisation/service",
-           send_daily_submission_batch: true,
-           send_weekly_submission_batch: true,
            pages: [
              create(:page, :with_address_settings, is_repeatable: true),
              create(:page, :with_date_settings),
@@ -43,6 +41,8 @@ RSpec.describe Reports::FormsCsvReportService do
            delivery_configurations: [
              create(:delivery_configuration, :immediate_email, formats: %w[csv json]),
              create(:delivery_configuration, :s3, formats: %w[csv]),
+             create(:delivery_configuration, :daily_email),
+             create(:delivery_configuration, :weekly_email),
            ])
   end
   let(:forms) { [form, create(:form, :live)] }

--- a/spec/services/reports/questions_csv_report_service_spec.rb
+++ b/spec/services/reports/questions_csv_report_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Reports::QuestionsCsvReportService do
     end
   end
   let(:form_with_all_answer_types) do
-    create(:form, :live, :with_support, submission_type: "email", payment_url: "https://www.gov.uk/payments/organisation/service", pages: [
+    create(:form, :live, :with_support, payment_url: "https://www.gov.uk/payments/organisation/service", pages: [
       create(:page, :with_address_settings, is_repeatable: true),
       create(:page, :with_date_settings),
       create(:page, answer_type: "email"),

--- a/spec/services/task_status_service_spec.rb
+++ b/spec/services/task_status_service_spec.rb
@@ -192,34 +192,38 @@ describe TaskStatusService do
 
     describe "submission_attachments_status" do
       context "with a new form" do
-        let(:form) { build(:form, :new_form, :with_group, group:) }
+        let(:form) { create(:form, :new_form, :with_group, group:) }
 
-        it "returns optional" do
-          expect(task_status_service.all_task_statuses[:submission_attachments_status]).to eq :optional
+        it "returns cannot start" do
+          expect(task_status_service.all_task_statuses[:submission_attachments_status]).to eq :cannot_start
         end
       end
 
-      context "with submission_type set to 'email'" do
-        let(:form) { build(:form, :new_form, :with_group, submission_type: "email", submission_format:, group:) }
+      context "when email delivery is enabled" do
+        let(:form) do
+          create(:form, :new_form, :with_group, group:, delivery_configurations: [
+            create(:delivery_configuration, :immediate_email, formats:),
+          ])
+        end
 
-        context "with submission format empty" do
-          let(:submission_format) { [] }
+        context "with no submission formats enabled" do
+          let(:formats) { [] }
 
           it "returns optional" do
             expect(task_status_service.all_task_statuses[:submission_attachments_status]).to eq :optional
           end
         end
 
-        context "with submission format csv" do
-          let(:submission_format) { %w[csv] }
+        context "with CSV attachments enabled" do
+          let(:formats) { %w[csv] }
 
           it "returns completed" do
             expect(task_status_service.all_task_statuses[:submission_attachments_status]).to eq :completed
           end
         end
 
-        context "with submission format has multiple values" do
-          let(:submission_format) { %w[csv json] }
+        context "with multiple submission formats enabled" do
+          let(:formats) { %w[csv json] }
 
           it "returns completed" do
             expect(task_status_service.all_task_statuses[:submission_attachments_status]).to eq :completed
@@ -227,8 +231,25 @@ describe TaskStatusService do
         end
       end
 
-      context "with submission_type set s3" do
-        let(:form) { build(:form, :new_form, :with_group, submission_type: "s3", submission_format: "csv", group:) }
+      context "with only S3 delivery is enabled" do
+        let(:form) do
+          create(:form, :new_form, :with_group, group:, delivery_configurations: [
+            create(:delivery_configuration, :s3),
+          ])
+        end
+
+        it "returns cannot start" do
+          expect(task_status_service.all_task_statuses[:submission_attachments_status]).to eq :cannot_start
+        end
+      end
+
+      context "with both email and S3 delivery are enabled" do
+        let(:form) do
+          create(:form, :new_form, :with_group, group:, delivery_configurations: [
+            create(:delivery_configuration, :immediate_email),
+            create(:delivery_configuration, :s3),
+          ])
+        end
 
         it "returns optional" do
           expect(task_status_service.all_task_statuses[:submission_attachments_status]).to eq :optional
@@ -237,29 +258,26 @@ describe TaskStatusService do
     end
 
     describe "batch_submissions_status" do
-      let(:form) { build(:form, :new_form, :with_group, group:, send_daily_submission_batch:, send_weekly_submission_batch:) }
+      let(:form) { create(:form, :new_form, :with_group, group:, delivery_configurations:) }
 
-      context "with send_daily_submission_batch set to true" do
-        let(:send_daily_submission_batch) { true }
-        let(:send_weekly_submission_batch) { false }
-
-        it "returns completed" do
-          expect(task_status_service.all_task_statuses[:batch_submissions_status]).to eq :completed
-        end
-      end
-
-      context "with send_weekly_submission_batch set to true" do
-        let(:send_daily_submission_batch) { false }
-        let(:send_weekly_submission_batch) { true }
+      context "with daily emails configured" do
+        let(:delivery_configurations) { [create(:delivery_configuration, :daily_email)] }
 
         it "returns completed" do
           expect(task_status_service.all_task_statuses[:batch_submissions_status]).to eq :completed
         end
       end
 
-      context "with send daily and weekly batches set to false" do
-        let(:send_daily_submission_batch) { false }
-        let(:send_weekly_submission_batch) { false }
+      context "with weekly emails configured" do
+        let(:delivery_configurations) { [create(:delivery_configuration, :weekly_email)] }
+
+        it "returns completed" do
+          expect(task_status_service.all_task_statuses[:batch_submissions_status]).to eq :completed
+        end
+      end
+
+      context "with no batch emails configured" do
+        let(:delivery_configurations) { [create(:delivery_configuration, :immediate_email)] }
 
         it "returns optional" do
           expect(task_status_service.all_task_statuses[:batch_submissions_status]).to eq :optional
@@ -692,7 +710,7 @@ describe TaskStatusService do
         support_contact_details_status: :completed,
         welsh_language_status: :optional,
         make_live_status: :completed,
-        submission_attachments_status: :optional,
+        submission_attachments_status: :cannot_start,
         batch_submissions_status: :optional,
         share_preview_status: :completed,
         submission_email_status: :completed,

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -5,8 +5,7 @@ describe "forms/_made_live_form.html.erb" do
   let(:past_week_metrics_data) { { weekly_submissions: 125, weekly_starts: 256 } }
   let(:what_happens_next_markdown) { "If you have not received a response within 5 working days, [contact our user support team](https://example.com)." }
   let(:form_metadata) do
-    create(:form, :live, declaration_markdown:, what_happens_next_markdown:, submission_type:, submission_format:,
-                         send_daily_submission_batch:, send_weekly_submission_batch:, send_copy_of_answers:)
+    create(:form, :live, declaration_markdown:, what_happens_next_markdown:, send_copy_of_answers:)
   end
   let(:form_document) do
     form_document_content = FormDocument::Content.from_form_document(form_metadata.live_form_document)
@@ -18,10 +17,6 @@ describe "forms/_made_live_form.html.erb" do
   let(:status) { :live }
   let(:preview_mode) { :preview_live }
   let(:questions_path) { Faker::Internet.url }
-  let(:submission_type) { "email" }
-  let(:submission_format) { [] }
-  let(:send_daily_submission_batch) { false }
-  let(:send_weekly_submission_batch) { false }
   let(:send_copy_of_answers) { "disabled" }
   let(:cloudwatch_service) { instance_double(CloudWatchService, past_week_metrics_data:) }
 
@@ -147,7 +142,9 @@ describe "forms/_made_live_form.html.erb" do
 
   context "when the submission type is 'email'" do
     context "when CSV submission is enabled" do
-      let(:submission_format) { %w[csv] }
+      let(:form_metadata) do
+        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: %w[csv])])
+      end
 
       it "tells the user they have CSVs enabled" do
         expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
@@ -156,7 +153,9 @@ describe "forms/_made_live_form.html.erb" do
     end
 
     context "when JSON submission is enabled" do
-      let(:submission_format) { %w[json] }
+      let(:form_metadata) do
+        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: %w[json])])
+      end
 
       it "tells the user they have JSON submissions enabled" do
         expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
@@ -165,7 +164,9 @@ describe "forms/_made_live_form.html.erb" do
     end
 
     context "when both CSV and JSON submissions are enabled" do
-      let(:submission_format) { %w[csv json] }
+      let(:form_metadata) do
+        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: %w[csv json])])
+      end
 
       it "tells the user they have CSV and JSON submissions enabled" do
         expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
@@ -174,7 +175,9 @@ describe "forms/_made_live_form.html.erb" do
     end
 
     context "when CSV submission is not enabled" do
-      let(:submission_format) { %w[] }
+      let(:form_metadata) do
+        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: [])])
+      end
 
       it "tells the user they do not have CSVs enabled" do
         expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
@@ -184,7 +187,9 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "when the submission type is 's3'" do
-    let(:submission_type) { "s3" }
+    let(:form_metadata) do
+      create(:form, :live, delivery_configurations: [create(:delivery_configuration, :s3)])
+    end
 
     it "does not include the CSV and JSON section" do
       expect(rendered).not_to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
@@ -196,7 +201,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "when only daily batches are enabled" do
-    let(:send_daily_submission_batch) { true }
+    let(:form_metadata) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :daily_email)]) }
 
     it "tells the user they getting a daily CSV" do
       expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.daily_enabled"))
@@ -204,7 +209,7 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "when only weekly batches are enabled" do
-    let(:send_weekly_submission_batch) { true }
+    let(:form_metadata) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :weekly_email)]) }
 
     it "tells the user they getting a weekly CSV" do
       expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.weekly_enabled"))
@@ -212,8 +217,12 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "when both daily and weekly batches are enabled" do
-    let(:send_daily_submission_batch) { true }
-    let(:send_weekly_submission_batch) { true }
+    let(:form_metadata) do
+      create(:form, :live, delivery_configurations: [
+        create(:delivery_configuration, :daily_email),
+        create(:delivery_configuration, :weekly_email),
+      ])
+    end
 
     it "tells the user they getting a daily and weekly CSV" do
       expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.daily_and_weekly_enabled"))
@@ -221,9 +230,6 @@ describe "forms/_made_live_form.html.erb" do
   end
 
   context "when neither daily or weekly batches are enabled" do
-    let(:send_daily_submission_batch) { false }
-    let(:send_weekly_submission_batch) { false }
-
     it "tells the user they have not opted to get a daily or weekly CSV" do
       expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.disabled"))
     end
@@ -423,7 +429,7 @@ describe "forms/_made_live_form.html.erb" do
 
   context "when the form has a Welsh translation" do
     let(:what_happens_next_markdown_cy) { "Os nad ydych wedi derbyn ymateb o fewn 5 diwrnod gwaith, [cysylltwch â’n tîm cymorth defnyddwyr](https://example.com)." }
-    let(:form_metadata) { create :form, :live, :with_welsh_translation, what_happens_next_markdown:, what_happens_next_markdown_cy:, submission_type:, submission_format: }
+    let(:form_metadata) { create :form, :live, :with_welsh_translation, what_happens_next_markdown:, what_happens_next_markdown_cy: }
     let(:welsh_form_document) do
       form_document_content = FormDocument::Content.from_form_document(form_metadata.live_welsh_form_document)
       form_document_content.first_made_live_at = 1.week.ago
@@ -462,7 +468,7 @@ describe "forms/_made_live_form.html.erb" do
     end
 
     context "when the form has a declaration" do
-      let(:form_metadata) { create :form, :live, :with_welsh_translation, declaration_markdown:, what_happens_next_markdown:, submission_type:, submission_format: }
+      let(:form_metadata) { create :form, :live, :with_welsh_translation, declaration_markdown:, what_happens_next_markdown: }
 
       it "contains a table displaying the declaration text in each language" do
         expect(rendered).to have_css(".govuk-summary-card__title", text: "Declaration")
@@ -475,7 +481,7 @@ describe "forms/_made_live_form.html.erb" do
 
     context "when the form has a GOV.UK Pay payment link" do
       let(:payment_url) { "https://www.gov.uk/payments/your-payment-link" }
-      let(:form_metadata) { create :form, :live, :with_welsh_translation, declaration_markdown:, what_happens_next_markdown:, submission_type:, submission_format:, payment_url: }
+      let(:form_metadata) { create :form, :live, :with_welsh_translation, declaration_markdown:, what_happens_next_markdown:, payment_url: }
 
       it "contains a table displaying the payment link in each language" do
         expect(rendered).to have_css(".govuk-summary-card__title", text: "GOV.UK Pay payment link")
@@ -495,7 +501,7 @@ describe "forms/_made_live_form.html.erb" do
     end
 
     context "with support details" do
-      let(:form_metadata) { create :form, :live, :with_welsh_translation, what_happens_next_markdown:, submission_type:, submission_format:, support_email: "support@example.gov.uk", support_phone: "phone details", support_url_text: "website", support_url: "www.example.gov.uk" }
+      let(:form_metadata) { create :form, :live, :with_welsh_translation, what_happens_next_markdown:, support_email: "support@example.gov.uk", support_phone: "phone details", support_url_text: "website", support_url: "www.example.gov.uk" }
 
       it "contains a table displaying the support details in each language" do
         expect(rendered).to have_css(".govuk-summary-card__title", text: "Your form’s contact details for support")

--- a/spec/views/forms/batch_submissions/new.html.erb_spec.rb
+++ b/spec/views/forms/batch_submissions/new.html.erb_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 describe "forms/batch_submissions/new.html.erb" do
-  let(:send_daily_submission_batch) { true }
-  let(:send_weekly_submission_batch) { true }
-  let(:form) { build(:form, id: 1, send_daily_submission_batch:, send_weekly_submission_batch:) }
+  let(:form) { create(:form) }
   let(:batch_submissions_input) { Forms::BatchSubmissionsInput.new(form:).assign_form_values }
 
   before do
@@ -39,25 +37,36 @@ describe "forms/batch_submissions/new.html.erb" do
     expect(rendered).to have_css(".govuk-label[for='forms-batch-submissions-input-batch-frequencies-daily-field']", text: "Get a daily CSV of submissions")
   end
 
-  context "when the form has send_daily_submission_batch set to true" do
-    let(:send_daily_submission_batch) { true }
+  context "when the form has daily batches enabled" do
+    let(:form) do
+      create(:form, delivery_configurations: [
+        create(:delivery_configuration, :daily_email),
+      ])
+    end
 
     it "renders the checkbox as checked" do
       expect(rendered).to have_checked_field("forms-batch-submissions-input-batch-frequencies-daily-field")
     end
   end
 
-  context "when the form has send_weekly_submission_batch set to true" do
-    let(:send_weekly_submission_batch) { true }
+  context "when the form has weekly batches enabled" do
+    let(:form) do
+      create(:form, delivery_configurations: [
+        create(:delivery_configuration, :weekly_email),
+      ])
+    end
 
-    it "renders the checkboxes as unchecked" do
+    it "renders the checkbox as checked" do
       expect(rendered).to have_checked_field("forms-batch-submissions-input-batch-frequencies-weekly-field")
     end
   end
 
   context "when the form has batch submissions disabled" do
-    let(:send_daily_submission_batch) { false }
-    let(:send_weekly_submission_batch) { false }
+    let(:form) do
+      create(:form, delivery_configurations: [
+        create(:delivery_configuration, :immediate_email),
+      ])
+    end
 
     it "renders the checkboxes as unchecked" do
       expect(rendered).to have_unchecked_field("forms-batch-submissions-input-batch-frequencies-daily-field")


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WMnjLlJV

The following columns have been replaced by the delivery_configurations table, and are no longer used by forms-runner
- submission_type
- submission_format
- send_daily_submission_batch
- send_weekly_submission_batch

Replace places where we were reading and updating these attributes with only reading and updating the DeliveryConfigurations.

This is in preparation to ignore and drop these columns. 

This PR does not update the rake tasks for configuring whether S3 submissions are enabled, this will be done in the next PR.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
