### PR TITLE
Move exit pages to condition

### DIFF
--- a/app/controllers/conditions/exit_page_controller.rb
+++ b/app/controllers/conditions/exit_page_controller.rb
@@ -1,11 +1,11 @@
-class Pages::ExitPageController < PagesController
+class Conditions::ExitPageController < PagesController
   before_action :can_add_page_routing, only: %i[new create delete destroy]
   before_action :ensure_answer_value_present, only: %i[new create]
 
   def new
     exit_page_input = Pages::ExitPageInput.new(form: current_form, page:, answer_value: params[:answer_value])
 
-    render template: "pages/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: false }
+    render template: "conditions/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: false }
   end
 
   def create
@@ -16,7 +16,7 @@ class Pages::ExitPageController < PagesController
       # https://trello.com/c/BfkZEIgM/3446-set-route-count-dynamically-instead-of-hard-coding-it
       redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.exit_page_created")
     else
-      render template: "pages/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: true }, status: :unprocessable_content
+      render template: "conditions/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: true }, status: :unprocessable_content
     end
   end
 
@@ -25,7 +25,7 @@ class Pages::ExitPageController < PagesController
 
     update_exit_page_input = Pages::UpdateExitPageInput.new(form: current_form, page:, record: condition).assign_condition_values
 
-    render template: "pages/exit_page/edit", locals: { update_exit_page_input:, preview_html: preview_html(update_exit_page_input), check_preview_validation: false }
+    render template: "conditions/exit_page/edit", locals: { update_exit_page_input:, preview_html: preview_html(update_exit_page_input), check_preview_validation: false }
   end
 
   def update
@@ -38,7 +38,7 @@ class Pages::ExitPageController < PagesController
     if update_exit_page_input.submit
       redirect_to edit_condition_path(form_id: current_form.id, page_id: page.id, condition_id: update_exit_page_input.record.id), success: t("banner.success.exit_page_updated")
     else
-      render template: "pages/exit_page/edit", locals: { update_exit_page_input:, preview_html: preview_html(update_exit_page_input), check_preview_validation: true }, status: :unprocessable_content
+      render template: "conditions/exit_page/edit", locals: { update_exit_page_input:, preview_html: preview_html(update_exit_page_input), check_preview_validation: true }, status: :unprocessable_content
     end
   end
 
@@ -62,7 +62,7 @@ class Pages::ExitPageController < PagesController
     end
 
     unless @delete_exit_page_input.confirmed?
-      return redirect_to edit_exit_page_path(@current_form.id, @page.id, @exit_page.id)
+      return redirect_to conditions_exit_page_edit_path(@current_form.id, @page.id, @exit_page.id)
     end
 
     @exit_page.destroy_and_update_form!

--- a/app/controllers/conditions/exit_page_controller.rb
+++ b/app/controllers/conditions/exit_page_controller.rb
@@ -23,7 +23,7 @@ class Conditions::ExitPageController < PagesController
   def edit
     condition = page.routing_conditions.find(params[:condition_id])
 
-    update_exit_page_input = Pages::UpdateExitPageInput.new(form: current_form, page:, record: condition).assign_condition_values
+    update_exit_page_input = Conditions::UpdateExitPageInput.new(form: current_form, page:, record: condition).assign_condition_values
 
     render template: "conditions/exit_page/edit", locals: { update_exit_page_input:, preview_html: preview_html(update_exit_page_input), check_preview_validation: false }
   end
@@ -33,7 +33,7 @@ class Conditions::ExitPageController < PagesController
 
     form_params = update_exit_page_input_params.merge(record: condition)
 
-    update_exit_page_input = Pages::UpdateExitPageInput.new(form_params)
+    update_exit_page_input = Conditions::UpdateExitPageInput.new(form_params)
 
     if update_exit_page_input.submit
       redirect_to edit_condition_path(form_id: current_form.id, page_id: page.id, condition_id: update_exit_page_input.record.id), success: t("banner.success.exit_page_updated")
@@ -89,7 +89,7 @@ private
   end
 
   def update_exit_page_input_params
-    params.require(:pages_update_exit_page_input).permit(:exit_page_heading, :exit_page_markdown).merge(form: current_form, page:)
+    params.require(:conditions_update_exit_page_input).permit(:exit_page_heading, :exit_page_markdown).merge(form: current_form, page:)
   end
 
   def ensure_answer_value_present

--- a/app/controllers/conditions/exit_page_controller.rb
+++ b/app/controllers/conditions/exit_page_controller.rb
@@ -3,13 +3,13 @@ class Conditions::ExitPageController < PagesController
   before_action :ensure_answer_value_present, only: %i[new create]
 
   def new
-    exit_page_input = Pages::ExitPageInput.new(form: current_form, page:, answer_value: params[:answer_value])
+    exit_page_input = Conditions::ExitPageInput.new(form: current_form, page:, answer_value: params[:answer_value])
 
     render template: "conditions/exit_page/new", locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: false }
   end
 
   def create
-    exit_page_input = Pages::ExitPageInput.new(exit_page_input_params)
+    exit_page_input = Conditions::ExitPageInput.new(exit_page_input_params)
 
     if exit_page_input.submit
       # TODO: Route number is hardcoded whilst we can only have one value for it
@@ -72,7 +72,7 @@ class Conditions::ExitPageController < PagesController
 
   def render_preview
     authorize current_form, :can_view_form?
-    exit_page_input = Pages::ExitPageInput.new(exit_page_markdown: params[:markdown])
+    exit_page_input = Conditions::ExitPageInput.new(exit_page_markdown: params[:markdown])
     exit_page_input.validate if params[:check_preview_validation] == "true"
 
     render json: { preview_html: preview_html(exit_page_input), errors: exit_page_input.errors[:exit_page_markdown] }.to_json
@@ -85,7 +85,7 @@ private
   end
 
   def exit_page_input_params
-    params.require(:pages_exit_page_input).permit(:exit_page_heading, :exit_page_markdown, :answer_value).merge(form: current_form, page:)
+    params.require(:conditions_exit_page_input).permit(:exit_page_heading, :exit_page_markdown, :answer_value).merge(form: current_form, page:)
   end
 
   def update_exit_page_input_params
