### PR TITLE
Move MOU feature specs into organisations specs

### DIFF
--- a/spec/features/mou/upgrade_user_changes_mou_spec.rb
+++ b/spec/features/mou/upgrade_user_changes_mou_spec.rb
@@ -3,48 +3,37 @@ require "rails_helper"
 describe "Assign an organisation to a user with a signed MOU", type: :feature do
   let(:user) { create :user, name: "Test User", organisation: nil }
   let!(:mou_signature) { create(:mou_signature, user:, organisation: nil, created_at: Time.zone.parse("September 1, 2023")) }
-  let(:organisation) { test_org }
+  let!(:organisation) { create :organisation, slug: "department-for-testing" }
 
-  it "a logged in user can sign an MOU" do
+  it "assigning an organisation to a user adds it to their MOU" do
     login_as_super_admin_user
-    when_i_visit_the_mou_index_page
-    then_i_can_see_the_mou_page
-    then_i_see_the_mou_with_no_organisation
-    then_i_visit_the_users_page
-    then_i_update_the_user_organisation
-    when_i_visit_the_mou_index_page
-    then_i_can_see_the_mou_page
+    when_i_update_the_user_organisation
+    then_i_visit_the_organisation_page
     then_i_see_the_mou_with_organisation
   end
 
 private
 
-  def when_i_visit_the_mou_index_page
-    visit mou_signatures_path
-  end
-
-  def then_i_can_see_the_mou_page
-    expect(page).to have_text "MOUs and agreements"
-  end
-
-  def then_i_see_the_mou_with_no_organisation
-    expect(page).to have_text mou_signature.user.name
-    expect(page).to have_text mou_signature.user.email
-    expect(page).to have_text "No organisation"
-  end
-
-  def then_i_visit_the_users_page
-    click_link mou_signature.user.email
-  end
-
-  def then_i_update_the_user_organisation
-    fill_in "Organisation", with: "#{organisation.name}\n"
+  def when_i_update_the_user_organisation
+    visit edit_user_path(user)
+    organisation_field = find_field "Organisation"
+    # The \n is important, it "presses enter" to confirm the autocomplete selection
+    organisation_field.fill_in with: "#{organisation.name}\n"
+    expect(organisation_field.value).to start_with organisation.name
     click_button "Save"
-    sleep 1
+    # wait for the save to finish before navigating away, or the form
+    # submission's redirect can clobber the next page visit
+    expect(page).to have_current_path(users_path)
+  end
+
+  def then_i_visit_the_organisation_page
+    visit organisation_path(organisation)
   end
 
   def then_i_see_the_mou_with_organisation
+    expect(page).to have_text "MOUs and agreements"
     expect(page).to have_text mou_signature.user.name
-    expect(page).to have_text organisation.name
+    expect(page).to have_link mou_signature.user.email
+    expect(page).to have_text "September 01, 2023"
   end
 end

--- a/spec/features/mou/view_signed_mous_spec.rb
+++ b/spec/features/mou/view_signed_mous_spec.rb
@@ -1,42 +1,35 @@
 require "rails_helper"
 
 describe "Check which MOUs have been signed", type: :feature do
-  let(:user) { super_admin_user }
-  let!(:mou_signatures) do
-    [create(:mou_signature, created_at: Time.zone.parse("October 12, 2023")),
-     create(:mou_signature, created_at: Time.zone.parse("September 1, 2023"))]
-  end
+  let(:organisation) { create :organisation, slug: "department-for-testing" }
+  let!(:mou_signature) { create(:mou_signature_for_organisation, organisation:, created_at: Time.zone.parse("October 12, 2023")) }
 
   before do
     login_as_super_admin_user
   end
 
-  it "super_admin's can see the MOUs page" do
-    then_i_click_on_the_mou_link
-    then_i_can_see_the_mou_page
+  it "super_admin's can see an organisation's signed MOUs" do
+    then_i_click_on_the_organisations_link
+    then_i_click_on_the_organisation
     then_i_can_see_the_mou_list
   end
 
 private
 
