### PR TITLE
Add exit page migration rake task

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -256,6 +256,20 @@ namespace :forms do
 
     puts JSON.pretty_generate(form_document.as_json)
   end
+
+  desc "Add exit page objects for all existing exit pages"
+  task sync_all_exit_pages: :environment do
+    Rails.logger.info "Starting with #{ExitPage.count} exit page objects"
+
+    Condition.find_each do |condition|
+      if condition.is_exit_page? && condition.exit_page.nil?
+        condition.sync_exit_page
+        condition.save!
+      end
+    end
+
+    Rails.logger.info "Finished with #{ExitPage.count} exit page objects"
+  end
 end
 
 def move_forms(form_ids, group_id)

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -753,4 +753,57 @@ RSpec.describe "forms.rake", type: :task do
       end
     end
   end
+
+  describe "forms:sync_all_exit_pages" do
+    subject(:task) do
+      Rake::Task["forms:sync_all_exit_pages"]
+    end
+
+    it "creates an exit page object for exit page conditions that are missing one" do
+      condition = create(:condition, :with_exit_page)
+
+      condition.exit_page.destroy!
+
+      expect {
+        task.invoke
+      }.to change(ExitPage, :count).by(1)
+
+      expect(condition.reload.exit_page).to be_present
+    end
+
+    it "creates an exit page that has the same properties as the condition's exit page content" do
+      condition = create(
+        :condition,
+        exit_page_heading: "Exit page heading",
+        exit_page_markdown: "Exit page markdown",
+        exit_page_heading_cy: "Welsh exit page heading",
+        exit_page_markdown_cy: "Welsh exit page markdown",
+      )
+
+      condition.exit_page.destroy!
+
+      task.invoke
+
+      expect(condition.reload.exit_page.markdown).to eq(condition.exit_page_markdown)
+      expect(condition.reload.exit_page.heading).to eq(condition.exit_page_heading)
+      expect(condition.reload.exit_page.markdown_cy).to eq(condition.exit_page_markdown_cy)
+      expect(condition.reload.exit_page.heading_cy).to eq(condition.exit_page_heading_cy)
+    end
+
+    it "does not create an exit page object when one already exists" do
+      create(:condition, :with_exit_page)
+
+      expect {
+        task.invoke
+      }.not_to change(ExitPage, :count)
+    end
+
+    it "does not create exit page objects for conditions that are not exit pages" do
+      create(:condition)
+
+      expect {
+        task.invoke
+      }.not_to change(ExitPage, :count)
+    end
+  end
 end


### PR DESCRIPTION
Adds the forms:sync_all_exit_pages task, which will identify all Conditions that have exit page content, but no exit page objects associated - and then sync them up.

Conditions will be touched by this change, as they need to have their exit_page_id updated when a new exit page is created and associated with them.

### What problem does this pull request solve?

https://trello.com/c/gZGRBU8Y/3172-change-add-edit-delete-exit-page-to-work-with-new-style-exit-page-model

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
