### PR TITLE
Handle one match or no matching organisations for the user

### DIFF
--- a/app/controllers/account/organisations_controller.rb
+++ b/app/controllers/account/organisations_controller.rb
@@ -3,6 +3,7 @@ module Account
     include AfterSignInPathHelper
 
     before_action :redirect_if_organisation_exists
+    before_action :render_if_no_matches
     skip_before_action :redirect_if_account_not_completed
 
     def edit
@@ -61,6 +62,10 @@ module Account
 
     def redirect_if_organisation_exists
       redirect_to root_path if current_user.organisation.present?
+    end
+
+    def render_if_no_matches
+      render :no_matches if allowed_organisations.empty?
     end
 
     def next_path

--- a/app/controllers/account/organisations_controller.rb
+++ b/app/controllers/account/organisations_controller.rb
@@ -6,6 +6,8 @@ module Account
     skip_before_action :redirect_if_account_not_completed
 
     def edit
+      return redirect_to show_confirm_account_organisation_path if allowed_organisations.one?
+
       @organisation_input = OrganisationInput.new(user: current_user, allowed_organisations:).assign_form_values
     end
 
@@ -21,11 +23,40 @@ module Account
       end
     end
 
+    def show_confirm
+      return redirect_to edit_account_organisation_path unless allowed_organisations.one?
+
+      @confirm_organisation_input = ConfirmOrganisationInput.new(organisation: allowed_organisations.sole)
+
+      render :confirm
+    end
+
+    def confirm
+      return redirect_to edit_account_organisation_path unless allowed_organisations.one?
+
+      organisation = allowed_organisations.sole
+      @confirm_organisation_input = ConfirmOrganisationInput.new(
+        confirm_organisation_input_params.merge(organisation: organisation),
+      )
+
+      return render :confirm, status: :unprocessable_content if @confirm_organisation_input.invalid?
+      return render :not_listed unless @confirm_organisation_input.confirmed?
+
+      current_user.update!(organisation: organisation)
+      Rails.logger.info("User chose their organisation", { organisation_id: organisation.id })
+
+      redirect_to next_path
+    end
+
   private
 
     def account_organisation_input_params
       params.fetch(:account_organisation_input, {}).permit(:organisation_id)
             .merge({ user: current_user, allowed_organisations: })
+    end
+
+    def confirm_organisation_input_params
+      params.require(:account_confirm_organisation_input).permit(:confirm)
     end
 
     def redirect_if_organisation_exists
@@ -37,11 +68,11 @@ module Account
     end
 
     def allowed_organisations
-      if FeatureService.enabled?(:show_relevant_organisations)
-        Organisation.not_closed.for_domain(current_user.email_domain).order(:name)
-      else
-        Organisation.not_closed.order(:name)
-      end
+      @allowed_organisations ||= if FeatureService.enabled?(:show_relevant_organisations)
+                                   Organisation.not_closed.for_domain(current_user.email_domain).order(:name)
+                                 else
+                                   Organisation.not_closed.order(:name)
+                                 end
     end
   end
 end

--- a/app/controllers/account/organisations_controller.rb
+++ b/app/controllers/account/organisations_controller.rb
@@ -15,7 +15,7 @@ module Account
       @organisation_input = OrganisationInput.new(account_organisation_input_params)
 
       if @organisation_input.not_listed_selected?
-        render :not_listed
+        render :no_matches
       elsif @organisation_input.submit
         redirect_to next_path
       else
@@ -40,7 +40,7 @@ module Account
       )
 
       return render :confirm, status: :unprocessable_content if @confirm_organisation_input.invalid?
-      return render :not_listed unless @confirm_organisation_input.confirmed?
+      return render :no_matches unless @confirm_organisation_input.confirmed?
 
       current_user.update!(organisation: organisation)
       Rails.logger.info("User chose their organisation", { organisation_id: organisation.id })