@@ -93,7 +93,7 @@ private
   end
 
   def ensure_answer_value_present
-    return if params[:answer_value].present? || params.dig(:pages_exit_page_input, :answer_value).present?
+    return if params[:answer_value].present? || params.dig(:conditions_exit_page_input, :answer_value).present?
 
     redirect_to new_condition_path(current_form.id, page.id)
   end

--- a/app/controllers/conditions/exit_page_controller.rb
+++ b/app/controllers/conditions/exit_page_controller.rb
@@ -44,7 +44,7 @@ class Conditions::ExitPageController < PagesController
 
   def delete
     @exit_page = page.routing_conditions.find(params[:condition_id])
-    @delete_exit_page_input = Pages::DeleteExitPageInput.new
+    @delete_exit_page_input = Conditions::DeleteExitPageInput.new
   end
 
   def destroy
@@ -55,7 +55,7 @@ class Conditions::ExitPageController < PagesController
 
     @exit_page = condition
 
-    @delete_exit_page_input = Pages::DeleteExitPageInput.new(params.require(:pages_delete_exit_page_input).permit(:confirm))
+    @delete_exit_page_input = Conditions::DeleteExitPageInput.new(params.require(:conditions_delete_exit_page_input).permit(:confirm))
 
     unless @delete_exit_page_input.valid?
       return render :delete, status: :unprocessable_content

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -100,7 +100,7 @@ class Pages::ConditionsController < PagesController
 
   def confirm_delete_exit_page
     condition = page.routing_conditions.find(params[:condition_id])
-    delete_exit_page_input = Pages::DeleteExitPageInput.new
+    delete_exit_page_input = Conditions::DeleteExitPageInput.new
 
     render template: "pages/conditions/confirm_delete_exit_page", locals: {
       answer_value: params.require(:answer_value),
@@ -115,7 +115,7 @@ class Pages::ConditionsController < PagesController
 
     return redirect_to form_pages_path(current_form.id) unless condition.exit_page?
 
-    delete_exit_page_input = Pages::DeleteExitPageInput.new(delete_exit_page_params)
+    delete_exit_page_input = Conditions::DeleteExitPageInput.new(delete_exit_page_params)
 
     unless delete_exit_page_input.valid?
       return render template: "pages/conditions/confirm_delete_exit_page", locals: {

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -28,7 +28,7 @@ class Pages::ConditionsController < PagesController
 
     if condition_input.submit
       if condition_input.create_exit_page?
-        redirect_to new_exit_page_path(current_form.id, page.id, answer_value: condition_input.answer_value)
+        redirect_to conditions_exit_page_new_path(current_form.id, page.id, answer_value: condition_input.answer_value)
       else
         # TODO: Route number is hardcoded whilst we can only have one value for it
         # https://trello.com/c/BfkZEIgM/3446-set-route-count-dynamically-instead-of-hard-coding-it
@@ -63,7 +63,7 @@ class Pages::ConditionsController < PagesController
 
     if condition_input.update_condition
       if condition_input.create_exit_page?
-        redirect_to edit_exit_page_path(current_form.id, page.id, condition.id)
+        redirect_to conditions_exit_page_edit_path(current_form.id, page.id, condition.id)
       else
         redirect_to show_routes_path(form_id: current_form.id, page_id: page.id), success: t("banner.success.route_updated", question_number: condition_input.page.position)
       end

--- a/app/controllers/pages/conditions_controller.rb
+++ b/app/controllers/pages/conditions_controller.rb
@@ -167,7 +167,7 @@ private
   end
 
   def delete_exit_page_params
-    params.require(:pages_delete_exit_page_input).permit(:confirm)
+    params.require(:conditions_delete_exit_page_input).permit(:confirm)
   end
 
   def new_condition_or_show_routes_path(page)

--- a/app/input_objects/conditions/delete_exit_page_input.rb
+++ b/app/input_objects/conditions/delete_exit_page_input.rb
@@ -1,0 +1,2 @@
+class Conditions::DeleteExitPageInput < DeleteConfirmationInput
+end

--- a/app/input_objects/conditions/exit_page_input.rb
+++ b/app/input_objects/conditions/exit_page_input.rb
@@ -1,4 +1,4 @@
-class Pages::ExitPageInput < BaseInput
+class Conditions::ExitPageInput < BaseInput
   attr_accessor :form, :page, :record, :exit_page_markdown, :exit_page_heading, :answer_value
 
   validates :exit_page_heading, :exit_page_markdown, :answer_value, presence: true

--- a/app/input_objects/conditions/update_exit_page_input.rb
+++ b/app/input_objects/conditions/update_exit_page_input.rb
@@ -1,4 +1,4 @@
-class Pages::UpdateExitPageInput < BaseInput
+class Conditions::UpdateExitPageInput < BaseInput
   attr_accessor :form, :page, :record, :exit_page_markdown, :exit_page_heading
 
   validates :exit_page_heading, :exit_page_markdown, presence: true

--- a/app/input_objects/pages/delete_exit_page_input.rb
+++ b/app/input_objects/pages/delete_exit_page_input.rb
@@ -1,2 +1,0 @@
-class Pages::DeleteExitPageInput < DeleteConfirmationInput
-end

--- a/app/views/conditions/exit_page/delete.html.erb
+++ b/app/views/conditions/exit_page/delete.html.erb
@@ -1,5 +1,5 @@
 <% set_page_title(title_with_error_prefix(t(".title"), @delete_exit_page_input.errors.any?)) %>
-<% content_for :back_link, govuk_back_link_to(edit_exit_page_path(@current_form.id, @page.id, @exit_page.id), t(".back_link")) %>
+<% content_for :back_link, govuk_back_link_to(conditions_exit_page_edit_path(@current_form.id, @page.id, @exit_page.id), t(".back_link")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -10,7 +10,7 @@
 
   <%= render(
     @delete_exit_page_input,
-    url: destroy_exit_page_path(condition_id: @exit_page.id, form_id: @current_form.id, page_id: @page.id),
+    url: conditions_exit_page_destroy_path(condition_id: @exit_page.id, form_id: @current_form.id, page_id: @page.id),
     caption_text: @exit_page.exit_page_heading,
     legend_text: t(".title"),
     hint_text: nil,

--- a/app/views/conditions/exit_page/edit.html.erb
+++ b/app/views/conditions/exit_page/edit.html.erb
@@ -22,7 +22,8 @@
         preview_html: preview_html,
         form_model: update_exit_page_input,
         label: t("helpers.label.pages_exit_page_input.exit_page_markdown"),
-        hint: t("helpers.hint.pages_exit_page_input.exit_page_markdown"),
+label: t("helpers.label.conditions_exit_page_input.exit_page_markdown"),
+hint: t("helpers.hint.conditions_exit_page_input.exit_page_markdown"),
         allow_headings: true) %>
 
       <div class="govuk-button-group">

--- a/app/views/conditions/exit_page/edit.html.erb
+++ b/app/views/conditions/exit_page/edit.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-    <%= form_with model: update_exit_page_input, url: update_exit_page_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id), method: 'PUT' do |f| %>
+    <%= form_with model: update_exit_page_input, url: conditions_exit_page_update_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id), method: 'PUT' do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= t("page_titles.routing_page_caption", question_number: update_exit_page_input.page.position) %></span>
@@ -15,10 +15,10 @@
       </h1>
 
       <%= f.govuk_text_field( :exit_page_heading, value: update_exit_page_input.exit_page_heading, label: { size: 'm' })  %>
-      
+
       <%= render MarkdownEditorComponent::View.new(:exit_page_markdown,
         form_builder: f,
-        render_preview_path: exit_page_render_preview_path(form_id: update_exit_page_input.form.id, page_id: update_exit_page_input.page.id, check_preview_validation:),
+        render_preview_path: conditions_exit_page_render_preview_path(form_id: update_exit_page_input.form.id, page_id: update_exit_page_input.page.id, check_preview_validation:),
         preview_html: preview_html,
         form_model: update_exit_page_input,
         label: t("helpers.label.pages_exit_page_input.exit_page_markdown"),
@@ -29,7 +29,7 @@
         <%= f.govuk_submit t("save_and_continue") %>
         <%= govuk_link_to t('cancel'), edit_condition_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id) %>
       </div>
-      <%= govuk_button_link_to t('.delete_exit_page'), delete_exit_page_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id), warning: true %>
+      <%= govuk_button_link_to t('.delete_exit_page'), conditions_exit_page_delete_path(update_exit_page_input.form.id, update_exit_page_input.page.id, update_exit_page_input.record.id), warning: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/conditions/exit_page/new.html.erb
+++ b/app/views/conditions/exit_page/new.html.erb
@@ -19,8 +19,8 @@
         render_preview_path: conditions_exit_page_render_preview_path(form_id: exit_page_input.form.id, page_id: exit_page_input.page.id, check_preview_validation:),
         preview_html: preview_html,
         form_model: exit_page_input,
