### PR TITLE
Exit pages on page list view

### DIFF
--- a/app/components/page_list_component/view.html.erb
+++ b/app/components/page_list_component/view.html.erb
@@ -49,10 +49,10 @@
               <% end %>
 
                 <% if page.routing_conditions.first.answer_value.present? %>
-                  <% answer_value_groups(page).each do |_, group| %>
+                  <% answer_value_groups(page).each do |group| %>
                     <p><%= condition_group_description(group) %></p>
                     <ul class="govuk-list govuk-list--bullet">
-                      <% group.each do |condition| %>
+                      <% group[:conditions].each do |condition| %>
                         <li>
                           <%= answer_value_text_for_condition2(condition) %>
                         </li>

--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -38,10 +38,13 @@ module PageListComponent
     end
 
     def condition_group_description(group)
-      if group.first.skip_to_end
+      case group[:group_type]
+      when :skip_to_end
         I18n.t("page_conditions.condition_group_description_end_of_form")
-      else
-        goto_page = @pages.find { |page| page.id == group.first.goto_page_id }
+      when :exit_page
+        I18n.t("page_conditions.condition_group_description_exit_page", exit_page_heading: group[:conditions].first.exit_page.heading, exit_page_index: group[:exit_page_index])
+      when :goto_page
+        goto_page = @pages.find { |page| page.id == group[:conditions].first.goto_page_id }
         I18n.t("page_conditions.condition_group_description", goto_page_question_text: goto_page.question_text, goto_page_question_number: goto_page.position)
       end
     end
@@ -103,10 +106,42 @@ module PageListComponent
     def answer_value_groups(page)
       answer_order = page.answer_settings&.selection_options&.map(&:value) || []
 
-      page.routing_conditions.to_a
+      conditions = page.routing_conditions.to_a
         .in_order_of(:answer_value, answer_order, filter: false)
-        .group_by(&:goto_page_id)
-        .sort_by { |goto_page_id, _| goto_page_id ? @pages.ids.index(goto_page_id) : Float::INFINITY }
+
+      groups = []
+
+      goto_page_groups = conditions.select { |condition| condition.goto_page_id.present? }.group_by(&:goto_page_id)
+      goto_page_groups.each_value do |grouped_conditions|
+        groups << {
+          group_type: :goto_page,
+          conditions: grouped_conditions,
+        }
+      end
+
+      skip_to_end_conditions = conditions.select(&:skip_to_end)
+
+      if skip_to_end_conditions.any?
+        groups << {
+          group_type: :skip_to_end,
+          conditions: skip_to_end_conditions,
+        }
+      end
+
+      exit_page_groups = conditions.select { |condition| condition.exit_page.present? }
+        .group_by { |condition| condition.exit_page.id }
+        .values
+        .sort_by { |grouped_conditions| grouped_conditions.first.exit_page&.created_at }
+
+      exit_page_groups.each_with_index do |grouped_conditions, index|
+        groups << {
+          group_type: :exit_page,
+          exit_page_index: index + 1,
+          conditions: grouped_conditions,
+        }
+      end
+
+      groups
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1610,6 +1610,7 @@ en:
     condition_goto_page_text_with_errors: "[Question not selected]"
     condition_group_description: 'Go to %{goto_page_question_number}, ‘%{goto_page_question_text}’ if the answer is:'
     condition_group_description_end_of_form: 'Go to the end of the form if the answer is:'
+    condition_group_description_exit_page: 'Go to exit page %{exit_page_index}, ‘%{exit_page_heading}’ if the answer is:'
     condition_list_key:
       one: Question %{question_number}’s route
       other: Question %{question_number}’s routes

--- a/spec/components/page_list_component/view_spec.rb
+++ b/spec/components/page_list_component/view_spec.rb
@@ -256,6 +256,52 @@ RSpec.describe PageListComponent::View, type: :component do
       end
     end
 