--- a/app/input_objects/account/confirm_organisation_input.rb
+++ b/app/input_objects/account/confirm_organisation_input.rb
@@ -1,0 +1,23 @@
+class Account::ConfirmOrganisationInput < BaseInput
+  attr_accessor :organisation, :confirm
+
+  RADIO_OPTIONS = { yes: "yes", no: "no" }.freeze
+
+  validate :validate_confirm
+
+  def confirmed?
+    confirm == RADIO_OPTIONS[:yes]
+  end
+
+  def values
+    RADIO_OPTIONS.keys
+  end
+
+private
+
+  def validate_confirm
+    if confirm.blank? || !RADIO_OPTIONS.values.include?(confirm)
+      errors.add(:confirm, :blank, organisation: organisation.name_with_abbreviation)
+    end
+  end
+end

--- a/app/views/account/organisations/confirm.html.erb
+++ b/app/views/account/organisations/confirm.html.erb
@@ -1,0 +1,22 @@
+<% set_page_title(title_with_error_prefix(t('page_titles.confirm_account_organisation'), @confirm_organisation_input.errors.any?)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @confirm_organisation_input, url: confirm_account_organisation_path) do |f| %>
+      <% if @confirm_organisation_input&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l">
+        <%= t('page_titles.confirm_account_organisation') %>
+      </h1>
+
+      <%= t('.body_html', organisation: @confirm_organisation_input.organisation.name_with_abbreviation) %>
+
+      <%= f.govuk_collection_radio_buttons :confirm,
+        @confirm_organisation_input.values, ->(option) { option },
+        legend: { text: t('.radios_legend', organisation: @confirm_organisation_input.organisation.name_with_abbreviation), size: 'm' } %>
+
+      <%= f.govuk_submit t("save_and_continue") %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/account/organisations/edit.html.erb
+++ b/app/views/account/organisations/edit.html.erb
@@ -12,7 +12,7 @@
           <%= t("page_titles.account_organisation") %>
         </h1>
 
-        <p><%= t("account.organisation.you_created_account_with", email_domain: @organisation_input.user.email_domain) %></p>
+        <p><%= t(".you_created_account_with", email_domain: @organisation_input.user.email_domain) %></p>
       <% end %>
 
       <% if @organisation_input.radios? %>
@@ -29,7 +29,7 @@
           <%= f.govuk_radio_button(
                 :organisation_id,
                 Account::OrganisationInput::NOT_LISTED_OPTION_VALUE,
-                label: { text: t("account.organisation.not_listed_option") },
+                label: { text: t(".not_listed_option") },
                 link_errors: false
               ) %>
         <% end %>
@@ -60,7 +60,7 @@
 
     <% unless @organisation_input.radios? %>
       <%= govuk_section_break(visible: true, size: "l") %>
-      <%= govuk_details(summary_text: t('account.organisation.details_summary'), text: t('account.organisation.not_listed_html', contact_link: contact_link)) %>
+      <%= govuk_details(summary_text: t('.details_summary'), text: t('.not_listed_html', contact_link: contact_link)) %>
     <% end %>
   </div>
 </div>

