### PR TITLE
Allow Conditions to be attached to an ExitPage

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -34,7 +34,7 @@ class Condition < ApplicationRecord
       exit_page.markdown_cy = legacy_exit_page_markdown_cy
     end
 
-    if legacy_exit_page_heading.blank? || legacy_exit_page_markdown.blank?
+    if (legacy_exit_page_heading.blank? || legacy_exit_page_markdown.blank?) && (exit_page_heading_changed? || exit_page_markdown_changed?)
       exit_page&.mark_for_destruction
     end
   end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -807,6 +807,18 @@ RSpec.describe Condition, type: :model do
           expect(condition.exit_page.markdown_cy).to be_nil
         end
       end
+
+      context "when the condition is attached to an external ExitPage" do
+        subject(:condition) { create :condition }
+
+        let(:external_exit_page) { create :exit_page }
+
+        it "doesn't delete the external exit page" do
+          condition.exit_page = external_exit_page
+          condition.save!
+          expect(condition.reload.exit_page).to eq(external_exit_page)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The previous code for syncing the ExitPage with the Condition deleted the associated ExitPage when the heading or markdown was blank.

This made it impossible to attach a Condition to an ExitPage.

This commit only deletes the exit page if either heading of markdown on the condition have been changed to blank.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