+    context "when the page has a route to an exit page" do
+      let!(:condition) { create :condition, :with_exit_page, routing_page_id: first_page.id, answer_value: "Option 1" }
+
+      before do
+        render_inline(page_list_component)
+      end
+
+      it "renders the condition description" do
+        condition_description = "Go to exit page 1, ‘#{condition.exit_page.heading}’ if the answer is:"
+        condition_answer_value = "‘#{condition.answer_value}’"
+
+        expect(page).to have_css("dd.govuk-summary-list__value", text: condition_description)
+        expect(page).to have_css("li", text: condition_answer_value)
+      end
+    end
+
+    context "when the page has routes to multiple exit pages" do
+      let!(:first_condition) { create :condition, :with_exit_page, routing_page_id: first_page.id, answer_value: "Option 1" }
+      let!(:second_condition) { create :condition, :with_exit_page, routing_page_id: first_page.id, answer_value: "Option 2" }
+      let!(:third_condition) do
+        create :condition,
+               exit_page_id: second_condition.exit_page.id,
+               routing_page_id: first_page.id, answer_value: "Option 3",
+               exit_page_heading: second_condition.exit_page.heading,
+               exit_page_markdown: second_condition.exit_page.markdown
+      end
+
+      before do
+        render_inline(page_list_component)
+      end
+
+      it "renders the conditions grouped by exit pages with indexing" do
+        first_condition_description = "Go to exit page 1, ‘#{first_condition.exit_page.heading}’ if the answer is:"
+        first_condition_answer_value = "‘#{first_condition.answer_value}’"
+        second_condition_description = "Go to exit page 2, ‘#{second_condition.exit_page.heading}’ if the answer is:"
+        second_condition_answer_value = "‘#{second_condition.answer_value}’"
+        third_condition_answer_value = "‘#{third_condition.answer_value}’"
+
+        expect(page).to have_css("dd.govuk-summary-list__value", text: first_condition_description)
+        expect(page).to have_css("li", text: first_condition_answer_value)
+        expect(page).to have_css("dd.govuk-summary-list__value", text: second_condition_description)
+        expect(page).to have_css("li", text: second_condition_answer_value)
+        expect(page).to have_css("li", text: third_condition_answer_value)
+      end
+    end
+
     context "when the page has an unconditional route" do
       context "when the route is to another page" do
         before do
@@ -466,10 +512,13 @@ RSpec.describe PageListComponent::View, type: :component do
     end
 
     describe "#condition_group_description" do
-      context "when skip_to_end is false" do
-        let(:group) do
-          [build(:condition, skip_to_end: false, goto_page_id: pages.third.id, answer_value: "Option 1")]
-        end
+      let(:group) do
+        { group_type:, conditions: [condition] }
+      end
+
+      context "when the group is a goto_page group" do
+        let(:group_type) { :goto_page }
+        let(:condition) { build(:condition, routing_page_id: pages.first.id, goto_page_id: pages.third.id, answer_value: "Option 1") }
 
         it "returns the correct description" do
           expected_text = "Go to #{pages.third.position}, ‘#{pages.third.question_text}’ if the answer is:"
@@ -477,13 +526,26 @@ RSpec.describe PageListComponent::View, type: :component do
         end
       end
 
-      context "when skip_to_end is true" do
-        let(:group) do
-          [build(:condition, skip_to_end: true, goto_page_id: nil)]
-        end
+      context "when the group is a skip to end group" do
+        let(:group_type) { :skip_to_end }
+        let(:condition) { build(:condition, skip_to_end: true, answer_value: "Option 1") }
 
         it "returns the correct description" do
           expected_text = "Go to the end of the form if the answer is:"
+          expect(page_list_component.condition_group_description(group)).to eq(expected_text)
+        end
+      end
+
+      context "when the group is an exit page group" do
+        let(:group) do
+          { group_type:, exit_page_index: 1, conditions: [condition] }
+        end
+
+        let(:group_type) { :exit_page }
+        let(:condition) { create(:condition, :with_exit_page, answer_value: "Option 1") }
+
+        it "returns the correct description" do
+          expected_text = "Go to exit page 1, ‘#{condition.exit_page.heading}’ if the answer is:"
           expect(page_list_component.condition_group_description(group)).to eq(expected_text)
         end
       end
@@ -541,6 +603,8 @@ RSpec.describe PageListComponent::View, type: :component do
         { value: "Option 1" },
         { value: "Option 2" },
         { value: "Option 3" },
+        { value: "Option 4" },
+        { value: "Option 5" },
       ]
     end
 
