### PR TITLE
Use organisation domains for email address validation

### DIFF
--- a/app/controllers/forms/contact_details_controller.rb
+++ b/app/controllers/forms/contact_details_controller.rb
@@ -19,7 +19,7 @@ module Forms
   private
 
     def contact_details_input_params
-      params.require(:forms_contact_details_input).permit(:email, :phone, :link_href, :link_text, contact_details_supplied: []).merge(form: current_form, current_user:)
+      params.require(:forms_contact_details_input).permit(:email, :phone, :link_href, :link_text, contact_details_supplied: []).merge(form: current_form)
     end
   end
 end

--- a/app/controllers/forms/welsh_translation_controller.rb
+++ b/app/controllers/forms/welsh_translation_controller.rb
@@ -86,7 +86,7 @@ module Forms
           { selection_options_cy_attributes: %i[id name_cy] },
           { condition_translations_attributes: WelshConditionTranslationInput.attribute_names },
         ],
-      ).merge(current_user:, form: current_form)
+      ).merge(form: current_form)
     end
 
     def delete_welsh_translation_params

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -25,7 +25,7 @@ private
 
   def load_form
     @current_form = Form.find(params[:form_id])
-    @current_form.set_task_status_service(TaskStatusService.new(form: @current_form, current_user:))
+    @current_form.set_task_status_service(TaskStatusService.new(form: @current_form))
     @initial_form_state = @current_form.state
   end
 

--- a/app/input_objects/forms/contact_details_input.rb
+++ b/app/input_objects/forms/contact_details_input.rb
@@ -1,5 +1,5 @@
 class Forms::ContactDetailsInput < BaseInput
-  attr_accessor :form, :email, :phone, :link_text, :link_href, :contact_details_supplied, :current_user
+  attr_accessor :form, :email, :phone, :link_text, :link_href, :contact_details_supplied
 
   validates :email, presence: true, email_address: true, if: -> { supplied :supply_email }
   validates :email, allowed_email_domain: true, if: -> { supplied :supply_email }

--- a/app/input_objects/forms/welsh_translation_input.rb
+++ b/app/input_objects/forms/welsh_translation_input.rb
@@ -2,7 +2,7 @@ class Forms::WelshTranslationInput < Forms::MarkCompleteInput
   include TextInputHelper
   include ActiveModel::Attributes
 
-  attr_accessor :current_user, :form, :page_translations
+  attr_accessor :form, :page_translations
 
   attribute :mark_complete
 

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -12,7 +12,7 @@ class FormTaskListService
   def initialize(form:, current_user:)
     @current_user = current_user
     @form = form
-    @form.set_task_status_service(TaskStatusService.new(form:, current_user:))
+    @form.set_task_status_service(TaskStatusService.new(form:))
     @task_statuses = form.all_task_statuses
     @task_counts = status_counts
   end

--- a/app/services/task_status_service.rb
+++ b/app/services/task_status_service.rb
@@ -1,7 +1,6 @@
 class TaskStatusService
-  def initialize(form:, current_user:)
+  def initialize(form:)
     @form = form
-    @current_user = current_user
   end
 
   def mandatory_tasks_completed?(ignore_missing_welsh: false)
@@ -175,7 +174,7 @@ private
 
   def welsh_translations_invalid
     @welsh_translations_invalid ||= begin
-      translation_input = Forms::WelshTranslationInput.new(form: @form, mark_complete: true, current_user: @current_user).assign_form_values
+      translation_input = Forms::WelshTranslationInput.new(form: @form, mark_complete: true).assign_form_values
       translation_input.invalid?
     end
   end

--- a/app/validators/allowed_email_domain_validator.rb
+++ b/app/validators/allowed_email_domain_validator.rb
@@ -9,14 +9,9 @@ class AllowedEmailDomainValidator < ActiveModel::EachValidator
 
       return if ALLOWED_SUBDOMAIN_REGEXES.any? { it.match?(value) }
 