-  def then_i_can_see_the_mou_list
-    expect(page).to have_text mou_signatures.first.organisation.name
-    expect(page).to have_link mou_signatures.first.user.email
-    expect(page).to have_text mou_signatures.first.user.name
-    expect(page).to have_text "October 12, 2023"
-
-    expect(page).to have_text mou_signatures.second.organisation.name
-    expect(page).to have_link mou_signatures.second.user.email
-    expect(page).to have_text mou_signatures.second.user.name
-    expect(page).to have_text "September 01, 2023"
-  end
-
-  def then_i_click_on_the_mou_link
+  def then_i_click_on_the_organisations_link
     visit root_path
-    click_link("MOUs")
+    click_link("Organisations")
   end
 
-  def then_i_can_see_the_mou_page
+  def then_i_click_on_the_organisation
+    click_link organisation.name_with_abbreviation
+  end
+
+  def then_i_can_see_the_mou_list
     expect(page).to have_text "MOUs and agreements"
+    expect(page).to have_text "Crown MOU"
+    expect(page).to have_text mou_signature.user.name
+    expect(page).to have_link mou_signature.user.email
+    expect(page).to have_text "October 12, 2023"
   end
 end

--- a/spec/features/organisations/upgrade_user_changes_mou_spec.rb
+++ b/spec/features/organisations/upgrade_user_changes_mou_spec.rb
@@ -5,11 +5,11 @@ describe "Assign an organisation to a user with a signed MOU", type: :feature do
   let!(:mou_signature) { create(:mou_signature, user:, organisation: nil, created_at: Time.zone.parse("September 1, 2023")) }
   let!(:organisation) { create :organisation, slug: "department-for-testing" }
 
-  it "assigning an organisation to a user adds it to their MOU" do
+  it "assigning an organisation to a user shows their MOU on the organisation's page" do
     login_as_super_admin_user
     when_i_update_the_user_organisation
-    then_i_visit_the_organisation_page
-    then_i_see_the_mou_with_organisation
+    and_i_visit_the_organisation_page
+    then_i_can_see_the_mou_for_the_user
   end
 
 private
@@ -26,11 +26,11 @@ private
     expect(page).to have_current_path(users_path)
   end
 
-  def then_i_visit_the_organisation_page
+  def and_i_visit_the_organisation_page
     visit organisation_path(organisation)
   end
 
-  def then_i_see_the_mou_with_organisation
+  def then_i_can_see_the_mou_for_the_user
     expect(page).to have_text "MOUs and agreements"
     expect(page).to have_text mou_signature.user.name
     expect(page).to have_link mou_signature.user.email

--- a/spec/features/organisations/view_signed_mous_spec.rb
+++ b/spec/features/organisations/view_signed_mous_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Check which MOUs have been signed", type: :feature do
+describe "View an organisation's signed MOUs", type: :feature do
   let(:organisation) { create :organisation, slug: "department-for-testing" }
   let!(:mou_signature) { create(:mou_signature_for_organisation, organisation:, created_at: Time.zone.parse("October 12, 2023")) }
 
@@ -8,20 +8,20 @@ describe "Check which MOUs have been signed", type: :feature do
     login_as_super_admin_user
   end
 
-  it "super_admin's can see an organisation's signed MOUs" do
-    then_i_click_on_the_organisations_link
-    then_i_click_on_the_organisation
+  it "super_admin's can see an organisation's signed MOUs on its page" do
+    when_i_click_on_the_organisations_link
+    and_i_click_on_the_organisation
     then_i_can_see_the_mou_list
   end
 
 private
 
-  def then_i_click_on_the_organisations_link
+  def when_i_click_on_the_organisations_link
     visit root_path
     click_link("Organisations")
   end
 
-  def then_i_click_on_the_organisation
+  def and_i_click_on_the_organisation
     click_link organisation.name_with_abbreviation
   end
 


### PR DESCRIPTION
## What

Rewrites the MOU feature specs to check signed MOUs on the organisation pages, then moves them from `spec/features/mou` to `spec/features/organisations`. The MOU signing flow spec stays where it is, as signing is unchanged.

## Why

The organisation pages already show each organisation's signed MOUs, so these specs describe organisations page behaviour and belong with the other organisations specs. This is split out from the branch removing the standalone MOU list page, so the spec changes can be reviewed on their own; the specs no longer depend on the list page, which makes that removal a smaller follow-up.

The rewrite also fixes a race in the upgrade spec: it now waits for the user save's redirect before navigating away, replacing the `sleep` it relied on, as the form submission's redirect could otherwise land after the next page visit and clobber the organisation page.