### PR TITLE
Replace form document associations

### DIFF
--- a/app/controllers/forms/archive_welsh_controller.rb
+++ b/app/controllers/forms/archive_welsh_controller.rb
@@ -42,7 +42,7 @@ module Forms
     def has_live_welsh_translation?
       # We assume all forms have an English version, which must be live.
       # So we check the form is live as well as having a Welsh translation.
-      current_form.is_live? && current_form.live_welsh_form_document.present?
+      current_form.is_live? && current_form.has_live_welsh_translation?
     end
   end
 end

--- a/app/controllers/forms/archived_controller.rb
+++ b/app/controllers/forms/archived_controller.rb
@@ -6,7 +6,7 @@ module Forms
       return redirect_to live_form_path if current_form.is_live?
       raise NotFoundError unless current_form.is_archived?
 
-      render :show_form, locals: { form_metadata: current_form, form_document: current_archived_form, welsh_form_document: }
+      render :show_form, locals: { form_metadata: current_form, form_document: current_live_or_archived_form, welsh_form_document: }
     end
 
     def show_pages
@@ -15,15 +15,15 @@ module Forms
       return redirect_to live_form_pages_path if current_form.is_live?
       raise NotFoundError unless current_form.is_archived?
 
-      render :show_pages, locals: { form_document: current_archived_form, welsh_form_document:, multiple_branches_enabled: FeatureService.new(group: current_form.group).enabled?(:multiple_branches) }
+      render :show_pages, locals: { form_document: current_live_or_archived_form, welsh_form_document:, multiple_branches_enabled: FeatureService.new(group: current_form.group).enabled?(:multiple_branches) }
     end
 
   private
 
     def welsh_form_document
-      return nil unless current_archived_form.has_welsh_translation?
+      return nil unless current_live_or_archived_form.has_welsh_translation?
 
-      current_archived_welsh_form
+      current_live_or_archived_welsh_form
     end
   end
 end

--- a/app/controllers/forms/copy_controller.rb
+++ b/app/controllers/forms/copy_controller.rb
@@ -3,10 +3,8 @@ module Forms
     def copy
       authorize current_form, :copy?
 
-      form = if tag == "live"
-               current_live_form
-             elsif tag == "archived"
-               current_archived_form
+      form = if %w[live archived].include? tag
+               current_live_or_archived_form
              else
                current_form
              end

--- a/app/controllers/forms/live_controller.rb
+++ b/app/controllers/forms/live_controller.rb
@@ -6,7 +6,7 @@ module Forms
       return redirect_to archived_form_path if current_form.is_archived?
       raise NotFoundError unless current_form.is_live?
 
-      render :show_form, locals: { form_metadata: current_form, form_document: current_live_form, welsh_form_document: }
+      render :show_form, locals: { form_metadata: current_form, form_document: current_live_or_archived_form, welsh_form_document: }
     end
 
     def show_pages
@@ -15,15 +15,15 @@ module Forms
       return redirect_to archived_form_pages_path if current_form.is_archived?
       raise NotFoundError unless current_form.is_live?
 
-      render :show_pages, locals: { form_document: current_live_form, welsh_form_document:, multiple_branches_enabled: FeatureService.new(group: current_form.group).enabled?(:multiple_branches) }
+      render :show_pages, locals: { form_document: current_live_or_archived_form, welsh_form_document:, multiple_branches_enabled: FeatureService.new(group: current_form.group).enabled?(:multiple_branches) }
     end
 
   private
 
     def welsh_form_document
-      return nil unless current_live_form.has_welsh_translation?
+      return nil unless current_live_or_archived_form.has_welsh_translation?
 
-      current_live_welsh_form
+      current_live_or_archived_welsh_form
     end
   end
 end

--- a/app/controllers/forms/make_live_controller.rb
+++ b/app/controllers/forms/make_live_controller.rb
@@ -31,7 +31,7 @@ module Forms
     end
 
     def render_new(status: :ok)
-      if current_form.live_welsh_form_document.present? && current_form.all_task_statuses[:welsh_language_status] == :in_progress
+      if current_form.has_live_welsh_translation? && current_form.all_task_statuses[:welsh_language_status] == :in_progress
         render "make_your_changes_to_english_live", status:, locals: { current_form: }
       elsif current_form.is_live?
         render "make_your_changes_live", status:, locals: { current_form: }

--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -59,11 +59,7 @@ module Forms
     def live_submission_email_updated?
       return false unless current_form.is_live?
 
-      current_live_form.submission_email != current_form.submission_email
-    end
-
-    def current_live_form
-      @current_live_form ||= FormDocument::Content.from_form_document(current_form.latest_form_document)
+      current_live_or_archived_form.submission_email != current_form.submission_email
     end
   end
 end

--- a/app/controllers/forms/submission_email_controller.rb
+++ b/app/controllers/forms/submission_email_controller.rb
@@ -63,7 +63,7 @@ module Forms
     end
 
     def current_live_form
-      @current_live_form ||= FormDocument::Content.from_form_document(current_form.live_form_document)
+      @current_live_form ||= FormDocument::Content.from_form_document(current_form.latest_form_document)
     end
   end
 end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -10,7 +10,7 @@ class FormsController < WebController
   end
 
   def current_live_welsh_form
-    @current_live_welsh_form ||= FormDocument::Content.from_form_document(current_form.live_welsh_form_document)
+    @current_live_welsh_form ||= FormDocument::Content.from_form_document(current_form.latest_welsh_form_document)
   end
 
   def current_archived_form

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -18,7 +18,7 @@ class FormsController < WebController
   end
 
   def current_archived_welsh_form
-    @current_archived_welsh_form ||= FormDocument::Content.from_form_document(current_form.archived_welsh_form_document)
+    @current_archived_welsh_form ||= FormDocument::Content.from_form_document(current_form.latest_welsh_form_document)
   end
 
 private

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -14,7 +14,7 @@ class FormsController < WebController
   end
 
   def current_archived_form
-    @current_archived_form ||= FormDocument::Content.from_form_document(current_form.archived_form_document)
+    @current_archived_form ||= FormDocument::Content.from_form_document(current_form.latest_form_document)
   end
 
   def current_archived_welsh_form

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -5,20 +5,12 @@ class FormsController < WebController
 
   attr_reader :current_form
 
-  def current_live_form
-    @current_live_form ||= FormDocument::Content.from_form_document(current_form.latest_form_document)
+  def current_live_or_archived_form
+    @current_live_or_archived_form ||= FormDocument::Content.from_form_document(current_form.latest_form_document)
   end
 
-  def current_live_welsh_form
-    @current_live_welsh_form ||= FormDocument::Content.from_form_document(current_form.latest_welsh_form_document)
-  end
-
-  def current_archived_form
-    @current_archived_form ||= FormDocument::Content.from_form_document(current_form.latest_form_document)
-  end
-
-  def current_archived_welsh_form
-    @current_archived_welsh_form ||= FormDocument::Content.from_form_document(current_form.latest_welsh_form_document)
+  def current_live_or_archived_welsh_form
+    @current_live_or_archived_welsh_form ||= FormDocument::Content.from_form_document(current_form.latest_welsh_form_document)
   end
 
 private

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -6,7 +6,7 @@ class FormsController < WebController
   attr_reader :current_form
 
   def current_live_form
-    @current_live_form ||= FormDocument::Content.from_form_document(current_form.live_form_document)
+    @current_live_form ||= FormDocument::Content.from_form_document(current_form.latest_form_document)
   end
 
   def current_live_welsh_form

--- a/app/mailers/admin_alerts/draft_created_mailer.rb
+++ b/app/mailers/admin_alerts/draft_created_mailer.rb
@@ -42,7 +42,7 @@ class AdminAlerts::DraftCreatedMailer < GovukNotifyRails::Mailer
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: form_url(form),
-      live_form_name: form.live_form_document.content["name"],
+      live_form_name: form.latest_form_document.content["name"],
       live_form_link: live_form_url(form),
       group_name: form.group.name,
       user_name: user.name,

