### PR TITLE
Add version to form documents

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -14,6 +14,7 @@ class Form < ApplicationRecord
   has_one :archived_welsh_form_document, -> { where tag: "archived", language: :cy }, class_name: "FormDocument"
   has_one :draft_welsh_form_document, -> { where tag: "draft", language: :cy }, class_name: "FormDocument"
   has_one :draft_form_document, -> { where tag: "draft", language: :en }, class_name: "FormDocument"
+  belongs_to :latest_form_document, class_name: "FormDocument", optional: true
   has_many :conditions, through: :pages, source: :routing_conditions
   has_many :exit_pages, through: :pages, source: :exit_pages
   has_many :delivery_configurations, dependent: :destroy

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -46,7 +46,7 @@ class Form < ApplicationRecord
 
   after_create :set_external_id
   after_update :update_draft_form_document
-  ATTRIBUTES_NOT_IN_FORM_DOCUMENT = %i[state external_id pages question_section_completed declaration_section_completed share_preview_completed welsh_completed].freeze
+  ATTRIBUTES_NOT_IN_FORM_DOCUMENT = %i[state external_id pages question_section_completed declaration_section_completed share_preview_completed welsh_completed latest_form_document_id].freeze
 
   attr_accessor :task_status_service
 

--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -120,6 +120,9 @@ private
     form_document.version = 1 if tag == LIVE_TAG
 
     form_document.save!
+
+    # use update_column to skip callbacks so we don't sync the draft form document again
+    form.update_column(:latest_form_document_id, form_document.id) if language == "en" && tag == LIVE_TAG
   end
 
   def delete_form_documents_by_tag(tag)

--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -117,6 +117,7 @@ private
       language:,
     )
     form_document.content = content
+    form_document.version = 1 if tag == LIVE_TAG
 
     form_document.save!
   end

--- a/db/migrate/20260811111936_add_version_to_form_documents.rb
+++ b/db/migrate/20260811111936_add_version_to_form_documents.rb
@@ -1,0 +1,5 @@
+class AddVersionToFormDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :form_documents, :version, :integer, null: true
+  end
+end

--- a/db/migrate/20260811140129_add_latest_form_document_id_to_forms.rb
+++ b/db/migrate/20260811140129_add_latest_form_document_id_to_forms.rb
@@ -1,0 +1,5 @@
+class AddLatestFormDocumentIdToForms < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :forms, :latest_form_document, null: true, foreign_key: { to_table: :form_documents, on_delete: :nullify }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_11_111936) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_140129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -168,6 +168,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_111936) do
     t.string "external_id"
     t.datetime "first_made_live_at"
     t.text "form_slug"
+    t.bigint "latest_form_document_id"
     t.text "name"
     t.string "payment_url"
     t.text "privacy_policy_url"
@@ -187,6 +188,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_111936) do
     t.boolean "welsh_completed", default: false
     t.text "what_happens_next_markdown"
     t.index ["external_id"], name: "index_forms_on_external_id", unique: true
+    t.index ["latest_form_document_id"], name: "index_forms_on_latest_form_document_id"
   end
 
   create_table "groups", force: :cascade do |t|
@@ -355,6 +357,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_111936) do
   add_foreign_key "exit_pages", "pages", column: "question_page_id", on_delete: :cascade
   add_foreign_key "form_documents", "forms"
   add_foreign_key "form_translations", "forms"
+  add_foreign_key "forms", "form_documents", column: "latest_form_document_id", on_delete: :nullify
   add_foreign_key "groups", "users", column: "creator_id"
   add_foreign_key "groups", "users", column: "upgrade_requester_id"
   add_foreign_key "memberships", "groups"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_145629) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_111936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -119,6 +119,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_145629) do
     t.string "language", default: "en", null: false
     t.text "tag", null: false, comment: "The tag for the form, for example: 'live' or 'draft'"
     t.datetime "updated_at", null: false
