### PR TITLE
Update content for delivery configurations

### DIFF
--- a/app/models/form_document/content.rb
+++ b/app/models/form_document/content.rb
@@ -57,9 +57,15 @@ class FormDocument::Content
   end
 
   def email_delivery_configuration
-    delivery_configurations.find do |delivery_configuration|
-      delivery_configuration["delivery_method"] == "email" && delivery_configuration["delivery_schedule"] == "immediate"
-    end
+    immediate_delivery_configuration("email")
+  end
+
+  def has_s3_delivery?
+    s3_delivery_configuration.present?
+  end
+
+  def s3_delivery_configuration
+    immediate_delivery_configuration("s3")
   end
 
   def daily_submission_batch_enabled?
@@ -71,6 +77,14 @@ class FormDocument::Content
   def weekly_submission_batch_enabled?
     delivery_configurations.any? do |delivery_configuration|
       delivery_configuration["delivery_schedule"] == "weekly"
+    end
+  end
+
+private
+
+  def immediate_delivery_configuration(delivery_method)
+    delivery_configurations.find do |delivery_configuration|
+      delivery_configuration["delivery_method"] == delivery_method && delivery_configuration["delivery_schedule"] == "immediate"
     end
   end
 end

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -147,13 +147,23 @@
 
     <h3 class="govuk-heading-m"><%= t(".how_you_get_completed_forms.title") %></h3>
 
-    <h4 class="govuk-heading-s"><%= t('.how_you_get_completed_forms.submission_email') %></h4>
-    <p class="govuk-!-text-break-word"><%= form_document.submission_email %></p>
-
+    <h4 class="govuk-heading-s"><%= t('.how_you_get_completed_forms.email.heading') %></h4>
     <% if form_document.has_email_delivery? %>
+      <p class="govuk-!-text-break-word"><%= t('.how_you_get_completed_forms.email.enabled', submission_email: form_document.submission_email) %></p>
+
       <% formats = ["email", *form_document.email_delivery_configuration["formats"]].join("_") %>
-      <h4 class="govuk-heading-s"><%= t(".how_you_get_completed_forms.csv_and_json") %></h4>
-      <p><%= t(".how_you_get_completed_forms.submission_format.email.#{formats}_html") %></p>
+      <p><%= t(".how_you_get_completed_forms.email.format.#{formats}_html") %></p>
+    <% else %>
+      <p><%= t('.how_you_get_completed_forms.email.disabled') %></p>
+    <% end %>
+
+    <h4 class="govuk-heading-s"><%= t('.how_you_get_completed_forms.s3.heading') %></h4>
+    <% if form_document.has_s3_delivery? %>
+      <p><%= t('.how_you_get_completed_forms.s3.enabled',
+        delivery_format: form_document.s3_delivery_configuration["formats"].sole.upcase,
+        bucket_name: form_document.s3_bucket_name) %></p>
+    <% else %>
+      <p><%= t('.how_you_get_completed_forms.s3.disabled') %></p>
     <% end %>
 
     <h4 class="govuk-heading-s"><%= t(".how_you_get_completed_forms.batch_submissions.title") %></h4>

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -168,11 +168,11 @@
 
     <h4 class="govuk-heading-s"><%= t(".how_you_get_completed_forms.batch_submissions.title") %></h4>
     <% if form_document.daily_submission_batch_enabled? && form_document.weekly_submission_batch_enabled? %>
-      <p><%= t(".how_you_get_completed_forms.batch_submissions.daily_and_weekly_enabled") %></p>
+      <p><%= t(".how_you_get_completed_forms.batch_submissions.daily_and_weekly_enabled", submission_email: form_document.submission_email) %></p>
     <% elsif form_document.daily_submission_batch_enabled? %>
-      <p><%= t(".how_you_get_completed_forms.batch_submissions.daily_enabled") %></p>
+      <p><%= t(".how_you_get_completed_forms.batch_submissions.daily_enabled", submission_email: form_document.submission_email) %></p>
     <% elsif form_document.weekly_submission_batch_enabled? %>
-      <p><%= t(".how_you_get_completed_forms.batch_submissions.weekly_enabled") %></p>
+      <p><%= t(".how_you_get_completed_forms.batch_submissions.weekly_enabled", submission_email: form_document.submission_email) %></p>
     <% else %>
       <p><%= t(".how_you_get_completed_forms.batch_submissions.disabled") %></p>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -504,11 +504,11 @@ en:
       draft_edit: Edit the draft of this form
       how_you_get_completed_forms:
         batch_submissions:
