### PR TITLE
Add multiple branch exit pages

### DIFF
--- a/app/controllers/pages/exit_pages_controller.rb
+++ b/app/controllers/pages/exit_pages_controller.rb
@@ -1,0 +1,49 @@
+class Pages::ExitPagesController < PagesController
+  before_action :check_multiple_branches_enabled
+  before_action :check_user_has_permission
+
+  def new
+    exit_page_input = Pages::ExitPageInput.new(page: page)
+
+    render locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: false }
+  end
+
+  def create
+    exit_page_input = Pages::ExitPageInput.new(exit_page_input_params)
+
+    if exit_page_input.submit
+      redirect_to routes_path(form_id: current_form.id), success: t("banner.success.exit_page_saved")
+    else
+      render :new, locals: { exit_page_input:, preview_html: preview_html(exit_page_input), check_preview_validation: true }, status: :unprocessable_content
+    end
+  end
+
+  def render_preview
+    exit_page_input = Pages::ExitPageInput.new(markdown: params[:markdown])
+    exit_page_input.validate if params[:check_preview_validation] == "true"
+
+    render json: { preview_html: preview_html(exit_page_input), errors: exit_page_input.errors[:markdown] }.to_json
+  end
+
+private
+
+  def exit_page_input_params
+    params.require(:pages_exit_page_input).permit(:heading, :markdown).merge(page:)
+  end
+
+  def check_user_has_permission
+    authorize current_form, :can_edit_form?
+  end
+
+  def check_multiple_branches_enabled
+    return if FeatureService.new(group: current_form.group).enabled?(:multiple_branches)
+
+    render "errors/not_found", status: :not_found, formats: :html
+  end
+
+  def preview_html(exit_page_input_object)
+    return t("exit_page.no_content_added_html") if exit_page_input_object.markdown.blank?
+
+    GovukFormsMarkdown.render(exit_page_input_object.markdown, locale: "en")
+  end
+end

--- a/app/input_objects/pages/exit_page_input.rb
+++ b/app/input_objects/pages/exit_page_input.rb
@@ -1,0 +1,13 @@
+class Pages::ExitPageInput < BaseInput
+  attr_accessor :page, :markdown, :heading
+
+  validates :heading, :markdown, presence: true
+  validates :heading, length: { maximum: 250 }
+  validates :markdown, markdown: { allow_headings: true }
+
+  def submit
+    return false if invalid?
+
+    ExitPage.create!(question_page: page, heading:, markdown:)
+  end
+end

