### PR TITLE
Stop hardcoding organisation ids in specs

### DIFF
--- a/spec/features/form/super_admin_view_forms_spec.rb
+++ b/spec/features/form/super_admin_view_forms_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "View forms", type: :feature do
   let(:org_forms) { [build(:form, id: 1, name: "Org form")] }
-  let(:other_org) { create :organisation, id: 2, slug: "Other org" }
+  let(:other_org) { create :organisation, slug: "Other org" }
   let(:other_org_user) { create :user, organisation: other_org }
   let(:other_org_forms) { [build(:form, id: 2, name: "Other org form")] }
   let(:other_org_group) { create :group, organisation_id: other_org.id }

--- a/spec/features/users/set_organisation_spec.rb
+++ b/spec/features/users/set_organisation_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 feature "Set or change a user's organisation", type: :feature do
   let!(:test_org) do
-    create(:organisation, id: 1, slug: "test-org")
+    create(:organisation, slug: "test-org")
   end
 
   before do
-    create(:organisation, id: 2, slug: "government-digital-service")
+    create(:organisation, slug: "government-digital-service")
     create_list :user, 6, organisation: test_org
     login_as_super_admin_user
   end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Membership, type: :model do
   end
 
   it "is invalid if the user and group are not in the same organisation" do
-    org1 = create :organisation, id: 1, slug: "test-org"
-    org2 = create :organisation, id: 2, slug: "ministry-of-testing"
+    org1 = create :organisation, slug: "test-org"
+    org2 = create :organisation, slug: "ministry-of-testing"
     user = create :user, organisation: org1
     group = create :group, organisation: org2
     membership = build(:membership, user:, group:)
@@ -54,7 +54,7 @@ RSpec.describe Membership, type: :model do
 
   describe ".destroy_invalid_organisation_memberships" do
     it "does not remove memberships for the same organisation" do
-      org1 = create :organisation, id: 1, slug: "test-org"
+      org1 = create :organisation, slug: "test-org"
       user = create :user, organisation: org1
       group = create :group, organisation: org1
       membership = create(:membership, user:, group:)
@@ -64,8 +64,8 @@ RSpec.describe Membership, type: :model do
     end
 
     it "removes mismatched memberships" do
-      org1 = create :organisation, id: 1, slug: "test-org"
-      org2 = create :organisation, id: 2, slug: "ministry-of-testing"
+      org1 = create :organisation, slug: "test-org"
+      org2 = create :organisation, slug: "ministry-of-testing"
       user = create :user, organisation: org1
       group = create :group, organisation: org1
       membership = create(:membership, user:, group:)
@@ -76,8 +76,8 @@ RSpec.describe Membership, type: :model do
     end
 
     it "does not remove memberships for other users" do
-      org1 = create :organisation, id: 1, slug: "test-org"
-      org2 = create :organisation, id: 2, slug: "ministry-of-testing"
+      org1 = create :organisation, slug: "test-org"
+      org2 = create :organisation, slug: "ministry-of-testing"
 
       user1 = create :user, organisation: org1
       user2 = create :user, organisation: org1

--- a/spec/requests/forms/change_name_controller_spec.rb
+++ b/spec/requests/forms/change_name_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Forms::ChangeNameController, type: :request do
   let(:form) { create(:form, name: "Form name", creator_id: 123) }
-  let(:organisation) { build :organisation, id: 1, slug: "test-org" }
+  let(:organisation) { build :organisation, slug: "test-org" }
   let(:user) { build :user, id: 1, organisation: }
   let(:group) { create(:group, organisation: user.organisation) }
 

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Forms::SubmissionEmailController, type: :request do
   include ActionView::Helpers::TextHelper
 
-  let(:organisation) { build :organisation, id: 1, slug: "test-org" }
+  let(:organisation) { build :organisation, slug: "test-org" }
   let(:user) { standard_user }
   let(:user_outside_group) { build :user, id: 2, organisation: }
 

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -1,20 +1,20 @@
 require "rails_helper"
 
 describe "users/edit.html.erb" do
+  let(:organisation) { create :organisation, slug: "test-org" }
   let(:user) do
     build(
       :user,
       id: 1,
-      organisation_id: 1,
+      organisation:,
       created_at: Time.zone.local(2023, 10, 16, 13, 24),
       last_signed_in_at: Time.zone.now,
     )
   end
 
   before do
-    create :organisation, id: 1, slug: "test-org"
-    create :organisation, id: 2, slug: "ministry-of-testing"
-    create :organisation, id: 3, slug: "department-for-tests", name: "Department for Tests", abbreviation: "DfT"
+    create :organisation, slug: "ministry-of-testing"
+    create :organisation, slug: "department-for-tests", name: "Department for Tests", abbreviation: "DfT"
 
     travel_to(Time.zone.local(2024, 8, 26, 11, 50)) do
       assign(:user, user)


### PR DESCRIPTION
### What problem does this pull request solve?

Some specs still created organisations with explicit primary keys (with `test_org` reserving id 1). Explicit-id inserts do not advance the Postgres id sequence, so on a freshly prepared database any example mixing a hardcoded-id organisation with a sequence-assigned one could fail with a unique constraint violation, depending on test order.

Nothing depends on the numeric ids, so this removes them and lets the database assign ids, distinguishing organisations by slug instead. This follows on from the factory changes in the same vein that removed hardcoded ids from the organisation factories.
