### PR TITLE
Update rake tasks for changing delivery configurations

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -19,6 +19,7 @@ class Form < ApplicationRecord
   has_many :conditions, through: :pages, source: :routing_conditions
   has_many :delivery_configurations, dependent: :destroy
   has_one :immediate_email_delivery_configuration, -> { where delivery_method: "email", delivery_schedule: "immediate" }, class_name: "DeliveryConfiguration"
+  has_one :s3_delivery_configuration, -> { where delivery_method: "s3", delivery_schedule: "immediate" }, class_name: "DeliveryConfiguration"
 
   translates :name,
              :privacy_policy_url,

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -73,75 +73,125 @@ namespace :forms do
     end
   end
 
-  namespace :submission_type do
-    desc "Set submission_type to email"
-    task :set_to_email, %i[form_id submission_formats] => :environment do |_, args|
-      submission_format = args[:submission_formats].nil? ? [] : args.to_a[1..]
-      submission_format = [] if submission_format == %w[email]
-
-      usage_message = "usage: rake forms:submission_type:set_to_email[<form_id>(, <submission_format>)*]".freeze
+  namespace :delivery_configurations do
+    desc "Enable email delivery for submissions"
+    task :enable_email, %i[form_id] => :environment do |_, args|
+      usage_message = "usage: rake forms:delivery_configurations:enable_email[<form_id>]".freeze
       abort usage_message if args[:form_id].blank?
 
-      supported_formats = %w[csv json]
-      abort "submission_format must be one of #{supported_formats.join(', ')}" unless submission_format.all? { supported_formats.include? it }
-
-      form_id = args[:form_id]
-      Rails.logger.info("Setting submission_type to email with submission_format #{submission_format} for form: #{form_id}")
-
-      form = Form.find(form_id)
-      form.submission_type = "email"
-      form.submission_format = submission_format
-
+      form = Form.find(args[:form_id])
       delivery_configuration = form.delivery_configurations.find_or_initialize_by(delivery_method: :email, delivery_schedule: :immediate)
-      delivery_configuration.formats = submission_format
       delivery_configuration.save!
 
-      form.delivery_configurations.where(delivery_method: :s3).destroy_all
+      # ensure draft form document is updated
+      form.delivery_configurations.reload
       form.save!
 
       if form.is_live?
-        form_document = form.live_form_document
-        content = form_document.content
+        form.form_documents.where(tag: "live").find_each do |form_document|
+          delivery_configurations = form_document["content"]["delivery_configurations"]
+          has_email_delivery = delivery_configurations.any? { |d| d["delivery_method"] == "email" && d["delivery_schedule"] == "immediate" }
 
-        content[:submission_type] = "email"
-        content[:submission_format] = submission_format
-        content[:delivery_configurations] = form.delivery_configurations.map(&:as_json)
-
-        form_document.save!
+          unless has_email_delivery
+            delivery_configurations << DeliveryConfiguration.new(form: form, delivery_method: "email", delivery_schedule: "immediate")
+          end
+          form_document.save!
+        end
       end
 
-      Rails.logger.info("Set submission_type to email with submission_format #{submission_format} for form: #{form_id}")
+      Rails.logger.info "Enabled email delivery for #{fmt_form(form)}"
     end
 
