### PR TITLE
Handle MissingTemplate errors

### DIFF
--- a/app/controllers/web_controller.rb
+++ b/app/controllers/web_controller.rb
@@ -23,6 +23,14 @@ class WebController < ApplicationController
     render "errors/forbidden", status: :forbidden, formats: :html
   end
 
+  rescue_from ActionView::MissingTemplate do |exception|
+    if request.format && request.format != :html
+      head :not_acceptable
+    else
+      raise exception
+    end
+  end
+
   PRIVILEGED_AUTH0_CONNECTION_STRATEGIES = %w[
     google-apps
   ].freeze

--- a/spec/controllers/web_controller_spec.rb
+++ b/spec/controllers/web_controller_spec.rb
@@ -200,4 +200,32 @@ describe WebController, type: :controller do
       expect(log_output.string).not_to include "authenticity_token"
     end
   end
+
+  context "when a template is missing" do
+    controller do
+      def missing_template
+        render "missing_template"
+      end
+    end
+
+    before do
+      request.env["warden"] = instance_double(
+        Warden::Proxy,
+        authenticate!: true,
+        authenticated?: true,
+        set_user: nil,
+        user: create(:user),
+      )
+      routes.draw { get "missing_template" => "web#missing_template" }
+    end
+
+    it "returns 406 when request format is not HTML" do
+      get :missing_template, format: :json
+      expect(response).to have_http_status(:not_acceptable)
+    end
+
+    it "raises the error when the request format is HTML" do
+      expect { get :missing_template, format: :html }.to raise_error(ActionView::MissingTemplate)
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/rFP7pQ46

If a MissingTemplate error is raised, and the format requested was not HTML, handle the error by returning a 406 Not Acceptable response.

If the format requested was HTML, re-raise the error as we should not expect to be missing templates for HTML requests handled by the WebController.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