-        label: t("helpers.label.pages_exit_page_input.exit_page_markdown"),
-        hint: t("helpers.hint.pages_exit_page_input.exit_page_markdown"),
+label: t("helpers.label.conditions_exit_page_input.exit_page_markdown"),
+hint: t("helpers.hint.conditions_exit_page_input.exit_page_markdown"),
         allow_headings: true) %>
 
       <%= f.hidden_field :answer_value, value: exit_page_input.answer_value %>

--- a/app/views/conditions/exit_page/new.html.erb
+++ b/app/views/conditions/exit_page/new.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-    <%= form_with model: exit_page_input, url: create_exit_page_path(exit_page_input.form.id, exit_page_input.page.id), method: 'POST' do |f| %>
+    <%= form_with model: exit_page_input, url: conditions_exit_page_create_path(exit_page_input.form.id, exit_page_input.page.id), method: 'POST' do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= t("page_titles.routing_page_caption", question_number: exit_page_input.page.position) %></span>
@@ -16,7 +16,7 @@
 
       <%= render MarkdownEditorComponent::View.new(:exit_page_markdown,
         form_builder: f,
-        render_preview_path: exit_page_render_preview_path(form_id: exit_page_input.form.id, page_id: exit_page_input.page.id, check_preview_validation:),
+        render_preview_path: conditions_exit_page_render_preview_path(form_id: exit_page_input.form.id, page_id: exit_page_input.page.id, check_preview_validation:),
         preview_html: preview_html,
         form_model: exit_page_input,
         label: t("helpers.label.pages_exit_page_input.exit_page_markdown"),
@@ -24,7 +24,7 @@
         allow_headings: true) %>
 
       <%= f.hidden_field :answer_value, value: exit_page_input.answer_value %>
-      
+
       <div class="govuk-button-group">
         <%= f.govuk_submit t("save_and_continue") %>
         <%= govuk_link_to t('cancel'), new_condition_path(exit_page_input.form.id, exit_page_input.page.id) %>

--- a/app/views/pages/conditions/confirm_delete_exit_page.html.erb
+++ b/app/views/pages/conditions/confirm_delete_exit_page.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: delete_exit_page_input, url: conditions_exit_page_update_path(condition_id: exit_page.id, form_id: @current_form.id, page_id: @page.id, params: { answer_value:, goto_page_id:})) do |f| %>
+    <%= form_with(model: delete_exit_page_input, url: update_change_exit_page_path(condition_id: exit_page.id, form_id: @current_form.id, page_id: @page.id, params: { answer_value:, goto_page_id:})) do |f| %>
       <% if delete_exit_page_input&.errors.any? %>
         <%= f.govuk_error_summary %>
       <% end %>

--- a/app/views/pages/conditions/confirm_delete_exit_page.html.erb
+++ b/app/views/pages/conditions/confirm_delete_exit_page.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: delete_exit_page_input, url: update_change_exit_page_path(condition_id: exit_page.id, form_id: @current_form.id, page_id: @page.id, params: { answer_value:, goto_page_id:})) do |f| %>
+    <%= form_with(model: delete_exit_page_input, url: conditions_exit_page_update_path(condition_id: exit_page.id, form_id: @current_form.id, page_id: @page.id, params: { answer_value:, goto_page_id:})) do |f| %>
       <% if delete_exit_page_input&.errors.any? %>
         <%= f.govuk_error_summary %>
       <% end %>
