### PR TITLE
Add new-style exit page to database seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -196,6 +196,40 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
   smoke_test_form.set_task_status_service(TaskStatusService.new(form: smoke_test_form))
   smoke_test_form.make_live!
 
+  e2e_s3_forms = Form.create!(
+    name: "S3 submission test form",
+    pages: [
+      Page.create(
+        question_text: "Single line of text",
+        answer_type: "text",
+        answer_settings: {
+          input_type: "single_line",
+        },
+      ),
+    ],
+    question_section_completed: true,
+    declaration_markdown: "",
+    declaration_section_completed: true,
+    privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
+    submission_email:,
+    support_email: "your.email+fakedata84701@gmail.com.gov.uk",
+    support_phone: "08000800",
+    what_happens_next_markdown: "Test",
+    share_preview_completed: true,
+    s3_bucket_region: "eu-west-2",
+    s3_bucket_name: "govuk-forms-submissions-to-s3-test",
+    s3_bucket_aws_account_id: "711966560482",
+    delivery_configurations: [
+      DeliveryConfiguration.create(
+        delivery_method: :s3,
+        delivery_schedule: :immediate,
+        formats: %w[csv],
+      ),
+    ],
+  )
+  e2e_s3_forms.set_task_status_service(TaskStatusService.new(form: e2e_s3_forms))
+  e2e_s3_forms.make_live!
+
   all_question_types_form = Form.create!(
     name: "All question types form",
     creator_id: craig.id,
@@ -281,40 +315,6 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
   )
   all_question_types_form.set_task_status_service(TaskStatusService.new(form: all_question_types_form))
   all_question_types_form.make_live!
-
-  e2e_s3_forms = Form.create!(
-    name: "s3 submission test form",
-    pages: [
-      Page.create(
-        question_text: "Single line of text",
-        answer_type: "text",
-        answer_settings: {
-          input_type: "single_line",
-        },
-      ),
-    ],
-    question_section_completed: true,
-    declaration_markdown: "",
-    declaration_section_completed: true,
-    privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
-    submission_email:,
-    support_email: "your.email+fakedata84701@gmail.com.gov.uk",
-    support_phone: "08000800",
-    what_happens_next_markdown: "Test",
-    share_preview_completed: true,
-    s3_bucket_region: "eu-west-2",
-    s3_bucket_name: "govuk-forms-submissions-to-s3-test",
-    s3_bucket_aws_account_id: "711966560482",
-    delivery_configurations: [
-      DeliveryConfiguration.create(
-        delivery_method: :s3,
-        delivery_schedule: :immediate,
-        formats: %w[csv],
-      ),
-    ],
-  )
-  e2e_s3_forms.set_task_status_service(TaskStatusService.new(form: e2e_s3_forms))
-  e2e_s3_forms.make_live!
 
   branch_route_form = Form.create!(
     name: "Branch route form",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -402,13 +402,18 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
     routing_page: branch_route_form.pages.first,
     goto_page: nil,
     answer_value: "No",
-    exit_page_heading: "You are not eligible to submit this form",
-    exit_page_markdown: <<~MARKDOWN,
-      To complete this form you must:
+    exit_page: ExitPage.create!(
+      question_page: branch_route_form.pages.first,
+      heading: "You are not eligible to submit this form",
+      markdown: <<~MARKDOWN,
+        To complete this form you must:
 
-        - Be over 16
-        - Confirmed that you are eligible to submit this form
-    MARKDOWN
+          - Be over 16
+          - Confirmed that you are eligible to submit this form
+      MARKDOWN
+    ),
+    exit_page_heading: ExitPage.last.heading,
+    exit_page_markdown: ExitPage.last.markdown,
   )
   branch_route_form.set_task_status_service(TaskStatusService.new(form: branch_route_form))
   branch_route_form.reload.make_live!


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Update the database seed to use the new-style exit page models alongside the old style of keeping the exit page content on the condition record.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