-    desc "Set submission_type to s3"
-    task :set_to_s3, %i[form_id s3_bucket_name s3_bucket_aws_account_id s3_bucket_region format] => :environment do |_, args|
-      usage_message = "usage: rake forms:submission_type:set_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>, <format>]".freeze
+    desc "Disable email delivery for submissions"
+    task :disable_email, %i[form_id] => :environment do |_, args|
+      usage_message = "usage: rake forms:delivery_configurations:disable_email[<form_id>]".freeze
+      abort usage_message if args[:form_id].blank?
+
+      form = Form.find(args[:form_id])
+      abort "Email delivery is not enabled" if form.immediate_email_delivery_configuration.nil?
+      abort "Form will have no delivery methods, enable S3 delivery first" if form.delivery_configurations.immediate.one?
+
+      form.delivery_configurations.where(delivery_method: :email, delivery_schedule: :immediate).destroy_all
+
+      # ensure draft form document is updated
+      form.delivery_configurations.reload
+      form.save!
+
+      if form.is_live?
+        form.form_documents.where(tag: "live").find_each do |form_document|
+          delivery_configurations = form_document["content"]["delivery_configurations"]
+          delivery_configurations.reject! { |d| d["delivery_method"] == "email" && d["delivery_schedule"] == "immediate" }
+          form_document.save!
+        end
+      end
+
+      Rails.logger.info "Disabled email delivery for #{fmt_form(form)}"
+    end
+
+    desc "Disable S3 delivery for submissions"
+    task :disable_s3, %i[form_id] => :environment do |_, args|
+      usage_message = "usage: rake forms:delivery_configurations:disable_s3[<form_id>]".freeze
+      abort usage_message if args[:form_id].blank?
+
+      form = Form.find(args[:form_id])
+      abort "S3 delivery is not enabled" if form.s3_delivery_configuration.nil?
+      abort "Form will have no delivery methods, enable email delivery first" if form.delivery_configurations.immediate.one?
+
+      form.s3_bucket_name = nil
+      form.s3_bucket_aws_account_id = nil
+      form.s3_bucket_region = nil
+      form.delivery_configurations.where(delivery_method: :s3, delivery_schedule: :immediate).destroy_all
+
+      # ensure draft form document is updated
+      form.delivery_configurations.reload
+      form.save!
+
+      if form.is_live?
+        form.form_documents.where(tag: "live").find_each do |form_document|
+          content = form_document.content
+
+          content["s3_bucket_name"] = nil
+          content["s3_bucket_aws_account_id"] = nil
+          content["s3_bucket_region"] = nil
+
+          delivery_configurations = content["delivery_configurations"]
+          delivery_configurations.reject! { |d| d["delivery_method"] == "s3" && d["delivery_schedule"] == "immediate" }
+
+          form_document.save!
+        end
+      end
+
+      Rails.logger.info "Disabled s3 delivery for #{fmt_form(form)}"
+    end
+
+    desc "Enable S3 delivery for submissions"
+    task :enable_s3, %i[form_id s3_bucket_name s3_bucket_aws_account_id s3_bucket_region format disable_email] => :environment do |_, args|
+      usage_message = "usage: rake forms:delivery_configurations:enable_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>, <format>, <disable_email>]".freeze
       abort usage_message if args[:form_id].blank?
       abort usage_message if args[:s3_bucket_name].blank?
       abort usage_message if args[:s3_bucket_aws_account_id].blank?
       abort usage_message if args[:s3_bucket_region].blank?
       abort usage_message if args[:format].blank?
+      abort usage_message if args[:disable_email].blank? || !args[:disable_email].in?(%w[true false])
       abort "s3_bucket_region must be one of eu-west-1 or eu-west-2" unless %w[eu-west-1 eu-west-2].include? args[:s3_bucket_region]
       abort "format must be one of csv or json" unless %w[csv json].include? args[:format]
 
-      submission_type = "s3"
-      submission_format = [args[:format]]
+      formats = [args[:format]]
+      disable_email = args[:disable_email] == "true"
 
-      Rails.logger.info("Setting submission_type to #{submission_type} and s3_bucket_name to #{args[:s3_bucket_name]} for form: #{args[:form_id]}")
+      Rails.logger.info("Enabling s3 submissions with s3_bucket_name #{args[:s3_bucket_name]} for form: #{args[:form_id]}")
       form = Form.find(args[:form_id])
-      form.submission_type = submission_type
-      form.submission_format = submission_format
       form.s3_bucket_name = args[:s3_bucket_name]
       form.s3_bucket_aws_account_id = args[:s3_bucket_aws_account_id]
       form.s3_bucket_region = args[:s3_bucket_region]
 
       delivery_configuration = form.delivery_configurations.find_or_initialize_by(delivery_method: :s3, delivery_schedule: :immediate)
-      delivery_configuration.formats = submission_format
+      delivery_configuration.formats = formats
       delivery_configuration.save!
 
-      # For now, disable email delivery per submission. After we've migrated to using the DeliveryConfigurations in
-      # forms-runner we can allow enabling both email and s3.
-      form.delivery_configurations.where(delivery_method: :email, delivery_schedule: :immediate).destroy_all
+      if disable_email
+        form.delivery_configurations.where(delivery_method: :email, delivery_schedule: :immediate).destroy_all
+      end
 
       form.save!
 
@@ -149,18 +199,32 @@ namespace :forms do
         form.form_documents.where(tag: "live").find_each do |form_document|
           content = form_document.content
 
-          content[:submission_type] = submission_type
-          content[:submission_format] = submission_format
-          content[:s3_bucket_name] = args[:s3_bucket_name]
-          content[:s3_bucket_aws_account_id] = args[:s3_bucket_aws_account_id]
-          content[:s3_bucket_region] = args[:s3_bucket_region]
-          content[:delivery_configurations] = form.delivery_configurations.map(&:as_json)
+          content["s3_bucket_name"] = args[:s3_bucket_name]
+          content["s3_bucket_aws_account_id"] = args[:s3_bucket_aws_account_id]
+          content["s3_bucket_region"] = args[:s3_bucket_region]
+
+          delivery_configurations = content["delivery_configurations"]
+          existing_s3_configuration = delivery_configurations.find { |d| d["delivery_method"] == "s3" && d["delivery_schedule"] == "immediate" }
+
+          if existing_s3_configuration.present?
+            existing_s3_configuration["formats"] = formats
+          else
+            delivery_configurations << DeliveryConfiguration.new(form: form, delivery_method: "s3", delivery_schedule: "immediate", formats: formats)
+          end
+
+          if disable_email
+            delivery_configurations.reject! { |d| d["delivery_method"] == "email" && d["delivery_schedule"] == "immediate" }
+          end
 
           form_document.save!
         end
       end
 
