### PR TITLE
Remove GOV_UK_APP_DOMAIN from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ ARG RAILS_ENV NODE_ENV
 ENV RAILS_ENV="${RAILS_ENV:-production}" \
     NODE_ENV="${NODE_ENV:-production}" \
     PATH="${PATH}:/home/ruby/.local/bin:/node_modules/.bin" \
-    USER="ruby" \
-    GOVUK_APP_DOMAIN="https://not-set"
+    USER="ruby"
 
 COPY --chown=ruby:ruby . .
 


### PR DESCRIPTION
We used to include the GDS sso gem, which also depends on plek. This meant we had to set the GOV_UK_APP_DOMAIN env var to a dummy value in order to run the application in production.

We no longer depend on the GDS sso gem or plek, so we can remove this value from the Dockerfile.

See:
https://docs.publishing.service.gov.uk/repos/plek.html

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