@@ -13,7 +13,7 @@
         <%= t('page_titles.confirm_delete_exit_page') %>
       </h1>
 
-      <%= t(".body_html", exit_page_heading: link_to(exit_page.exit_page_heading, edit_exit_page_path(@current_form.id, @page.id, exit_page.id))) %>
+      <%= t(".body_html", exit_page_heading: link_to(exit_page.exit_page_heading, conditions_exit_page_edit_path(@current_form.id, @page.id, exit_page.id))) %>
 
       <%= f.govuk_collection_radio_buttons :confirm,
                                            delete_exit_page_input.values, ->(option) { option }, ->(option) { t('helpers.label.confirm_delete_exit_page_input.options.' + "#{option}") },

--- a/app/views/pages/conditions/edit.html.erb
+++ b/app/views/pages/conditions/edit.html.erb
@@ -49,7 +49,7 @@
 
       <% if condition_input.record.exit_page? %>
         <p class="govuk-body">
-          <%= govuk_link_to t("page_conditions.edit_exit_page", exit_page_heading: condition_input.record.exit_page_heading), edit_exit_page_path(condition_input.form.id, condition_input.page.id, condition_input.record.id) %>
+          <%= govuk_link_to t("page_conditions.edit_exit_page", exit_page_heading: condition_input.record.exit_page_heading), conditions_exit_page_edit_path(condition_input.form.id, condition_input.page.id, condition_input.record.id) %>
         </p>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,6 +326,15 @@ en:
     up_to_3000_options: You can have up to 3,000 options.
     up_to_30_options: You can have up to 30 options.
   cancel: Cancel
+  conditions:
+    exit_page:
+      delete:
+        back_link: Back to edit exit page
+        banner: If you delete this exit page, the route to it will also be deleted
+        title: Are you sure you want to delete this exit page?
+      edit:
+        back_link: Back to edit route 1
+        delete_exit_page: Delete exit page
   contact_details:
     new:
       body_html: |
@@ -1848,14 +1857,6 @@ en:
     delete_question: Delete question
     destroy:
       success: The question, ‘%{question_text}’, has been deleted
-    exit_page:
-      delete:
-        back_link: Back to edit exit page
-        banner: If you delete this exit page, the route to it will also be deleted
-        title: Are you sure you want to delete this exit page?
-      edit:
-        back_link: Back to edit route 1
-        delete_exit_page: Delete exit page
     heading: Edit question
     index:
       add_a_question_route: Add a question route

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -3,6 +3,16 @@ en:
   activemodel:
     errors:
       models:
+        conditions/exit_page_input:
+          attributes:
+            answer_value:
+              blank: Select the answer to base this route on
+            exit_page_heading:
+              blank: Enter a page heading
+              too_long: The page heading must be shorter than 5,000 characters
+            exit_page_markdown:
+              blank: Enter page content
+              too_long: The page content must be shorter than 5,000 characters
         pages/conditions_input:
           attributes:
             answer_value:
@@ -18,16 +28,6 @@ en:
           attributes:
             confirm:
               blank: Select yes if you want to delete this route
-        pages/exit_page_input:
-          attributes:
-            answer_value:
-              blank: Select the answer to base this route on
-            exit_page_heading:
-              blank: Enter a page heading
-              too_long: The page heading must be shorter than 5,000 characters
-            exit_page_markdown:
-              blank: Enter page content
-              too_long: The page content must be shorter than 5,000 characters
         pages/routing_page_input:
           attributes:
             routing_page_id:
@@ -42,19 +42,19 @@ en:
               too_long: The page content must be shorter than 5,000 characters
   helpers:
     hint:
-      pages_exit_page_input:
+      conditions_exit_page_input:
         exit_page_heading: Use a heading that summarises why someone cannot continue with the form. For example, ‘You’re not eligible for this service’.
         exit_page_markdown: Explain why they cannot continue to use the form and, if possible, tell them what they should do instead.
       pages_update_exit_page_input:
         exit_page_heading: Use a heading that summarises why someone cannot continue with the form. For example, ‘You’re not eligible for this service’.
         exit_page_markdown: Explain why they cannot continue to use the form and, if possible, tell them what they should do instead.
     label:
+      conditions_exit_page_input:
+        exit_page_heading: Page heading
+        exit_page_markdown: Page content
       pages_conditions_input:
         answer_value: If the answer selected is
         goto_page_id: skip the person to
-      pages_exit_page_input:
-        exit_page_heading: Page heading
-        exit_page_markdown: Page content
       pages_update_exit_page_input:
         exit_page_heading: Page heading
         exit_page_markdown: Page content

--- a/config/locales/pages/conditions.yml
+++ b/config/locales/pages/conditions.yml
@@ -13,6 +13,14 @@ en:
             exit_page_markdown:
               blank: Enter page content
               too_long: The page content must be shorter than 5,000 characters
+        conditions/update_exit_page_input:
+          attributes:
+            exit_page_heading:
+              blank: Enter a page heading
+              too_long: The page heading must be shorter than 5,000 characters
+            exit_page_markdown:
+              blank: Enter page content
+              too_long: The page content must be shorter than 5,000 characters
         pages/conditions_input:
           attributes:
             answer_value:
@@ -32,29 +40,21 @@ en:
           attributes:
             routing_page_id:
               blank: Select the question you want to add a route from
-        pages/update_exit_page_input:
-          attributes:
-            exit_page_heading:
-              blank: Enter a page heading
-              too_long: The page heading must be shorter than 5,000 characters
-            exit_page_markdown:
-              blank: Enter page content
-              too_long: The page content must be shorter than 5,000 characters
   helpers:
     hint:
       conditions_exit_page_input:
         exit_page_heading: Use a heading that summarises why someone cannot continue with the form. For example, ‘You’re not eligible for this service’.
         exit_page_markdown: Explain why they cannot continue to use the form and, if possible, tell them what they should do instead.
-      pages_update_exit_page_input:
+      conditions_update_exit_page_input:
         exit_page_heading: Use a heading that summarises why someone cannot continue with the form. For example, ‘You’re not eligible for this service’.
         exit_page_markdown: Explain why they cannot continue to use the form and, if possible, tell them what they should do instead.
     label:
       conditions_exit_page_input:
         exit_page_heading: Page heading
         exit_page_markdown: Page content