-      Rails.logger.info("Set submission_type to #{submission_type} and s3_bucket_name to #{args[:s3_bucket_name]} for form: #{args[:form_id]}")
+      if disable_email
+        Rails.logger.info("Enabled s3 submissions to bucket #{args[:s3_bucket_name]} and disabled email submissions for form: #{args[:form_id]}")
+      else
+        Rails.logger.info("Enabled s3 submissions to bucket #{args[:s3_bucket_name]} for form: #{args[:form_id]}. Email submissions are still enabled.")
+      end
     end
   end
 

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -347,463 +347,354 @@ RSpec.describe "forms.rake", type: :task do
     end
   end
 
-  describe "forms:submission_type:set_to_email" do
+  describe "forms:delivery_configurations:enable_email" do
     subject(:task) do
-      Rake::Task["forms:submission_type:set_to_email"]
+      Rake::Task["forms:delivery_configurations:enable_email"]
     end
 
-    let(:form) do
-      create(:form, :live, submission_type: "s3", submission_format: [], delivery_configurations: [
-        create(:delivery_configuration, :s3),
-        create(:delivery_configuration, :daily_email),
-      ])
-    end
-    let!(:other_form) do
-      create(:form, :live, submission_type: "s3", submission_format: [], delivery_configurations: [
-        create(:delivery_configuration, :s3),
-      ])
-    end
+    let(:form) { create(:form) }
 
-    context "when the form is live" do
-      it "sets a form's submission_type to email" do
-        expect { task.invoke(form.id) }
-          .to change { form.reload.submission_type }.to("email")
+    context "with valid arguments" do
+      it "adds immediate email delivery to the form" do
+        expect {
+          task.invoke(form.id)
+        }.to change { form.reload.delivery_configurations.where(delivery_method: "email", delivery_schedule: "immediate").count }
+               .by(1)
       end
 
-      it "creates a DeliveryConfiguration for immediate email deliveries and removes the DeliveryConfiguration for s3" do
+      it "updates the draft form document delivery configurations" do
         task.invoke(form.id)