-          daily_and_weekly_enabled: You are getting daily and weekly batches of completed forms.
-          daily_enabled: You are getting a daily batch of completed forms.
+          daily_and_weekly_enabled: You are getting daily and weekly batches of completed forms sent to %{submission_email}.
+          daily_enabled: You are getting a daily batch of completed forms sent to %{submission_email}.
           disabled: You have not opted to get a daily or weekly batch of completed forms.
           title: Daily and weekly CSVs
-          weekly_enabled: You are getting a weekly batch of completed forms.
+          weekly_enabled: You are getting a weekly batch of completed forms sent to %{submission_email}.
         email:
           disabled: You have not opted to get completed forms by email.
           enabled: You’re getting completed forms sent to %{submission_email}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -509,18 +509,23 @@ en:
           disabled: You have not opted to get a daily or weekly batch of completed forms.
           title: Daily and weekly CSVs
           weekly_enabled: You are getting a weekly batch of completed forms.
-        csv_and_json: CSV and JSON
-        submission_email: Email
-        submission_format:
-          email:
+        email:
+          disabled: You have not opted to get completed forms by email.
+          enabled: You’re getting completed forms sent to %{submission_email}.
+          format:
             email_csv_html: |
-              Each completed form is also attached to the email as a CSV file.</br>
-              You have not opted to get each completed form as a JSON file.
-            email_csv_json_html: Each completed form is also attached to the email as a CSV file and a JSON file.
-            email_html: You have not opted to also get each completed form as a JSON or CSV file.
+              Data from each completed form is also attached to the email as a CSV file.</br>
+              You have not opted to get data from each completed form as a JSON file.
+            email_csv_json_html: Data from each completed form is also attached to the email as a CSV file and a JSON file.
+            email_html: You have not opted to also get data from each completed form attached to the email as a JSON or CSV file.
             email_json_html: |
-              Each completed form is also attached to the email as a JSON file.</br>
-              You have not opted to get each completed form as a CSV file.
+              Data from each completed form is also attached to the email as a JSON file.</br>
+              You have not opted to get data from each completed form attached to the email as a CSV file.
+          heading: Email
+        s3:
+          disabled: You have not opted to receive completed forms in an AWS S3 bucket.
+          enabled: You’re receiving %{delivery_format} files in the AWS S3 bucket %{bucket_name}
+          heading: AWS S3 bucket
         title: How you get completed forms
       live_form_url: Form URL
       live_form_url_multilingual:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2255,8 +2255,8 @@ en:
       s3_details:
         summary_content_html: |
           <p>You can get completed forms sent to an AWS S3 bucket instead of an email address.</p>
-          <p>To find out more about this option, including how to set it up, <a href="https://www.forms.service.gov.uk/processing-completed-form-submissions">read our guidance on processing completed form submissions</a>.</p>
-          <p>You still need to set an email address here to mark this task complete. When you switch to an S3 bucket, you’ll stop getting completed forms by email.</p>
+          <p>You need to set an email address here to mark this task complete, even if you want to receive completed forms in an AWS S3 bucket.</p>
+          <p>To find out how to set up an AWS S3 bucket, <a href="https://www.forms.service.gov.uk/processing-completed-form-submissions">read our guidance on processing completed form submissions</a>.</p>
         summary_text: Get completed forms sent to an AWS S3 bucket
   share_preview:
     body_html: |

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -307,7 +307,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
       DeliveryConfiguration.create(
         delivery_method: :s3,
         delivery_schedule: :immediate,
-        formats: [],
+        formats: %w[csv],
       ),
     ],
   )

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -136,63 +136,71 @@ describe "forms/_made_live_form.html.erb" do
 
   it "contains information about how you get completed forms" do
     expect(rendered).to have_css("h3", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.title"))
-    expect(rendered).to have_xpath("//h3[text()='#{I18n.t('forms.made_live_form.how_you_get_completed_forms.title')}']/following-sibling::h4", text: "Email")
-    expect(rendered).to have_text(form_document.submission_email)
   end
 
-  context "when the submission type is 'email'" do
+  context "when only email submissions are configured" do
+    let(:formats) { [] }
+    let(:form_metadata) do
+      create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: formats)])
+    end
+
+    it "tells the user that email submission is enabled" do
+      expect(rendered).to have_xpath("//h3[text()='#{I18n.t('forms.made_live_form.how_you_get_completed_forms.title')}']/following-sibling::h4", text: "Email")
+      expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.email.enabled", submission_email: form_document.submission_email))
+    end
+
     context "when CSV submission is enabled" do
-      let(:form_metadata) do
-        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: %w[csv])])
-      end
+      let(:formats) { %w[csv] }
 
       it "tells the user they have CSVs enabled" do
-        expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
-        expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.submission_format.email.email_csv_html"))
+        expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.email.format.email_csv_html"))
       end
     end
 
     context "when JSON submission is enabled" do