+      conditions_update_exit_page_input:
+        exit_page_heading: Page heading
+        exit_page_markdown: Page content
       pages_conditions_input:
         answer_value: If the answer selected is
         goto_page_id: skip the person to
-      pages_update_exit_page_input:
-        exit_page_heading: Page heading
-        exit_page_markdown: Page content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,13 +145,19 @@ Rails.application.routes.draw do
           delete "/:condition_id/delete" => "pages/conditions#destroy", as: :destroy_condition
           get "/:condition_id/confirm-delete-exit-page" => "pages/conditions#confirm_delete_exit_page", as: :confirm_change_exit_page
           post "/:condition_id/confirm-delete-exit-page" => "pages/conditions#update_change_exit_page", as: :update_change_exit_page
-          get "/exit-page/new" => "pages/exit_page#new", as: :new_exit_page
-          post "/exit-page/new" => "pages/exit_page#create", as: :create_exit_page
-          post "/exit-page-preview" => "pages/exit_page#render_preview", as: :exit_page_render_preview
-          get "/exit-page/:condition_id" => "pages/exit_page#edit", as: :edit_exit_page
-          put "/exit-page/:condition_id" => "pages/exit_page#update", as: :update_exit_page
-          get "/exit-page/:condition_id/delete" => "pages/exit_page#delete", as: :delete_exit_page
-          delete "/exit-page/:condition_id" => "pages/exit_page#destroy", as: :destroy_exit_page
+
+          # These are the legacy exit page routes. Exit pages for multiple branches will be based on page
+          scope module: :conditions, as: :conditions do
+            scope "/exit-page", as: :exit_page do
+              get "/new" => "exit_page#new", as: :new
+              post "/new" => "exit_page#create", as: :create
+              post "/preview" => "exit_page#render_preview", as: :render_preview
+              get "/:condition_id" => "exit_page#edit", as: :edit
+              put "/:condition_id" => "exit_page#update", as: :update
+              get "/:condition_id/delete" => "exit_page#delete", as: :delete
+              delete "/:condition_id" => "exit_page#destroy", as: :destroy
+            end
+          end
         end
 
         scope "/routes" do

--- a/spec/input_objects/conditions/exit_page_input_spec.rb
+++ b/spec/input_objects/conditions/exit_page_input_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Pages::ExitPageInput, type: :model do
+RSpec.describe Conditions::ExitPageInput, type: :model do
   let(:exit_page_input) { described_class.new(form:, page:, answer_value:) }
   let(:form) { create :form, :ready_for_routing }
   let(:pages) { form.pages }
@@ -18,35 +18,35 @@ RSpec.describe Pages::ExitPageInput, type: :model do
 
   describe "validations" do
     it "is invalid if answer_value is nil" do
-      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.answer_value.blank")
+      error_message = I18n.t("activemodel.errors.models.conditions/exit_page_input.attributes.answer_value.blank")
       exit_page_input.answer_value = nil
       expect(exit_page_input).to be_invalid
       expect(exit_page_input.errors.full_messages_for(:answer_value)).to include("Answer value #{error_message}")
     end
 
     it "is invalid if exit_page_heading is nil" do
-      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_heading.blank")
+      error_message = I18n.t("activemodel.errors.models.conditions/exit_page_input.attributes.exit_page_heading.blank")
       exit_page_input.exit_page_heading = nil
       expect(exit_page_input).to be_invalid
       expect(exit_page_input.errors.full_messages_for(:exit_page_heading)).to include("Exit page heading #{error_message}")
     end
 
     it "is invalid if exit_page_markdown is nil" do
-      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_markdown.blank")
+      error_message = I18n.t("activemodel.errors.models.conditions/exit_page_input.attributes.exit_page_markdown.blank")
       exit_page_input.exit_page_markdown = nil
       expect(exit_page_input).to be_invalid
       expect(exit_page_input.errors.full_messages_for(:exit_page_markdown)).to include("Exit page markdown #{error_message}")
     end
 
     it "is invalid if exit_page_heading is too long" do
-      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_heading.too_long")
+      error_message = I18n.t("activemodel.errors.models.conditions/exit_page_input.attributes.exit_page_heading.too_long")
       exit_page_input.exit_page_heading = "a" * 5000
       expect(exit_page_input).to be_invalid
       expect(exit_page_input.errors.full_messages_for(:exit_page_heading)).to include("Exit page heading #{error_message}")
     end
 
     it "in invalid if exit_page_markdown is too long" do
-      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_markdown.too_long")
+      error_message = I18n.t("activemodel.errors.models.conditions/exit_page_input.attributes.exit_page_markdown.too_long")
       exit_page_input.exit_page_markdown = "a" * 5000
       expect(exit_page_input).to be_invalid
       expect(exit_page_input.errors.full_messages_for(:exit_page_markdown)).to include("Exit page markdown #{error_message}")

--- a/spec/input_objects/conditions/update_exit_page_input_spec.rb
+++ b/spec/input_objects/conditions/update_exit_page_input_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Pages::UpdateExitPageInput, type: :model do
+RSpec.describe Conditions::UpdateExitPageInput, type: :model do
   let(:update_exit_page_input) { described_class.new(form:, page:, record: condition) }
   let(:form) { create :form, :ready_for_routing }
   let(:page) { form.pages.first }
@@ -15,21 +15,21 @@ RSpec.describe Pages::UpdateExitPageInput, type: :model do
     end
 
     it "is invalid if exit_page_markdown is nil" do
-      error_message = I18n.t("activemodel.errors.models.pages/update_exit_page_input.attributes.exit_page_markdown.blank")
+      error_message = I18n.t("activemodel.errors.models.conditions/update_exit_page_input.attributes.exit_page_markdown.blank")
       update_exit_page_input.exit_page_markdown = nil
       expect(update_exit_page_input).to be_invalid
       expect(update_exit_page_input.errors.full_messages_for(:exit_page_markdown)).to include("Exit page markdown #{error_message}")
     end
 
     it "is invalid if exit_page_heading is too long" do