-      # TODO: we might not want to check against current user domain
-      # when we have a proper allow list?
-      # https://trello.com/c/NQj6zljA/3449-make-email-domain-validation-check-against-allowed-domains-rather-than-just-govuk-and-the-users-current-domain
-      if record.respond_to?(:current_user) && record.current_user.present?
-        user_domain_with_at = record.current_user.email
-          .then { |email| email[email.rindex("@")..] }
-        return if user_domain_with_at && value.end_with?(user_domain_with_at)
-      end
+      domain = value.split("@").last
+      organisation_domains = record.try(:form)&.group&.organisation&.organisation_domains
+      return if organisation_domains&.any? { |organisation_domain| domain == organisation_domain.domain }
     end
 
     record.errors.add(attribute, :non_government_email)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -193,7 +193,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
       ),
     ],
   )
-  smoke_test_form.set_task_status_service(TaskStatusService.new(form: smoke_test_form, current_user: nil))
+  smoke_test_form.set_task_status_service(TaskStatusService.new(form: smoke_test_form))
   smoke_test_form.make_live!
 
   all_question_types_form = Form.create!(
@@ -279,7 +279,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
       ),
     ],
   )
-  all_question_types_form.set_task_status_service(TaskStatusService.new(form: all_question_types_form, current_user: craig))
+  all_question_types_form.set_task_status_service(TaskStatusService.new(form: all_question_types_form))
   all_question_types_form.make_live!
 
   e2e_s3_forms = Form.create!(
@@ -313,7 +313,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
       ),
     ],
   )
-  e2e_s3_forms.set_task_status_service(TaskStatusService.new(form: e2e_s3_forms, current_user: craig))
+  e2e_s3_forms.set_task_status_service(TaskStatusService.new(form: e2e_s3_forms))
   e2e_s3_forms.make_live!
 
   branch_route_form = Form.create!(
@@ -410,7 +410,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
         - Confirmed that you are eligible to submit this form
     MARKDOWN
   )
-  branch_route_form.set_task_status_service(TaskStatusService.new(form: branch_route_form, current_user: craig))
+  branch_route_form.set_task_status_service(TaskStatusService.new(form: branch_route_form))
   branch_route_form.reload.make_live!
 
   none_of_the_above_form = Form.create!(
@@ -465,7 +465,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
       ),
     ],
   )
-  none_of_the_above_form.set_task_status_service(TaskStatusService.new(form: none_of_the_above_form, current_user: craig))
+  none_of_the_above_form.set_task_status_service(TaskStatusService.new(form: none_of_the_above_form))
   none_of_the_above_form.make_live!
 
   welsh_form = Form.create!(
@@ -534,7 +534,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     ],
   )
 
-  welsh_form.set_task_status_service(TaskStatusService.new(form: welsh_form, current_user: craig))
+  welsh_form.set_task_status_service(TaskStatusService.new(form: welsh_form))
   welsh_form.make_live!
 
   multiple_branch_form = Form.create!(
@@ -644,7 +644,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     goto_page: multiple_branch_form.pages[5],
     answer_value: "Northern Ireland",
   )
-  multiple_branch_form.set_task_status_service(TaskStatusService.new(form: multiple_branch_form, current_user: craig))
+  multiple_branch_form.set_task_status_service(TaskStatusService.new(form: multiple_branch_form))
   multiple_branch_form.make_live!
 
   copy_of_answers_form = Form.create!(
@@ -677,7 +677,7 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
       ),
     ],
   )
-  copy_of_answers_form.set_task_status_service(TaskStatusService.new(form: multiple_branch_form, current_user: craig))
+  copy_of_answers_form.set_task_status_service(TaskStatusService.new(form: multiple_branch_form))
   copy_of_answers_form.make_live!
 
   # add forms to groups

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -35,7 +35,7 @@ namespace :forms do
 
     # the make_live event guard checks the form's task statuses through a
     # service that is normally injected by the controller