--- a/app/views/pages/exit_pages/new.html.erb
+++ b/app/views/pages/exit_pages/new.html.erb
@@ -1,0 +1,40 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.exit_page_new"), exit_page_input.errors&.any?)) %>
+<% content_for :back_link, govuk_back_link_to(routes_path(@current_form.id), t(".back_link")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <%= form_with model: exit_page_input, url: exit_pages_path(@current_form.id, exit_page_input.page.id), method: 'POST' do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("page_titles.exit_page_new_caption", question_number: exit_page_input.page.position) %></span>
+        <span class="govuk-visually-hidden"> - </span>
+        <%= t("page_titles.add_exit_page") %>
+      </h1>
+
+      <%= govuk_summary_list(actions: false) do |summary_list|
+          summary_list.with_row do |row|
+              row.with_key { t("page_route_card.question_name_short", question_number: exit_page_input.page.position) }
+              row.with_value { "#{exit_page_input.page.question_text}" }
+          end;
+      end %>
+
+      <%= f.govuk_text_field( :heading, label: { size: 'm' } )  %>
+
+      <%= render MarkdownEditorComponent::View.new(:markdown,
+        form_builder: f,
+        render_preview_path: render_preview_exit_pages_path(form_id: @current_form.id, page_id: exit_page_input.page.id, check_preview_validation:),
+        preview_html: preview_html,
+        form_model: exit_page_input,
+        label: t("helpers.label.pages_exit_page_input.markdown"),
+        hint: t("helpers.hint.pages_exit_page_input.markdown"),
+        allow_headings: true) %>
+
+      <div class="govuk-button-group">
+        <%= f.govuk_submit t("save_and_continue") %>
+        <%= govuk_link_to t('cancel'), routes_path(@current_form.id) %>
+      </div>
+    <% end %>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,6 +256,7 @@ en:
     success:
       exit_page_created: Your exit page has been added
       exit_page_deleted: Your exit page has been deleted
+      exit_page_saved: Your exit page has been saved
       exit_page_updated: Your exit page has been saved
       form:
         batch_submissions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1709,6 +1709,7 @@ en:
     email_code_sent: Confirmation code sent
     error_prefix: 'Error: '
     exit_page_new: Add exit page
+    exit_page_new_caption: Question %{question_number}’s exit pages
     forbidden: You cannot view this page
     group_confirm_new: Create a new group for forms
     group_confirm_upgrade_request: Request to upgrade this trial group
@@ -1858,6 +1859,9 @@ en:
     delete_question: Delete question
     destroy:
       success: The question, ‘%{question_text}’, has been deleted
+    exit_pages:
+      new:
+        back_link: Back to edit question routes
     heading: Edit question
     index:
       add_a_question_route: Add a question route

--- a/config/locales/input_objects/exit_pages.yml
+++ b/config/locales/input_objects/exit_pages.yml
@@ -1,0 +1,23 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        pages/exit_page_input:
+          attributes:
+            heading:
+              blank: Enter a page heading
+              too_long: Page heading must be %{count} characters or less
+            markdown:
+              blank: Enter page content
+              too_long: Page content must be %{count} characters or less
+              unsupported_markdown_syntax: Page content can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
+  helpers:
+    hint:
+      pages_exit_page_input:
+        heading: Use a heading that summarises why someone cannot continue with the form. For example, ‘You’re not eligible for this service’.
+        markdown: Explain why they cannot continue to use the form and, if possible, tell them what they should do instead.
+    label:
+      pages_exit_page_input:
+        heading: Page heading
+        markdown: Page content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,12 @@ Rails.application.routes.draw do
           end
         end
 
+        resources :exit_pages, only: %i[new create], path: "exit-pages", module: :pages do
+          collection do
+            post "/preview" => "exit_pages#render_preview", as: :render_preview
+          end
+        end
+
         scope "/routes" do
           get "/" => "pages/routes#show", as: :show_routes
           get "/delete" => "pages/routes#delete", as: :delete_routes

--- a/spec/input_objects/pages/exit_page_input_spec.rb
+++ b/spec/input_objects/pages/exit_page_input_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Pages::ExitPageInput, type: :model do
+  subject(:exit_page_input) { described_class.new(heading:, markdown:) }
+
+  let(:heading) { "the heading" }
+  let(:markdown) { "some markdown" }
+
+  describe "validations" do
+    it "is invalid if heading is nil" do
+      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.heading.blank")
+      exit_page_input.heading = nil
+      expect(exit_page_input).to be_invalid
+      expect(exit_page_input.errors.full_messages_for(:heading)).to include("Heading #{error_message}")
+    end
+
+    it "is invalid if markdown is nil" do
+      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.markdown.blank")
+      exit_page_input.markdown = nil
+      expect(exit_page_input).to be_invalid
+      expect(exit_page_input.errors.full_messages_for(:markdown)).to include("Markdown #{error_message}")
+    end
+
+    it "is invalid if heading is too long" do
+      error_message = I18n.t("activemodel.errors.models.pages/exit_page_input.attributes.heading.too_long", count: 250)
+      exit_page_input.heading = "a" * 251
+      expect(exit_page_input).to be_invalid
+      expect(exit_page_input.errors.full_messages_for(:heading)).to include("Heading #{error_message}")
+    end
+
+    it_behaves_like "a markdown field with headings allowed", :mark_complete do
+      let(:model) { exit_page_input }
+      let(:attribute) { :markdown }
+    end
+  end
+
+  describe "#submit" do
+    subject(:exit_page_input) { described_class.new(heading:, markdown:, page:) }
+
+    let(:heading) { "the heading" }
+    let(:markdown) { "some markdown" }
+    let(:page) { create :page }
+
+    it "returns a truthy value" do
+      expect(exit_page_input.submit).to be_truthy
+    end
+
+    it "creates an exit page" do
+      expect {
+        exit_page_input.submit
+      }.to change(ExitPage, :count).by(1)
+
+      expect(page.exit_pages.first.question_page).to eq(page)
+      expect(page.exit_pages.first.heading).to eq(heading)
+      expect(page.exit_pages.first.markdown).to eq(markdown)
+    end
+
+    context "when the exit page is invalid" do
+      let(:heading) { nil }
+
+      it "returns false" do
+        expect(exit_page_input.submit).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/pages/exit_pages_controller_spec.rb
+++ b/spec/requests/pages/exit_pages_controller_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+RSpec.describe Pages::ExitPagesController, :feature_multiple_branches, type: :request do
+  let(:form) { create(:form, :with_group, :with_pages, pages_count: 1, group:) }
+  let(:page) { form.pages.first }
+  let(:group) { create(:group, organisation: test_org, memberships: [create(:membership, user: standard_user)]) }
+
+  before do
+    login_as standard_user
+  end
+
+  describe "#new" do
+    before do
+      get new_exit_page_path(form_id: form.id, page_id: page.id)
+    end
+
+    it "renders the template" do
+      expect(response).to have_rendered("exit_pages/new")
+      expect(response.body).to include("Add exit page")
+    end
+
+    context "when the multiple branches feature is not enabled", feature_multiple_branches: false do
+      it "is forbidden" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the user is not in the form's group" do
+      let(:group) { create(:group, organisation: test_org, memberships: []) }
+
+      it "returns a forbidden status code" do
+        expect(response).to have_http_status :forbidden
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:params) { { pages_exit_page_input: { heading: "Exit Page Heading", markdown: "Exit Page Markdown" } } }
+
+    before do
+      post exit_pages_path(form_id: form.id, page_id: page.id, params:)
+    end
+
+    it "creates an exit page" do
+      expect(response).to redirect_to(routes_path(form.id))
+      expect(flash[:success]).to eq(I18n.t("banner.success.exit_page_saved"))
+
+      exit_page = page.reload.exit_pages.first
+
+      expect(exit_page.heading).to eq("Exit Page Heading")
+      expect(exit_page.markdown).to eq("Exit Page Markdown")
+    end
+
+    context "when the user doesn't submit valid params" do
+      let(:params) { { pages_exit_page_input: { heading: nil, markdown: nil } } }
+
+      it "renders the exit page template" do
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to render_template("exit_pages/new")
+      end
+    end
+
+    context "when the multiple branches feature is not enabled", feature_multiple_branches: false do
+      it "is forbidden" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the user is not in the form's group" do
+      let(:group) { create(:group, organisation: test_org, memberships: []) }
+
+      it "returns a forbidden status code" do
+        expect(response).to have_http_status :forbidden
+      end
+    end
+  end
+
+  describe "#render_preview" do
+    let(:markdown) { "[Markdown](https://example.com)" }
+
+    before do
+      post render_preview_exit_pages_path(form_id: form.id, page_id: page.id), params: { markdown: }
+    end
+
+    it "returns a JSON object containing the converted HTML" do
+      expected_preview_html = <<~HTML.strip
+        <p class="govuk-body"><a href="https://example.com" class="govuk-link" rel="noreferrer noopener" target="_blank">Markdown (opens in new tab)</a></p>
+      HTML
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq({
+        preview_html: expected_preview_html,
+        errors: [],
+      }.to_json)
+    end
+
+    context "when markdown is blank" do
+      let(:markdown) { "" }
+
+      it "returns a JSON object containing the converted HTML" do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq({ preview_html: I18n.t("markdown_editor.no_markdown_content_html"), errors: [] }.to_json)
+      end
+    end
+
+    context "when the multiple branches feature is not enabled", feature_multiple_branches: false do
+      it "is forbidden" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the user is not in the form's group" do
+      let(:group) { create(:group, organisation: test_org, memberships: []) }
+
+      it "returns a forbidden status code" do
+        expect(response).to have_http_status :forbidden
+      end
+    end
+  end
+end

