### PR TITLE
Change exit page model

### DIFF
--- a/app/models/concerns/condition_methods.rb
+++ b/app/models/concerns/condition_methods.rb
@@ -1,6 +1,6 @@
 module ConditionMethods
   def is_exit_page?
-    !exit_page_markdown.nil? || try(:exit_page_id).present?
+    !exit_page_markdown.nil?
   end
 
   alias_method :exit_page?, :is_exit_page?

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -52,9 +52,8 @@ class Condition < ApplicationRecord
   end
 
   def destroy_and_update_form!
-    exit_page_to_delete = exit_page
+    exit_page.presence&.destroy!
     destroy! && form.save_question_changes!
-    exit_page_to_delete.presence&.destroy! # unless FeatureService.new(group: form.group).enabled?(:multiple_branches)
   end
 
   def validation_errors

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -10,7 +10,6 @@ class Condition < ApplicationRecord
 
   has_one :form, through: :routing_page
   belongs_to :exit_page, optional: true, autosave: true
-  validates_associated :exit_page
 
   before_destroy :destroy_postconditions
   before_validation :sync_exit_page

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -9,15 +9,40 @@ class Condition < ApplicationRecord
   belongs_to :goto_page, class_name: "Page", optional: true
 
   has_one :form, through: :routing_page
-  belongs_to :exit_page, optional: true
+  belongs_to :exit_page, optional: true, autosave: true
+  validates_associated :exit_page
 
   before_destroy :destroy_postconditions
+  before_validation :sync_exit_page
 
   translates :exit_page_heading
   translates :exit_page_markdown, presence: false # Without presence here, the value is nil if set to ""
 
-  def self.create_and_update_form!(...)
-    condition = Condition.new(...)
+  alias_method :legacy_exit_page_heading, :exit_page_heading
+  alias_method :legacy_exit_page_heading=, :exit_page_heading=
+  def legacy_exit_page_heading_cy = legacy_exit_page_heading(locale: :cy)
+  alias_method :legacy_exit_page_markdown, :exit_page_markdown
+  alias_method :legacy_exit_page_markdown=, :exit_page_markdown=
+  def legacy_exit_page_markdown_cy = legacy_exit_page_markdown(locale: :cy)
+
+  def sync_exit_page
+    if legacy_exit_page_heading.present? && legacy_exit_page_markdown.present?
+      self.exit_page ||= build_exit_page(question_page: routing_page)
+
+      exit_page.heading = legacy_exit_page_heading
+      exit_page.markdown = legacy_exit_page_markdown
+      exit_page.heading_cy = legacy_exit_page_heading_cy
+      exit_page.markdown_cy = legacy_exit_page_markdown_cy
+    end
+
+    if legacy_exit_page_heading.blank? || legacy_exit_page_markdown.blank?
+      exit_page&.mark_for_destruction
+    end
+  end
+
+  def self.create_and_update_form!(**args)
+    condition = Condition.new(**args)
+
     condition.save_and_update_form
     condition
   end
@@ -28,7 +53,9 @@ class Condition < ApplicationRecord
   end
 
   def destroy_and_update_form!
+    exit_page_to_delete = exit_page
     destroy! && form.save_question_changes!
+    exit_page_to_delete.presence&.destroy! # unless FeatureService.new(group: form.group).enabled?(:multiple_branches)
   end
 
   def validation_errors
@@ -38,6 +65,30 @@ class Condition < ApplicationRecord
       warning_routing_to_next_page,
       warning_goto_page_before_routing_page,
     ].compact
+  end
+
+  def exit_page_heading(locale: nil, **options)
+    exit_page&.heading(locale:, **options) || legacy_exit_page_heading(locale:, **options)
+  end
+
+  def exit_page_heading=(value, locale: nil, **options)
+    public_send(:legacy_exit_page_heading=, value, locale: locale, **options)
+  end
+
+  def exit_page_heading_cy
+    exit_page&.heading_cy || legacy_exit_page_heading_cy
+  end
+
+  def exit_page_markdown(locale: nil, **options)
+    exit_page&.markdown(locale:, **options) || legacy_exit_page_markdown(locale:, **options)
+  end
+
+  def exit_page_markdown=(value, locale: nil, **options)
+    public_send(:legacy_exit_page_markdown=, value, locale: locale, **options)
+  end
+
+  def exit_page_markdown_cy
+    exit_page&.markdown_cy || legacy_exit_page_markdown_cy
   end
 
   def warning_goto_page_doesnt_exist