--- a/app/views/account/organisations/no_matches.html.erb
+++ b/app/views/account/organisations/no_matches.html.erb
@@ -1,0 +1,7 @@
+<% set_page_title(t("page_titles.no_matching_organisation")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('page_titles.no_matching_organisation') %></h1>
+    <%= t('.body_html', contact_link: contact_link) %>
+  </div>
+</div>

--- a/app/views/account/organisations/not_listed.html.erb
+++ b/app/views/account/organisations/not_listed.html.erb
@@ -1,7 +1,0 @@
-<% set_page_title(t("page_titles.organisation_not_listed")) %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('page_titles.organisation_not_listed') %></h1>
-    <%= t('.not_listed_html', contact_link: contact_link) %>
-  </div>
-</div>

--- a/app/views/account/organisations/not_listed.html.erb
+++ b/app/views/account/organisations/not_listed.html.erb
@@ -2,6 +2,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.organisation_not_listed') %></h1>
-    <%= t('account.organisation.not_listed_html', contact_link: contact_link) %>
+    <%= t('.not_listed_html', contact_link: contact_link) %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,9 +12,9 @@ en:
           <p>At the moment, GOV.UK Forms is only available to central government organisations. If you’re from an organisation outside central government, you can <a href="https://www.forms.service.gov.uk/forthcoming-features">read about future plans for GOV.UK Forms</a>.</p>
         not_listed_option: The organisation I work for is not listed
         you_created_account_with: You created your account using an @%{email_domain} email address.
-      not_listed:
-        not_listed_html: |
-          <p>If you’re from a central government organisation that’s not listed, %{contact_link}.</p>
+      no_matches:
+        body_html: |
+          <p>If you’re from a central government organisation, %{contact_link}.</p>
           <p>At the moment, GOV.UK Forms is only available to central government organisations. If you’re from an organisation outside central government, you can <a href="https://www.forms.service.gov.uk/forthcoming-features">read about future plans for GOV.UK Forms</a>.</p>
     terms_of_use:
       accessibility:
@@ -1723,10 +1723,10 @@ en:
     new_group: Give your group a name
     new_page: Edit question
     new_secondary_skip: 'Route for any other answer: set questions to skip'
+    no_matching_organisation: Sorry, we couldn’t match your email address to an organisation
     non_crown_agreement_confirmation: You’ve agreed to the GOV.UK Forms agreement
     non_crown_agreement_new: GOV.UK Forms agreement
     not_found: Page not found
-    organisation_not_listed: What to do if your organisation is not listed
     organisations: Organisations
     payment_link: Add a link to a payment page on GOV.UK Pay
     privacy_policy: Provide a link to privacy information for this form

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,9 @@
 en:
   account:
     organisations:
+      confirm:
+        body_html: "<p>Based on the email address you used to create your account, we think your organisation is <strong>%{organisation}</strong>.</p>"
+        radios_legend: Do you work for %{organisation}?
       edit:
         details_summary: If your organisation is not listed
         not_listed_html: |
@@ -1682,6 +1685,7 @@ en:
     change_name: Name your form
     change_order_pages_added_error: Sorry, we could not save the new question order
     change_page_order: Change your question order
+    confirm_account_organisation: Confirm your organisation
     confirm_delete_exit_page: Your exit page will be deleted
     confirm_email: Enter the confirmation code
     confirm_email_success: Email address confirmed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,13 +1,18 @@
 ---
 en:
   account:
-    organisation:
-      details_summary: If your organisation is not listed
-      not_listed_html: |
-        <p>If you’re from a central government organisation that’s not listed, %{contact_link}.</p>
-        <p>At the moment, GOV.UK Forms is only available to central government organisations. If you’re from an organisation outside central government, you can <a href="https://www.forms.service.gov.uk/forthcoming-features">read about future plans for GOV.UK Forms</a>.</p>
-      not_listed_option: The organisation I work for is not listed
-      you_created_account_with: You created your account using an @%{email_domain} email address.
+    organisations:
+      edit:
+        details_summary: If your organisation is not listed
+        not_listed_html: |
+          <p>If you’re from a central government organisation that’s not listed, %{contact_link}.</p>
+          <p>At the moment, GOV.UK Forms is only available to central government organisations. If you’re from an organisation outside central government, you can <a href="https://www.forms.service.gov.uk/forthcoming-features">read about future plans for GOV.UK Forms</a>.</p>
+        not_listed_option: The organisation I work for is not listed
+        you_created_account_with: You created your account using an @%{email_domain} email address.
+      not_listed:
+        not_listed_html: |
+          <p>If you’re from a central government organisation that’s not listed, %{contact_link}.</p>
+          <p>At the moment, GOV.UK Forms is only available to central government organisations. If you’re from an organisation outside central government, you can <a href="https://www.forms.service.gov.uk/forthcoming-features">read about future plans for GOV.UK Forms</a>.</p>
     terms_of_use:
       accessibility:
         heading: Make forms that are easy to use and accessible

--- a/config/locales/input_objects/confirm_organisation.yml
+++ b/config/locales/input_objects/confirm_organisation.yml
@@ -1,0 +1,15 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        account/confirm_organisation_input:
+          attributes:
+            confirm:
+              blank: Select ‘Yes’ if you work for %{organisation}
+  helpers:
+    label:
+      account_confirm_organisation_input:
+        confirm_options:
+          'no': No, I work for a different organisation
+          'yes': 'Yes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,9 +210,13 @@ Rails.application.routes.draw do
 
   namespace :account do
     resource :name, only: %i[edit update]
-    resource :organisation, only: %i[edit update]
     resource :terms_of_use, controller: :terms_of_use, only: %i[edit update]
     resource :contact_for_research, controller: :contact_for_research, only: %i[edit update]
+
+    resource :organisation, only: %i[edit update] do
+      get "/confirm", to: "organisations#show_confirm", as: :show_confirm
+      post "/confirm", to: "organisations#confirm", as: :confirm
+    end
   end
 
   resources :organisations, only: %i[index show] do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,6 +43,8 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
   test_org.organisation_domains.create! domain: "digital.cabinet-office.gov.uk"
   test_org.organisation_domains.create! domain: "dsit.gov.uk"
   mot_org = Organisation.create! slug: "ministry-of-tests", name: "Ministry of Tests", abbreviation: "MOT"
+  mot_org.organisation_domains.create! domain: "example.com"
+  mot_org.organisation_domains.create! domain: "example.gov.uk"
   Organisation.create! slug: "department-for-testing", name: "Department for Testing", abbreviation: "DfT"
   Organisation.create! slug: "closed-org", name: "Closed Org", abbreviation: "CO", closed: true
 

--- a/spec/features/account/complete_user_account_spec.rb
+++ b/spec/features/account/complete_user_account_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
-feature "Add account organisation to user without organisation", type: :feature do
-  let(:user) { create :user, :with_no_org, name: nil, terms_agreed_at: nil }
-  let!(:organisation) { create :organisation }
+feature "Add account organisation to user without organisation", :feature_show_relevant_organisations, type: :feature do
+  let(:domain) { "example.gov.uk" }
+  let(:user) { create :user, :with_no_org, email: Faker::Internet.email(domain: domain), name: nil, terms_agreed_at: nil }
+  let!(:organisation) { create :organisation, organisation_domains: [create(:organisation_domain, domain: domain)] }
 
   before do
     OmniAuth.config.test_mode = true
@@ -12,6 +13,9 @@ feature "Add account organisation to user without organisation", type: :feature 
     )
 
     allow(Settings).to receive(:auth_provider).and_return("auth0")