+    t.integer "version"
     t.index ["form_id", "tag", "language"], name: "index_form_documents_on_form_id_tag_and_language", unique: true
     t.index ["form_id"], name: "index_form_documents_on_form_id"
   end

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,0 +1,9 @@
+namespace :data_migrations do
+  desc "backfill version for existing live and archived form documents"
+  task set_version_on_form_documents: :environment do
+    FormDocument.where(tag: %i[live archived]).find_each do |form_document|
+      form_document.update!(version: 1) if form_document.version.nil?
+      form_document.form.update!(latest_form_document: form_document) if form_document.language == "en"
+    end
+  end
+end

--- a/spec/factories/models/form_documents.rb
+++ b/spec/factories/models/form_documents.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :form_document do
     form { association :form }
     tag { "draft" }
+    version { nil }
 
     trait :live do
       tag { "live" }

--- a/spec/factories/models/form_documents.rb
+++ b/spec/factories/models/form_documents.rb
@@ -6,10 +6,12 @@ FactoryBot.define do
 
     trait :live do
       tag { "live" }
+      version { 1 }
     end
 
     trait :archived do
       tag { "archived" }
+      version { 1 }
     end
 
     trait :draft do

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -105,7 +105,7 @@ FactoryBot.define do
       after(:create) do |form|
         form.available_languages.each do |language|
           Mobility.with_locale(language) do
-            form_document = FormDocument.create!(form:, tag: "live", content: form.as_form_document(live_at: form.updated_at), language:)
+            form_document = FormDocument.create!(form:, tag: "live", content: form.as_form_document(live_at: form.updated_at), language:, version: 1)
             form.update_column(:latest_form_document_id, form_document.id) if language == "en"
           end
         end
@@ -124,7 +124,7 @@ FactoryBot.define do
       after(:create) do |form|
         form.available_languages.each do |language|
           Mobility.with_locale(language) do
-            form_document = FormDocument.create!(form:, tag: "archived", content: form.as_form_document(live_at: form.updated_at), language:)
+            form_document = FormDocument.create!(form:, tag: "archived", content: form.as_form_document(live_at: form.updated_at), language:, version: 1)
             form.update_column(:latest_form_document_id, form_document.id) if language == "en"
           end
         end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -105,7 +105,8 @@ FactoryBot.define do
       after(:create) do |form|
         form.available_languages.each do |language|
           Mobility.with_locale(language) do
-            FormDocument.create(form:, tag: "live", content: form.as_form_document(live_at: form.updated_at), language:)
+            form_document = FormDocument.create!(form:, tag: "live", content: form.as_form_document(live_at: form.updated_at), language:)
+            form.update_column(:latest_form_document_id, form_document.id) if language == "en"
           end
         end
       end
@@ -123,7 +124,8 @@ FactoryBot.define do
       after(:create) do |form|
         form.available_languages.each do |language|
           Mobility.with_locale(language) do
-            FormDocument.create(form:, tag: "archived", content: form.as_form_document(live_at: form.updated_at), language:)
+            form_document = FormDocument.create!(form:, tag: "archived", content: form.as_form_document(live_at: form.updated_at), language:)
+            form.update_column(:latest_form_document_id, form_document.id) if language == "en"
           end
         end
       end