--- a/app/models/exit_page.rb
+++ b/app/models/exit_page.rb
@@ -1,6 +1,7 @@
 class ExitPage < ApplicationRecord
   extend Mobility
   belongs_to :question_page, class_name: "Page", optional: false
+  has_many :conditions, class_name: "Condition", dependent: :nullify
 
   validates :heading, presence: true
   validates :markdown, presence: true

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -17,6 +17,7 @@ class Form < ApplicationRecord
   has_one :draft_welsh_form_document, -> { where tag: "draft", language: :cy }, class_name: "FormDocument"
   has_one :draft_form_document, -> { where tag: "draft", language: :en }, class_name: "FormDocument"
   has_many :conditions, through: :pages, source: :routing_conditions
+  has_many :exit_pages, through: :pages, source: :exit_pages
   has_many :delivery_configurations, dependent: :destroy
   has_one :immediate_email_delivery_configuration, -> { where delivery_method: "email", delivery_schedule: "immediate" }, class_name: "DeliveryConfiguration"
   has_one :s3_delivery_configuration, -> { where delivery_method: "s3", delivery_schedule: "immediate" }, class_name: "DeliveryConfiguration"

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -59,8 +59,8 @@ class Page < ApplicationRecord
       form.save_question_changes!
 
       if answer_type_changed_from_selection_only_one_option || answer_settings_changed_from_only_one_option
-        exit_pages.destroy_all
         check_conditions.destroy_all
+        exit_pages.destroy_all
       end
     end
 

--- a/app/services/revert_draft_form_service.rb
+++ b/app/services/revert_draft_form_service.rb
@@ -188,6 +188,7 @@ private
     form.translations.where(locale: :cy).delete_all
     Page::Translation.where(locale: :cy, page_id: form.page_ids).delete_all
     Condition::Translation.where(locale: :cy, condition_id: form.condition_ids).delete_all
+    ExitPage::Translation.where(locale: :cy, exit_page_id: form.exit_page_ids).delete_all
   end
 
   def revert_delivery_configurations(form_document_content)

--- a/app/services/revert_draft_form_service.rb
+++ b/app/services/revert_draft_form_service.rb
@@ -117,6 +117,8 @@ private
     condition.routing_page = Page.find_by!(external_id: condition_data["routing_page_id"]) if condition_data["routing_page_id"]
     condition.check_page = Page.find_by!(external_id: condition_data["check_page_id"]) if condition_data["check_page_id"]
     condition.goto_page = Page.find_by!(external_id: condition_data["goto_page_id"]) if condition_data["goto_page_id"]
+    condition.exit_page_heading = condition_data["exit_page_heading"]
+    condition.exit_page_markdown = condition_data["exit_page_markdown"]
   end
 
   def welsh_form_document_exists?(tag)

--- a/spec/factories/models/conditions.rb
+++ b/spec/factories/models/conditions.rb
@@ -12,10 +12,6 @@ FactoryBot.define do
     exit_page_heading { nil }
     exit_page_markdown { nil }
 
-    # Define the association but we want to set it to nil by default
-    association :exit_page
-    exit_page_id { nil }
-
     trait :with_exit_page do
       goto_page { nil }
       exit_page_heading { "Exit page heading" }

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -720,4 +720,103 @@ RSpec.describe Condition, type: :model do
       end
     end
   end