--- a/spec/views/pages/exit_pages/new.html.erb_spec.rb
+++ b/spec/views/pages/exit_pages/new.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe "exit_pages/new.html.erb" do
+  let(:form) { build_stubbed :form, :with_pages, pages: [build_stubbed(:page, id: 1)] }
+  let(:page) { form.pages.first }
+  let(:exit_page_input) { Pages::ExitPageInput.new(page:) }
+
+  def render_page
+    assign(:current_form, form)
+    render template: "pages/exit_pages/new", locals: { exit_page_input:, preview_html: "", check_preview_validation: false }
+  end
+
+  it "has the correct title" do
+    render_page
+    expect(view.content_for(:title)).to have_content("Add exit page")
+  end
+
+  it "has the correct back link" do
+    render_page
+    expect(view.content_for(:back_link)).to have_link("Back to edit question routes", href: routes_path(form.id))
+  end
+
+  it "has the correct heading and caption" do
+    render_page
+    expect(rendered).to have_selector "h1", text: "Question 1’s exit pages"
+    expect(rendered).to have_selector "h1", text: "Add exit page"
+  end
+
+  it "shows the page title as a summary list" do
+    render_page
+    expect(rendered).to have_css(".govuk-summary-list__key", text: "Question #{page.position}")
+    expect(rendered).to have_css(".govuk-summary-list__value", text: page.question_text)
+  end
+
+  it "shows error messages" do
+    exit_page_input.errors.add(:heading, "Error: Heading can't be blank")
+    render_page
+    expect(rendered).to have_text("Error: Heading can't be blank")
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/gecvdskV/3173-change-add-edit-delete-exit-page-to-work-with-multiple-branches

This PR adds a new exit page controller, input object and view to add exit pages under the multiple branches flag.

Currently there are no guards to adding exit pages to pages. I think we probably want to prevent exit pages based on the question type. I think we can add that later though. It also doesn't add update and delete which I'll do in other PRs.

There is no link from the new routes page (or anywhere else). To check the new page use the URL directly, for example:
http://localhost:3000/forms/6/pages/23/exit-pages/new

<img width="1276" height="2217" alt="image" src="https://github.com/user-attachments/assets/58c22dd1-cd07-417d-81eb-6e3599dca6e7" />


<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