+
+    # add another org so a list of options is displayed
+    create :organisation, organisation_domains: [create(:organisation_domain, domain: domain)]
   end
 
   after do
@@ -47,7 +51,7 @@ private
   end
 
   def and_i_select_an_organisation
-    fill_in "Select your organisation", with: "#{organisation.name}\n"
+    choose organisation.name_with_abbreviation
     click_button "Save and continue"
   end
 

--- a/spec/input_objects/account/confirm_organisation_input_spec.rb
+++ b/spec/input_objects/account/confirm_organisation_input_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe Account::ConfirmOrganisationInput do
+  subject(:input) { described_class.new(organisation:) }
+
+  let(:organisation) { build :organisation, name: "Ministry of Tests", abbreviation: "MOT" }
+
+  describe "validations" do
+    it "is valid when confirm is set to a valid value" do
+      input.confirm = "yes"
+      expect(input).to be_valid
+    end
+
+    it "is invalid when confirm is blank" do
+      input.confirm = ""
+      expect(input).to be_invalid
+
+      expect(input.errors.full_messages_for(:confirm)).to include(
+        "Confirm Select ‘Yes’ if you work for Ministry of Tests (MOT)",
+      )
+    end
+
+    it "is invalid when confirm is set to an invalid value" do
+      input.confirm = "invalid"
+      expect(input).to be_invalid
+
+      expect(input.errors.full_messages_for(:confirm)).to include(
+        "Confirm Select ‘Yes’ if you work for Ministry of Tests (MOT)",
+      )
+    end
+  end
+end