-      let(:form_metadata) do
-        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: %w[json])])
-      end
+      let(:formats) { %w[json] }
 
       it "tells the user they have JSON submissions enabled" do
-        expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
-        expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.submission_format.email.email_json_html"))
+        expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.email.format.email_json_html"))
       end
     end
 
     context "when both CSV and JSON submissions are enabled" do
-      let(:form_metadata) do
-        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: %w[csv json])])
-      end
+      let(:formats) { %w[csv json] }
 
       it "tells the user they have CSV and JSON submissions enabled" do
-        expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
-        expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.submission_format.email.email_csv_json_html"))
+        expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.email.format.email_csv_json_html"))
       end
     end
 
-    context "when CSV submission is not enabled" do
-      let(:form_metadata) do
-        create(:form, :live, delivery_configurations: [create(:delivery_configuration, :immediate_email, formats: [])])
-      end
+    context "when no email submission attachments are enabled" do
+      let(:formats) { [] }
 
-      it "tells the user they do not have CSVs enabled" do
-        expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
-        expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.submission_format.email.email_html"))
+      it "tells the user they do not have CSV or JSON enabled" do
+        expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.email.format.email_html"))
       end
+    end
+
+    it "tells the user that S3 is not enabled" do
+      expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.s3.heading"))
+      expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.s3.disabled"))
     end
   end
 
-  context "when the submission type is 's3'" do
+  context "when only S3 delivery is configured" do
     let(:form_metadata) do
-      create(:form, :live, delivery_configurations: [create(:delivery_configuration, :s3)])
+      create(:form, :live, :with_s3_configuration, delivery_configurations: [create(:delivery_configuration, :s3)])
     end
 
-    it "does not include the CSV and JSON section" do
-      expect(rendered).not_to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.csv_and_json"))
+    it "tells the user that s3 submission are enabled" do
+      expect(rendered).to have_css("h4", text: I18n.t("forms.made_live_form.how_you_get_completed_forms.s3.heading"))
+      expect(rendered).to have_text(I18n.t("forms.made_live_form.how_you_get_completed_forms.s3.enabled",
+                                           delivery_format: "CSV", bucket_name: form_document.s3_bucket_name))
+    end
+
+    it "tells the user that email submissions are not enabled" do
+      expect(rendered).to have_xpath("//h3[text()='#{I18n.t('forms.made_live_form.how_you_get_completed_forms.title')}']/following-sibling::h4", text: "Email")
+      expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.email.disabled"))
     end
   end
 

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -212,7 +212,7 @@ describe "forms/_made_live_form.html.erb" do
     let(:form_metadata) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :daily_email)]) }
 
     it "tells the user they getting a daily CSV" do
-      expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.daily_enabled"))
+      expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.daily_enabled", submission_email: form_document.submission_email))
     end
   end
 
@@ -220,7 +220,7 @@ describe "forms/_made_live_form.html.erb" do
     let(:form_metadata) { create(:form, :live, delivery_configurations: [create(:delivery_configuration, :weekly_email)]) }
 
     it "tells the user they getting a weekly CSV" do
-      expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.weekly_enabled"))
+      expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.weekly_enabled", submission_email: form_document.submission_email))
     end
   end
 
@@ -233,7 +233,7 @@ describe "forms/_made_live_form.html.erb" do
     end
 
     it "tells the user they getting a daily and weekly CSV" do
-      expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.daily_and_weekly_enabled"))
+      expect(rendered).to include(I18n.t("forms.made_live_form.how_you_get_completed_forms.batch_submissions.daily_and_weekly_enabled", submission_email: form_document.submission_email))
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WMnjLlJV/245-allow-both-email-and-s3-submissions-simultaneously

Update:
- Details component content on submission email page now that both S3 and email can be enabled at the same time.
- The live form page to display when S3 submissions are enabled, and when email submissions are disabled. The CSV/JSON attachments section has moved under the `Email` heading, as this is relevant for email submissions only.

New details component content:

<img width="551" height="241" alt="Screenshot 2026-07-29 at 16 57 07" src="https://github.com/user-attachments/assets/903bb57c-65f6-4452-b104-f9fca84c8b3d" />

Live form page for a form with only email enabled, with CSV attachments enabled:

<img width="583" height="354" alt="Screenshot 2026-07-29 at 10 37 44" src="https://github.com/user-attachments/assets/43b14ff8-08e9-464d-ab5f-ea4a91dd0865" />

Live form page for a form with email disabled and S3 enabled:

<img width="583" height="286" alt="Screenshot 2026-07-29 at 10 37 21" src="https://github.com/user-attachments/assets/278f0594-cc72-4a02-b969-1a0e9e810dd4" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