+
+  describe "using the new ExitPage model" do
+    describe "#sync_exit_page" do
+      context "when no associated exit page exists" do
+        context "when exit page heading is set but not exit page markdown" do
+          subject(:condition) { build :condition, routing_page_id: create(:page).id, exit_page_heading: "Exit page heading" }
+
+          it "does not create an associated exit page" do
+            condition.save!
+            expect(condition.reload.exit_page).to be_nil
+          end
+        end
+
+        context "when exit page markdown is set but not exit page heading" do
+          subject(:condition) { build :condition, routing_page_id: create(:page).id, exit_page_markdown: "Exit page markdown" }
+
+          it "does not create an associated exit page" do
+            condition.save!
+            expect(condition.reload.exit_page).to be_nil
+          end
+        end
+
+        context "when exit page heading and markdown are set" do
+          subject(:condition) { build :condition, routing_page_id: create(:page).id, exit_page_heading: "Exit page heading", exit_page_markdown: "Exit page markdown" }
+
+          it "creates an associated exit page" do
+            condition.save!
+            expect(condition.reload.exit_page).to be_present
+          end
+
+          it "passes the exit page values to the new exit page" do
+            condition.save!
+            expect(condition.reload.exit_page.markdown).to eq(condition.exit_page_markdown)
+            expect(condition.reload.exit_page.heading).to eq(condition.exit_page_heading)
+          end
+
+          context "when the condition has a Welsh translation for exit page content" do
+            subject(:condition) do
+              build(
+                :condition,
+                routing_page_id: create(:page).id,
+                exit_page_heading: "Exit page heading",
+                exit_page_markdown: "Exit page markdown",
+                exit_page_heading_cy: "Exit page Welsh heading",
+                exit_page_markdown_cy: "Exit page Welsh markdown",
+              )
+            end
+
+            it "passes the exit page Welsh values to the new exit page" do
+              condition.save!
+              expect(condition.reload.exit_page.markdown_cy).to eq(condition.exit_page_markdown_cy)
+              expect(condition.reload.exit_page.heading_cy).to eq(condition.exit_page_heading_cy)
+            end
+          end
+        end
+      end
+
+      context "when an associated exit page exists" do
+        subject(:condition) do
+          create(
+            :condition,
+            routing_page_id: create(:page).id,
+            exit_page_heading: "Exit page heading",
+            exit_page_markdown: "Exit page markdown",
+            exit_page_heading_cy: "Exit page Welsh heading",
+            exit_page_markdown_cy: "Exit page Welsh markdown",
+          )
+        end
+
+        it "updates the associated exit page" do
+          updated_markdown = "New markdown"
+          condition.exit_page_markdown = updated_markdown
+          condition.save!
+          expect(condition.reload.exit_page.markdown).to eq(updated_markdown)
+          expect(condition.reload.exit_page.heading).to eq(condition.exit_page_heading)
+        end
+
+        it "removes the associated exit page if the condition no longer has exit page markdown" do
+          condition.exit_page_markdown = nil
+          condition.save!
+          expect(condition.reload.exit_page).to be_nil
+        end
+
+        it "removes the associated exit page if the condition no longer has exit page heading" do
+          condition.exit_page_heading = nil
+          condition.save!
+          expect(condition.reload.exit_page).to be_nil
+        end
+
+        it "removes Welsh translations without deleting the exit page" do
+          condition.exit_page_markdown_cy = nil
+          condition.save!
+          condition.exit_page.reload
+          expect(condition.exit_page).to be_present
+          expect(condition.exit_page.markdown_cy).to be_nil
+        end
+      end
+    end
+  end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -271,15 +271,6 @@ RSpec.describe Condition, type: :model do
         expect(condition.warning_goto_page_doesnt_exist).to be_nil
       end
     end
-
-    context "when exit_page_id is present using ExitPage" do
-      let(:exit_page) { create :exit_page }
-      let(:condition) { create :condition, routing_page_id: routing_page.id, goto_page_id: nil, exit_page_id: exit_page.id }
-
-      it "returns nil" do
-        expect(condition.warning_goto_page_doesnt_exist).to be_nil
-      end
-    end
   end
 
   describe "#warning_answer_doesnt_exist" do
@@ -654,8 +645,7 @@ RSpec.describe Condition, type: :model do
     end
 
     context "when the condition has an ExitPage" do
