### PR TITLE
Generalise feature flag rake tasks and specs

### DIFF
--- a/lib/tasks/groups.rake
+++ b/lib/tasks/groups.rake
@@ -35,25 +35,20 @@ namespace :groups do
     end
   end
 
-  desc "Toggle multiple_branches_enabled for a group"
-  task :toggle_multiple_branches_enabled, %i[group_id] => :environment do |_, args|
-    usage_message = "usage: rake groups:toggle_multiple_branches_enabled[<group_external_id>]".freeze
-    abort usage_message if args[:group_id].blank?
-    toggle_group_feature_flag(args[:group_id], "multiple_branches_enabled")
-  end
+  desc "Toggle a group-scoped feature flag for a group"
+  task :toggle_feature_flag, %i[feature_name group_id] => :environment do |_, args|
+    usage_message = "usage: rake groups:toggle_feature_flag[<feature_name>, <group_external_id>]".freeze
+    abort usage_message if args[:feature_name].blank? || args[:group_id].blank?
 
-  desc "Toggle custom_branding_enabled for a group"
-  task :toggle_custom_branding_enabled, %i[group_id] => :environment do |_, args|
-    usage_message = "usage: rake groups:toggle_custom_branding_enabled[<group_external_id>]".freeze
-    abort usage_message if args[:group_id].blank?
-    toggle_group_feature_flag(args[:group_id], "custom_branding_enabled")
-  end
+    # accept the feature name with or without the _enabled suffix
+    attribute_name = "#{args[:feature_name].delete_suffix('_enabled')}_enabled"
 
-  desc "Toggle save_and_return_enabled for a group"
-  task :toggle_save_and_return_enabled, %i[group_id] => :environment do |_, args|
-    usage_message = "usage: rake groups:toggle_save_and_return_enabled[<group_external_id>]".freeze
-    abort usage_message if args[:group_id].blank?
-    toggle_group_feature_flag(args[:group_id], "save_and_return_enabled")
+    unless Group.feature_flag_attributes.include?(attribute_name)
+      valid_names = Group.feature_flag_attributes.map { |attribute| attribute.delete_suffix("_enabled") }
+      abort "unknown feature flag: #{args[:feature_name]}. Valid feature flags: #{valid_names.join(', ')}"
+    end
+
+    toggle_group_feature_flag(args[:group_id], attribute_name)
   end
 end
 

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,10 +22,25 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    include_examples expected_value_test, :exit_pages, features, { "enabled_by_group" => true }
-    include_examples expected_value_test, :multiple_branches, features, { "enabled_by_group" => true }
-    include_examples expected_value_test, :save_and_return, features, { "enabled_by_group" => true }
     include_examples expected_value_test, :show_relevant_organisations, features, false
+
+    describe "group-scoped feature flags" do
+      group_features = features.select { |_, config| config.is_a?(Hash) && config["enabled_by_group"] }
+
+      it "has a settings entry for every feature flag column on the groups table" do
+        feature_flag_columns = Group.column_names.grep(/_enabled\z/)
+        settings_feature_columns = group_features.keys.map { |name| "#{name}_enabled" }
+
+        expect(settings_feature_columns).to include(*feature_flag_columns)
+      end
+
+      it "has a label for every feature flag on the feature flags page" do
+        Group.feature_flag_attributes.each do |attribute|
+          translation_key = "groups.feature_flags.flags.#{attribute}"
+          expect(I18n.exists?(translation_key)).to be(true), "expected a translation for #{translation_key}"
+        end
+      end
+    end
   end
 
   describe "forms_api" do

--- a/spec/lib/tasks/groups.rake_spec.rb
+++ b/spec/lib/tasks/groups.rake_spec.rb
@@ -48,15 +48,30 @@ RSpec.describe "groups.rake", type: :task do
     end
   end
 
