### PR TITLE
Add rake task for populating domains from a list

### DIFF
--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -158,6 +158,44 @@ namespace :organisations do
         Rails.logger.info("Added domains for #{organisation.name}: #{domains.join(', ')}")
       end
     end
+
+    desc "Populate organisation domains from a list of organisations and domains"
+    task :populate_from_list, [] => :environment do |_, args|
+      organisations_and_domains = args.to_a
+
+      usage_message = "usage: rake organisations:domains:populate_from_list[Department for testing:dftest.gov.uk\,testing.gov.uk,Example Org:example.gov.uk]".freeze
+      abort usage_message if organisations_and_domains.empty?
+
+      organisations_successfully_populated = []
+      missing_organisations = []
+
+      organisations_and_domains.map { it.split(":") }.each do |organisation_and_domain|
+        org_name = organisation_and_domain.first
+        domains = organisation_and_domain.second.split(",")
+
+        organisation = Organisation.find_by(name: org_name)
+
+        if organisation.present?
+          Rails.logger.info("Adding domains for organisation #{org_name}")
+
+          domains.each do |domain|
+            Rails.logger.info("Adding domain #{domain} to organisation #{org_name}")
+            if organisation.organisation_domains.find_by(domain:).present?
+              Rails.logger.info("Skipped adding domain #{domain} as it already exists for organisation #{org_name}")
+            else
+              organisation.organisation_domains.create!(domain: domain)
+              Rails.logger.info("Successfully added #{domain} to organisation #{org_name}")
+            end
+          end
+          organisations_successfully_populated.push(org_name)
+        else
+          missing_organisations.push(org_name)
+        end
+      end
+
+      Rails.logger.info "Domains were successfully populated for the following organisations: #{organisations_successfully_populated.join(', ')}" if organisations_successfully_populated.any?
+      Rails.logger.info "The following organisations could not be found: #{missing_organisations.join(', ')}" if missing_organisations.any?
+    end
   end
 end
 

--- a/spec/lib/tasks/organisations.rake_spec.rb
+++ b/spec/lib/tasks/organisations.rake_spec.rb
@@ -389,4 +389,66 @@ RSpec.describe "organisations.rake", type: :task do
       expect(second_organisation.reload.organisation_domains.pluck(:domain)).to match_array(%w[service.gov.uk])
     end
   end
+
+  describe "organisations:domains:populate_from_list" do
+    subject(:task) do
+      Rake::Task["organisations:domains:populate_from_list"]
+    end
+
+    let!(:organisation) { create :organisation, slug: "test-org", name: "Test Org" }
+
+    it "adds domains to an organisation" do
+      expect(Rails.logger).to receive(:info).with("Adding domains for organisation Test Org")
+      expect(Rails.logger).to receive(:info).with("Adding domain example.gov.uk to organisation Test Org")
+      expect(Rails.logger).to receive(:info).with("Adding domain example.org to organisation Test Org")
+      expect(Rails.logger).to receive(:info).with("Successfully added example.gov.uk to organisation Test Org")
+      expect(Rails.logger).to receive(:info).with("Successfully added example.org to organisation Test Org")
+      expect(Rails.logger).to receive(:info).with("Domains were successfully populated for the following organisations: Test Org")
+
+      expect {
+        task.invoke("Test Org:example.gov.uk\,example.org")
+      }.to change { organisation.reload.organisation_domains.pluck(:domain) }
+        .from([])
+        .to(match_array(%w[example.gov.uk example.org]))
+    end
+
+    it "raises an error when a domain is invalid" do
+      expect {
+        task.invoke("Test Org:not a domain")
+      }.to raise_error(ActiveRecord::RecordInvalid, /Enter a domain name in the correct format, like subdomain\.gov\.uk/)
+
+      expect(organisation.reload.organisation_domains).to be_empty
+    end
+
+    context "when a domain already exists for an organisation" do
+      before do
+        create :organisation_domain, organisation:, domain: "example.gov.uk"
+      end
+
+      it "skips the existing domain" do
+        expect(Rails.logger).to receive(:info).with("Adding domains for organisation Test Org")
+        expect(Rails.logger).to receive(:info).with("Adding domain example.gov.uk to organisation Test Org")
+        expect(Rails.logger).to receive(:info).with("Skipped adding domain example.gov.uk as it already exists for organisation Test Org")
+        expect(Rails.logger).to receive(:info).with("Adding domain example.org to organisation Test Org")
+        expect(Rails.logger).to receive(:info).with("Successfully added example.org to organisation Test Org")
+        expect(Rails.logger).to receive(:info).with("Domains were successfully populated for the following organisations: Test Org")
+
+        expect {
+          task.invoke("Test Org:example.gov.uk\,example.org")
+        }.to change { organisation.reload.organisation_domains.pluck(:domain) }
+          .from(["example.gov.uk"])
+          .to(match_array(%w[example.gov.uk example.org]))
+      end
+    end
+
+    context "when a an organisation cannot be found" do
+      it "skips the existing domain" do
+        expect(Rails.logger).to receive(:info).with("The following organisations could not be found: Renamed Test Org")
+
+        expect {
+          task.invoke("Renamed Test Org:example.gov.uk\,example.org")
+        }.not_to(change { organisation.reload.organisation_domains.pluck(:domain) })
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/KTHYph7i/3195-get-latest-organisation-email-domains-data-from-notify

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds a new rake task for uploading the domain data from Notify.

This takes a list of arguments in the form `An organisation name:example.com\,example.gov.uk`, e.g.:
```zsh
bin/rake "organisations:domains:populate_from_list[Government Digital Service:digital.cabinet-office.gov.uk\,dsit.gov.uk,Department for Science\, Innovation and Technology:dsit.gov.uk]"
```

This uses a list of arguments which is a bit unwieldy - ideally we'd use CSV for this, but that makes it hard to run this task in production without adding the full CSV to the repo. When running this in production it probably makes sense to run this in a few smaller batches.

I've tested locally with the real Notify data and the latest organisations from the GOV.UK organisations API.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