-    form.set_task_status_service(TaskStatusService.new(form:, current_user: nil))
+    form.set_task_status_service(TaskStatusService.new(form:))
 
     events = Form.event_path(from: form.aasm.current_state, to: args[:state].to_sym)
 

--- a/spec/input_objects/forms/contact_details_input_spec.rb
+++ b/spec/input_objects/forms/contact_details_input_spec.rb
@@ -14,13 +14,6 @@ RSpec.describe Forms::ContactDetailsInput, type: :model do
           expect(contact_details_input).to be_invalid
         end
 
-        it "is invalid if it is not a government email address" do
-          contact_details_input = build :contact_details_input, email: "something@gmail.com"
-          expect(contact_details_input).to be_invalid
-
-          expect(contact_details_input.errors).to be_added :email, :non_government_email
-        end
-
         it_behaves_like "a field that rejects invalid email addresses" do
           let(:model) { build :contact_details_input }
           let(:attribute) { :email }
@@ -31,12 +24,23 @@ RSpec.describe Forms::ContactDetailsInput, type: :model do
           expect(contact_details_input).to be_valid
         end
 
-        context "when the user has an email address in an email domain not ending with .gov.uk" do
-          let(:current_user) { build :user, email: "user@non-departmental.example" }
+        context "when the email is a non-government email address" do
+          let(:form) { create :form, :with_group }
+          let(:contact_details_input) { build :contact_details_input, email: "something@non-departmental.example", form: form }
 
-          it "is valid if given an email address in the same domain as the user" do
-            contact_details_input = build(:contact_details_input, email: "something@non-departmental.example", current_user:)
-            expect(contact_details_input).to be_valid
+          it "is invalid" do
+            expect(contact_details_input).to be_invalid
+            expect(contact_details_input.errors).to be_added :email, :non_government_email
+          end
+
+          context "and the organisation has an associated domain matching the email" do
+            before do
+              create :organisation_domain, organisation: form.group.organisation, domain: "non-departmental.example"
+            end
+
+            it "is valid" do
+              expect(contact_details_input).to be_valid
+            end
           end
         end
       end

--- a/spec/input_objects/forms/make_live_input_spec.rb
+++ b/spec/input_objects/forms/make_live_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Forms::MakeLiveInput, type: :model do
   let(:user) { build :user }
 
   before do
-    form.set_task_status_service(TaskStatusService.new(form:, current_user: user))
+    form.set_task_status_service(TaskStatusService.new(form:))
   end
 
   describe "validations" do

--- a/spec/input_objects/forms/submission_email_input_spec.rb
+++ b/spec/input_objects/forms/submission_email_input_spec.rb
@@ -22,23 +22,24 @@ RSpec.describe Forms::SubmissionEmailInput, type: :model do
       expect(submission_email_input).to be_valid
     end
 
-    context "when the user has an email address in an email domain not ending with .gov.uk" do
-      before do
-        submission_email_input_with_user.current_user = OpenStruct.new(
-          name: "Arms Length Body User",
-          email: "user@alb.example",
-        )
+    context "when the email is a non-government email address" do
+      it "is invalid" do
+        submission_email_input = build :submission_email_input, temporary_submission_email: "a@gmail.com"
+        expect(submission_email_input).to be_invalid
       end
 
-      it "is valid if given an email address in the same domain as the user" do
-        submission_email_input_with_user.temporary_submission_email = "submissions@alb.example"
-        expect(submission_email_input_with_user).to be_valid
-      end
-    end
+      context "and the organisation has an associated domain matching the email" do
+        let(:form) { create :form, :with_group }
 
-    it "is invalid if given an email address for a non-government inbox" do
-      submission_email_input = build :submission_email_input, temporary_submission_email: "a@gmail.com"
-      expect(submission_email_input).to be_invalid
+        before do
+          create :organisation_domain, organisation: form.group.organisation, domain: "alb.example"
+        end
+
+        it "is valid" do
+          submission_email_input_with_user.temporary_submission_email = "submissions@alb.example"
+          expect(submission_email_input_with_user).to be_valid
+        end
+      end
     end
 
     it "is invalid if not given an email address" do

