### PR TITLE
Update FormDocumentSyncService for new unique indexes

### DIFF
--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -11,10 +11,10 @@ class FormDocumentSyncService
 
   def synchronize_live_form
     FormDocument.transaction do
-      synchronize_documents_for_tag(LIVE_TAG, live_at: form.updated_at)
-
       # A new live version replaces any previous archived version
       delete_form_documents_by_tag(ARCHIVED_TAG)
+
+      synchronize_documents_for_tag(LIVE_TAG, live_at: form.updated_at)
     end
   end
 
@@ -23,9 +23,6 @@ class FormDocumentSyncService
       # Ensure we only archive forms that are currently live
       raise ActiveRecord::RecordNotFound, "Cannot archive a form that has no live version." unless live_documents.exists?
 
-      # Remove any pre-existing archived documents
-      delete_form_documents_by_tag(ARCHIVED_TAG)
-
       # Change all live documents to archived
       live_documents.update_all(tag: ARCHIVED_TAG)
     end
@@ -33,14 +30,11 @@ class FormDocumentSyncService
 
   def synchronize_archived_welsh_form
     FormDocument.transaction do
-      # Ensure we only archive forms that are currently live
-      raise ActiveRecord::RecordNotFound, "Cannot archive a form that has no live version." unless FormDocument.where(form:, tag: LIVE_TAG, language: "cy").exists?
+      live_welsh_form_document = FormDocument.find_by(form:, tag: LIVE_TAG, language: "cy")
 
-      # Remove any pre-existing archived documents
-      FormDocument.where(form:, tag: ARCHIVED_TAG, language: "cy").delete_all
+      raise ActiveRecord::RecordNotFound, "Cannot archive a form that has no live version." unless live_welsh_form_document
 
-      # Change all live documents to archived
-      FormDocument.where(form:, tag: LIVE_TAG, language: "cy").update_all(tag: ARCHIVED_TAG)
+      live_welsh_form_document.update!(tag: ARCHIVED_TAG)
 
       # Update the content of the live version to show that it doesn't support welsh anymore
       FormDocument.where(form:, tag: [LIVE_TAG, DRAFT_TAG], language: "en").find_each do |live_document|
@@ -57,36 +51,31 @@ class FormDocumentSyncService
       # If we've already made the Welsh version live, changes to the Welsh version must be made live at the same time by calling a different method
       raise ActiveRecord::RecordNotFound, "Cannot make changes to only the live English form if there is already a live Welsh version." if FormDocument.where(form:, tag: LIVE_TAG, language: "cy").exists?
 
-      content = form_content("en", live_at: form.updated_at)
-      update_or_create_form_document(LIVE_TAG, content, "en")
-
-      # Update the content of the live English version to to not include Welsh in available_languages
-      FormDocument.where(form:, tag: [LIVE_TAG], language: "en").find_each do |live_document|
-        live_document.content["available_languages"] = %w[en]
-        live_document.save!
-      end
-
       # A new live version replaces any previous archived version
       delete_form_documents_by_tag(ARCHIVED_TAG)
+
+      content = form_content("en", live_at: form.updated_at)
+      content["available_languages"] = %w[en] # don't include Welsh in available languages
+      update_or_create_form_document(LIVE_TAG, content, "en")
     end
   end
 
   def synchronize_only_live_welsh_form
     FormDocument.transaction do
+      live_english_form_document = FormDocument.find_by(form:, tag: LIVE_TAG, language: "en")
+
       # Ensure we only make Welsh version live if there is already an existing live English version
-      raise ActiveRecord::RecordNotFound, "Cannot make Welsh version live unless there is already a live English version." unless FormDocument.where(form:, tag: LIVE_TAG, language: "en").exists?
+      raise ActiveRecord::RecordNotFound, "Cannot make Welsh version live unless there is already a live English version." unless live_english_form_document
+
+      # A new live version replaces the archived version
+      delete_form_documents_by_tag(ARCHIVED_TAG)
 
       content = form_content("cy", live_at: form.updated_at)
       update_or_create_form_document(LIVE_TAG, content, "cy")
 
       # Update the content of the live English version to show that it now supports Welsh
-      FormDocument.where(form:, tag: [LIVE_TAG], language: "en").find_each do |live_document|
-        live_document.content["available_languages"] = %w[en cy]
-        live_document.save!
-      end
-
-      # A new live version replaces any previous archived version
-      delete_form_documents_by_tag(ARCHIVED_TAG)
+      live_english_form_document.content["available_languages"] = %w[en cy]
+      live_english_form_document.save!
     end
   end
 

--- a/spec/services/form_document_sync_service_spec.rb
+++ b/spec/services/form_document_sync_service_spec.rb
@@ -137,31 +137,6 @@ RSpec.describe FormDocumentSyncService do
         }.to(change { live_form_document.reload.tag }.from("live").to("archived"))
       end
     end
-
-    context "when there is an existing archived form document" do
-      before do
-        create :form_document, :live, form:, content: "live content"
-        create :form_document, :archived, form:, content: "old archived content"
-      end
-
-      it "replaces the archived form document" do
-        service.synchronize_archived_form
-        expect(FormDocument.find_by!(form:, tag: "archived").content).to eq("live content")
-      end
-
-      context "and deleting the existing archived FormDocuments fails" do
-        before do
-          allow(service).to receive(:delete_form_documents_by_tag).with(FormDocumentSyncService::ARCHIVED_TAG)
-            .and_raise(ActiveRecord::StatementInvalid)
-        end
-
-        it "does not change the archived FormDocument" do
-          expect {
-            service.synchronize_archived_form
-          }.to raise_error(ActiveRecord::StatementInvalid).and(not_change { form.reload.archived_form_document.content })
-        end
-      end
-    end
   end
 
   describe "#synchronize_archived_welsh_form" do
@@ -207,18 +182,6 @@ RSpec.describe FormDocumentSyncService do
         expect {
           service.synchronize_archived_welsh_form
         }.to(change { live_form_document_en.reload.content["available_languages"] }.from(%w[en cy]).to(%w[en]))
-      end
-    end
-
-    context "when there is an existing archived Welsh form document" do
-      before do
-        create :form_document, :live, form:, content: "live content cy", language: "cy"
-        create :form_document, :archived, form:, content: "old archived content cy", language: "cy"
-      end
-
-      it "replaces the archived form document" do
-        service.synchronize_archived_form
-        expect(FormDocument.find_by!(form:, tag: "archived", language: "cy").content).to eq("live content cy")
       end
     end
   end
@@ -480,7 +443,7 @@ RSpec.describe FormDocumentSyncService do
         end
       end
 
-      context "when there is an existing archived form document" do
+      context "when there is an existing archived Welsh form document" do
         before do
           create :form_document, :archived, form:, language: "cy"
         end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/dGv0TrD1

We're not yet updating the service to increment the version number when a form goes live.

However, we need to update the service to handle the new unique indexes we want to add that will enforce that there is only one form document per version per language for a form.

Ensure we delete archived form documents before creating a new live form document so we only ever have one live or archived form document per language per form.

We also don't need to handle the case where there is an existing archived form document when archiving a form, as this can never happen and will soon be enforced by the new unique indexes.

I've verified that no existing form has both live and archived form documents for the same language on any environment using the query:

```SELECT form_id from form_documents where tag IN ('live', 'archived') group by form_id, language having count(1) > 1;```

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
