### PR TITLE
Search organisations by email domain

### DIFF
--- a/app/frontend/styles/_app_filter.scss
+++ b/app/frontend/styles/_app_filter.scss
@@ -5,6 +5,28 @@
     background: govuk-colour("black", $variant: "tint-95");
   }
 
+  // Bottom-align the inputs in a row of filters, so that they line up even
+  // when one filter's hint text wraps onto more lines than its neighbours'
+  .govuk-grid-row {
+    display: flex;
+    flex-wrap: wrap;
+
+    > * {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+
+  .govuk-form-group {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+
+    > :last-child {
+      margin-top: auto;
+    }
+  }
+
   .govuk-hint {
     color: govuk-functional-colour(text);
   }

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -20,8 +20,14 @@ class Organisation < ApplicationRecord
 
   scope :by_name, lambda { |name|
     if name.present?
-      where("lower(name) LIKE :search OR lower(abbreviation) LIKE :search",
-            search: "%#{sanitize_sql_like(name.downcase)}%")
+      where(
+        "lower(name) LIKE :search OR lower(abbreviation) LIKE :search OR EXISTS (
+          SELECT 1 FROM organisation_domains
+          WHERE organisation_domains.organisation_id = organisations.id
+            AND organisation_domains.domain LIKE :search
+        )",
+        search: "%#{sanitize_sql_like(name.downcase)}%",
+      )
     end
   }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1565,8 +1565,8 @@ en:
           signed: Any agreement signed
         clear_filter: Clear filter
         name:
-          hint: Enter name or abbreviation
-          label: Name
+          hint: Enter name, abbreviation or email domain
+          label: Search
         sort:
           agreement_date: Date first agreement signed (newest first)
           draft_forms: Draft forms (most first)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe Organisation, type: :model do
         expect(described_class.by_name("dft")).to contain_exactly(transport_org)
       end
 
+      it "matches a partial email domain, ignoring case" do
+        create :organisation_domain, organisation: justice_org, domain: "justice.gov.uk"
+        create :organisation_domain, organisation: transport_org, domain: "transport.gov.uk"
+
+        expect(described_class.by_name("Justice.gov")).to contain_exactly(justice_org)
+      end
+
+      it "does not return duplicates when multiple domains match" do
+        create :organisation_domain, organisation: justice_org, domain: "justice.gov.uk"
+        create :organisation_domain, organisation: justice_org, domain: "digital.justice.gov.uk"
+
+        expect(described_class.by_name("justice.gov")).to contain_exactly(justice_org)
+      end
+
       it "returns all organisations when the name is blank" do
         expect(described_class.by_name(nil)).to contain_exactly(justice_org, transport_org)
         expect(described_class.by_name("")).to contain_exactly(justice_org, transport_org)

--- a/spec/requests/organisations_controller_spec.rb
+++ b/spec/requests/organisations_controller_spec.rb
@@ -77,6 +77,15 @@ RSpec.describe OrganisationsController, type: :request do
         expect(response.body).not_to include(organisation.name)
       end
 
+      it "filters organisations by email domain" do
+        create :organisation_domain, organisation: closed_organisation, domain: "example.gov.uk"
+
+        get path, params: { filter: { name: "example.gov.uk" } }
+
+        expect(response.body).to include(closed_organisation.name)
+        expect(response.body).not_to include(organisation.name)
+      end
+
       it "filters organisations with a Crown MOU" do
         get path, params: { filter: { agreement_type: "crown" } }
 


### PR DESCRIPTION
Finding which organisation uses a particular email domain currently means scanning the email domains report, which lists every organisation and its domains in one long table.

This extends the search box on the organisations index to also match organisation email domains, so the organisations page can answer that question directly. If we're happy with this, the report can be retired in a follow-up.

<img width="1073" height="771" alt="image" src="https://github.com/user-attachments/assets/7a272be2-34fe-4021-86b7-b508fae08dbe" />