--- a/spec/input_objects/forms/welsh_translation_input_spec.rb
+++ b/spec/input_objects/forms/welsh_translation_input_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe Forms::WelshTranslationInput, type: :model do
   subject(:welsh_translation_input) { described_class.new(new_input_data) }
 
-  let(:current_user) { build :user }
   let(:form) { build_form }
   let(:page) do
     create :page,
@@ -19,7 +18,6 @@ RSpec.describe Forms::WelshTranslationInput, type: :model do
 
   let(:new_input_data) do
     {
-      current_user:,
       form:,
       mark_complete:,
       name_cy: "New Welsh name",
@@ -55,7 +53,7 @@ RSpec.describe Forms::WelshTranslationInput, type: :model do
       payment_url: "https://www.gov.uk/english-payment",
       payment_url_cy: "https://www.gov.uk/payments/your-welsh-payment-link",
     }
-    build(:form, default_attributes.merge(attributes))
+    build(:form, :with_group, default_attributes.merge(attributes))
   end
 
   def build_empty_welsh_form
@@ -197,12 +195,13 @@ RSpec.describe Forms::WelshTranslationInput, type: :model do
               expect(welsh_translation_input.errors.full_messages_for(:support_email_cy)).to include "Support email cy #{I18n.t('activemodel.errors.models.forms/welsh_translation_input.attributes.support_email_cy.non_government_email')}"
             end
 
-            context "when the user has an email address with the same domain" do
-              let(:current_user) { build :user, email: "user@example.com" }
+            context "and the organisation has an associated domain matching the email" do
+              before do
+                create :organisation_domain, organisation: form.group.organisation, domain: "example.com"
+              end
 
               it "is valid" do
                 expect(welsh_translation_input).to be_valid
-                expect(welsh_translation_input.errors.full_messages_for(:support_email_cy)).to be_empty
               end
             end
           end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe Form, type: :model do
   subject(:form) { described_class.new }
 
-  let(:current_user) { build :user }
-
   describe "factory" do
     it "has a valid factory" do
       form = create :form
@@ -39,7 +37,7 @@ RSpec.describe Form, type: :model do
 
     describe "task status traits" do
       before do
-        form.set_task_status_service(TaskStatusService.new(form:, current_user:))
+        form.set_task_status_service(TaskStatusService.new(form:))
       end
 
       describe "ready for live trait" do
@@ -511,7 +509,7 @@ RSpec.describe Form, type: :model do
 
   describe "FormStateMachine" do
     before do
-      form.set_task_status_service(TaskStatusService.new(form:, current_user:))
+      form.set_task_status_service(TaskStatusService.new(form: form))
     end
 
     describe "#make_live!" do
@@ -873,7 +871,7 @@ RSpec.describe Form, type: :model do
 
   describe "#all_incomplete_tasks" do
     before do
-      form.set_task_status_service(TaskStatusService.new(form:, current_user:))
+      form.set_task_status_service(TaskStatusService.new(form: form))
     end
 
     context "when a form is complete and ready to be made live" do
@@ -960,7 +958,7 @@ RSpec.describe Form, type: :model do
     let(:form) { build :form, :live, :with_group, group: }
 
     before do
-      form.set_task_status_service(TaskStatusService.new(form:, current_user:))
+      form.set_task_status_service(TaskStatusService.new(form:))
     end
 
     it "returns a hash with each of the task statuses" do
@@ -1443,7 +1441,7 @@ RSpec.describe Form, type: :model do
     let(:form) { create :form }
 
     before do
-      form.set_task_status_service(TaskStatusService.new(form:, current_user:))
+      form.set_task_status_service(TaskStatusService.new(form:))
     end
 
     context "when the language being checked is English" do