--- a/spec/requests/account/organisations_controller_spec.rb
+++ b/spec/requests/account/organisations_controller_spec.rb
@@ -95,9 +95,9 @@ describe Account::OrganisationsController do
         create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
       end
 
-      it "renders the not_listed template" do
+      it "renders the no_matches template" do
         put account_organisation_path, params: params
-        expect(response).to render_template(:not_listed)
+        expect(response).to render_template(:no_matches)
       end
 
       it "does not update the user's organisation" do
@@ -217,10 +217,10 @@ describe Account::OrganisationsController do
       context "when 'no' is selected" do
         let(:params) { { account_confirm_organisation_input: { confirm: "no" } } }
 
-        it "renders the not_listed template and does not update the user's organisation" do
+        it "renders the no_matches template and does not update the user's organisation" do
           post confirm_account_organisation_path, params: params
           expect(user.reload.organisation).to be_nil
-          expect(response).to render_template(:not_listed)
+          expect(response).to render_template(:no_matches)
         end
       end
 

--- a/spec/requests/account/organisations_controller_spec.rb
+++ b/spec/requests/account/organisations_controller_spec.rb
@@ -29,6 +29,13 @@ describe Account::OrganisationsController do
             expect(input_object.allowed_organisations).to match_array(matching_orgs)
           end
 
+          context "when there are no organisations the user can select" do
+            it "renders the no_matches template" do
+              get edit_account_organisation_path
+              expect(response).to render_template(:no_matches)
+            end
+          end
+
           context "when there is only one organisation the user can select" do
             it "redirects to the confirm organisation path" do
               create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
@@ -165,6 +172,13 @@ describe Account::OrganisationsController do
         end
       end
     end
+
+    context "when there are no organisations the user can select" do
+      it "renders the no_matches template" do
+        put account_organisation_path, params: {}
+        expect(response).to render_template(:no_matches)
+      end
+    end
   end
 
   describe "GET #show_confirm", :feature_show_relevant_organisations do
@@ -178,6 +192,13 @@ describe Account::OrganisationsController do
         input_object = assigns(:confirm_organisation_input)
         expect(input_object).to be_a(Account::ConfirmOrganisationInput)
         expect(input_object.organisation).to eq(organisation)
+      end
+    end
+
+    context "when there are no organisations the user can select" do
+      it "renders the no_matches template" do
+        get show_confirm_account_organisation_path
+        expect(response).to render_template(:no_matches)
       end
     end
 
@@ -236,6 +257,13 @@ describe Account::OrganisationsController do
           error = I18n.t("activemodel.errors.models.account/confirm_organisation_input.attributes.confirm.blank", organisation: organisation.name_with_abbreviation)
           expect(response.body).to include(error)
         end
+      end
+    end
+
+    context "when there are no organisations the user can select" do
+      it "renders the no_matches template" do
+        post confirm_account_organisation_path, params: params
+        expect(response).to render_template(:no_matches)
       end
     end
 

--- a/spec/requests/account/organisations_controller_spec.rb
+++ b/spec/requests/account/organisations_controller_spec.rb
@@ -9,49 +9,59 @@ describe Account::OrganisationsController do
   end
 
   describe "GET #edit" do
-    context "when the user does not have an organisation" do
-      it "renders the edit template" do
-        get edit_account_organisation_path
-        expect(response).to render_template(:edit)
-      end
+    context "when there is more than one organisation the user can select" do
+      context "when the user does not have an organisation" do
+        context "when the show_relevant_organisations feature is enabled", :feature_show_relevant_organisations do
+          it "assign the input object with allowed organisations limited by the user's domain" do
+            matching_orgs = [
+              create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]),
+              create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]),
+            ]
+            create(:organisation, organisation_domains: [create(:organisation_domain, domain: "example.com")])
+            create(:organisation, closed: true, organisation_domains: [create(:organisation_domain, domain: domain)])
 
