### PR TITLE
Add exit page position methods

### DIFF
--- a/app/components/page_list_component/view.rb
+++ b/app/components/page_list_component/view.rb
@@ -133,10 +133,12 @@ module PageListComponent
         .values
         .sort_by { |grouped_conditions| grouped_conditions.first.exit_page&.created_at }
 
-      exit_page_groups.each_with_index do |grouped_conditions, index|
+      exit_page_positions = ExitPage.positions_for_page(page)
+
+      exit_page_groups.each do |grouped_conditions|
         groups << {
           group_type: :exit_page,
-          exit_page_index: index + 1,
+          exit_page_index: exit_page_positions[grouped_conditions.first.exit_page.id],
           conditions: grouped_conditions,
         }
       end

--- a/app/models/exit_page.rb
+++ b/app/models/exit_page.rb
@@ -15,4 +15,14 @@ class ExitPage < ApplicationRecord
       "markdown" => markdown,
     }
   end
+
+  def position
+    question_page.exit_pages.order(:created_at).pluck(:id).index(id).to_i + 1
+  end
+
+  def self.positions_for_page(question_page)
+    question_page.exit_pages.order(:created_at).pluck(:id).each_with_index.to_h do |exit_page_id, index|
+      [exit_page_id, index + 1]
+    end
+  end
 end

--- a/spec/models/exit_page_spec.rb
+++ b/spec/models/exit_page_spec.rb
@@ -69,4 +69,36 @@ RSpec.describe ExitPage, type: :model do
       expect(exit_page.as_form_document_exit_page).to match a_hash_including("id" => exit_page.id, "heading" => exit_page.heading, "markdown" => exit_page.markdown)
     end
   end
+
+  describe "#position" do
+    let!(:question_page) { create(:page) }
+    let!(:exit_page) { create(:exit_page, question_page:) }
+
+    it "returns the position of the exit page" do
+      expect(exit_page.position).to eq(1)
+    end
+
+    context "when there are multiple exit pages" do
+      let!(:second_exit_page) { create(:exit_page, question_page:) }
+
+      it "returns the position of the exit page" do
+        expect(second_exit_page.position).to eq(2)
+      end
+    end
+  end
+
+  describe ".positions_for_page" do
+    let!(:question_page) { create(:page) }
+    let!(:first_exit_page) { create(:exit_page, question_page:, created_at: Time.zone.local(2024, 1, 1, 9, 0, 0)) }
+    let!(:second_exit_page) { create(:exit_page, question_page:, created_at: Time.zone.local(2024, 1, 1, 9, 5, 0)) }
+    let!(:zeroth_exit_page) { create(:exit_page, question_page:, created_at: Time.zone.local(2024, 1, 1, 8, 0, 0)) }
+
+    it "returns the exit page positions in created_at order" do
+      expect(described_class.positions_for_page(question_page)).to include(
+        zeroth_exit_page.id => 1,
+        first_exit_page.id => 2,
+        second_exit_page.id => 3,
+      )
+    end
+  end
 end


### PR DESCRIPTION
We need to occasionally list exit pages in their created at order, and rather than having to work out each time which position the exit page occupies in that order, this method can do that.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