--- a/spec/requests/forms/contact_details_controller_spec.rb
+++ b/spec/requests/forms/contact_details_controller_spec.rb
@@ -66,40 +66,41 @@ RSpec.describe Forms::ContactDetailsController, type: :request do
     end
 
     context "when given an email address for a non-government inbox" do
-      let(:params) { { forms_contact_details_input: { contact_details_supplied: ["", "supply_email"], email: "a@gmail.com", form: } } }
+      let(:domain) { "public-sector-org.example" }
+      let(:email) { Faker::Internet.email(domain:) }
+      let(:params) { { forms_contact_details_input: { contact_details_supplied: ["", "supply_email"], email: email, form: } } }
 
-      it "does not update the form" do
-        expect {
+      context "when the domain is not associated with the organisation" do
+        it "does not update the form" do
+          expect {
+            post(contact_details_create_path(form_id: form.id), params:)
+          }.not_to(change { form.reload.support_email })
+        end
+
+        it "shows the error state" do
           post(contact_details_create_path(form_id: form.id), params:)
-        }.not_to(change { form.reload.support_email })
+          expect(response).to render_template(:new)
+          expect(response.body).to include I18n.t("error_summary.heading")
+          expect(response.body).to include I18n.t("errors.messages.non_government_email")
+          expect(response).to have_http_status :unprocessable_content
+        end
       end
 
-      it "shows the error state" do
-        post(contact_details_create_path(form_id: form.id), params:)
-        expect(response).to render_template(:new)
-        expect(response.body).to include I18n.t("error_summary.heading")
-        expect(response.body).to include I18n.t("errors.messages.non_government_email")
-        expect(response).to have_http_status :unprocessable_content
-      end
-    end
+      context "when the domain is associated with the organisation" do
+        before do
+          create :organisation_domain, organisation: group.organisation, domain: domain
+        end
 
-    context "when current user has a government email address not ending with .gov.uk" do
-      let(:current_user) do
-        standard_user.update!(email: "user@public-sector-org.example")
-        standard_user
-      end
+        it "updates the form" do
+          expect {
+            post(contact_details_create_path(form_id: form.id), params:)
+          }.to change { form.reload.support_email }.to(email)
+        end
 
-      let(:params) { { forms_contact_details_input: { contact_details_supplied: ["", "supply_email"], email: "a@public-sector-org.example", form: } } }
-
-      it "updates the form" do
-        expect {
+        it "redirects to the confirmation page" do
           post(contact_details_create_path(form_id: form.id), params:)
-        }.to change { form.reload.support_email }.to("a@public-sector-org.example")
-      end
-
-      it "redirects to the confirmation page" do
-        post(contact_details_create_path(form_id: form.id), params:)
-        expect(response).to redirect_to(form_path(form_id: form.id))
+          expect(response).to redirect_to(form_path(form_id: form.id))
+        end
       end
     end
   end

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
   let(:group) { create(:group, organisation:, status: :active) }
 
   before do
-    form.set_task_status_service(TaskStatusService.new(form:, current_user: user))
+    form.set_task_status_service(TaskStatusService.new(form:))
   end
 
   describe "#new" do

--- a/spec/requests/forms/submission_email_controller_spec.rb
+++ b/spec/requests/forms/submission_email_controller_spec.rb
@@ -48,32 +48,44 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
 
   describe "#create" do
     let(:temporary_submission_email) { user.email }
+    let(:params) do
+      {
+        forms_submission_email_input: {
+          temporary_submission_email:,
+          notify_response_id: Faker::Internet.uuid,
+        },
+      }
+    end
 
     before do
       allow(submission_email_mailer_spy).to receive(:send_confirmation_code)
-
-      post(
-        submission_email_path(form.id),
-        params: {
-          forms_submission_email_input: {
-            temporary_submission_email:,
-            notify_response_id: Faker::Internet.uuid,
-          },
-        },
-      )
     end
 
     it "redirects to the email code sent page" do
+      post(submission_email_path(form.id), params: params)
       expect(response).to redirect_to(submission_email_code_sent_path(form.id))
     end
 