-  describe "groups:toggle_multiple_branches_enabled" do
-    subject(:task) { Rake::Task["groups:toggle_multiple_branches_enabled"] }
+  describe "groups:toggle_feature_flag" do
+    subject(:task) { Rake::Task["groups:toggle_feature_flag"] }
 
-    it "with correct arguments toggles multiple_branches_enabled for the group" do
-      group = create(:group, multiple_branches_enabled: false)
+    let(:feature_flag) { Group.feature_flag_attributes.first }
+    let(:feature_name) { feature_flag.delete_suffix("_enabled") }
+
+    before do
+      skip "no group feature flags are configured" if Group.feature_flag_attributes.empty?
+    end
+
+    it "with correct arguments toggles the feature flag on for the group" do
+      group = create(:group, feature_flag => false)
 
       expect {
-        task.invoke(group.external_id)
-      }.to change { group.reload.multiple_branches_enabled }.from(false).to(true)
+        task.invoke(feature_name, group.external_id)
+      }.to change { group.reload.send(feature_flag) }.from(false).to(true)
+    end
+
+    it "with correct arguments toggles the feature flag off for the group" do
+      group = create(:group, feature_flag => true)
+
+      expect {
+        task.invoke(feature_name, group.external_id)
+      }.to change { group.reload.send(feature_flag) }.from(true).to(false)
     end
 
     it "with no arguments raises an error" do
@@ -66,62 +81,25 @@ RSpec.describe "groups.rake", type: :task do
       .and output(/usage/).to_stderr
     end
 
-    it "with invalid group id raises an error" do
-      invalid_args = %w[some_id_that_does_not_exist]
+    it "with no group id raises an error" do
       expect {
-        task.invoke(*invalid_args)
-      }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-  end
-
-  describe "groups:toggle_custom_branding_enabled" do
-    subject(:task) { Rake::Task["groups:toggle_custom_branding_enabled"] }
-
-    it "with correct arguments toggles custom_branding_enabled for the group" do
-      group = create(:group, custom_branding_enabled: false)
-
-      expect {
-        task.invoke(group.external_id)
-      }.to change { group.reload.custom_branding_enabled }.from(false).to(true)
-    end
-
-    it "with no arguments raises an error" do
-      expect {
-        task.invoke
+        task.invoke(feature_name)
       }.to raise_error(SystemExit)
       .and output(/usage/).to_stderr
     end
 
-    it "with invalid group id raises an error" do
-      invalid_args = %w[some_id_that_does_not_exist]
-      expect {
-        task.invoke(*invalid_args)
-      }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-  end
-
-  describe "groups:toggle_save_and_return_enabled" do
-    subject(:task) { Rake::Task["groups:toggle_save_and_return_enabled"] }
-
-    it "with correct arguments toggles save_and_return_enabled for the group" do
-      group = create(:group, save_and_return_enabled: false)
+    it "with an unknown feature name lists the valid feature flags" do
+      group = create(:group)
 
       expect {
-        task.invoke(group.external_id)
-      }.to change { group.reload.save_and_return_enabled }.from(false).to(true)
-    end
-
-    it "with no arguments raises an error" do
-      expect {
-        task.invoke
+        task.invoke("not_a_feature", group.external_id)
       }.to raise_error(SystemExit)
-      .and output(/usage/).to_stderr
+      .and output(/unknown feature flag: not_a_feature. Valid feature flags: .*#{feature_name}/).to_stderr
     end
 
     it "with invalid group id raises an error" do
-      invalid_args = %w[some_id_that_does_not_exist]
       expect {
-        task.invoke(*invalid_args)
+        task.invoke(feature_name, "some_id_that_does_not_exist")
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Adding a group-scoped feature flag currently requires a copy-pasted rake task and copy-pasted spec blocks on top of the migration, settings entry and locale label. This PR replaces the per-flag rake tasks with a single parameterised task and the per-flag spec assertions with consistency checks, so a new flag only needs the migration, a `config/settings.yml` entry and an `en.yml` label.