--- a/spec/lib/tasks/data_migrations.rake_spec.rb
+++ b/spec/lib/tasks/data_migrations.rake_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe "data_migrations.rake", type: :task do
+  describe "data_migrations:set_version_on_form_documents" do
+    subject(:task) do
+      Rake::Task["data_migrations:set_version_on_form_documents"]
+    end
+
+    context "when the version is not set for form documents" do
+      let!(:live_form) { create :form, :live, :with_welsh_translation }
+      let!(:archived_form) { create :form, :archived, :with_welsh_translation }
+      let!(:draft_form) { create :form, :with_welsh_translation }
+
+      before do
+        live_form.live_form_document.update!(version: nil)
+        live_form.live_welsh_form_document.update!(version: nil)
+        archived_form.archived_form_document.update!(version: nil)
+        archived_form.archived_welsh_form_document.update!(version: nil)
+      end
+
+      it "sets version to 1 for all live and archived form documents" do
+        task.invoke
+
+        expect(live_form.live_form_document.reload.version).to eq(1)
+        expect(live_form.live_welsh_form_document.reload.version).to eq(1)
+        expect(archived_form.archived_form_document.reload.version).to eq(1)
+        expect(archived_form.archived_welsh_form_document.reload.version).to eq(1)
+      end
+
+      it "does not set version for draft form documents" do
+        task.invoke
+
+        expect(draft_form.draft_form_document.reload.version).to be_nil
+        expect(draft_form.draft_welsh_form_document.reload.version).to be_nil
+      end
+
+      it "updates latest_form_document_id to the English version" do
+        task.invoke
+
+        expect(live_form.reload.latest_form_document_id).to eq(live_form.live_form_document.id)
+        expect(archived_form.reload.latest_form_document_id).to eq(archived_form.archived_form_document.id)
+      end
+
+      it "does not update the latest_form_document_id for draft forms" do
+        task.invoke
+
+        expect(draft_form.reload.latest_form_document_id).to be_nil
+      end
+    end
+
+    context "when the version is set for form documents" do
+      let!(:live_form) { create :form, :live, :with_welsh_translation }
+
+      before do
+        live_form.live_form_document.update!(version: 2)
+        live_form.live_welsh_form_document.update!(version: 2)
+      end
+
+      it "does not change the version for form documents that already have a version set" do
+        task.invoke
+
+        expect(live_form.live_form_document.reload.version).to eq(2)
+        expect(live_form.live_welsh_form_document.reload.version).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/models/form_document/content_spec.rb
+++ b/spec/models/form_document/content_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe FormDocument::Content, type: :model do
                              submission_type
                              submission_format
                              send_daily_submission_batch
-                             send_weekly_submission_batch]
+                             send_weekly_submission_batch
+                             latest_form_document_id]
     expected_attributes = form.attributes.except(*excluded_attributes)
     expect(form_document_content).to have_attributes(expected_attributes)
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -7,26 +7,37 @@ RSpec.describe Form, type: :model do
     it "has a valid factory" do
       form = create :form
       expect(form).to be_valid
+      expect(form.draft_form_document).to be_present
     end
 
     it "has a live trait" do
-      form = build :form, :live
+      form = create :form, :live
       expect(form.state).to eq "live"
+      expect(form.live_form_document).to be_present
+      expect(form.latest_form_document_id).to eq(form.live_form_document.id)
     end
 
     it "has a live with draft trait" do
-      form = build :form, :live_with_draft
+      form = create :form, :live_with_draft
       expect(form.state).to eq "live_with_draft"
+      expect(form.live_form_document).to be_present
+      expect(form.draft_form_document).to be_present
+      expect(form.latest_form_document_id).to eq(form.live_form_document.id)
     end
 
     it "has an archived trait" do
-      form = build :form, :archived
+      form = create :form, :archived
       expect(form.state).to eq "archived"
+      expect(form.archived_form_document).to be_present
+      expect(form.latest_form_document_id).to eq(form.archived_form_document.id)
     end
 
     it "has an archived with draft trait" do
-      form = build :form, :archived_with_draft
+      form = create :form, :archived_with_draft
       expect(form.state).to eq "archived_with_draft"
+      expect(form.archived_form_document).to be_present
+      expect(form.draft_form_document).to be_present
+      expect(form.latest_form_document_id).to eq(form.archived_form_document.id)
     end
 
     it "has a ready for routing trait" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Form, type: :model do
       form = create :form, :live
       expect(form.state).to eq "live"
       expect(form.live_form_document).to be_present
+      expect(form.live_form_document.version).to eq(1)
       expect(form.latest_form_document_id).to eq(form.live_form_document.id)
     end
 
@@ -29,6 +30,7 @@ RSpec.describe Form, type: :model do
       form = create :form, :archived
       expect(form.state).to eq "archived"
       expect(form.archived_form_document).to be_present
+      expect(form.archived_form_document.version).to eq(1)
       expect(form.latest_form_document_id).to eq(form.archived_form_document.id)
     end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1192,7 +1192,7 @@ RSpec.describe Form, type: :model do
     end
 
     it "includes all attributes for the form" do