-      error_message = I18n.t("activemodel.errors.models.pages/update_exit_page_input.attributes.exit_page_heading.too_long")
+      error_message = I18n.t("activemodel.errors.models.conditions/update_exit_page_input.attributes.exit_page_heading.too_long")
       update_exit_page_input.exit_page_heading = "a" * 5000
       expect(update_exit_page_input).to be_invalid
       expect(update_exit_page_input.errors.full_messages_for(:exit_page_heading)).to include("Exit page heading #{error_message}")
     end
 
     it "is invalid if exit_page_markdown is too long" do
-      error_message = I18n.t("activemodel.errors.models.pages/update_exit_page_input.attributes.exit_page_markdown.too_long")
+      error_message = I18n.t("activemodel.errors.models.conditions/update_exit_page_input.attributes.exit_page_markdown.too_long")
       update_exit_page_input.exit_page_markdown = "a" * 5000
       expect(update_exit_page_input).to be_invalid
       expect(update_exit_page_input.errors.full_messages_for(:exit_page_markdown)).to include("Exit page markdown #{error_message}")

--- a/spec/input_objects/pages/update_exit_page_input_spec.rb
+++ b/spec/input_objects/pages/update_exit_page_input_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Pages::UpdateExitPageInput, type: :model do
 
   describe "validations" do
     it "is invalid if exit_page_heading is nil" do
-      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_heading.blank")
+      error_message = I18n.t("activemodel.errors.models.conditions/exit_page_input.attributes.exit_page_heading.blank")
       update_exit_page_input.exit_page_heading = nil
       expect(update_exit_page_input).to be_invalid
       expect(update_exit_page_input.errors.full_messages_for(:exit_page_heading)).to include("Exit page heading #{error_message}")

--- a/spec/requests/pages/conditions/exit_page_controller_spec.rb
+++ b/spec/requests/pages/conditions/exit_page_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Conditions::ExitPageController, type: :request do
   end
 
   describe "#create" do
-    let(:params) { { pages_exit_page_input: { exit_page_heading: "Exit Page Heading", exit_page_markdown: "Exit Page Markdown", answer_value: } } }
+    let(:params) { { conditions_exit_page_input: { exit_page_heading: "Exit Page Heading", exit_page_markdown: "Exit Page Markdown", answer_value: } } }
 
     before do
       post conditions_exit_page_create_path(form_id: form.id, page_id: selected_page.id, params:)
@@ -77,7 +77,7 @@ RSpec.describe Conditions::ExitPageController, type: :request do
     end
 
     context "when form submit fails" do
-      let(:params) { { pages_exit_page_input: { exit_page_heading: nil, exit_page_markdown: nil, answer_value: } } }
+      let(:params) { { conditions_exit_page_input: { exit_page_heading: nil, exit_page_markdown: nil, answer_value: } } }
 
       it "renders new page with a 422 error code" do
         expect(response).to have_http_status(:unprocessable_content)
@@ -229,7 +229,7 @@ RSpec.describe Conditions::ExitPageController, type: :request do
 
       it "returns a JSON object containing the converted HTML with an error" do
         expect(response).to have_http_status(:ok)
-        expect(response.body).to eq({ preview_html: I18n.t("exit_page.no_content_added_html"), errors: [I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.exit_page_markdown.blank")] }.to_json)
+        expect(response.body).to eq({ preview_html: I18n.t("exit_page.no_content_added_html"), errors: [I18n.t("activemodel.errors.models.conditions/exit_page_input.attributes.exit_page_markdown.blank")] }.to_json)
       end
 
       context "when validation is disabled" do

--- a/spec/requests/pages/conditions/exit_page_controller_spec.rb
+++ b/spec/requests/pages/conditions/exit_page_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Pages::ExitPageController, type: :request do
+RSpec.describe Conditions::ExitPageController, type: :request do
   let(:form) { create :form, :ready_for_routing, id: 1 }
   let(:pages) { form.pages }
   let(:page) do
@@ -29,11 +29,11 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
   describe "#new" do
     before do
-      get new_exit_page_path(form_id: form.id, page_id: selected_page.id, answer_value: answer_value)
+      get conditions_exit_page_new_path(form_id: form.id, page_id: selected_page.id, answer_value: answer_value)
     end
 
     it "renders the new exit page template" do
-      expect(response).to render_template("pages/exit_page/new")
+      expect(response).to render_template("conditions/exit_page/new")
     end
 
     context "when user should not be allowed to add routes to pages" do
@@ -59,7 +59,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
     let(:params) { { pages_exit_page_input: { exit_page_heading: "Exit Page Heading", exit_page_markdown: "Exit Page Markdown", answer_value: } } }
 
     before do
-      post create_exit_page_path(form_id: form.id, page_id: selected_page.id, params:)
+      post conditions_exit_page_create_path(form_id: form.id, page_id: selected_page.id, params:)
     end
 
     it "redirects to the show routes page with a success message" do
@@ -81,7 +81,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
       it "renders new page with a 422 error code" do
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response).to render_template("pages/exit_page/new")
+        expect(response).to render_template("conditions/exit_page/new")
       end
     end
 
@@ -98,11 +98,11 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
   describe "#edit" do
     before do
-      get edit_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id)
+      get conditions_exit_page_edit_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id)
     end
 
     it "renders the edit exit page template" do
-      expect(response).to render_template("pages/exit_page/edit")
+      expect(response).to render_template("conditions/exit_page/edit")
     end
   end
 
@@ -110,7 +110,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
     let(:params) { { pages_update_exit_page_input: { exit_page_heading: "Exit Page Heading", exit_page_markdown: "Exit Page Markdown" } } }
 
     before do
-      put update_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
+      put conditions_exit_page_update_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
     end
 
     it "redirects to the edit condition page with a success message" do
@@ -124,7 +124,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
       it "renders edit page with a 422 error code" do
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response).to render_template("pages/exit_page/edit")
+        expect(response).to render_template("conditions/exit_page/edit")
       end
     end
   end
@@ -133,11 +133,11 @@ RSpec.describe Pages::ExitPageController, type: :request do
     before do
       allow(condition).to receive(:exit_page?).and_return(true)
 