-        expect(form.reload.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to contain_exactly(
-          ["email", "immediate", []],
-          ["email", "daily", %w[csv]],
-        )
+
+        expect(form.reload.draft_form_document.content["delivery_configurations"])
+          .to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
       end
 
-      it "updates a form's live form document" do
-        task.invoke(form.id)
-        content = form.live_form_document.reload.content
-        expect(content["submission_type"]).to eq("email")
-        expect(content["submission_format"]).to eq([])
-        expect(content["delivery_configurations"]).to contain_exactly(
-          {
-            "delivery_method" => "email",
-            "delivery_schedule" => "immediate",
-            "formats" => [],
-          },
-          {
-            "delivery_method" => "email",
-            "delivery_schedule" => "daily",
-            "formats" => %w[csv],
-          },
-        )
+      context "when the form is live" do
+        let(:form) { create(:form, :live, :with_welsh_translation) }
+
+        it "updates the live form documents delivery configurations" do
+          task.invoke(form.id)
+
+          expect(form.reload.live_form_document.content["delivery_configurations"])
+            .to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
+          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+            .to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
+        end
       end
 
-      it "updates the form's draft form document" do
-        task.invoke(form.id)
-        content = form.draft_form_document.reload.content
-        expect(content["submission_type"]).to eq("email")
-        expect(content["submission_format"]).to eq([])
-        expect(content["delivery_configurations"]).to contain_exactly(
-          {
-            "delivery_method" => "email",
-            "delivery_schedule" => "immediate",
-            "formats" => [],
-          },
-          {
-            "delivery_method" => "email",
-            "delivery_schedule" => "daily",
-            "formats" => %w[csv],
-          },
-        )
-      end
+      context "when email is already enabled" do
+        let(:form) { create(:form, :live, :with_welsh_translation) }
 
-      it "does not update a different form" do
-        expect { task.invoke(form.id) }
-          .not_to(change { other_form.reload.submission_type })
+        it "does not change the delivery configurations or form documents" do
+          task.invoke(form.id)
+
+          delivery_configuration_count = form.reload.delivery_configurations.where(delivery_method: "email", delivery_schedule: "immediate").count
+          draft_content = form.reload.draft_form_document.content.deep_dup
+          live_content = form.reload.live_form_document.content.deep_dup
+          live_welsh_content = form.reload.live_welsh_form_document.content.deep_dup
+
+          task.invoke(form.id)
+
+          expect(form.reload.delivery_configurations.where(delivery_method: "email", delivery_schedule: "immediate").count)
+            .to eq(delivery_configuration_count)
+
+          expect(form.reload.draft_form_document.content).to eq(draft_content)
+          expect(form.reload.live_form_document.content).to eq(live_content)
+          expect(form.reload.live_welsh_form_document&.content).to eq(live_welsh_content)
+        end
       end
     end
 
-    context "when the form is draft" do
-      let(:form) { create :form, submission_type: "s3" }
-
-      it "sets a form's submission_type to email" do
-        expect { task.invoke(form.id) }
-          .to change { form.reload.submission_type }.to("email")
-      end
-
-      it "updates the form's draft form document" do
-        task.invoke(form.id)
-        expect(form.draft_form_document.reload.content["submission_type"]).to eq("email")
-        expect(form.draft_form_document.reload.content["submission_format"]).to eq([])
-      end
-    end
-
-    context "when the provided submission format is empty" do
-      let(:form) { create :form, :live, submission_type: "s3", submission_format: %w[json] }
-
-      it "sets a form's submission format to empty" do
-        expect { task.invoke(form.id) }
-          .to change { form.reload.submission_format }.to([])
-      end
-
-      it "sets a form's submission_type to email" do
-        expect { task.invoke(form.id) }
-          .to change { form.reload.submission_type }.to("email")
-      end
-    end
-
-    context "when the provided submission format is email" do
-      let(:form) { create :form, :live, submission_type: "s3", submission_format: %w[json] }
-
-      it "sets a form's submission format to empty" do
-        expect { task.invoke(form.id, "email") }
-          .to change { form.reload.submission_format }.to([])
-      end
-
-      it "sets a form's submission_type to email" do
-        expect { task.invoke(form.id, "email") }
-          .to change { form.reload.submission_type }.to("email")
-      end
-
-      it "creates a DeliveryConfiguration with blank format" do
-        task.invoke(form.id, "email")
-        expect(form.reload.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to include(
-          ["email", "immediate", []],
-        )
-      end
-    end
-
-    context "when the provided submission format is csv" do
-      it "sets a form's submission format to csv" do
-        expect { task.invoke(form.id, "csv") }
-          .to change { form.reload.submission_format }.to(%w[csv])
-      end
-
-      it "sets a form's submission_type to email" do
-        expect { task.invoke(form.id, "csv") }
-          .to change { form.reload.submission_type }.to("email")
-      end
-
-      it "creates a DeliveryConfiguration with csv format" do
-        task.invoke(form.id, "csv")
-        expect(form.reload.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to include(
-          ["email", "immediate", %w[csv]],
-        )
-      end
-    end
-
-    context "when the provided submission formate is json" do
-      it "sets a form's submission format to json" do
-        expect { task.invoke(form.id, "json") }
-          .to change { form.reload.submission_format }.to(%w[json])
-      end
-
-      it "sets a form's submission_type to email" do
-        expect { task.invoke(form.id, "json") }
-          .to change { form.reload.submission_type }.to("email")
-      end
-
-      it "creates a DeliveryConfiguration with json format" do
-        task.invoke(form.id, "json")
-        expect(form.reload.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to include(
-          ["email", "immediate", %w[json]],
-        )
-      end
-    end
-
-    context "when the provided submission format is csv, json" do
-      it "sets a form's submission format to csv and json" do
-        expect { task.invoke(form.id, "csv", "json") }
-          .to change { form.reload.submission_format }.to(%w[csv json])
-      end
-
-      it "sets a form's submission_type to email" do
-        expect { task.invoke(form.id, "csv", "json") }
-          .to change { form.reload.submission_type }.to("email")
-      end
-
-      it "creates a DeliveryConfiguration with the provided formats" do
-        task.invoke(form.id, "csv", "json")
-        expect(form.reload.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to include(
-          ["email", "immediate", %w[csv json]],
-        )
-      end
-    end
-
-    context "when the provided submission_type is s3" do
-      it "aborts with a usage message" do
-        expect { task.invoke(form.id, "s3") }
-          .to raise_error(SystemExit)
-                .and output("submission_format must be one of csv, json\n").to_stderr
-      end
-    end
-
-    context "without arguments" do
-      it "aborts with a usage message" do
+    context "with invalid arguments" do
+      it "aborts with a usage message when the form id is missing" do
         expect {
           task.invoke
         }.to raise_error(SystemExit)
-               .and output("usage: rake forms:submission_type:set_to_email[<form_id>(, <submission_format>)*]\n").to_stderr
+               .and output(/usage: rake forms:delivery_configurations:enable_email\[<form_id>\]/).to_stderr
       end
     end
   end
 
-  describe "forms:submission_type:set_to_s3" do
+  describe "forms:delivery_configurations:disable_email" do
     subject(:task) do
-      Rake::Task["forms:submission_type:set_to_s3"]
+      Rake::Task["forms:delivery_configurations:disable_email"]
     end
 
     let(:form) do
-      create(:form, :with_welsh_translation, :live, delivery_configurations: [
+      create(:form, :live, :with_welsh_translation, delivery_configurations: [
         create(:delivery_configuration, :immediate_email),
-        create(:delivery_configuration, :daily_email),
+        create(:delivery_configuration, :s3),
       ])
     end
-    let!(:other_form) { create :form, :live }
-    let(:s3_bucket_name) { "a-bucket" }
-    let(:s3_bucket_aws_account_id) { "an-aws-account-id" }
-    let(:s3_bucket_region) { "eu-west-1" }
-    let(:format) { "csv" }
-    let(:valid_args) { [form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region, format] }
 
-    context "when the form is live" do
-      context "when the format is csv" do
-        it "sets a form's submission_type to s3" do
-          expect { task.invoke(*valid_args) }
-            .to change { form.reload.submission_type }.to("s3")
-        end
-
-        it "sets a form's submission_format to csv" do
-          expect { task.invoke(*valid_args) }
-            .to change { form.reload.submission_format }.to(%w[csv])
-        end
-
-        it "replaces the immediate email DeliveryConfiguration with an s3 configuration" do
-          task.invoke(*valid_args)
-          expect(form.reload.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to contain_exactly(
-            ["s3", "immediate", %w[csv]],
-            ["email", "daily", %w[csv]],
-          )
-        end
-
-        it "updates the live form document" do
-          task.invoke(*valid_args)
-          form_document = form.live_form_document.reload
-          expect(form_document.content["submission_type"]).to eq("s3")
-          expect(form_document.content["submission_format"]).to eq(%w[csv])
-          expect(form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
-          expect(form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
-          expect(form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
-          expect(form_document.content["delivery_configurations"]).to contain_exactly(
-            {
-              "delivery_method" => "s3",
-              "delivery_schedule" => "immediate",
-              "formats" => %w[csv],
-            },
-            {
-              "delivery_method" => "email",
-              "delivery_schedule" => "daily",
-              "formats" => %w[csv],
-            },
-          )
-        end
-
-        it "updates the live Welsh form document" do
-          task.invoke(*valid_args)
-          welsh_form_document = form.live_welsh_form_document.reload
-          expect(welsh_form_document.content["submission_type"]).to eq("s3")
-          expect(welsh_form_document.content["submission_format"]).to eq(%w[csv])
-          expect(welsh_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
-          expect(welsh_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
-          expect(welsh_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
-          expect(welsh_form_document.content["delivery_configurations"]).to contain_exactly(
-            {
-              "delivery_method" => "s3",
-              "delivery_schedule" => "immediate",
-              "formats" => %w[csv],
-            },
-            {
-              "delivery_method" => "email",
-              "delivery_schedule" => "daily",
-              "formats" => %w[csv],
-            },
-          )
-        end
-
-        it "updates the draft form document" do
-          task.invoke(*valid_args)
-          form_document = form.draft_form_document.reload
-          expect(form_document.content["submission_type"]).to eq("s3")
-          expect(form_document.content["submission_format"]).to eq(%w[csv])
-          expect(form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
-          expect(form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
-          expect(form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
-          expect(form_document.content["delivery_configurations"]).to contain_exactly(
-            {
-              "delivery_method" => "s3",
-              "delivery_schedule" => "immediate",
-              "formats" => %w[csv],
-            },
-            {
-              "delivery_method" => "email",
-              "delivery_schedule" => "daily",
-              "formats" => %w[csv],
-            },
-          )
-        end
+    context "with valid arguments" do
+      it "removes immediate email delivery from the form" do
+        expect {
+          task.invoke(form.id)
+        }.to change { form.reload.delivery_configurations.where(delivery_method: "email", delivery_schedule: "immediate").count }
+               .by(-1)
       end
 
-      context "when the format is json" do
-        let(:format) { "json" }
+      it "updates the draft form document delivery configurations" do
+        task.invoke(form.id)
 
-        it "sets a form's submission_type to s3" do
-          expect { task.invoke(*valid_args) }
-            .to change { form.reload.submission_type }.to("s3")
-        end
-
-        it "sets a form's submission_format to json" do
-          expect { task.invoke(*valid_args) }
-            .to change { form.reload.submission_format }.to(%w[json])
-        end
-
-        it "replaces the immediate email DeliveryConfiguration with an s3 configuration with json format" do
-          task.invoke(*valid_args)
-          expect(form.reload.delivery_configurations.pluck(:delivery_method, :delivery_schedule, :formats)).to contain_exactly(
-            ["s3", "immediate", %w[json]],
-            ["email", "daily", %w[csv]],
-          )
-        end
-
-        it "updates the live form document" do
-          task.invoke(*valid_args)
-          form_document = form.live_form_document.reload
-          expect(form_document.content["submission_type"]).to eq("s3")
-          expect(form_document.content["submission_format"]).to eq(%w[json])
-          expect(form_document.content["delivery_configurations"]).to include(
-            {
-              "delivery_method" => "s3",
-              "delivery_schedule" => "immediate",
-              "formats" => %w[json],
-            },
-          )
-        end
-
-        it "updates the draft form document" do
-          task.invoke(*valid_args)
-          form_document = form.draft_form_document.reload
-          expect(form_document.content["submission_type"]).to eq("s3")
-          expect(form_document.content["submission_format"]).to eq(%w[json])
-          expect(form_document.content["delivery_configurations"]).to include(
-            {
-              "delivery_method" => "s3",
-              "delivery_schedule" => "immediate",
-              "formats" => %w[json],
-            },
-          )
-        end
+        expect(form.reload.draft_form_document.content["delivery_configurations"])
+          .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
       end
 
-      it "sets a form's s3_bucket_name" do
-        expect { task.invoke(*valid_args) }
-          .to change { form.reload.s3_bucket_name }.to(s3_bucket_name)
-      end
+      context "when the form is live" do
+        it "updates the live form documents delivery configurations" do
+          task.invoke(form.id)
 
-      it "sets a form's s3_bucket_aws_account_id" do
-        expect { task.invoke(*valid_args) }
-          .to change { form.reload.s3_bucket_aws_account_id }.to(s3_bucket_aws_account_id)
-      end
-
-      it "sets a form's s3_bucket_region" do
-        expect { task.invoke(*valid_args) }
-          .to change { form.reload.s3_bucket_region }.to(s3_bucket_region)
-      end
-
-      it "does not update a different form" do
-        expect { task.invoke(*valid_args) }
-          .not_to(change { other_form.reload.submission_type })
+          expect(form.reload.live_form_document.content["delivery_configurations"])
+            .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
+          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+            .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
+        end
       end
     end
 
-    context "when the form is draft" do
-      let(:form) { create :form }
-
-      it "updates the draft form document" do
-        task.invoke(*valid_args)
-        form_document = form.draft_form_document.reload
-        expect(form_document.content["submission_type"]).to eq("s3")
-        expect(form_document.content["submission_format"]).to eq([format])
-        expect(form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
-        expect(form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
-        expect(form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
-        expect(form_document.content["delivery_configurations"]).to include(
-          {
-            "delivery_method" => "s3",
-            "delivery_schedule" => "immediate",
-            "formats" => %w[csv],
-          },
-        )
-      end
-    end
-
-    context "without arguments" do
-      it "aborts with a usage message" do
+    context "with invalid arguments" do
+      it "aborts with a usage message when the form id is missing" do
         expect {
           task.invoke
         }.to raise_error(SystemExit)
-               .and output("usage: rake forms:submission_type:set_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>, <format>]\n").to_stderr
+               .and output(/usage: rake forms:delivery_configurations:disable_email\[<form_id>\]/).to_stderr
+      end
+
+      context "when email is already disabled" do
+        let(:form) do
+          create(:form, :live, :with_welsh_translation, delivery_configurations: [create(:delivery_configuration, :s3)])
+        end
+
+        it "aborts with an error" do
+          expect {
+            task.invoke(form.id)
+          }.to raise_error(SystemExit)
+                 .and output(/Email delivery is not enabled/).to_stderr
+        end
+      end
+
+      context "when the form would have no delivery methods if email delivery is disabled" do
+        let(:form) do
+          create(:form, :live, :with_welsh_translation, :with_email_delivery)
+        end
+
+        it "aborts with an error" do
+          expect {
+            task.invoke(form.id)
+          }.to raise_error(SystemExit)
+                 .and output(/Form will have no delivery methods, enable S3 delivery first/).to_stderr
+        end
+      end
+    end
+  end
+
+  describe "forms:delivery_configurations:disable_s3" do
+    subject(:task) do
+      Rake::Task["forms:delivery_configurations:disable_s3"]
+    end
+
+    let(:form) do
+      create(:form, :live, :with_welsh_translation, :with_s3_configuration, delivery_configurations: [
+        create(:delivery_configuration, :s3),
+        create(:delivery_configuration, :immediate_email),
+      ])
+    end
+
+    context "with valid arguments" do
+      it "removes immediate S3 delivery from the form" do
+        expect {
+          task.invoke(form.id)
+        }.to change { form.reload.delivery_configurations.where(delivery_method: "s3", delivery_schedule: "immediate").count }
+               .by(-1)
+      end
+
+      it "clears the form S3 configuration" do
+        expect {
+          task.invoke(form.id)
+        }.to change { form.reload.s3_bucket_name }.to(nil)
+                                                  .and change { form.reload.s3_bucket_aws_account_id }.to(nil)
+                                                                                                      .and change { form.reload.s3_bucket_region }.to(nil)
+      end
+
+      it "updates the draft form document" do
+        task.invoke(form.id)
+
+        expect(form.reload.draft_form_document.content["s3_bucket_name"]).to be_nil
+        expect(form.reload.draft_form_document.content["s3_bucket_aws_account_id"]).to be_nil
+        expect(form.reload.draft_form_document.content["s3_bucket_region"]).to be_nil
+        expect(form.reload.draft_form_document.content["delivery_configurations"])
+          .not_to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate"))
+      end
+
+      context "when the form is live" do
+        it "updates the live form documents" do
+          task.invoke(form.id)
+
+          expect(form.reload.live_form_document.content["s3_bucket_name"]).to be_nil
+          expect(form.reload.live_form_document.content["s3_bucket_aws_account_id"]).to be_nil
+          expect(form.reload.live_form_document.content["s3_bucket_region"]).to be_nil
+          expect(form.reload.live_form_document.content["delivery_configurations"])
+            .not_to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate"))
+
+          expect(form.reload.live_welsh_form_document.content["s3_bucket_name"]).to be_nil
+          expect(form.reload.live_welsh_form_document.content["s3_bucket_aws_account_id"]).to be_nil
+          expect(form.reload.live_welsh_form_document.content["s3_bucket_region"]).to be_nil
+          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+            .not_to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate"))
+        end
       end
     end
 
-    context "without bucket name argument" do
-      it "aborts with a usage message" do
+    context "with invalid arguments" do
+      it "aborts with a usage message when the form id is missing" do
         expect {
-          task.invoke(1)
+          task.invoke
         }.to raise_error(SystemExit)
-               .and output("usage: rake forms:submission_type:set_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>, <format>]\n").to_stderr
+               .and output(/usage: rake forms:delivery_configurations:disable_s3\[<form_id>\]/).to_stderr
+      end
+
+      context "when S3 delivery is not enabled" do
+        let(:form) do
+          create(:form, :live, :with_welsh_translation, :with_email_delivery)
+        end
+
+        it "aborts with an error" do
+          expect {
+            task.invoke(form.id)
+          }.to raise_error(SystemExit)
+                 .and output(/S3 delivery is not enabled/).to_stderr
+        end
+      end
+
+      context "when the form would have no delivery methods if S3 delivery is disabled" do
+        let(:form) do
+          create(:form, :live, :with_welsh_translation, delivery_configurations: [create(:delivery_configuration, :s3)])
+        end
+
+        it "aborts with an error" do
+          expect {
+            task.invoke(form.id)
+          }.to raise_error(SystemExit)
+                 .and output(/Form will have no delivery methods, enable email delivery first/).to_stderr
+        end
+      end
+    end
+  end
+
+  describe "forms:delivery_configurations:enable_s3" do
+    subject(:task) do
+      Rake::Task["forms:delivery_configurations:enable_s3"]
+    end
+
+    let(:form) { create(:form, :live, :with_welsh_translation, :with_email_delivery) }
+    let(:s3_bucket_name) { "test-bucket" }
+    let(:s3_bucket_aws_account_id) { "123456789012" }
+    let(:s3_bucket_region) { "eu-west-1" }
+    let(:format) { "csv" }
+    let(:disable_email) { "false" }
+    let(:valid_args) { [form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region, format, disable_email] }
+
+    context "with valid arguments" do
+      it "updates the form S3 configuration" do
+        expect {
+          task.invoke(*valid_args)
+        }.to change { form.reload.s3_bucket_name }.to(s3_bucket_name)
+                                                  .and change { form.reload.s3_bucket_aws_account_id }.to(s3_bucket_aws_account_id)
+                                                                                                      .and change { form.reload.s3_bucket_region }.to(s3_bucket_region)
+      end
+
+      it "adds S3 delivery and keeps email enabled" do
+        expect {
+          task.invoke(*valid_args)
+        }.to change { form.reload.delivery_configurations.where(delivery_method: "s3", delivery_schedule: "immediate").count }
+               .by(1)
+
+        expect(form.reload.delivery_configurations.where(delivery_method: "email", delivery_schedule: "immediate").count)
+          .to eq(1)
+        expect(form.reload.delivery_configurations.find_by(delivery_method: "s3", delivery_schedule: "immediate").formats)
+          .to eq([format])
+      end
+
+      it "updates the draft and live form documents" do
+        task.invoke(*valid_args)
+
+        expect(form.reload.draft_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
+        expect(form.reload.draft_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
+        expect(form.reload.draft_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
+
+        expect(form.reload.live_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
+        expect(form.reload.live_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
+        expect(form.reload.live_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
+
+        expect(form.reload.live_welsh_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
+        expect(form.reload.live_welsh_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
+        expect(form.reload.live_welsh_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
+
+        expect(form.reload.draft_form_document.content["delivery_configurations"])
+          .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => [format]))
+        expect(form.reload.live_form_document.content["delivery_configurations"])
+          .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => [format]))
+        expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+          .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => [format]))
+      end
+
+      context "when there is already an S3 delivery configuration" do
+        let(:form) do
+          create(:form, :live, :with_welsh_translation, delivery_configurations: [
+            create(:delivery_configuration, :s3, formats: %w[json]),
+          ])
+        end
+
+        it "updates the format for the existing configuration" do
+          task.invoke(*valid_args)
+
+          expect(form.reload.delivery_configurations.find_by(delivery_method: "s3", delivery_schedule: "immediate").formats)
+            .to eq(%w[csv])
+
+          expect(form.reload.draft_form_document.content["delivery_configurations"])
+            .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => %w[csv]))
+          expect(form.reload.live_form_document.content["delivery_configurations"])
+            .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => %w[csv]))
+          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+            .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => %w[csv]))
+        end
+      end
+
+      context "when disable_email is true" do
+        let(:disable_email) { "true" }
+
+        it "removes email delivery" do
+          expect {
+            task.invoke(*valid_args)
+          }.to change { form.reload.delivery_configurations.where(delivery_method: "email", delivery_schedule: "immediate").count }
+                 .by(-1)
+
+          expect(form.reload.draft_form_document.content["delivery_configurations"])
+            .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
+          expect(form.reload.live_form_document.content["delivery_configurations"])
+            .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
+          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+            .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
+
+          expect(form.reload.live_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
+          expect(form.reload.live_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
+          expect(form.reload.live_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
+
+          expect(form.reload.live_welsh_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
+          expect(form.reload.live_welsh_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
+          expect(form.reload.live_welsh_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
+        end
       end
     end
 
-    context "without AWS account ID argument" do
-      it "aborts with a usage message" do
+    context "with invalid arguments" do
+      it "aborts with a usage message when the form id is missing" do
         expect {
-          task.invoke(1, s3_bucket_name)
+          task.invoke
         }.to raise_error(SystemExit)
-               .and output("usage: rake forms:submission_type:set_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>, <format>]\n").to_stderr
-      end
-    end
-
-    context "without region argument" do
-      it "aborts with a usage message" do
-        expect {
-          task.invoke(1, s3_bucket_name, s3_bucket_aws_account_id)
-        }.to raise_error(SystemExit)
-               .and output("usage: rake forms:submission_type:set_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>, <format>]\n").to_stderr
-      end
-    end
-
-    context "without format argument" do
-      it "aborts with a usage message" do
-        expect {
-          task.invoke(1, s3_bucket_name, s3_bucket_aws_account_id, "eu-west-2")
-        }.to raise_error(SystemExit)
-               .and output("usage: rake forms:submission_type:set_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>, <format>]\n").to_stderr
-      end
-    end
-
-    context "when region is not allowed" do
-      it "aborts with message" do
-        expect {
-          task.invoke(1, s3_bucket_name, s3_bucket_aws_account_id, "eu-west-3", "csv")
-        }.to raise_error(SystemExit)
-               .and output("s3_bucket_region must be one of eu-west-1 or eu-west-2\n").to_stderr
-      end
-    end
-
-    context "when format is invalid" do
-      it "aborts with a usage message" do
-        expect {
-          task.invoke(1, s3_bucket_name, s3_bucket_aws_account_id, "eu-west-2", "xml")
-        }.to raise_error(SystemExit)
-               .and output("format must be one of csv or json\n").to_stderr
+               .and output(/usage: rake forms:delivery_configurations:enable_s3\[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>, <format>, <disable_email>\]/).to_stderr
       end
     end
   end
@@ -829,28 +720,28 @@ RSpec.describe "forms.rake", type: :task do
       expect {
         task.invoke(form.id)
       }.to raise_error(SystemExit)
-         .and output(/usage: rake forms:show_form_document\[<form_id>, <tag>, <language>\]/).to_stderr
+             .and output(/usage: rake forms:show_form_document\[<form_id>, <tag>, <language>\]/).to_stderr
     end
 
     it "aborts when the tag is invalid" do
       expect {
         task.invoke(form.id, "invalid", "en")
       }.to raise_error(SystemExit)
-         .and output(/tag must be one of draft, live or archived/).to_stderr
+             .and output(/tag must be one of draft, live or archived/).to_stderr
     end
 
     it "aborts when the language is invalid" do
       expect {
         task.invoke(form.id, "draft", "invalid")
       }.to raise_error(SystemExit)
-         .and output(/language must be en or cy/).to_stderr
+             .and output(/language must be en or cy/).to_stderr
     end
 
     it "aborts when the requested form document is missing" do
       expect {
         task.invoke(form.id, "draft", "cy")
       }.to raise_error(SystemExit)
-         .and output(/form #{form.id} \("#{form.name}"\) does not have a draft cy form document/).to_stderr
+             .and output(/form #{form.id} \("#{form.name}"\) does not have a draft cy form document/).to_stderr
     end
 
     context "when a form has a Welsh translation" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WMnjLlJV

Update the rake tasks for enabling/disabling S3 and email submissions to have the following tasks:
- enable_s3
- disable_s3
- enable_email
- disable_email

These tasks will now only edit the delivery_configurations and not edit the submission_type and submission_format which are deprecated and unused.

The new tasks make it possible to have both S3 and email submissions enabled at the same time.

### Review notes

As the tasks and tests have changed quite significantly, it might be easier to review using the split diff view or by checking to code out locally to look at the new tasks.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