-    context "when user submits an invalid email address" do
-      let(:temporary_submission_email) { "a@gmail.com" }
+    context "when user submits a non-government email address" do
+      let(:domain) { "ogd.example" }
+      let(:temporary_submission_email) { Faker::Internet.email(domain:) }
 
       it "does not accept the submission email address" do
+        post(submission_email_path(form.id), params: params)
         expect(response.body).to include I18n.t("error_summary.heading")
         expect(response.body).to include I18n.t("errors.messages.non_government_email")
         expect(response).to have_http_status :unprocessable_content
+      end
+
+      context "and the organisation has an associated domain matching the email" do
+        before do
+          create :organisation_domain, organisation: group.organisation, domain: domain
+        end
+
+        it "redirects to the email code sent page" do
+          post(submission_email_path(form.id), params: params)
+          expect(response).to redirect_to(submission_email_code_sent_path(form.id))
+        end
       end
     end
 
@@ -81,15 +93,8 @@ RSpec.describe Forms::SubmissionEmailController, type: :request do
       let(:user) { user_outside_group }
 
       it "is forbidden" do
+        post(submission_email_path(form.id), params: params)
         expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context "when current user has a government email address not ending with .gov.uk" do
-      let(:user) { standard_user.tap { |user| user.email = "user@alb.example" } }
-
-      it "redirects to the email code sent page" do
-        expect(response).to redirect_to(submission_email_code_sent_path(form.id))
       end
     end
   end

--- a/spec/requests/forms/welsh_translation_controller_spec.rb
+++ b/spec/requests/forms/welsh_translation_controller_spec.rb
@@ -128,8 +128,10 @@ RSpec.describe Forms::WelshTranslationController, type: :request do
         expect(flash).to be_empty
       end
 
-      context "and the current user is signed in with an email address at the same domain" do
-        let(:standard_user) { build :user, :standard, organisation: test_org, email: Faker::Internet.email(domain:) }
+      context "and the organisation has an associated domain matching the email" do
+        before do
+          create :organisation_domain, organisation: group.organisation, domain: domain
+        end
 
         it "redirects to the form task list and displays a success banner including text about being marked complete" do
           post(welsh_translation_create_path(id), params:)

--- a/spec/services/make_form_live_service_spec.rb
+++ b/spec/services/make_form_live_service_spec.rb
@@ -8,7 +8,7 @@ describe MakeFormLiveService do
   let(:current_user) { build :user }
 
   before do
-    current_form.set_task_status_service(TaskStatusService.new(form: current_form, current_user:))
+    current_form.set_task_status_service(TaskStatusService.new(form: current_form))
   end
 
   describe "#make_live" do

--- a/spec/services/org_admin_alerts_service_spec.rb
+++ b/spec/services/org_admin_alerts_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe OrgAdminAlertsService do
 
   before do
     GroupForm.create!(form: form, group:)
-    form.set_task_status_service(TaskStatusService.new(form:, current_user:))
+    form.set_task_status_service(TaskStatusService.new(form:))
   end
 
   describe "#form_made_live" do

--- a/spec/services/step_summary_card_service_spec.rb
+++ b/spec/services/step_summary_card_service_spec.rb
@@ -14,10 +14,8 @@ describe StepSummaryCardService do
 
   let(:pages) { form.pages }
 
-  let(:current_user) { build :user }
-
   before do
-    form.set_task_status_service(TaskStatusService.new(form:, current_user:))
+    form.set_task_status_service(TaskStatusService.new(form:))
   end
 
   describe "#all_options_for_answer_type" do

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -16,10 +16,8 @@ describe StepSummaryTableService do
   let(:form_document_step) { FormDocument::Step.new(page.as_form_document_step(nil)) }
   let(:welsh_form_document) { FormDocument::Content.from_form_document(form.live_welsh_form_document) }
 
-  let(:current_user) { build :user }
-
   before do