-      get delete_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id)
+      get conditions_exit_page_delete_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id)
     end
 
     it "renders the delete exit page template with the correct assignments" do
-      expect(response).to render_template("pages/exit_page/delete")
+      expect(response).to render_template("conditions/exit_page/delete")
       expect(assigns(:exit_page)).to eq(condition)
       expect(assigns(:delete_exit_page_input)).to be_a(Pages::DeleteExitPageInput)
     end
@@ -157,7 +157,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
     let(:params) { { pages_delete_exit_page_input: { confirm: "yes" } } }
 
     before do
-      delete destroy_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
+      delete conditions_exit_page_destroy_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
     end
 
     it "redirects to form pages path with a success message and deletes the exit page" do
@@ -171,7 +171,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
       let(:params) { { pages_delete_exit_page_input: { confirm: nil } } }
 
       it "renders the delete template again" do
-        expect(response).to render_template("pages/exit_page/delete")
+        expect(response).to render_template("conditions/exit_page/delete")
       end
     end
 
@@ -179,7 +179,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
       let(:params) { { pages_delete_exit_page_input: { confirm: "no" } } }
 
       it "redirects to form pages path without deleting the exit page" do
-        expect(response).to redirect_to(edit_exit_page_path(form.id, page.id, condition.id))
+        expect(response).to redirect_to(conditions_exit_page_edit_path(form.id, page.id, condition.id))
         expect(Condition.exists?(condition.id)).to be true
       end
     end
@@ -189,7 +189,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
 
       before do
         allow(condition).to receive(:exit_page?).and_return(false)
-        delete destroy_exit_page_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
+        delete conditions_exit_page_destroy_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
       end
 
       it "redirects to the form pages page" do
@@ -213,7 +213,7 @@ RSpec.describe Pages::ExitPageController, type: :request do
     let(:check_preview_validation) { "true" }
 
     before do
-      post exit_page_render_preview_path(form_id: form.id, page_id: page.id), params: { markdown:, check_preview_validation: }
+      post conditions_exit_page_render_preview_path(form_id: form.id, page_id: page.id), params: { markdown:, check_preview_validation: }
     end
 
     it "returns a JSON object containing the converted HTML" do

--- a/spec/requests/pages/conditions/exit_page_controller_spec.rb
+++ b/spec/requests/pages/conditions/exit_page_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Conditions::ExitPageController, type: :request do
   end
 
   describe "#update" do
-    let(:params) { { pages_update_exit_page_input: { exit_page_heading: "Exit Page Heading", exit_page_markdown: "Exit Page Markdown" } } }
+    let(:params) { { conditions_update_exit_page_input: { exit_page_heading: "Exit Page Heading", exit_page_markdown: "Exit Page Markdown" } } }
 
     before do
       put conditions_exit_page_update_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
@@ -120,7 +120,7 @@ RSpec.describe Conditions::ExitPageController, type: :request do
     end
 
     context "when form submit fails" do
-      let(:params) { { pages_update_exit_page_input: { exit_page_heading: nil, exit_page_markdown: nil } } }
+      let(:params) { { conditions_update_exit_page_input: { exit_page_heading: nil, exit_page_markdown: nil } } }
 
       it "renders edit page with a 422 error code" do
         expect(response).to have_http_status(:unprocessable_content)

--- a/spec/requests/pages/conditions/exit_page_controller_spec.rb
+++ b/spec/requests/pages/conditions/exit_page_controller_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Conditions::ExitPageController, type: :request do
     it "renders the delete exit page template with the correct assignments" do
       expect(response).to render_template("conditions/exit_page/delete")
       expect(assigns(:exit_page)).to eq(condition)
-      expect(assigns(:delete_exit_page_input)).to be_a(Pages::DeleteExitPageInput)
+      expect(assigns(:delete_exit_page_input)).to be_a(Conditions::DeleteExitPageInput)
     end
 
     context "when user should not be allowed to add/delete routes to pages" do
@@ -154,7 +154,7 @@ RSpec.describe Conditions::ExitPageController, type: :request do
   end
 
   describe "#destroy" do
-    let(:params) { { pages_delete_exit_page_input: { confirm: "yes" } } }
+    let(:params) { { conditions_delete_exit_page_input: { confirm: "yes" } } }
 
     before do
       delete conditions_exit_page_destroy_path(form_id: form.id, page_id: selected_page.id, condition_id: condition.id, params:)
@@ -168,7 +168,7 @@ RSpec.describe Conditions::ExitPageController, type: :request do
     end
 
     context "when confirmation is not provided" do
-      let(:params) { { pages_delete_exit_page_input: { confirm: nil } } }
+      let(:params) { { conditions_delete_exit_page_input: { confirm: nil } } }
 
       it "renders the delete template again" do
         expect(response).to render_template("conditions/exit_page/delete")
@@ -176,7 +176,7 @@ RSpec.describe Conditions::ExitPageController, type: :request do
     end
 
     context "when confirmation is no" do
-      let(:params) { { pages_delete_exit_page_input: { confirm: "no" } } }
+      let(:params) { { conditions_delete_exit_page_input: { confirm: "no" } } }
 
       it "redirects to form pages path without deleting the exit page" do
         expect(response).to redirect_to(conditions_exit_page_edit_path(form.id, page.id, condition.id))

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
         condition_id: condition.id,
         answer_value: answer_value,
         goto_page_id: goto_page_id,
-        params: { pages_delete_exit_page_input: { confirm: } },
+        params: { conditions_delete_exit_page_input: { confirm: } },
       )
     end
 

--- a/spec/requests/pages/conditions_controller_spec.rb
+++ b/spec/requests/pages/conditions_controller_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
         let(:group) { create(:group, organisation: standard_user.organisation) }
 
         it "redirects to the new exit page" do
-          expect(response).to redirect_to new_exit_page_path(form_id: form.id, page_id: page.id, answer_value: "Wales")
+          expect(response).to redirect_to conditions_exit_page_new_path(form_id: form.id, page_id: page.id, answer_value: "Wales")
         end
       end
 