-      let(:exit_page) { create :exit_page, question_page: check_page }
-      let(:condition) { create :condition, exit_page_id: exit_page.id, routing_page_id: check_page.id }
+      let(:condition) { create :condition, :with_exit_page, routing_page_id: check_page.id }
 
       it "includes the exit_page_id" do
         expect(condition.as_json).to include({

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -481,13 +481,12 @@ RSpec.describe Page, type: :model do
     end
 
     context "when page has routing conditions and ExitPages" do
-      let(:routing_conditions) { [create(:condition, exit_page:)] }
+      let(:routing_conditions) { [create(:condition)] }
       let(:check_conditions) { routing_conditions }
-      let(:exit_page) { create :exit_page }
+      let(:exit_page) { create :exit_page, question_page: page }
 
       before do
-        exit_page.question_page = page
-        exit_page.save!
+        routing_conditions.first.exit_page = exit_page
       end
 
       it "does not delete existing conditions or ExitPages" do
@@ -792,14 +791,10 @@ RSpec.describe Page, type: :model do
     end
 
     context "when the page has an ExitPage" do
-      let!(:exit_page) { create :exit_page, question_page: page }
-
-      before do
-        create(:condition, routing_page_id: page.id, check_page_id: page.id, exit_page:)
-      end
+      let!(:condition) { create(:condition, :with_exit_page, routing_page_id: page.id, check_page_id: page.id) }
 
       it "includes the exit page" do
-        expect(page.reload.as_form_document_step(second_page)["exit_pages"].first).to match a_hash_including("id" => exit_page.id, "markdown" => exit_page.markdown, "heading" => exit_page.heading)
+        expect(page.reload.as_form_document_step(second_page)["exit_pages"].first).to match a_hash_including("id" => condition.exit_page_id, "markdown" => condition.exit_page.markdown, "heading" => condition.exit_page.heading)
       end
     end
   end

--- a/spec/services/revert_draft_form_service_spec.rb
+++ b/spec/services/revert_draft_form_service_spec.rb
@@ -137,6 +137,58 @@ describe RevertDraftFormService do
       end
     end
 
+    context "with an exit page condition" do
+      let(:live_form) { create(:form, :ready_for_live, pages_count: 1) }
+
+      before do
+        live_form.pages.first.update!(answer_type: "selection", answer_settings: { "only_one_option" => "true", "selection_options" => [{ "name" => "Yes" }, { "name" => "No" }] })
+        live_form.pages.first.routing_conditions.create!(
+          answer_value: "No",
+          routing_page_id: live_form.pages.first.id,
+          check_page_id: live_form.pages.first.id,
+          exit_page_heading: "You cannot continue",
+          exit_page_markdown: "Please contact us",
+        )
+        FormDocument.create!(form: live_form, tag: "live", content: live_form.as_form_document(live_at: live_form.updated_at))
+        live_form.update!(state: :live_with_draft)
+      end
+
+      context "when the exit page content is changed in the draft" do
+        before do
+          condition = live_form.pages.first.routing_conditions.first
+          condition.update!(exit_page_heading: "Something else", exit_page_markdown: "Something else entirely")
+        end
+
+        it "restores the original exit page content" do
+          revert_draft(live_tag)
+
+          live_form.reload
+          condition = live_form.pages.first.routing_conditions.first
+
+          expect(condition.exit_page_heading).to eq("You cannot continue")
+          expect(condition.exit_page_markdown).to eq("Please contact us")
+        end
+      end
+
+      context "when the exit page is removed in the draft" do
+        before do
+          condition = live_form.pages.first.routing_conditions.first
+          condition.update!(exit_page_heading: nil, exit_page_markdown: nil)
+        end
+
+        it "restores the original exit page and its ExitPage record" do
+          revert_draft(live_tag)
+
+          live_form.reload
+          condition = live_form.pages.first.routing_conditions.first
+
+          expect(condition.exit_page).to be_present
+          expect(condition.exit_page_heading).to eq("You cannot continue")
+          expect(condition.exit_page_markdown).to eq("Please contact us")
+        end
+      end
+    end
+
     context "when the delivery configurations are changed in the draft" do
       let(:live_form) do
         create(:form, :live, delivery_configurations: [

--- a/spec/support/shared_examples/condition_methods.rb
+++ b/spec/support/shared_examples/condition_methods.rb
@@ -11,12 +11,6 @@ RSpec.shared_examples "implements condition methods" do
       subject.exit_page_id = nil
       expect(subject.is_exit_page?).to be true
     end
-
-    it "returns true when exit_page_id is present" do
-      subject.exit_page_markdown = nil
-      subject.exit_page_id = 1
-      expect(subject.is_exit_page?).to be true
-    end
   end
 
   describe "#secondary_skip?" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/gZGRBU8Y/3172-change-add-edit-delete-exit-page-to-work-with-new-style-exit-page-model

An ExitPage will be created and destroyed in conjunction with Conditions having their exit page markdown and headings modified. 

This means that any exit page changes that take place in the app from this point forward will synchronise the Exit Page table with changes to exit pages. We still need to create a migration to update all existing exit page Conditions so that they have a corresponding ExitPage. 

This also holds for translations for exit pages, which will also be mapped over to the Exit Page table. 

Areas of the app that we've tested this with - CRUDding exit pages, CRUDding exit page translations, copying a form, deleting the draft of a live/archived form 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