-      context "when the show_relevant_organisations feature is enabled", :feature_show_relevant_organisations do
-        it "assign the input object with allowed organisations limited by the user's domain" do
-          matching_orgs = [
-            create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]),
-            create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]),
-          ]
-          create(:organisation, organisation_domains: [create(:organisation_domain, domain: "example.com")])
-          create(:organisation, closed: true, organisation_domains: [create(:organisation_domain, domain: domain)])
+            get edit_account_organisation_path
 
-          get edit_account_organisation_path
+            expect(response).to render_template(:edit)
 
-          input_object = assigns(:organisation_input)
-          expect(input_object).to be_a(Account::OrganisationInput)
-          expect(input_object.allowed_organisations).to match_array(matching_orgs)
+            input_object = assigns(:organisation_input)
+            expect(input_object).to be_a(Account::OrganisationInput)
+            expect(input_object.allowed_organisations).to match_array(matching_orgs)
+          end
+
+          context "when there is only one organisation the user can select" do
+            it "redirects to the confirm organisation path" do
+              create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
+
+              get edit_account_organisation_path
+              expect(response).to redirect_to(show_confirm_account_organisation_path)
+            end
+          end
+        end
+
+        context "when the show_relevant_organisations feature is disabled", feature_show_relevant_organisations: false do
+          it "assigns the input object with all not closed organisations" do
+            orgs = create_list(:organisation, 2)
+            create(:organisation, closed: true)
+
+            get edit_account_organisation_path
+
+            expect(response).to render_template(:edit)
+
+            input_object = assigns(:organisation_input)
+            expect(input_object).to be_a(Account::OrganisationInput)
+            expect(input_object.allowed_organisations).to match_array(orgs)
+          end
         end
       end
 
-      context "when the show_relevant_organisations feature is disabled", feature_show_relevant_organisations: false do
-        it "assigns the input object with all not closed organisations" do
-          orgs = create_list(:organisation, 2)
-          create(:organisation, closed: true)
+      context "when the user already has an organisation" do
+        let(:user) { create(:user) }
 
+        it "redirects to the root path" do
           get edit_account_organisation_path
-
-          input_object = assigns(:organisation_input)
-          expect(input_object).to be_a(Account::OrganisationInput)
-          expect(input_object.allowed_organisations).to match_array(orgs)
+          expect(response).to redirect_to(root_path)
         end
-      end
-    end
-
-    context "when the user already has an organisation" do
-      let(:user) { create(:user) }
-
-      it "redirects to the root path" do
-        get edit_account_organisation_path
-        expect(response).to redirect_to(root_path)
       end
     end
   end
@@ -81,6 +91,10 @@ describe Account::OrganisationsController do
     context "when the not listed radio option is selected" do
       let(:params) { { account_organisation_input: { organisation_id: Account::OrganisationInput::NOT_LISTED_OPTION_VALUE } } }
 
+      before do
+        create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
+      end
+
       it "renders the not_listed template" do
         put account_organisation_path, params: params
         expect(response).to render_template(:not_listed)
@@ -95,6 +109,10 @@ describe Account::OrganisationsController do
 
     context "with invalid parameters" do
       let(:invalid_params) { { account_organisation_input: { organisation_id: nil } } }