-    form.set_task_status_service(TaskStatusService.new(form:, current_user:))
+    form.set_task_status_service(TaskStatusService.new(form:))
   end
 
   def create_form(attributes = {})

--- a/spec/services/task_status_service_spec.rb
+++ b/spec/services/task_status_service_spec.rb
@@ -2,12 +2,10 @@ require "rails_helper"
 
 describe TaskStatusService do
   subject(:task_status_service) do
-    described_class.new(form:, current_user:)
+    described_class.new(form:)
   end
 
   let(:group) { create :group }
-
-  let(:current_user) { build(:user, role: :standard) }
 
   before do
     form.set_task_status_service(task_status_service)
@@ -337,15 +335,6 @@ describe TaskStatusService do
 
         it "returns completed" do
           expect(task_status_service.all_task_statuses[:welsh_language_status]).to eq :completed
-        end
-
-        context "and the support email contains a non-gov.uk email with the same domain as the user" do
-          let(:current_user) { build(:user, role: :standard, email: "example@example.com") }
-          let(:form) { create(:form, :ready_for_live, :with_group, :with_welsh_translation, welsh_completed: true, group:, support_email_cy: "support@example.com") }
-
-          it "returns completed" do
-            expect(task_status_service.all_task_statuses[:welsh_language_status]).to eq :completed
-          end
         end
       end
 

--- a/spec/validator/allowed_email_domain_validator_spec.rb
+++ b/spec/validator/allowed_email_domain_validator_spec.rb
@@ -14,6 +14,13 @@ class AllowedEmailDomainModelWithCurrentUser
   validates :email, allowed_email_domain: true
 end
 
+class AllowedEmailDomainModelWithForm
+  include ActiveModel::Model
+  attr_accessor :form, :email
+
+  validates :email, allowed_email_domain: true
+end
+
 RSpec.describe AllowedEmailDomainValidator do
   let(:model) { AllowedEmailDomainModel.new }
 
@@ -42,13 +49,13 @@ RSpec.describe AllowedEmailDomainValidator do
     expect(model).to be_invalid
   end
 
-  context "with model with current_user" do
-    let(:current_user) { build :user, email: "a@ogd.example" }
-    let(:model) { AllowedEmailDomainModelWithCurrentUser.new(current_user:) }
+  context "with model with a form" do
+    let(:form) { create(:form, :with_group) }
+    let(:model) { AllowedEmailDomainModelWithForm.new(form:) }
 
-    it "validates email with .gov.uk" do
-      model.email = "inbox@test.gov.uk"
-      expect(model).to be_valid
+    before do
+      create(:organisation_domain, organisation: form.group.organisation, domain: "somewhere.gov.uk")
+      create(:organisation_domain, organisation: form.group.organisation, domain: "ogd.example")
     end
 
     it "does not validate any non-govuk email" do
@@ -56,13 +63,18 @@ RSpec.describe AllowedEmailDomainValidator do
       expect(model).to be_invalid
     end
 
-    it "validates email with same domain as user" do
+    it "validates email with domain associated with organisation" do
       model.email = "b@ogd.example"
       expect(model).to be_valid
     end
 
-    it "does not validate email with different domain to user" do
-      model.email = "b@dogd.example"
+    it "does not validate email with sub-domain of domain associated with organisation" do
+      model.email = "b@sub.ogd.example"
+      expect(model).to be_invalid
+    end
+
+    it "does not validate email that contains a domain associated with the organisation" do
+      model.email = "b@notogd.example"
       expect(model).to be_invalid
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/NQj6zljA

For submission and contact email addresses, we were were allowing email addresses on known government domains or with a domain matching the current user's domain.

Instead of looking at the current user's domain, we now look at the domains associated with the organisation the form belongs to.

Only allow non-government email addresses with domains exactly matching the organisation's domains rather than sub-domains. If we need to allow a sub-domain, we can add it to the organisation's domains. We can revisit this if we think it's too restrictive.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