--- a/app/mailers/admin_alerts/draft_created_mailer.rb
+++ b/app/mailers/admin_alerts/draft_created_mailer.rb
@@ -29,7 +29,7 @@ class AdminAlerts::DraftCreatedMailer < GovukNotifyRails::Mailer
     send_mail(to_email:, personalisation: {
       form_name: form.name,
       form_link: form_url(form),
-      archived_form_name: form.archived_form_document.content["name"],
+      archived_form_name: form.latest_form_document.content["name"],
       archived_form_link: archived_form_url(form),
       group_name: form.group.name,
       user_name: user.name,

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -8,12 +8,12 @@ class Form < ApplicationRecord
   has_one :form_submission_email, dependent: :destroy
   has_one :group_form, dependent: :destroy
   has_many :form_documents, dependent: :destroy
-  has_one :live_form_document, -> { where tag: "live", language: :en }, class_name: "FormDocument"
   has_one :live_welsh_form_document, -> { where tag: "live", language: :cy }, class_name: "FormDocument"
   has_one :archived_form_document, -> { where tag: "archived", language: :en }, class_name: "FormDocument"
   has_one :archived_welsh_form_document, -> { where tag: "archived", language: :cy }, class_name: "FormDocument"
   has_one :draft_welsh_form_document, -> { where tag: "draft", language: :cy }, class_name: "FormDocument"
   has_one :draft_form_document, -> { where tag: "draft", language: :en }, class_name: "FormDocument"
+
   belongs_to :latest_form_document, class_name: "FormDocument", optional: true
   has_one :latest_welsh_form_document,
           -> { where(language: "cy").where.not(version: nil).order(version: :desc) },
@@ -235,7 +235,7 @@ class Form < ApplicationRecord
   end
 
   def changed_from_live_version?(language:)
-    live_document = language == "cy" ? live_welsh_form_document : live_form_document
+    live_document = language == "cy" ? live_welsh_form_document : latest_form_document
     return false if live_document.blank?
 
     ignored_keys = %w[live_at available_languages updated_at]
@@ -316,7 +316,7 @@ private
   end
 
   def english_version_has_been_made_live?
-    has_live_version && live_form_document.present?
+    has_live_version && latest_form_document.present?
   end
 
   def welsh_version_ready?

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -8,7 +8,6 @@ class Form < ApplicationRecord
   has_one :form_submission_email, dependent: :destroy
   has_one :group_form, dependent: :destroy
   has_many :form_documents, dependent: :destroy
-  has_one :archived_form_document, -> { where tag: "archived", language: :en }, class_name: "FormDocument"
   has_one :archived_welsh_form_document, -> { where tag: "archived", language: :cy }, class_name: "FormDocument"
   has_one :draft_welsh_form_document, -> { where tag: "draft", language: :cy }, class_name: "FormDocument"
   has_one :draft_form_document, -> { where tag: "draft", language: :en }, class_name: "FormDocument"

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -8,7 +8,6 @@ class Form < ApplicationRecord
   has_one :form_submission_email, dependent: :destroy
   has_one :group_form, dependent: :destroy
   has_many :form_documents, dependent: :destroy
-  has_one :live_welsh_form_document, -> { where tag: "live", language: :cy }, class_name: "FormDocument"
   has_one :archived_form_document, -> { where tag: "archived", language: :en }, class_name: "FormDocument"
   has_one :archived_welsh_form_document, -> { where tag: "archived", language: :cy }, class_name: "FormDocument"
   has_one :draft_welsh_form_document, -> { where tag: "draft", language: :cy }, class_name: "FormDocument"
@@ -235,7 +234,7 @@ class Form < ApplicationRecord
   end
 
   def changed_from_live_version?(language:)
-    live_document = language == "cy" ? live_welsh_form_document : latest_form_document
+    live_document = language == "cy" ? latest_welsh_form_document : latest_form_document
     return false if live_document.blank?
 
     ignored_keys = %w[live_at available_languages updated_at]
@@ -246,6 +245,10 @@ class Form < ApplicationRecord
 
   def only_s3_delivery_enabled?
     delivery_configurations.immediate.one? && delivery_configurations.immediate.first.delivery_method == "s3"
+  end
+
+  def has_live_welsh_translation?
+    latest_welsh_form_document&.tag == "live"
   end
 
 private
@@ -308,11 +311,11 @@ private
   end
 
   def can_make_english_version_live?
-    has_draft_version && all_ready_for_live?(ignore_missing_welsh: true) && live_welsh_form_document.blank?
+    has_draft_version && all_ready_for_live?(ignore_missing_welsh: true) && !has_live_welsh_translation?
   end
 
   def can_make_welsh_version_live?
-    english_version_has_been_made_live? && !changed_from_live_version?(language: "en") && welsh_version_ready? && live_welsh_form_document.blank?
+    english_version_has_been_made_live? && !changed_from_live_version?(language: "en") && welsh_version_ready? && !has_live_welsh_translation?
   end
 
   def english_version_has_been_made_live?

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -15,6 +15,10 @@ class Form < ApplicationRecord
   has_one :draft_welsh_form_document, -> { where tag: "draft", language: :cy }, class_name: "FormDocument"
   has_one :draft_form_document, -> { where tag: "draft", language: :en }, class_name: "FormDocument"
   belongs_to :latest_form_document, class_name: "FormDocument", optional: true
+  has_one :latest_welsh_form_document,
+          -> { where(language: "cy").where.not(version: nil).order(version: :desc) },
+          class_name: "FormDocument"
+
   has_many :conditions, through: :pages, source: :routing_conditions
   has_many :exit_pages, through: :pages, source: :exit_pages
   has_many :delivery_configurations, dependent: :destroy

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -234,7 +234,7 @@ class Form < ApplicationRecord
   end
 
   def changed_from_live_version?(language:)
-    live_document = language == "cy" ? latest_welsh_form_document : latest_form_document
+    live_document = latest_live_or_archived_form_document(language:)
     return false if live_document.blank?
 
     ignored_keys = %w[live_at available_languages updated_at]
@@ -245,6 +245,10 @@ class Form < ApplicationRecord
 
   def only_s3_delivery_enabled?
     delivery_configurations.immediate.one? && delivery_configurations.immediate.first.delivery_method == "s3"
+  end
+
+  def latest_live_or_archived_form_document(language:)
+    FormDocument.latest_live_or_archived(form_id: id, language: language)
   end
 
   def has_live_welsh_translation?

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -8,7 +8,6 @@ class Form < ApplicationRecord
   has_one :form_submission_email, dependent: :destroy
   has_one :group_form, dependent: :destroy
   has_many :form_documents, dependent: :destroy
-  has_one :archived_welsh_form_document, -> { where tag: "archived", language: :cy }, class_name: "FormDocument"
   has_one :draft_welsh_form_document, -> { where tag: "draft", language: :cy }, class_name: "FormDocument"
   has_one :draft_form_document, -> { where tag: "draft", language: :en }, class_name: "FormDocument"
 
@@ -252,6 +251,10 @@ class Form < ApplicationRecord
 
   def has_live_welsh_translation?
     latest_welsh_form_document&.tag == "live"
+  end
+
+  def has_archived_welsh_translation?
+    latest_welsh_form_document&.tag == "archived"
   end
 
 private

--- a/app/presenters/form_list_presenter.rb
+++ b/app/presenters/form_list_presenter.rb
@@ -79,7 +79,7 @@ private
       "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh version</p>".html_safe
     elsif form.draft_welsh_form_document.present?
       "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh draft</p>".html_safe
-    elsif form.archived_welsh_form_document.present?
+    elsif form.has_archived_welsh_translation?
       "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With archived Welsh version</p>".html_safe
     end
   end

--- a/app/presenters/form_list_presenter.rb
+++ b/app/presenters/form_list_presenter.rb
@@ -75,7 +75,7 @@ private
   end
 
   def welsh_status(form)
-    if form.live_welsh_form_document.present?
+    if form.has_live_welsh_translation?
       "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh version</p>".html_safe
     elsif form.draft_welsh_form_document.present?
       "<p class=\"govuk-!-margin-bottom-1 govuk-!-margin-top-2 govuk-hint\">With Welsh draft</p>".html_safe

--- a/app/services/archive_form_service.rb
+++ b/app/services/archive_form_service.rb
@@ -15,16 +15,12 @@ class ArchiveFormService
   end
 
   def archive_welsh_only
-    return unless has_live_welsh_form?
+    return unless form.has_live_welsh_translation?
 
     archive_welsh_form_document
   end
 
 private
-
-  def has_live_welsh_form?
-    form.live_welsh_form_document.present?
-  end
 
   def archive_welsh_form_document
     FormDocumentSyncService.new(form).synchronize_archived_welsh_form

--- a/app/services/form_task_list_service.rb
+++ b/app/services/form_task_list_service.rb
@@ -251,7 +251,7 @@ private
   end
 
   def display_make_languages_live_tasks?
-    @form.live_welsh_form_document.blank? && @form.has_welsh_translation?
+    !@form.has_live_welsh_translation? && @form.has_welsh_translation?
   end
 
   def live_title_name

--- a/app/services/make_form_live_service.rb
+++ b/app/services/make_form_live_service.rb
@@ -9,7 +9,7 @@ class MakeFormLiveService
     @current_form = current_form
     @current_form_was_live = current_form.is_live?
     @current_form_was_archived = current_form.is_archived?
-    @current_live_form = FormDocument::Content.from_form_document(current_form.live_form_document) if current_form.is_live?
+    @current_live_form = FormDocument::Content.from_form_document(current_form.latest_form_document) if current_form.is_live?
     @current_user = current_user
     @language = language
   end

--- a/app/services/make_form_live_service.rb
+++ b/app/services/make_form_live_service.rb
@@ -9,7 +9,7 @@ class MakeFormLiveService
     @current_form = current_form
     @current_form_was_live = current_form.is_live?
     @current_form_was_archived = current_form.is_archived?
-    @current_live_form = FormDocument::Content.from_form_document(current_form.latest_form_document) if current_form.is_live?
+    @current_live_or_archived_form = FormDocument::Content.from_form_document(current_form.latest_form_document) if current_form.is_live?
     @current_user = current_user
     @language = language
   end
@@ -19,8 +19,8 @@ class MakeFormLiveService
 
     if live_form_submission_email_has_changed
       SubmissionEmailMailer.alert_email_change(
-        live_email: @current_live_form.submission_email,
-        form_name: @current_live_form.name,
+        live_email: @current_live_or_archived_form.submission_email,
+        form_name: @current_live_or_archived_form.name,
         creator_name: @current_user.name,
         creator_email: @current_user.email,
       ).deliver_now
@@ -65,6 +65,6 @@ private
   end
 
   def live_form_submission_email_has_changed
-    @current_form_was_live && @current_live_form.submission_email != @current_form.submission_email
+    @current_form_was_live && @current_live_or_archived_form.submission_email != @current_form.submission_email
   end
 end

--- a/app/services/task_status_service.rb
+++ b/app/services/task_status_service.rb
@@ -158,7 +158,7 @@ private
 
   def make_only_welsh_live_status
     return :not_started if @form.can_make_language_live?(language: "cy")
-    return :completed if @form.live_welsh_form_document.present?
+    return :completed if @form.has_live_welsh_translation?
 
     :cannot_start
   end
@@ -168,7 +168,7 @@ private
     # and show the make live task and link. In this case, we will show a warning
     # message on the make live page asking the user to update the Welsh before
     # the form can be made live.
-    ignore_missing_welsh = @form.live_welsh_form_document.present?
+    ignore_missing_welsh = @form.has_live_welsh_translation?
     mandatory_tasks_completed?(ignore_missing_welsh:) ? :not_started : :cannot_start
   end
 

--- a/app/views/forms/_made_live_form.html.erb
+++ b/app/views/forms/_made_live_form.html.erb
@@ -278,7 +278,7 @@
       <% if status == :live %>
         <%= govuk_button_link_to t(".archive_this_form"), archive_form_path(form_document.id), warning: true %>
         <%= govuk_button_link_to("Make a copy of this form", copy_form_path(form_metadata.id, "live"), secondary: true) %>
-        <% if form_metadata.live_welsh_form_document.present? %>
+        <% if form_metadata.has_live_welsh_translation? %>
           <%= govuk_button_link_to t(".archive_welsh"), archive_welsh_path(form_document.id), secondary: true %>
         <% end %>
       <% elsif status == :archived %>

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe "forms.rake", type: :task do
         it "updates the live form documents delivery configurations" do
           task.invoke(form.id)
 
-          expect(form.reload.live_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_form_document.content["delivery_configurations"])
             .to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
           expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
             .to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
@@ -390,7 +390,7 @@ RSpec.describe "forms.rake", type: :task do
 
           delivery_configuration_count = form.reload.delivery_configurations.where(delivery_method: "email", delivery_schedule: "immediate").count
           draft_content = form.reload.draft_form_document.content.deep_dup
-          live_content = form.reload.live_form_document.content.deep_dup
+          live_content = form.reload.latest_form_document.content.deep_dup
           live_welsh_content = form.reload.live_welsh_form_document.content.deep_dup
 
           task.invoke(form.id)
@@ -399,7 +399,7 @@ RSpec.describe "forms.rake", type: :task do
             .to eq(delivery_configuration_count)
 
           expect(form.reload.draft_form_document.content).to eq(draft_content)
-          expect(form.reload.live_form_document.content).to eq(live_content)
+          expect(form.reload.latest_form_document.content).to eq(live_content)
           expect(form.reload.live_welsh_form_document&.content).to eq(live_welsh_content)
         end
       end
@@ -446,7 +446,7 @@ RSpec.describe "forms.rake", type: :task do
         it "updates the live form documents delivery configurations" do
           task.invoke(form.id)
 
-          expect(form.reload.live_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
           expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
@@ -532,10 +532,10 @@ RSpec.describe "forms.rake", type: :task do
         it "updates the live form documents" do
           task.invoke(form.id)
 
-          expect(form.reload.live_form_document.content["s3_bucket_name"]).to be_nil
-          expect(form.reload.live_form_document.content["s3_bucket_aws_account_id"]).to be_nil
-          expect(form.reload.live_form_document.content["s3_bucket_region"]).to be_nil
-          expect(form.reload.live_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_form_document.content["s3_bucket_name"]).to be_nil
+          expect(form.reload.latest_form_document.content["s3_bucket_aws_account_id"]).to be_nil
+          expect(form.reload.latest_form_document.content["s3_bucket_region"]).to be_nil
+          expect(form.reload.latest_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate"))
 
           expect(form.reload.live_welsh_form_document.content["s3_bucket_name"]).to be_nil
@@ -624,9 +624,9 @@ RSpec.describe "forms.rake", type: :task do
         expect(form.reload.draft_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
         expect(form.reload.draft_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
 
-        expect(form.reload.live_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
-        expect(form.reload.live_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
-        expect(form.reload.live_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
+        expect(form.reload.latest_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
+        expect(form.reload.latest_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
+        expect(form.reload.latest_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
 
         expect(form.reload.live_welsh_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
         expect(form.reload.live_welsh_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
@@ -634,7 +634,7 @@ RSpec.describe "forms.rake", type: :task do
 
         expect(form.reload.draft_form_document.content["delivery_configurations"])
           .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => [format]))
-        expect(form.reload.live_form_document.content["delivery_configurations"])
+        expect(form.reload.latest_form_document.content["delivery_configurations"])
           .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => [format]))
         expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
           .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => [format]))
@@ -655,7 +655,7 @@ RSpec.describe "forms.rake", type: :task do
 
           expect(form.reload.draft_form_document.content["delivery_configurations"])
             .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => %w[csv]))
-          expect(form.reload.live_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_form_document.content["delivery_configurations"])
             .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => %w[csv]))
           expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
             .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => %w[csv]))
@@ -673,14 +673,14 @@ RSpec.describe "forms.rake", type: :task do
 
           expect(form.reload.draft_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
-          expect(form.reload.live_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
           expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
 
-          expect(form.reload.live_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
-          expect(form.reload.live_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
-          expect(form.reload.live_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
+          expect(form.reload.latest_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
+          expect(form.reload.latest_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
+          expect(form.reload.latest_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
 
           expect(form.reload.live_welsh_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
           expect(form.reload.live_welsh_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe "forms.rake", type: :task do
 
           expect(form.reload.latest_form_document.content["delivery_configurations"])
             .to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
-          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_welsh_form_document.content["delivery_configurations"])
             .to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
         end
       end
@@ -391,7 +391,7 @@ RSpec.describe "forms.rake", type: :task do
           delivery_configuration_count = form.reload.delivery_configurations.where(delivery_method: "email", delivery_schedule: "immediate").count
           draft_content = form.reload.draft_form_document.content.deep_dup
           live_content = form.reload.latest_form_document.content.deep_dup
-          live_welsh_content = form.reload.live_welsh_form_document.content.deep_dup
+          live_welsh_content = form.reload.latest_welsh_form_document.content.deep_dup
 
           task.invoke(form.id)
 
@@ -400,7 +400,7 @@ RSpec.describe "forms.rake", type: :task do
 
           expect(form.reload.draft_form_document.content).to eq(draft_content)
           expect(form.reload.latest_form_document.content).to eq(live_content)
-          expect(form.reload.live_welsh_form_document&.content).to eq(live_welsh_content)
+          expect(form.reload.latest_welsh_form_document&.content).to eq(live_welsh_content)
         end
       end
     end
@@ -448,7 +448,7 @@ RSpec.describe "forms.rake", type: :task do
 
           expect(form.reload.latest_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
-          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_welsh_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
         end
       end
@@ -538,10 +538,10 @@ RSpec.describe "forms.rake", type: :task do
           expect(form.reload.latest_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate"))
 
-          expect(form.reload.live_welsh_form_document.content["s3_bucket_name"]).to be_nil
-          expect(form.reload.live_welsh_form_document.content["s3_bucket_aws_account_id"]).to be_nil
-          expect(form.reload.live_welsh_form_document.content["s3_bucket_region"]).to be_nil
-          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_welsh_form_document.content["s3_bucket_name"]).to be_nil
+          expect(form.reload.latest_welsh_form_document.content["s3_bucket_aws_account_id"]).to be_nil
+          expect(form.reload.latest_welsh_form_document.content["s3_bucket_region"]).to be_nil
+          expect(form.reload.latest_welsh_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate"))
         end
       end
@@ -628,15 +628,15 @@ RSpec.describe "forms.rake", type: :task do
         expect(form.reload.latest_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
         expect(form.reload.latest_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
 
-        expect(form.reload.live_welsh_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
-        expect(form.reload.live_welsh_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
-        expect(form.reload.live_welsh_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
+        expect(form.reload.latest_welsh_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
+        expect(form.reload.latest_welsh_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
+        expect(form.reload.latest_welsh_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
 
         expect(form.reload.draft_form_document.content["delivery_configurations"])
           .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => [format]))
         expect(form.reload.latest_form_document.content["delivery_configurations"])
           .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => [format]))
-        expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+        expect(form.reload.latest_welsh_form_document.content["delivery_configurations"])
           .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => [format]))
       end
 
@@ -657,7 +657,7 @@ RSpec.describe "forms.rake", type: :task do
             .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => %w[csv]))
           expect(form.reload.latest_form_document.content["delivery_configurations"])
             .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => %w[csv]))
-          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_welsh_form_document.content["delivery_configurations"])
             .to include(a_hash_including("delivery_method" => "s3", "delivery_schedule" => "immediate", "formats" => %w[csv]))
         end
       end
@@ -675,16 +675,16 @@ RSpec.describe "forms.rake", type: :task do
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
           expect(form.reload.latest_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
-          expect(form.reload.live_welsh_form_document.content["delivery_configurations"])
+          expect(form.reload.latest_welsh_form_document.content["delivery_configurations"])
             .not_to include(a_hash_including("delivery_method" => "email", "delivery_schedule" => "immediate"))
 
           expect(form.reload.latest_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
           expect(form.reload.latest_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
           expect(form.reload.latest_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
 
-          expect(form.reload.live_welsh_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
-          expect(form.reload.live_welsh_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
-          expect(form.reload.live_welsh_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
+          expect(form.reload.latest_welsh_form_document.content["s3_bucket_name"]).to eq(s3_bucket_name)
+          expect(form.reload.latest_welsh_form_document.content["s3_bucket_aws_account_id"]).to eq(s3_bucket_aws_account_id)
+          expect(form.reload.latest_welsh_form_document.content["s3_bucket_region"]).to eq(s3_bucket_region)
         end
       end
     end

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "forms.rake", type: :task do
 
         form.reload
         expect(form.first_made_live_at).not_to be_nil
-        expect(form.archived_form_document).not_to be_nil
+        expect(form.latest_form_document).not_to be_nil
       end
 
       it "sets a draft form's state to archived_with_draft by transitioning through two intermediate states" do

--- a/spec/mailers/admin_alerts/draft_created_mailer_spec.rb
+++ b/spec/mailers/admin_alerts/draft_created_mailer_spec.rb
@@ -77,7 +77,7 @@ describe AdminAlerts::DraftCreatedMailer, type: :mailer do
     it "includes the personalisation" do
       expect(mail.govuk_notify_personalisation[:form_name]).to eq(new_draft_name)
       expect(mail.govuk_notify_personalisation[:form_link]).to eq(form_url(archived_form))
-      expect(mail.govuk_notify_personalisation[:archived_form_name]).to eq(archived_form.archived_form_document.content["name"])
+      expect(mail.govuk_notify_personalisation[:archived_form_name]).to eq(archived_form.latest_form_document.content["name"])
       expect(mail.govuk_notify_personalisation[:archived_form_link]).to eq(archived_form_url(archived_form))
       expect(mail.govuk_notify_personalisation[:group_name]).to eq(archived_form.group.name)
       expect(mail.govuk_notify_personalisation[:user_name]).to eq(user.name)

--- a/spec/mailers/admin_alerts/draft_created_mailer_spec.rb
+++ b/spec/mailers/admin_alerts/draft_created_mailer_spec.rb
@@ -109,7 +109,7 @@ describe AdminAlerts::DraftCreatedMailer, type: :mailer do
     it "includes the personalisation" do
       expect(mail.govuk_notify_personalisation[:form_name]).to eq(new_draft_name)
       expect(mail.govuk_notify_personalisation[:form_link]).to eq(form_url(live_form))
-      expect(mail.govuk_notify_personalisation[:live_form_name]).to eq(live_form.live_form_document.content["name"])
+      expect(mail.govuk_notify_personalisation[:live_form_name]).to eq(live_form.latest_form_document.content["name"])
       expect(mail.govuk_notify_personalisation[:live_form_link]).to eq(live_form_url(live_form))
       expect(mail.govuk_notify_personalisation[:group_name]).to eq(live_form.group.name)
       expect(mail.govuk_notify_personalisation[:user_name]).to eq(user.name)

--- a/spec/models/form_document/content_spec.rb
+++ b/spec/models/form_document/content_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FormDocument::Content, type: :model do
   subject(:form_document_content) { described_class.from_form_document(form_document) }
 
   let(:form) { create :form, :live }
-  let(:form_document) { form.live_form_document }
+  let(:form_document) { form.latest_form_document }
 
   it "ignores any attributes that are not defined" do
     expect(described_class.new(foo: "bar").attributes).not_to include(:foo)
@@ -12,7 +12,7 @@ RSpec.describe FormDocument::Content, type: :model do
 
   describe "#made_live_date" do
     let(:form_document) do
-      form.live_form_document.tap do |form_document|
+      form.latest_form_document.tap do |form_document|
         form_document.content["first_made_live_at"] = first_made_live_at
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe FormDocument::Content, type: :model do
 
   describe ".from_form_document" do
     let(:form) { create :form, :live }
-    let(:form_document) { form.live_form_document }
+    let(:form_document) { form.latest_form_document }
 
     it "creates a FormDocument::Content" do
       expect(described_class.from_form_document(form_document)).to be_a(described_class)
@@ -99,7 +99,7 @@ RSpec.describe FormDocument::Content, type: :model do
     end
 
     context "when available_languages is not set" do
-      let(:form_document) { form.live_form_document }
+      let(:form_document) { form.latest_form_document }
 
       it "returns false" do
         form_document.content.delete("available_languages")

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1697,4 +1697,18 @@ RSpec.describe Form, type: :model do
       end
     end
   end
+
+  describe "#latest_live_or_archived_form_document" do
+    let(:form) { create(:form, :live, :with_welsh_translation) }
+
+    before do
+      allow(FormDocument).to receive(:latest_live_or_archived).and_call_original
+    end
+
+    it "calls FormDocument.latest_live_or_archived with the language" do
+      form_document = form.latest_live_or_archived_form_document(language: "cy")
+      expect(form_document).to eq(FormDocument.find_by(form_id: form.id, language: "cy", tag: "live"))
+      expect(FormDocument).to have_received(:latest_live_or_archived).with(form_id: form.id, language: "cy")
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -360,32 +360,6 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  describe "live_welsh_form_document" do
-    context "when there is no live Welsh form document" do
-      subject(:form) { create :form, :live }
-
-      it "returns nil" do
-        expect(form.live_welsh_form_document).to be_nil
-      end
-    end
-
-    context "when there is a live Welsh form document" do
-      subject(:form) { create :form, :live, :with_welsh_translation }
-
-      it "returns the live form document" do
-        expect(form.live_welsh_form_document).to be_a(FormDocument)
-      end
-    end
-
-    context "when there only an archived Welsh form document" do
-      subject(:form) { create :form, :archived, :with_welsh_translation }
-
-      it "returns nil" do
-        expect(form.live_welsh_form_document).to be_nil
-      end
-    end
-  end
-
   describe "archived_form_document" do
     context "when there is no archived form document" do
       it "returns nil" do
@@ -499,7 +473,7 @@ RSpec.describe Form, type: :model do
       subject(:form) { create :form, :live }
 
       it "returns nil" do
-        expect(form.live_welsh_form_document).to be_nil
+        expect(form.latest_welsh_form_document).to be_nil
       end
     end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -27,17 +27,17 @@ RSpec.describe Form, type: :model do
     it "has an archived trait" do
       form = create :form, :archived
       expect(form.state).to eq "archived"
-      expect(form.archived_form_document).to be_present
-      expect(form.archived_form_document.version).to eq(1)
-      expect(form.latest_form_document_id).to eq(form.archived_form_document.id)
+      expect(form.latest_form_document).to be_present
+      expect(form.latest_form_document.tag).to eq "archived"
+      expect(form.latest_form_document.version).to eq(1)
     end
 
     it "has an archived with draft trait" do
       form = create :form, :archived_with_draft
       expect(form.state).to eq "archived_with_draft"
-      expect(form.archived_form_document).to be_present
+      expect(form.latest_form_document).to be_present
+      expect(form.latest_form_document.tag).to eq "archived"
       expect(form.draft_form_document).to be_present
-      expect(form.latest_form_document_id).to eq(form.archived_form_document.id)
     end
 
     it "has a ready for routing trait" do
@@ -360,30 +360,6 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  describe "archived_form_document" do
-    context "when there is no archived form document" do
-      it "returns nil" do
-        expect(form.archived_form_document).to be_nil
-      end
-    end
-
-    context "when there is an archived form document" do
-      subject(:form) { create :form, :archived }
-
-      it "returns nil" do
-        expect(form.archived_form_document).to be_a(FormDocument)
-      end
-    end
-
-    context "when there is only a live form document" do
-      subject(:form) { create :form, :live }
-
-      it "returns nil" do
-        expect(form.archived_form_document).to be_nil
-      end
-    end
-  end
-
   describe "archived_welsh_form_document" do
     context "when there is no archived Welsh form document" do
       subject(:form) { create :form, :archived }
@@ -568,8 +544,9 @@ RSpec.describe Form, type: :model do
         form.archive_live_form!
       end
 
-      it "creates a archived form document" do
-        expect { form.archive_live_form! }.to change { form.reload.archived_form_document }.from(nil)
+      it "archives the form document" do
+        form.archive_live_form!
+        expect(form.reload.latest_form_document.tag).to eq("archived")
       end
     end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -13,17 +13,15 @@ RSpec.describe Form, type: :model do
     it "has a live trait" do
       form = create :form, :live
       expect(form.state).to eq "live"
-      expect(form.live_form_document).to be_present
-      expect(form.live_form_document.version).to eq(1)
-      expect(form.latest_form_document_id).to eq(form.live_form_document.id)
+      expect(form.latest_form_document).to be_present
+      expect(form.latest_form_document.version).to eq(1)
     end
 
     it "has a live with draft trait" do
       form = create :form, :live_with_draft
       expect(form.state).to eq "live_with_draft"
-      expect(form.live_form_document).to be_present
+      expect(form.latest_form_document).to be_present
       expect(form.draft_form_document).to be_present
-      expect(form.latest_form_document_id).to eq(form.live_form_document.id)
     end
 
     it "has an archived trait" do
@@ -362,30 +360,6 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  describe "live_form_document" do
-    context "when there is no live form document" do
-      it "returns nil" do
-        expect(form.live_form_document).to be_nil
-      end
-    end
-
-    context "when there is a live form document" do
-      subject(:form) { create :form, :live }
-
-      it "returns the live form document" do
-        expect(form.live_form_document).to be_a(FormDocument)
-      end
-    end
-
-    context "when there only an archived form document" do
-      subject(:form) { create :form, :archived }
-
-      it "returns nil" do
-        expect(form.live_form_document).to be_nil
-      end
-    end
-  end
-
   describe "live_welsh_form_document" do
     context "when there is no live Welsh form document" do
       subject(:form) { create :form, :live }
@@ -573,7 +547,7 @@ RSpec.describe Form, type: :model do
       end
 
       it "creates a live form document" do
-        expect { form.make_live! }.to change { form.reload.live_form_document }.from(nil)
+        expect { form.make_live! }.to change { form.reload.latest_form_document }.from(nil)
       end
 
       context "when first_made_live_at is not already set" do
@@ -587,7 +561,7 @@ RSpec.describe Form, type: :model do
         it "populates first_made_live_at in the live FormDocument" do
           freeze_time do
             form.make_live!
-            expect(form.reload.live_form_document.reload.content["first_made_live_at"]).to eq(Time.zone.now.iso8601(6))
+            expect(form.reload.latest_form_document.reload.content["first_made_live_at"]).to eq(Time.zone.now.iso8601(6))
           end
         end
 
@@ -1678,7 +1652,8 @@ RSpec.describe Form, type: :model do
 
         context "when the form already has a live English form document" do
           before do
-            create :form_document, :live, form:, language: "en", content: form.as_form_document
+            form_document = create :form_document, :live, form:, language: "en", content: form.as_form_document
+            form.update!(latest_form_document: form_document)
           end
 
           context "when the form does not have a live Welsh form document" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -360,32 +360,6 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  describe "archived_welsh_form_document" do
-    context "when there is no archived Welsh form document" do
-      subject(:form) { create :form, :archived }
-
-      it "returns nil" do
-        expect(form.archived_welsh_form_document).to be_nil
-      end
-    end
-
-    context "when there is an archived Welsh form document" do
-      subject(:form) { create :form, :archived, :with_welsh_translation }
-
-      it "returns nil" do
-        expect(form.archived_welsh_form_document).to be_a(FormDocument)
-      end
-    end
-
-    context "when there is only a live Welsh form document" do
-      subject(:form) { create :form, :live, :with_welsh_translation }
-
-      it "returns nil" do
-        expect(form.archived_welsh_form_document).to be_nil
-      end
-    end
-  end
-
   describe "draft_welsh_form_document" do
     context "when there is no draft Welsh form document" do
       subject(:form) { create :form }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -520,6 +520,42 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "latest_welsh_form_document" do
+    context "when there is no live Welsh form document" do
+      subject(:form) { create :form, :live }
+
+      it "returns nil" do
+        expect(form.live_welsh_form_document).to be_nil
+      end
+    end
+
+    context "when there are multiple live Welsh form documents" do
+      subject(:form) { create :form, :live, :with_welsh_translation }
+
+      before do
+        create :form_document, :live, form: form, language: "cy", version: 2
+      end
+
+      it "returns the latest live Welsh form document" do
+        expect(form.latest_welsh_form_document).to be_a(FormDocument)
+        expect(form.latest_welsh_form_document.version).to eq(2)
+      end
+    end
+
+    context "when the latest Welsh form document is archived" do
+      subject(:form) { create :form, :live, :with_welsh_translation }
+
+      before do
+        create :form_document, :archived, form: form, language: "cy", version: 2
+      end
+
+      it "returns the latest archived Welsh form document" do
+        expect(form.latest_welsh_form_document).to be_a(FormDocument)
+        expect(form.latest_welsh_form_document.version).to eq(2)
+      end
+    end
+  end
+
   describe "FormStateMachine" do
     before do
       form.set_task_status_service(TaskStatusService.new(form: form))

--- a/spec/requests/forms/make_live_controller_spec.rb
+++ b/spec/requests/forms/make_live_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
           it "does not change the live form document" do
             expect {
               post(make_live_path(form_id: form.id), params: form_params)
-            }.not_to(change { form.reload.live_form_document.updated_at })
+            }.not_to(change { form.reload.latest_form_document.updated_at })
           end
 
           it "does not send an email to the organisation admins" do
@@ -188,7 +188,7 @@ RSpec.describe Forms::MakeLiveController, type: :request do
           it "updates the form document" do
             expect {
               post(make_live_path(form_id: form.id), params: form_params)
-            }.to(change { form.reload.live_form_document.updated_at })
+            }.to(change { form.reload.latest_form_document.updated_at })
           end
         end
       end

--- a/spec/requests/reports_controller_spec.rb
+++ b/spec/requests/reports_controller_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe ReportsController, type: :request do
     let(:form) do
       form = create(:form, :live, :ready_for_routing)
       create(:condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, answer_value: "Option 1", goto_page_id: form.pages.second.id)
-      form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+      form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
       form
     end
     let(:forms) { [form] }
@@ -199,7 +199,7 @@ RSpec.describe ReportsController, type: :request do
       form = create(:form, :live, :ready_for_routing)
       create(:condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, answer_value: "Option 1", goto_page_id: form.pages.third.id)
       create(:condition, routing_page_id: form.pages.second.id, check_page_id: form.pages.first.id, goto_page_id: form.pages.fourth.id)
-      form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+      form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
       form
     end
     let(:forms) { [form] }
@@ -588,7 +588,7 @@ RSpec.describe ReportsController, type: :request do
       let(:form) do
         form = create(:form, :live, :ready_for_routing)
         create(:condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, answer_value: "Option 1", goto_page_id: form.pages.second.id)
-        form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+        form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
         form
       end
       let(:forms) { [form, *create_list(:form, 2, :live)] }

--- a/spec/services/form_copy_service_spec.rb
+++ b/spec/services/form_copy_service_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe FormCopyService do
         source_form.reload
 
         # Update the live form document to include the pages and conditions
-        source_form.live_form_document.update!(content: source_form.as_form_document)
+        source_form.latest_form_document.update!(content: source_form.as_form_document)
       end
 
       it "copies routing conditions to the new form" do
@@ -194,7 +194,7 @@ RSpec.describe FormCopyService do
         source_form.reload
 
         # Update the live form document to include the pages and conditions
-        source_form.live_form_document.update!(content: source_form.as_form_document)
+        source_form.latest_form_document.update!(content: source_form.as_form_document)
       end
 
       it "copies exit page conditions" do

--- a/spec/services/make_form_live_service_spec.rb
+++ b/spec/services/make_form_live_service_spec.rb
@@ -4,7 +4,7 @@ describe MakeFormLiveService do
   subject(:make_form_live_service) { described_class.call(current_form:, current_user:) }
 
   let(:current_form) { create :form, :ready_for_live }
-  let(:live_form_document) { current_form.live_form_document }
+  let(:live_form_document) { current_form.latest_form_document }
   let(:current_user) { build :user }
 
   before do

--- a/spec/services/reports/feature_report_service_spec.rb
+++ b/spec/services/reports/feature_report_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Reports::FeatureReportService do
   let(:form_documents) do
     forms.map do |form|
       # FormDocumentsService adds in the welsh_completed details as part of the database query
-      form.live_form_document.as_json
+      form.latest_form_document.as_json
           .merge({
             "welsh_completed" => form.welsh_completed,
           })
@@ -62,13 +62,13 @@ RSpec.describe Reports::FeatureReportService do
     create(:condition, :with_exit_page, routing_page_id: form.pages[0].id, check_page_id: form.pages[0].id, answer_value: "Option 1")
     create(:condition, routing_page_id: form.pages[1].id, check_page_id: form.pages[1].id, answer_value: "Option 1", goto_page_id: form.pages[3].id)
     create(:condition, routing_page_id: form.pages[2].id, check_page_id: form.pages[1].id, goto_page_id: form.pages[4].id)
-    form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+    form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
   let(:basic_route_form) do
     form = create(:form, :live, :ready_for_routing)
     create(:condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, answer_value: "Option 1", skip_to_end: true)
-    form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+    form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
   let(:copied_form) do
@@ -336,7 +336,7 @@ RSpec.describe Reports::FeatureReportService do
         create(:page, :with_selection_settings, is_optional: true),
         create(:page, :with_selection_settings, is_optional: false),
       ])
-      form_document = form.live_form_document.as_json
+      form_document = form.latest_form_document.as_json
 
       questions = described_class.new([form_document]).selection_questions_with_none_of_the_above
       expect(questions.length).to eq 1

--- a/spec/services/reports/form_documents_service_spec.rb
+++ b/spec/services/reports/form_documents_service_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Reports::FormDocumentsService do
     create(:condition, :with_exit_page, routing_page_id: form.pages[0].id, check_page_id: form.pages[0].id, answer_value: "Option 1")
     create(:condition, routing_page_id: form.pages[1].id, check_page_id: form.pages[1].id, answer_value: "Option 1", goto_page_id: form.pages[3].id)
     create(:condition, routing_page_id: form.pages[2].id, check_page_id: form.pages[1].id, goto_page_id: form.pages[4].id)
-    form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+    form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
 
   let(:basic_route_form) do
     form = create(:form, :live, :ready_for_routing)
     create(:condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, answer_value: "Option 1", skip_to_end: true)
-    form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+    form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
 
@@ -31,7 +31,7 @@ RSpec.describe Reports::FormDocumentsService do
     create(:condition, routing_page_id: form.pages[2].id, check_page_id: form.pages[1].id, answer_value: "Option 2", goto_page_id: form.pages[4].id)
     create(:condition, routing_page_id: form.pages[6].id, check_page_id: form.pages[6].id, answer_value: "Option 1", goto_page_id: form.pages[8].id)
     create(:condition, routing_page_id: form.pages[7].id, check_page_id: form.pages[6].id, answer_value: "Option 2", goto_page_id: form.pages[9].id)
-    form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+    form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
 
@@ -127,19 +127,19 @@ RSpec.describe Reports::FormDocumentsService do
     end
 
     context "when form has one step with one secondary skip condition" do
-      let(:form_document) { branch_route_form.live_form_document }
+      let(:form_document) { branch_route_form.latest_form_document }
 
       it { is_expected.to be true }
     end
 
     context "when form has two steps each with one secondary skip condition" do
-      let(:form_document) { form_with_2_branch_routes.live_form_document }
+      let(:form_document) { form_with_2_branch_routes.latest_form_document }
 
       it { is_expected.to be true }
     end
 
     context "when form has no secondary skip conditions" do
-      let(:form_document) { basic_route_form.live_form_document }
+      let(:form_document) { basic_route_form.latest_form_document }
 
       it { is_expected.to be false }
     end
@@ -151,19 +151,19 @@ RSpec.describe Reports::FormDocumentsService do
     end
 
     context "when form has one step with one secondary skip condition" do
-      let(:form_document) { branch_route_form.live_form_document }
+      let(:form_document) { branch_route_form.latest_form_document }
 
       it { is_expected.to eq 1 }
     end
 
     context "when form has two steps each with one secondary skip condition" do
-      let(:form_document) { form_with_2_branch_routes.live_form_document }
+      let(:form_document) { form_with_2_branch_routes.latest_form_document }
 
       it { is_expected.to eq 2 }
     end
 
     context "when form has no secondary skip conditions" do
-      let(:form_document) { basic_route_form.live_form_document }
+      let(:form_document) { basic_route_form.latest_form_document }
 
       it { is_expected.to eq 0 }
     end
@@ -171,7 +171,7 @@ RSpec.describe Reports::FormDocumentsService do
 
   describe ".step_has_secondary_skip_route?" do
     context "when step is check page for secondary skip condition" do
-      let(:form_document) { branch_route_form.live_form_document }
+      let(:form_document) { branch_route_form.latest_form_document }
       let(:step) { form_document["content"]["steps"][1] }
 
       it "returns true" do
@@ -180,7 +180,7 @@ RSpec.describe Reports::FormDocumentsService do
     end
 
     context "when step is not check page for secondary skip condition" do
-      let(:form_document) { branch_route_form.live_form_document }
+      let(:form_document) { branch_route_form.latest_form_document }
       let(:step) { form_document["content"]["steps"][3] }
 
       it "returns false" do
@@ -189,7 +189,7 @@ RSpec.describe Reports::FormDocumentsService do
     end
 
     context "when form has no secondary skip conditions" do
-      let(:form_document) { basic_route_form.live_form_document }
+      let(:form_document) { basic_route_form.latest_form_document }
       let(:step) { form_document["content"]["steps"][0] }
 
       it "returns false" do
@@ -204,13 +204,13 @@ RSpec.describe Reports::FormDocumentsService do
     end
 
     context "when form has one step with one exit page" do
-      let(:form_document) { branch_route_form.live_form_document }
+      let(:form_document) { branch_route_form.latest_form_document }
 
       it { is_expected.to be true }
     end
 
     context "when form has no exit pages" do
-      let(:form_document) { basic_route_form.live_form_document }
+      let(:form_document) { basic_route_form.latest_form_document }
 
       it { is_expected.to be false }
     end
@@ -222,7 +222,7 @@ RSpec.describe Reports::FormDocumentsService do
         create(:page, is_repeatable:),
       ])
     end
-    let(:form_document) { form.live_form_document }
+    let(:form_document) { form.latest_form_document }
 
     context "when the form has a question with add another answer" do
       let(:is_repeatable) { true }
@@ -249,7 +249,7 @@ RSpec.describe Reports::FormDocumentsService do
     context "when form has a daily delivery_configuration" do
       let(:form_document) do
         create(:form, :live, delivery_configurations: [create(:delivery_configuration, :daily_email)])
-          .live_form_document
+          .latest_form_document
       end
 
       it "returns true" do
@@ -258,7 +258,7 @@ RSpec.describe Reports::FormDocumentsService do
     end
 
     context "when form does not have a daily delivery_configuration" do
-      let(:form_document) { create(:form, :live).live_form_document }
+      let(:form_document) { create(:form, :live).latest_form_document }
 
       it "returns false" do
         expect(daily_submission_batch_enabled).to be false
@@ -274,7 +274,7 @@ RSpec.describe Reports::FormDocumentsService do
     context "when form has weekly delivery_configuration" do
       let(:form_document) do
         create(:form, :live, delivery_configurations: [create(:delivery_configuration, :weekly_email)])
-          .live_form_document
+          .latest_form_document
       end
 
       it "returns true" do
@@ -283,7 +283,7 @@ RSpec.describe Reports::FormDocumentsService do
     end
 
     context "when form does not have a weekly delivery_configuration" do
-      let(:form_document) { create(:form, :live).live_form_document }
+      let(:form_document) { create(:form, :live).latest_form_document }
 
       it "returns false" do
         expect(weekly_submission_batch_enabled).to be false

--- a/spec/services/reports/forms_csv_report_service_spec.rb
+++ b/spec/services/reports/forms_csv_report_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Reports::FormsCsvReportService do
   let(:form_documents) do
     forms.map do |form|
       # FormDocumentsService adds in the organisation and group details as part of the database query
-      form.live_form_document.as_json
+      form.latest_form_document.as_json
           .merge({
             "organisation_name" => organisation_name,
             "organisation_id" => organisation_id,

--- a/spec/services/reports/questions_csv_report_service_spec.rb
+++ b/spec/services/reports/questions_csv_report_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Reports::QuestionsCsvReportService do
   let(:form_documents) do
     forms.map do |form|
       # FormDocumentsService adds in the organisation and group details as part of the database query
-      form.live_form_document.as_json
+      form.latest_form_document.as_json
           .merge({
             "organisation_name" => organisation_name,
             "organisation_id" => organisation_id,
@@ -41,13 +41,13 @@ RSpec.describe Reports::QuestionsCsvReportService do
     create(:condition, :with_exit_page, routing_page_id: form.pages[0].id, check_page_id: form.pages[0].id, answer_value: "Option 1")
     create(:condition, routing_page_id: form.pages[1].id, check_page_id: form.pages[1].id, answer_value: "Option 1", goto_page_id: form.pages[3].id)
     create(:condition, routing_page_id: form.pages[2].id, check_page_id: form.pages[1].id, goto_page_id: form.pages[4].id)
-    form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+    form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
   let(:basic_route_form) do
     form = create(:form, :live, :ready_for_routing)
     create(:condition, routing_page_id: form.pages.first.id, check_page_id: form.pages.first.id, answer_value: "Option 1", skip_to_end: true)
-    form.live_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
+    form.latest_form_document.update!(content: form.reload.as_form_document(live_at: form.updated_at))
     form
   end
   let(:forms) { [form_with_all_answer_types, branch_route_form, basic_route_form] }

--- a/spec/services/reports/selection_question_service_spec.rb
+++ b/spec/services/reports/selection_question_service_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Reports::SelectionQuestionService do
       ]
 
       [
-        create(:form, :live, pages: form_1_pages).live_form_document.as_json,
-        create(:form, :live, pages: form_2_pages).live_form_document.as_json,
+        create(:form, :live, pages: form_1_pages).latest_form_document.as_json,
+        create(:form, :live, pages: form_2_pages).latest_form_document.as_json,
       ]
     end
 

--- a/spec/services/step_summary_card_service_spec.rb
+++ b/spec/services/step_summary_card_service_spec.rb
@@ -5,7 +5,7 @@ describe StepSummaryCardService do
     described_class.new(step: form_document_step, steps: form_document_steps, multiple_branches_enabled:)
   end
 
-  let(:form_document_content) { FormDocument::Content.from_form_document(form.live_form_document) }
+  let(:form_document_content) { FormDocument::Content.from_form_document(form.latest_form_document) }
   let(:form_document_steps) { form_document_content.steps }
   let(:form_document_step) { FormDocument::Step.new(page.as_form_document_step(nil)) }
   let(:multiple_branches_enabled) { false }

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -9,7 +9,7 @@ describe StepSummaryTableService do
   let(:pages) { [page] }
   let(:page) { create(:page) }
 
-  let(:form_document_content) { FormDocument::Content.from_form_document(form.live_form_document) }
+  let(:form_document_content) { FormDocument::Content.from_form_document(form.latest_form_document) }
   let(:welsh_form_document_content) { FormDocument::Content.from_form_document(form.live_welsh_form_document) }
   let(:form_document_steps) { form_document_content.steps }
   let(:welsh_form_document_steps) { welsh_form_document.steps }

--- a/spec/services/step_summary_table_service_spec.rb
+++ b/spec/services/step_summary_table_service_spec.rb
@@ -10,11 +10,11 @@ describe StepSummaryTableService do
   let(:page) { create(:page) }
 
   let(:form_document_content) { FormDocument::Content.from_form_document(form.latest_form_document) }
-  let(:welsh_form_document_content) { FormDocument::Content.from_form_document(form.live_welsh_form_document) }
+  let(:welsh_form_document_content) { FormDocument::Content.from_form_document(form.latest_welsh_form_document) }
   let(:form_document_steps) { form_document_content.steps }
   let(:welsh_form_document_steps) { welsh_form_document.steps }
   let(:form_document_step) { FormDocument::Step.new(page.as_form_document_step(nil)) }
-  let(:welsh_form_document) { FormDocument::Content.from_form_document(form.live_welsh_form_document) }
+  let(:welsh_form_document) { FormDocument::Content.from_form_document(form.latest_welsh_form_document) }
 
   before do
     form.set_task_status_service(TaskStatusService.new(form:))

--- a/spec/services/task_status_service_spec.rb
+++ b/spec/services/task_status_service_spec.rb
@@ -539,7 +539,7 @@ describe TaskStatusService do
         let(:welsh_form_document) { build(:form_document, :live, form:, language: "cy", content: form.as_form_document) }
 
         before do
-          allow(form).to receive(:live_welsh_form_document).and_return(welsh_form_document)
+          allow(form).to receive(:latest_welsh_form_document).and_return(welsh_form_document)
         end
 
         context "when the form already has a live Welsh version" do

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -346,7 +346,7 @@ describe "forms/_made_live_form.html.erb" do
       let(:status) { :archived }
       let(:form_metadata) { create :form, :archived }
       let(:form_document) do
-        form_document_content = FormDocument::Content.from_form_document(form_metadata.archived_form_document)
+        form_document_content = FormDocument::Content.from_form_document(form_metadata.latest_form_document)
         form_document_content.live_at = 1.week.ago
         form_document_content
       end
@@ -364,7 +364,7 @@ describe "forms/_made_live_form.html.erb" do
       let(:status) { :archived }
       let(:form_metadata) { create :form, :archived_with_draft }
       let(:form_document) do
-        form_document_content = FormDocument::Content.from_form_document(form_metadata.archived_form_document)
+        form_document_content = FormDocument::Content.from_form_document(form_metadata.latest_form_document)
         form_document_content.live_at = 1.week.ago
         form_document_content
       end

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe "forms/_made_live_form.html.erb" do
     create(:form, :live, declaration_markdown:, what_happens_next_markdown:, send_copy_of_answers:)
   end
   let(:form_document) do
-    form_document_content = FormDocument::Content.from_form_document(form_metadata.live_form_document)
+    form_document_content = FormDocument::Content.from_form_document(form_metadata.latest_form_document)
     form_document_content.first_made_live_at = 1.week.ago
     form_document_content
   end
@@ -276,7 +276,7 @@ describe "forms/_made_live_form.html.erb" do
 
   context "with no support information set" do
     let(:form_document) do
-      form_document_content = FormDocument::Content.from_form_document(form_metadata.live_form_document)
+      form_document_content = FormDocument::Content.from_form_document(form_metadata.latest_form_document)
       form_document_content.support_email = nil
       form_document_content.support_url_text = nil
       form_document_content.support_url = nil

--- a/spec/views/forms/_made_live_form.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form.html.erb_spec.rb
@@ -387,7 +387,7 @@ describe "forms/_made_live_form.html.erb" do
     context "when the form is live and the form has a welsh translation" do
       let(:form_metadata) { create :form, :live, :with_welsh_translation }
       let(:welsh_form_document) do
-        FormDocument::Content.from_form_document(form_metadata.live_welsh_form_document)
+        FormDocument::Content.from_form_document(form_metadata.latest_welsh_form_document)
       end
 
       it "template contains a link to archive the welsh version of the form" do
@@ -439,7 +439,7 @@ describe "forms/_made_live_form.html.erb" do
     let(:what_happens_next_markdown_cy) { "Os nad ydych wedi derbyn ymateb o fewn 5 diwrnod gwaith, [cysylltwch â’n tîm cymorth defnyddwyr](https://example.com)." }
     let(:form_metadata) { create :form, :live, :with_welsh_translation, what_happens_next_markdown:, what_happens_next_markdown_cy: }
     let(:welsh_form_document) do
-      form_document_content = FormDocument::Content.from_form_document(form_metadata.live_welsh_form_document)
+      form_document_content = FormDocument::Content.from_form_document(form_metadata.latest_welsh_form_document)
       form_document_content.first_made_live_at = 1.week.ago
       form_document_content
     end

--- a/spec/views/forms/_made_live_form_pages.html.erb_spec.rb
+++ b/spec/views/forms/_made_live_form_pages.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "forms/_made_live_form_pages.html.erb" do
   let(:form) { create :form, :live }
-  let(:form_document) { FormDocument::Content.from_form_document(form.live_form_document) }
+  let(:form_document) { FormDocument::Content.from_form_document(form.latest_form_document) }
   let(:welsh_form_document) { nil }
   let(:status) { :live }
   let(:show_form_path) { Faker::Internet.url }

--- a/spec/views/forms/archived/show_form.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_form.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "archived/show_form.html.erb" do
   let(:form_metadata) { create :form, :archived }
-  let(:form_document) { FormDocument::Content.from_form_document(form_metadata.archived_form_document) }
+  let(:form_document) { FormDocument::Content.from_form_document(form_metadata.latest_form_document) }
   let(:welsh_form_document) { nil }
 
   before do

--- a/spec/views/forms/archived/show_form.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_form.html.erb_spec.rb
@@ -37,7 +37,7 @@ describe "archived/show_form.html.erb" do
   context "when the form has a Welsh translation" do
     let(:form_metadata) { create :form, :archived, :with_welsh_translation }
     let(:welsh_form_document) do
-      form_document_content = FormDocument::Content.from_form_document(form_metadata.archived_welsh_form_document)
+      form_document_content = FormDocument::Content.from_form_document(form_metadata.latest_welsh_form_document)
       form_document_content.first_made_live_at = 1.week.ago
       form_document_content
     end

--- a/spec/views/forms/archived/show_pages.html.erb_spec.rb
+++ b/spec/views/forms/archived/show_pages.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "forms/archived/show_pages.html.erb" do
   let(:form) { create :form, :archived }
-  let(:form_document) { FormDocument::Content.from_form_document(form.archived_form_document) }
+  let(:form_document) { FormDocument::Content.from_form_document(form.latest_form_document) }
   let(:welsh_form_document) { nil }
   let(:multiple_branches_enabled) { false }
 

--- a/spec/views/forms/live/show_form.html.erb_spec.rb
+++ b/spec/views/forms/live/show_form.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "forms/live/show_form.html.erb" do
   let(:form_metadata) { create :form, :live }
-  let(:form_document) { FormDocument::Content.from_form_document(form_metadata.live_form_document) }
+  let(:form_document) { FormDocument::Content.from_form_document(form_metadata.latest_form_document) }
   let(:welsh_form_document) { nil }
 
   before do

--- a/spec/views/forms/live/show_form.html.erb_spec.rb
+++ b/spec/views/forms/live/show_form.html.erb_spec.rb
@@ -33,7 +33,7 @@ describe "forms/live/show_form.html.erb" do
   context "when the form has a Welsh translation" do
     let(:form_metadata) { create :form, :live, :with_welsh_translation, declaration_markdown: "Declaration" }
     let(:welsh_form_document) do
-      form_document_content = FormDocument::Content.from_form_document(form_metadata.live_welsh_form_document)
+      form_document_content = FormDocument::Content.from_form_document(form_metadata.latest_welsh_form_document)
       form_document_content.first_made_live_at = 1.week.ago
       form_document_content
     end

--- a/spec/views/forms/live/show_pages.html.erb_spec.rb
+++ b/spec/views/forms/live/show_pages.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "forms/live/show_pages.html.erb" do
   let(:form) { create :form, :live }
-  let(:form_document) { FormDocument::Content.from_form_document(form.live_form_document) }
+  let(:form_document) { FormDocument::Content.from_form_document(form.latest_form_document) }
   let(:welsh_form_document) { nil }
   let(:multiple_branches_enabled) { false }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/dGv0TrD1

Replace the associations on the Form model to get live/archived the FormDocuments by tag to instead get the FormDocument with the highest version number.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