+
+      before do
+        create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
+      end
 
       it "does not update the user's organisation" do
         expect {
@@ -113,6 +131,10 @@ describe Account::OrganisationsController do
       context "when the selected organisation does not match the user's email domain" do
         let(:organisation) { create(:organisation, organisation_domains: [create(:organisation_domain, domain: "other.gov.uk")]) }
         let(:invalid_params) { { account_organisation_input: { organisation_id: organisation.id } } }
+
+        before do
+          create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
+        end
 
         it "does not update the user's organisation" do
           expect {
@@ -133,10 +155,99 @@ describe Account::OrganisationsController do
         let(:organisation) { create(:organisation, organisation_domains: [create(:organisation_domain, domain: "other.gov.uk")]) }
         let(:params) { { account_organisation_input: { organisation_id: organisation.id } } }
 
+        before do
+          create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
+        end
+
         it "updates the user's organisation" do
           put account_organisation_path, params: params
           expect(user.reload.organisation).to eq(organisation)
         end
+      end
+    end
+  end
+
+  describe "GET #show_confirm", :feature_show_relevant_organisations do
+    context "when there is only one organisation the user can select" do
+      let!(:organisation) { create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]) }
+
+      it "renders the confirm template" do
+        get show_confirm_account_organisation_path
+        expect(response).to render_template(:confirm)
+
+        input_object = assigns(:confirm_organisation_input)
+        expect(input_object).to be_a(Account::ConfirmOrganisationInput)
+        expect(input_object.organisation).to eq(organisation)
+      end
+    end
+
+    context "when there is more than one organisation the user can select" do
+      before do
+        create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
+        create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
+      end
+
+      it "redirects to the edit route" do
+        get show_confirm_account_organisation_path
+        expect(response).to redirect_to edit_account_organisation_path
+      end
+    end
+  end
+
+  describe "POST #confirm", :feature_show_relevant_organisations do
+    let(:params) { { account_confirm_organisation_input: { confirm: "yes" } } }
+
+    context "when there is only one organisation the user can select" do
+      let!(:organisation) { create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)]) }
+
+      context "when 'yes' is selected" do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(AfterSignInPathHelper).to receive(:after_sign_in_next_path).and_return("/next-path")
+          # rubocop:enable RSpec/AnyInstance
+        end
+
+        it "updates the user's organisation and redirects to the next path" do
+          post confirm_account_organisation_path, params: params
+          expect(user.reload.organisation).to eq(organisation)
+          expect(response).to redirect_to("/next-path")
+        end
+      end
+
+      context "when 'no' is selected" do
+        let(:params) { { account_confirm_organisation_input: { confirm: "no" } } }
+
+        it "renders the not_listed template and does not update the user's organisation" do
+          post confirm_account_organisation_path, params: params
+          expect(user.reload.organisation).to be_nil
+          expect(response).to render_template(:not_listed)
+        end
+      end
+
+      context "when the params are invalid" do
+        let(:params) { { account_confirm_organisation_input: { confirm: "" } } }
+
+        it "renders the confirm template with an error message" do
+          post confirm_account_organisation_path, params: params
+          expect(user.reload.organisation).to be_nil
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response).to render_template(:confirm)
+
+          error = I18n.t("activemodel.errors.models.account/confirm_organisation_input.attributes.confirm.blank", organisation: organisation.name_with_abbreviation)
+          expect(response.body).to include(error)
+        end
+      end
+    end
+
+    context "when there is more than one organisation the user can select" do
+      before do
+        create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
+        create(:organisation, organisation_domains: [create(:organisation_domain, domain: domain)])
+      end
+
+      it "redirects to the edit route" do
+        post confirm_account_organisation_path, params: params
+        expect(response).to redirect_to edit_account_organisation_path
       end
     end
   end