-      form_attributes = described_class.attribute_names - %w[id state external_id pages question_section_completed declaration_section_completed share_preview_completed welsh_completed]
+      form_attributes = described_class.attribute_names - %w[id state external_id pages question_section_completed declaration_section_completed share_preview_completed welsh_completed latest_form_document_id]
       expect(form.as_form_document).to match a_hash_including(*form_attributes)
     end
 

--- a/spec/requests/forms/delete_confirmation_controller_spec.rb
+++ b/spec/requests/forms/delete_confirmation_controller_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe Forms::DeleteConfirmationController, type: :request do
         expect(flash[:success]).to eq "The draft form, ‘Form 1’, has been deleted"
       end
 
+      context "when the form is live" do
+        let(:form) { create(:form, :live) }
+
+        it "deletes the form and redirects" do
+          expect(response).to redirect_to(group_path(group))
+          expect(Form.exists?(form.id)).to be false
+        end
+      end
+
       context "when current user is not in group for form" do
         let(:membership) { nil }
 

--- a/spec/services/form_document_sync_service_spec.rb
+++ b/spec/services/form_document_sync_service_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe FormDocumentSyncService do
 
         expect(FormDocument.last).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at), version: 1)
       end
+
+      it "sets the latest_form_document_id on the form" do
+        service.synchronize_live_form
+        expect(form.reload.latest_form_document_id).to eq(FormDocument.last.id)
+      end
     end
 
     context "when there is an existing live form document" do
@@ -89,6 +94,11 @@ RSpec.describe FormDocumentSyncService do
         welsh_doc = FormDocument.find_by(form:, tag: "live", language: "cy")
         expect(english_doc.version).to eq(1)
         expect(welsh_doc.version).to eq(1)
+      end
+
+      it "sets the latest_form_document_id on the form to the English form document" do
+        service.synchronize_live_form
+        expect(form.reload.latest_form_document_id).to eq(FormDocument.find_by(form:, tag: "live", language: "en").id)
       end
 
       context "and the Welsh form fails to save" do
@@ -230,6 +240,11 @@ RSpec.describe FormDocumentSyncService do
         expect(FormDocument.find_by(form:, tag: "draft", language: "en").version).to be_nil
       end
 
+      it "does not set the latest_form_document_id" do
+        service.update_draft_form_document
+        expect(form.reload.latest_form_document_id).to be_nil
+      end
+
       context "when there is a declaration in Welsh but not in English translations" do
         let(:form) { create(:form, available_languages: %w[en cy], declaration_markdown: "", declaration_markdown_cy: "Shouldn't be here") }
 
@@ -305,6 +320,11 @@ RSpec.describe FormDocumentSyncService do
         }.to change(FormDocument, :count).by(1)
 
         expect(FormDocument.last).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at), version: 1)
+      end
+
+      it "sets the latest_form_document_id on the form" do
+        service.synchronize_only_live_english_form
+        expect(form.reload.latest_form_document_id).to eq(FormDocument.find_by(form:, tag: "live", language: "en").id)
       end
     end
 
@@ -414,7 +434,8 @@ RSpec.describe FormDocumentSyncService do
 
     context "when there is a live English form document" do
       before do
-        create :form_document, :live, form:, language: "en", content: { "available_languages" => %w[en] }
+        form_document = create :form_document, :live, form:, language: "en", content: { "available_languages" => %w[en] }
+        form.latest_form_document_id = form_document.id
       end
 
       context "when there is no existing Welsh form document" do
@@ -428,6 +449,12 @@ RSpec.describe FormDocumentSyncService do
           expect(welsh_form_document.content["available_languages"]).to eq %w[en cy]
           expect(welsh_form_document.version).to eq 1
           expect(welsh_form_document).to have_attributes(form:, tag: "live", content: welsh_form_content)
+        end
+
+        it "does not change the latest_live_form_document_id" do
+          expect {
+            service.synchronize_only_live_welsh_form
+          }.to(not_change { form.reload.latest_form_document_id })
         end
       end
 

--- a/spec/services/form_document_sync_service_spec.rb
+++ b/spec/services/form_document_sync_service_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe FormDocumentSyncService do
           service.synchronize_live_form
         }.to change(FormDocument, :count).by(1)
 
