### PR TITLE
Add a CSV report for draft forms and questions for draft forms

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -179,21 +179,23 @@ class ReportsController < WebController
     questions_feature_report(tag, params[:action], questions, type: :selection_questions_with_none_of_the_above)
   end
 
-  def live_forms_csv
-    forms = Reports::FormDocumentsService.form_documents(tag: "live-or-archived")
+  def forms_csv
+    tag = params[:tag]
+    forms = Reports::FormDocumentsService.form_documents(tag:)
 
     send_data Reports::FormsCsvReportService.new(forms).csv,
               type: "text/csv; charset=iso-8859-1",
-              disposition: "attachment; filename=#{csv_filename('live-or-archived_forms_report')}"
+              disposition: "attachment; filename=#{csv_filename("#{tag}_forms_report")}"
   end
 
-  def live_questions_csv
-    forms = Reports::FormDocumentsService.form_documents(tag: "live-or-archived")
+  def questions_csv
+    tag = params[:tag]
+    forms = Reports::FormDocumentsService.form_documents(tag:)
     questions = Reports::FeatureReportService.new(forms).questions
 
     send_data Reports::QuestionsCsvReportService.new(questions).csv,
               type: "text/csv; charset=iso-8859-1",
-              disposition: "attachment; filename=#{csv_filename('live-or-archived_questions_report')}"
+              disposition: "attachment; filename=#{csv_filename("#{tag}_questions_report")}"
   end
 
   def contact_for_research

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -184,7 +184,7 @@ class ReportsController < WebController
 
     send_data Reports::FormsCsvReportService.new(forms).csv,
               type: "text/csv; charset=iso-8859-1",
-              disposition: "attachment; filename=#{csv_filename('live_forms_report')}"
+              disposition: "attachment; filename=#{csv_filename('live-or-archived_forms_report')}"
   end
 
   def live_questions_csv
@@ -193,7 +193,7 @@ class ReportsController < WebController
 
     send_data Reports::QuestionsCsvReportService.new(questions).csv,
               type: "text/csv; charset=iso-8859-1",
-              disposition: "attachment; filename=#{csv_filename('live_questions_report')}"
+              disposition: "attachment; filename=#{csv_filename('live-or-archived_questions_report')}"
   end
 
   def contact_for_research

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -10,8 +10,10 @@
     </ul>
     <p><%= t(".download_form_data_as_a_csv_file") %></p>
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= govuk_link_to t("reports.csv_downloads.forms"), report_forms_csv_path(tag: "live-or-archived"), no_visited_state: true %></li>
-      <li><%= govuk_link_to t("reports.csv_downloads.questions"), report_questions_csv_path(tag: "live-or-archived"), no_visited_state: true %></li>
+      <li><%= govuk_link_to t("reports.csv_downloads.forms", tag: tag_label("live-or-archived")), report_forms_csv_path(tag: "live-or-archived"), no_visited_state: true %></li>
+      <li><%= govuk_link_to t("reports.csv_downloads.forms", tag: tag_label("draft")), report_forms_csv_path(tag: "draft"), no_visited_state: true %></li>
+      <li><%= govuk_link_to t("reports.csv_downloads.questions", tag: tag_label("live-or-archived")), report_questions_csv_path(tag: "live-or-archived"), no_visited_state: true %></li>
+      <li><%= govuk_link_to t("reports.csv_downloads.questions", tag: tag_label("draft")), report_questions_csv_path(tag: "draft"), no_visited_state: true %></li>
     </ul>
     <p><%= t(".user_reports") %></p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -10,8 +10,8 @@
     </ul>
     <p><%= t(".download_form_data_as_a_csv_file") %></p>
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= govuk_link_to t("reports.csv_downloads.forms"), report_live_forms_csv_path, no_visited_state: true %></li>
-      <li><%= govuk_link_to t("reports.csv_downloads.questions"), report_live_questions_csv_path, no_visited_state: true %></li>
+      <li><%= govuk_link_to t("reports.csv_downloads.forms"), report_forms_csv_path(tag: "live-or-archived"), no_visited_state: true %></li>
+      <li><%= govuk_link_to t("reports.csv_downloads.questions"), report_questions_csv_path(tag: "live-or-archived"), no_visited_state: true %></li>
     </ul>
     <p><%= t(".user_reports") %></p>
     <ul class="govuk-list govuk-list--bullet">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1983,8 +1983,8 @@ en:
         name: Name
       title: Users interested in research
     csv_downloads:
-      forms: Download data about all live or archived forms
-      questions: Download all questions in live or archived forms
+      forms: Download data about all %{tag} forms
+      questions: Download all questions in %{tag} forms
     features:
       answer_types:
         heading: Answer type usage

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,10 +284,11 @@ Rails.application.routes.draw do
       get "selection-questions-with-none-of-the-above", to: "reports#selection_questions_with_none_of_the_above", as: :report_selection_questions_with_none_of_the_above
     end
 
+    get "/forms/:tag/csv", constraints: { tag: /(draft|live|live-or-archived)/ }, to: "reports#forms_csv", as: :report_forms_csv
+    get "/forms/:tag/questions/csv", constraints: { tag: /(draft|live|live-or-archived)/ }, to: "reports#questions_csv", as: :report_questions_csv
+
     get "add_another_answer", to: "reports#add_another_answer", as: :report_add_another_answer
     get "last-signed-in-at", to: "reports#last_signed_in_at", as: :report_last_signed_in_at
-    get "live-forms-csv", to: "reports#live_forms_csv", as: :report_live_forms_csv
-    get "live-questions-csv", to: "reports#live_questions_csv", as: :report_live_questions_csv
     get "contact-for-research", to: "reports#contact_for_research", as: :report_contact_for_research
     get "users-per-organisation", to: "reports#users_per_organisation", as: :report_users_per_organisation
     get "organisation-email-domains", to: "reports#organisation_domains", as: :report_organisation_domains

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -586,11 +586,12 @@ RSpec.describe ReportsController, type: :request do
       end
     end
 
-    describe "#live_forms_csv" do
+    describe "#forms_csv" do
       let(:forms) do
         live_forms = create_list(:form, 2, :live)
         archived_form = create(:form, :archived)
-        [*live_forms, archived_form]
+        draft_forms = create_list(:form, 2)
+        [*live_forms, archived_form, *draft_forms]
       end
       let(:expected_csv_filename) { "live-or-archived_forms_report-2025-05-15 15:31:57 UTC.csv" }
 
@@ -599,7 +600,7 @@ RSpec.describe ReportsController, type: :request do
 
         travel_to Time.utc(2025, 5, 15, 15, 31, 57)
 
-        get report_live_forms_csv_path
+        get report_forms_csv_path(tag: "live-or-archived")
       end
 
       it_behaves_like "csv response"
@@ -716,11 +717,12 @@ RSpec.describe ReportsController, type: :request do
       end
     end
 
-    describe "#live_questions_csv" do
+    describe "#questions_csv" do
       let(:forms) do
         live_forms = create_list(:form, 2, :live, pages_count: 3)
         archived_form = create(:form, :archived, pages_count: 2)
-        [*live_forms, archived_form]
+        draft_forms = create_list(:form, 2)
+        [*live_forms, archived_form, *draft_forms]
       end
       let(:expected_csv_filename) { "live-or-archived_questions_report-2025-05-15 15:31:57 UTC.csv" }
 
@@ -729,7 +731,7 @@ RSpec.describe ReportsController, type: :request do
 
         travel_to Time.utc(2025, 5, 15, 15, 31, 57)
 
-        get report_live_questions_csv_path
+        get report_questions_csv_path(tag: "live-or-archived")
       end
 
       it_behaves_like "csv response"

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -592,7 +592,7 @@ RSpec.describe ReportsController, type: :request do
         archived_form = create(:form, :archived)
         [*live_forms, archived_form]
       end
-      let(:expected_csv_filename) { "live_forms_report-2025-05-15 15:31:57 UTC.csv" }
+      let(:expected_csv_filename) { "live-or-archived_forms_report-2025-05-15 15:31:57 UTC.csv" }
 
       before do
         login_as_super_admin_user
@@ -722,7 +722,7 @@ RSpec.describe ReportsController, type: :request do
         archived_form = create(:form, :archived, pages_count: 2)
         [*live_forms, archived_form]
       end
-      let(:expected_csv_filename) { "live_questions_report-2025-05-15 15:31:57 UTC.csv" }
+      let(:expected_csv_filename) { "live-or-archived_questions_report-2025-05-15 15:31:57 UTC.csv" }
 
       before do
         login_as_super_admin_user


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/IhIrRadP/3710-create-download-all-questions-in-draft-forms-report <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Add a way to get a CSV report on draft forms, or questions in draft forms. We need this to be able to figure out how many teams might be affected by the multiple branching feature (see https://trello.com/c/4Z0D0i3E/3182-check-if-there-are-any-other-forms-that-use-more-than-10-options-with-branching).

Note: I'm not sure how long it will take to generate this report in production; it might end up being quite large and being slower than the 30s allowed for responses. I tested in dev, but there are only about 350 draft forms there, with less than 1000 questions for draft forms, while prod has over 2950 draft forms, so it wasn't representative.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