--- a/spec/views/account/organisations/confirm.html.erb_spec.rb
+++ b/spec/views/account/organisations/confirm.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe "account/organisations/confirm.html.erb" do
+  let(:confirm_organisation_input) { Account::ConfirmOrganisationInput.new(organisation: organisation) }
+  let(:organisation) { build_stubbed(:organisation, name: "Department for Testing", abbreviation: "DOT") }
+
+  before do
+    assign(:confirm_organisation_input, confirm_organisation_input)
+  end
+
+  context "when there are no errors" do
+    before do
+      render
+    end
+
+    it "sets the page title" do
+      expect(view.content_for(:title)).to eq(t("page_titles.confirm_account_organisation"))
+    end
+
+    it "displays the organisation name in the paragraph text" do
+      expect(rendered).to have_content("we think your organisation is Department for Testing (DOT)")
+    end
+
+    it "displays the form" do
+      expect(rendered).to have_selector('form[action="/account/organisation/confirm"][method="post"]')
+      expect(rendered).to have_button(I18n.t("save_and_continue"))
+    end
+
+    it "has the expected radios legend" do
+      expect(rendered).to have_selector("legend", text: "Do you work for Department for Testing (DOT)?")
+    end
+
+    it "renders yes and no radio buttons" do
+      expect(rendered).to have_selector('input[type="radio"][value="yes"]')
+      expect(rendered).to have_selector('input[type="radio"][value="no"]')
+    end
+
+    it "has the expected labels for the radio buttons" do
+      expect(rendered).to have_selector('label[for="account-confirm-organisation-input-confirm-yes-field"]', text: "Yes")
+      expect(rendered).to have_selector('label[for="account-confirm-organisation-input-confirm-no-field"]', text: "No, I work for a different organisation")
+    end
+  end
+
+  context "when there are errors" do
+    before do
+      confirm_organisation_input.errors.add(:base, "Some error")
+      render
+    end
+
+    it "displays the error summary" do
+      expect(rendered).to have_selector(".govuk-error-summary")
+    end
+
+    it "sets the page title with error prefix" do
+      expect(view.content_for(:title)).to eq(title_with_error_prefix(t("page_titles.confirm_account_organisation"), true))
+    end
+  end
+end

--- a/spec/views/account/organisations/edit.html.erb_spec.rb
+++ b/spec/views/account/organisations/edit.html.erb_spec.rb
@@ -60,7 +60,7 @@ describe "account/organisations/edit.html.erb" do
       end
 
       it "displays the user's email domain" do
-        expect(rendered).to have_content(I18n.t("account.organisation.you_created_account_with", email_domain: "example.com"))
+        expect(rendered).to have_content(I18n.t("account.organisations.edit.you_created_account_with", email_domain: "example.com"))
       end
 
       context "when there are fewer than 30 organisations" do
@@ -81,7 +81,7 @@ describe "account/organisations/edit.html.erb" do
 
         it "has a radio button for organisation not listed" do
           expect(rendered).to have_selector("input[type='radio'][value='not_listed'][name='account_organisation_input[organisation_id]']")
-          expect(rendered).to have_selector("label[for='account-organisation-input-organisation-id-not-listed-field']", text: I18n.t("account.organisation.not_listed_option"))
+          expect(rendered).to have_selector("label[for='account-organisation-input-organisation-id-not-listed-field']", text: I18n.t("account.organisations.edit.not_listed_option"))
         end
 
         it "does not render the not listed details component" do
@@ -112,7 +112,7 @@ describe "account/organisations/edit.html.erb" do
 
         it "renders the not listed details component" do
           expect(rendered).to have_selector("details.govuk-details")
-          expect(rendered).to have_selector("summary.govuk-details__summary", text: I18n.t("account.organisation.details_summary"))
+          expect(rendered).to have_selector("summary.govuk-details__summary", text: I18n.t("account.organisations.edit.details_summary"))
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/LH68oEwk

- When only one organisation has a domain matching the user's email address, display a different page with "Yes" and "No" radio buttons for the user to confirm whether it is their organisation.
- When no organisations match the user's email address, display the page telling them to contact support.

The page shown when there is only one matching organisation:

<img width="1112" height="1005" alt="Screenshot 2026-07-29 at 12 22 43" src="https://github.com/user-attachments/assets/f3b3b5f9-5b4d-4001-bd33-683cf20e88d2" />

If "No" is selected, we display the same page as we show if there were no organisations found matching the user's domain:

<img width="1112" height="682" alt="Screenshot 2026-07-29 at 12 22 52" src="https://github.com/user-attachments/assets/54ae487b-db46-40e7-9f34-75a544f5ea08" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