-        expect(FormDocument.last).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at))
+        expect(FormDocument.last).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at), version: 1)
       end
     end
 
     context "when there is an existing live form document" do
-      let!(:form_document) { create :form_document, :live, form:, content: form.as_form_document }
+      let!(:form_document) { create :form_document, :live, form:, content: form.as_form_document, version: 1 }
 
       it "updates the live form document" do
         new_name = "new name"
@@ -32,6 +32,11 @@ RSpec.describe FormDocumentSyncService do
       it "updates the live_at date in the form document" do
         service.synchronize_live_form
         expect(FormDocument.last["content"]).to include("live_at" => form.reload.updated_at.as_json)
+      end
+
+      it "maintains the version as 1" do
+        service.synchronize_live_form
+        expect(form_document.reload.version).to eq(1)
       end
     end
 
@@ -78,6 +83,14 @@ RSpec.describe FormDocumentSyncService do
         expect(FormDocument.where(form:, tag: "draft", language: "cy")).to exist
       end
 
+      it "creates live form documents with version 1" do
+        service.synchronize_live_form
+        english_doc = FormDocument.find_by(form:, tag: "live", language: "en")
+        welsh_doc = FormDocument.find_by(form:, tag: "live", language: "cy")
+        expect(english_doc.version).to eq(1)
+        expect(welsh_doc.version).to eq(1)
+      end
+
       context "and the Welsh form fails to save" do
         before do
           allow(service).to receive(:update_or_create_form_document).and_call_original
@@ -108,30 +121,10 @@ RSpec.describe FormDocumentSyncService do
     context "when there is an existing live form document" do
       let!(:live_form_document) { create :form_document, :live, form:, content: "content" }
 
-      it "destroys the live form document" do
+      it "updates the live form document to be archived" do
         expect {
           service.synchronize_archived_form
-        }.to(change { FormDocument.exists?(form:, tag: "live") }.from(true).to(false))
-      end
-
-      it "creates the archived form document" do
-        expect {
-          service.synchronize_archived_form
-        }.to(change { FormDocument.exists?(form:, tag: "archived", content: live_form_document.content) }.from(false).to(true))
-      end
-
-      context "when the live FormDocument fails to delete" do
-        before do
-          allow(service).to receive(:delete_form_documents_by_tag).and_call_original
-          allow(service).to receive(:delete_form_documents_by_tag).with(FormDocumentSyncService::ARCHIVED_TAG)
-            .and_raise(ActiveRecord::RecordInvalid.new(live_form_document), "simulated FormDocument deleting error")
-        end
-
-        it "does not create the live FormDocument" do
-          expect {
-            service.synchronize_archived_form
-          }.to raise_error(ActiveRecord::RecordInvalid).and not_change(FormDocument, :count)
-        end
+        }.to(change { live_form_document.reload.tag }.from("live").to("archived"))
       end
     end
 
@@ -176,16 +169,10 @@ RSpec.describe FormDocumentSyncService do
       let!(:live_form_document_cy) { create :form_document, :live, form:, language: "cy", content: { "available_languages" => %w[en cy] } }
       let!(:live_form_document_en) { create :form_document, :live, form:, language: "en", content: { "available_languages" => %w[en cy] } }
 
-      it "destroys the live welsh form document" do
+      it "updates the live welsh form document to be archived" do
         expect {
-          service.synchronize_archived_welsh_form
-        }.to(change { FormDocument.exists?(form:, tag: "live", language: "cy") }.from(true).to(false))
-      end
-
-      it "creates the archived welsh form document" do
-        expect {
-          service.synchronize_archived_welsh_form
-        }.to(change { FormDocument.exists?(form:, tag: "archived", content: live_form_document_cy.content) }.from(false).to(true))
+          service.synchronize_archived_form
+        }.to(change { live_form_document_cy.reload.tag }.from("live").to("archived"))
       end
 
       it "changes the available languages in form to only include English" do
@@ -238,6 +225,11 @@ RSpec.describe FormDocumentSyncService do
         }.to(change { FormDocument.exists?(form:, tag: "draft") }.from(false).to(true))
       end
 