@@ -304,7 +304,7 @@ RSpec.describe Pages::ConditionsController, type: :request do
 
       it "redirects to the edit exit page" do
         put update_condition_path(form_id: form.id, page_id: page.id, condition_id: condition.id, params:)
-        expect(response).to redirect_to edit_exit_page_path(form_id: form.id, page_id: page.id, condition_id: condition.id)
+        expect(response).to redirect_to conditions_exit_page_edit_path(form_id: form.id, page_id: page.id, condition_id: condition.id)
       end
     end
 

--- a/spec/views/pages/conditions/confirm_delete_exit_page.html.erb_spec.rb
+++ b/spec/views/pages/conditions/confirm_delete_exit_page.html.erb_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "pages/conditions/confirm_delete_exit_page.html.erb" do
   let(:form) { create :form, pages: [page] }
   let(:page) { build :page, id: 1, form_id: 1, position: 1 }
-  let(:exit_page_input) { Pages::DeleteExitPageInput.new }
+  let(:exit_page_input) { Conditions::DeleteExitPageInput.new }
   let(:exit_page) { build :condition, :with_exit_page, id: 1 }
 
   before do

--- a/spec/views/pages/conditions/exit_page/delete.html.erb_spec.rb
+++ b/spec/views/pages/conditions/exit_page/delete.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "pages/exit_page/delete.html.erb" do
+describe "conditions/exit_page/delete.html.erb" do
   let(:form) { create :form }
   let(:pages) do
     build_list(:page, 3) do |page, i|
@@ -16,7 +16,7 @@ describe "pages/exit_page/delete.html.erb" do
     assign(:exit_page, exit_page)
     assign(:delete_exit_page_input, exit_page_input)
 
-    render template: "pages/exit_page/delete"
+    render template: "conditions/exit_page/delete"
   end
 
   it "sets the correct title" do

--- a/spec/views/pages/conditions/exit_page/delete.html.erb_spec.rb
+++ b/spec/views/pages/conditions/exit_page/delete.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe "conditions/exit_page/delete.html.erb" do
       page.id = i + 1
     end
   end
-  let(:exit_page_input) { Pages::DeleteExitPageInput.new }
+  let(:exit_page_input) { Conditions::DeleteExitPageInput.new }
   let(:exit_page) { build :condition, :with_exit_page, id: 1 }
 
   before do

--- a/spec/views/pages/conditions/exit_page/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/exit_page/edit.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe "pages/exit_page/edit.html.erb" do
   let(:group) { build :group }
   let(:pages) { form.pages }
   let(:condition) { create :condition, :with_exit_page, routing_page_id: pages.first.id, check_page_id: pages.first.id, answer_value: "Option 1" }
-  let(:update_exit_page_input) { Pages::UpdateExitPageInput.new(form:, page: pages.first, record: condition).assign_condition_values }
+  let(:update_exit_page_input) { Conditions::UpdateExitPageInput.new(form:, page: pages.first, record: condition).assign_condition_values }
 
   before do
     render template: "conditions/exit_page/edit", locals: { update_exit_page_input:, preview_html: "Preview HTML", check_preview_validation: "true" }

--- a/spec/views/pages/conditions/exit_page/edit.html.erb_spec.rb
+++ b/spec/views/pages/conditions/exit_page/edit.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe "pages/exit_page/edit.html.erb" do
   let(:update_exit_page_input) { Pages::UpdateExitPageInput.new(form:, page: pages.first, record: condition).assign_condition_values }
 
   before do
-    render template: "pages/exit_page/edit", locals: { update_exit_page_input:, preview_html: "Preview HTML", check_preview_validation: "true" }
+    render template: "conditions/exit_page/edit", locals: { update_exit_page_input:, preview_html: "Preview HTML", check_preview_validation: "true" }
   end
 
   it "sets the correct title" do

--- a/spec/views/pages/conditions/exit_page/new.html.erb_spec.rb
+++ b/spec/views/pages/conditions/exit_page/new.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe "pages/exit_page/new.html.erb" do
   let(:exit_page_input) { Pages::ExitPageInput.new(form:, page: pages.first, answer_value: "Option 1") }
 
   before do
-    render template: "pages/exit_page/new", locals: { exit_page_input:, preview_html: "Preview HTML", check_preview_validation: "true" }
+    render template: "conditions/exit_page/new", locals: { exit_page_input:, preview_html: "Preview HTML", check_preview_validation: "true" }
   end
 
   it "sets the correct title" do

--- a/spec/views/pages/conditions/exit_page/new.html.erb_spec.rb
+++ b/spec/views/pages/conditions/exit_page/new.html.erb_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "pages/exit_page/new.html.erb" do
   let(:form) { create :form, :ready_for_routing }
   let(:pages) { form.pages }
-  let(:exit_page_input) { Pages::ExitPageInput.new(form:, page: pages.first, answer_value: "Option 1") }
+  let(:exit_page_input) { Conditions::ExitPageInput.new(form:, page: pages.first, answer_value: "Option 1") }
 
   before do
     render template: "conditions/exit_page/new", locals: { exit_page_input:, preview_html: "Preview HTML", check_preview_validation: "true" }


### PR DESCRIPTION
### Move the existing exit page controllers and input objects out the way

Trello card: https://trello.com/c/gecvdskV/3173-change-add-edit-delete-exit-page-to-work-with-multiple-branches

We are changing how exit pages are created, updated and deleted for the multiple branch feature.

We can't delete the existing exit pages code because they are still being used in production until we switch to multiple branch routing.

To add the new exit page routes for multiple branches we need to move the existing code out of the way. We are moving it instead of adapting it because there are differences in the new implementation, such as not depending on conditions.

When the new routes for exit pages have been added and the multiple branches feature is released, we will be able to remove the exit page code under conditions.

This PR shouldn't create any difference in how the product behaves. It's a code refactor to make implementing exit pages for multiple branches easier.

## Details

This is split into commits. The main changes are moving the controller under Condition, instead of Page and moving input objects.

The URLs for exit pages don't change but the path helpers have. We go through the code and tests to update them to the new values.

To move the input objects, we need to change the locales to match and check the controllers expect the correct params. Both depend on the name of the input object.

Whilst this PR is big, most of the changes are just altering the names of things.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