@@ -549,7 +613,8 @@ RSpec.describe PageListComponent::View, type: :component do
         create(:condition, routing_page_id: pages[0].id, answer_value: "Option 1", goto_page_id: pages[2].id),
         create(:condition, routing_page_id: pages[0].id, answer_value: "Option 2", goto_page_id: pages[2].id),
         create(:condition, routing_page_id: pages[0].id, answer_value: "Option 3", goto_page_id: pages[3].id),
-        create(:condition, routing_page_id: pages[0].id, answer_value: nil, goto_page_id: nil, skip_to_end: true),
+        create(:condition, routing_page_id: pages[0].id, answer_value: "Option 4", goto_page_id: nil, skip_to_end: true),
+        create(:condition, :with_exit_page, routing_page_id: pages[0].id, answer_value: "Option 5"),
       ]
     end
 
@@ -559,11 +624,12 @@ RSpec.describe PageListComponent::View, type: :component do
       conditions
     end
 
-    it "groups conditions by goto_page_id" do
+    it "groups conditions by goto page, skip to end, and exit page" do
       expected = [
-        [pages[2].id, [conditions[0], conditions[1]]],
-        [pages[3].id, [conditions[2]]],
-        [nil, [conditions[3]]],
+        { group_type: :goto_page, conditions: [conditions[0], conditions[1]] },
+        { group_type: :goto_page, conditions: [conditions[2]] },
+        { group_type: :skip_to_end, conditions: [conditions[3]] },
+        { group_type: :exit_page, exit_page_index: 1, conditions: [conditions[4]] },
       ]
       result = page_list_component.answer_value_groups(form.pages.first)
       expect(result).to eq expected
@@ -572,17 +638,20 @@ RSpec.describe PageListComponent::View, type: :component do
     context "when given a different order of selection options" do
       let(:selection_options) do
         [
+          { value: "Option 5" },
+          { value: "Option 4" },
           { value: "Option 3" },
           { value: "Option 2" },
           { value: "Option 1" },
         ]
       end
 
-      it "returns the conditions in the same order" do
+      it "returns the condition groupings based on the selection options order" do
         expected = [
-          [pages[2].id, [conditions[1], conditions[0]]],
-          [pages[3].id, [conditions[2]]],
-          [nil, [conditions[3]]],
+          { group_type: :goto_page, conditions: [conditions[2]] },
+          { group_type: :goto_page, conditions: [conditions[1], conditions[0]] },
+          { group_type: :skip_to_end, conditions: [conditions[3]] },
+          { group_type: :exit_page, exit_page_index: 1, conditions: [conditions[4]] },
         ]
 
         result = page_list_component.answer_value_groups(form.pages.first)
@@ -602,11 +671,11 @@ RSpec.describe PageListComponent::View, type: :component do
 
       it "sorts groups by page position, not page id" do
         expected = [
-          [pages[2].id, [conditions[0], conditions[1]]],
-          [pages[3].id, [conditions[2]]],
-          [nil, [conditions[3]]],
+          { group_type: :goto_page, conditions: [conditions[0], conditions[1]] },
+          { group_type: :goto_page, conditions: [conditions[2]] },
+          { group_type: :skip_to_end, conditions: [conditions[3]] },
+          { group_type: :exit_page, exit_page_index: 1, conditions: [conditions[4]] },
         ]
-
         result = page_list_component.answer_value_groups(form.pages.first)
         expect(result).to eq expected
       end


### PR DESCRIPTION
### What problem does this pull request solve?

When conditions lead to exit pages, this is displayed on the page list
view.

The order of conditions being displayed is:
 - Conditions that go to another page, in order of the pages they go to
 - Conditions that skip to the end
 - Conditions that go to an exit page, in order of the exit pages'
   created_at values

Within each condition grouping, the answer values are displayed in the
order that they appear in the question.

https://trello.com/c/ul4Ot2Sn/3174-change-add-and-edit-your-questions-page-to-show-multiple-exit-pages

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
The image below shows a question which has:
 - A route to another page
 - A route that skips to the end
 - A route that goes to the exit page "I have a special passport"
 - Two routes that both go to the exit page "You should get a passport"

<img width="796" height="710" alt="image" src="https://github.com/user-attachments/assets/5e3b19a6-37f8-4699-ad8b-8e2ad2d439f5" />



### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