+      it "creates a draft form document without a version" do
+        service.update_draft_form_document
+        expect(FormDocument.find_by(form:, tag: "draft", language: "en").version).to be_nil
+      end
+
       context "when there is a declaration in Welsh but not in English translations" do
         let(:form) { create(:form, available_languages: %w[en cy], declaration_markdown: "", declaration_markdown_cy: "Shouldn't be here") }
 
@@ -271,6 +263,11 @@ RSpec.describe FormDocumentSyncService do
         expect {
           service.update_draft_form_document
         }.to change { form_document.reload.content["name"] }.to(new_name)
+      end
+
+      it "does not set a version on the draft form document" do
+        service.update_draft_form_document
+        expect(form_document.reload.version).to be_nil
       end
 
       context "when there is also a live form document" do
@@ -307,7 +304,7 @@ RSpec.describe FormDocumentSyncService do
           service.synchronize_only_live_english_form
         }.to change(FormDocument, :count).by(1)
 
-        expect(FormDocument.last).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at))
+        expect(FormDocument.last).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at), version: 1)
       end
     end
 
@@ -326,6 +323,11 @@ RSpec.describe FormDocumentSyncService do
         service.synchronize_only_live_english_form
         expect(FormDocument.last["content"]).to include("live_at" => form.reload.updated_at.as_json)
       end
+
+      it "maintains the version as 1" do
+        service.synchronize_only_live_english_form
+        expect(form_document.reload.version).to eq(1)
+      end
     end
 
     context "when there is an existing archived form document" do
@@ -342,7 +344,7 @@ RSpec.describe FormDocumentSyncService do
       it "creates the live form document" do
         expect {
           service.synchronize_only_live_english_form
-        }.to(change { FormDocument.exists?(form:, tag: "live") }.from(false).to(true))
+        }.to(change { FormDocument.exists?(form:, tag: "live", version: 1) }.from(false).to(true))
       end
 
       context "and deleting the archived FormDocument fails" do
@@ -369,6 +371,7 @@ RSpec.describe FormDocumentSyncService do
 
         expect(FormDocument.where(form:, tag: "live", language: "en")).to exist
         expect(FormDocument.where(form:, tag: "live", language: "en").first.content["available_languages"]).to eq %w[en]
+        expect(FormDocument.where(form:, tag: "live", language: "en").first.version).to eq 1
         expect(FormDocument.where(form:, tag: "live", language: "cy")).not_to exist
       end
 
@@ -423,12 +426,13 @@ RSpec.describe FormDocumentSyncService do
 
           welsh_form_document = FormDocument.where(form:, tag: "live", language: "cy").first
           expect(welsh_form_document.content["available_languages"]).to eq %w[en cy]
+          expect(welsh_form_document.version).to eq 1
           expect(welsh_form_document).to have_attributes(form:, tag: "live", content: welsh_form_content)
         end
       end
 
       context "when there is an existing live Welsh form document" do
-        let!(:form_document) { create :form_document, :live, form:, language: "cy", content: welsh_form_content }
+        let!(:form_document) { create :form_document, :live, form:, language: "cy", content: welsh_form_content, version: 1 }
 
         it "updates the live form document" do
           new_name = "new name"
@@ -441,6 +445,11 @@ RSpec.describe FormDocumentSyncService do
         it "updates the live_at date in the form document" do
           service.synchronize_only_live_welsh_form
           expect(FormDocument.last["content"]).to include("live_at" => form.reload.updated_at.as_json)
+        end
+
+        it "maintains the version as 1" do
+          service.synchronize_only_live_welsh_form
+          expect(form_document.reload.version).to eq(1)
         end
       end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/dGv0TrD1

Add a version column to FormDocuments to support having multiple immutable versions of FormDocuments. Create new live form documents with a version number of 1, and add a rake task to backfill existing live/archived form documents to be version 1, as we can still currently only have one live/archived version per language per form.

A future PR will make it so that we can have multiple versions and we increment the version number when a draft is made live.

Also adds a `latest_form_document` foreign key relation to forms to make it easiest to get the latest version for constructing feature reports.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
