### PR TITLE
Search users by name or email in one box

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,8 +44,7 @@ private
 
   def filtered_users
     policy_scope(User)
-      .by_name(filter_params[:name])
-      .by_email(filter_params[:email])
+      .by_search(filter_params[:search])
       .by_organisation_id(filter_params[:organisation_id])
       .by_role(filter_params[:role])
       .by_has_access(filter_params[:has_access])
@@ -63,7 +62,7 @@ private
   end
 
   def filter_params
-    params[:filter]&.permit(:name, :email, :organisation_id, :role, :has_access)&.tap do |filters|
+    params[:filter]&.permit(:search, :organisation_id, :role, :has_access)&.tap do |filters|
       clear_param_if_autocomplete_empty(filters, :organisation_id, params.dig(:filter, :organisation_id_raw))
     end || {}
   end

--- a/app/input_objects/users/filter_input.rb
+++ b/app/input_objects/users/filter_input.rb
@@ -2,10 +2,10 @@ module Users
   class FilterInput < BaseInput
     include UsersHelper
 
-    attr_accessor :email, :name, :organisation_id, :role, :has_access
+    attr_accessor :search, :organisation_id, :role, :has_access
 
     def has_filters?
-      [email, name, organisation_id, role, has_access].any?(&:present?)
+      [search, organisation_id, role, has_access].any?(&:present?)
     end
 
     def access_options

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,18 +43,6 @@ class User < ApplicationRecord
       .order({ name: :asc })
   }
 
-  scope :by_name, lambda { |name|
-    if name.present?
-      where("lower(users.name) LIKE ?", "%#{sanitize_sql_like(name.downcase)}%")
-    end
-  }
-
-  scope :by_email, lambda { |email|
-    if email.present?
-      where("lower(email) LIKE ?", "%#{sanitize_sql_like(email.downcase)}%")
-    end
-  }
-
   scope :by_search, lambda { |search|
     if search.present?
       where("lower(users.name) LIKE :search OR lower(users.email) LIKE :search",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,13 @@ class User < ApplicationRecord
     end
   }
 
+  scope :by_search, lambda { |search|
+    if search.present?
+      where("lower(users.name) LIKE :search OR lower(users.email) LIKE :search",
+            search: "%#{sanitize_sql_like(search.downcase)}%")
+    end
+  }
+
   scope :by_organisation_id, lambda { |organisation_id|
     if organisation_id.present?
       joins(:organisation).where(organisation: { id: organisation_id })

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -6,14 +6,9 @@
   <%= form_with(model: @filter_input, scope: :filter, url: users_path, method: 'get', local: true, class: 'govuk-clearfix') do |f| %>
     <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-padding-right-3">
       <div class="govuk-grid-column-one-third">
-        <%= f.govuk_text_field :name,
-          label: { text: t('users.index.filter.name.label'), size: 's' },
-          hint: { text: t('users.index.filter.name.hint') } %>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <%= f.govuk_text_field :email,
-          label: { text: t('users.index.filter.email.label'), size: 's' },
-          hint: { text: t('users.index.filter.email.hint') } %>
+        <%= f.govuk_text_field :search,
+          label: { text: t('users.index.filter.search.label'), size: 's' },
+          hint: { text: t('users.index.filter.search.hint') } %>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= render DfE::Autocomplete::View.new(
@@ -29,8 +24,6 @@
           ),
         ) %>
       </div>
-    </div>
-    <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-padding-right-3">
       <div class="govuk-grid-column-one-third">
         <%= f.govuk_collection_select :role,
           @filter_input.role_options,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2397,15 +2397,9 @@ en:
       download_filtered: Download data about the filtered users as a CSV file
       filter:
         clear_filter: Clear filter
-        email:
-          hint: Enter full or partial email
-          label: Email
         has_access:
           hint: Select access permission
           label: Access
-        name:
-          hint: Enter full or partial name
-          label: Name
         organisation:
           hint: Select an organisation
           label: Organisation
@@ -2413,6 +2407,9 @@ en:
         role:
           hint: Select a role
           label: Role
+        search:
+          hint: Enter name or email address
+          label: Search
         submit: Filter
       name_blank: No name set
       organisation_blank: No organisation set

--- a/spec/input_objects/users/filter_input_spec.rb
+++ b/spec/input_objects/users/filter_input_spec.rb
@@ -2,16 +2,8 @@ require "rails_helper"
 
 RSpec.describe Users::FilterInput, type: :model do
   describe "#has_filters?" do
-    context "when the name filter is set" do
-      subject(:input) { described_class.new(name: "foo") }
-
-      it "returns true" do
-        expect(input.has_filters?).to be true
-      end
-    end
-
-    context "when the email filter is set" do
-      subject(:input) { described_class.new(email: "foo") }
+    context "when the search filter is set" do
+      subject(:input) { described_class.new(search: "foo") }
 
       it "returns true" do
         expect(input.has_filters?).to be true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -231,6 +231,31 @@ describe User, type: :model do
         end
       end
 
+      describe ".by_search" do
+        let!(:matched_by_name) { create(:user, name: "Sir Abcdefg Higjklmop", email: "sir.smith@example.com") }
+        let!(:matched_by_email) { create(:user, name: "Lord Smith", email: "lord.abcdefg@example.com") }
+
+        it "returns users with a partial name match, ignoring case" do
+          expect(described_class.by_search("higjklmop")).to contain_exactly(matched_by_name)
+        end
+
+        it "returns users with a partial email match, ignoring case" do
+          expect(described_class.by_search("Lord.Abcdefg")).to contain_exactly(matched_by_email)
+        end
+
+        it "matches names and emails with a single search term" do
+          expect(described_class.by_search("abcdefg")).to contain_exactly(matched_by_name, matched_by_email)
+        end
+
+        it "returns all users when the search term is nil" do
+          expect(described_class.by_search(nil).size).to eq 4
+        end
+
+        it "returns all users when the search term is blank" do
+          expect(described_class.by_search("").size).to eq 4
+        end
+      end
+
       describe ".by_organisation_id" do
         let!(:matched_user) { create(:user, organisation: organisation) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -185,52 +185,6 @@ describe User, type: :model do
         create_list(:user, 2, organisation: other_org)
       end
 
-      describe ".by_name" do
-        let!(:matched_user) { create(:user, name: "Sir Abcdefg Higjklmop") }
-        let!(:other_matched_user) { create(:user, name: "Lord Abcdefg Smith") }
-
-        it "returns users with partial match" do
-          expect(described_class.by_name("Abcdefg")).to contain_exactly(matched_user, other_matched_user)
-        end
-
-        it "returns users with case insensitive match" do
-          expect(described_class.by_name("Higjklmop")).to contain_exactly(matched_user)
-        end
-
-        it "returns all users when provided name is nil" do
-          expect(described_class.by_name(nil).size).to eq 4
-        end
-
-        it "returns all users when provided name is blank" do
-          expect(described_class.by_name("").size).to eq 4
-        end
-      end
-
-      describe ".by_email" do
-        let!(:matched_user) { create(:user, email: "sir.abcdefg.higjklmnop@example.com") }
-        let!(:other_matched_user) { create(:user, email: "lord.abcdefg.smith@example.com") }
-
-        it "returns users with partial match" do
-          expect(described_class.by_email(".abcdefg")).to contain_exactly(matched_user, other_matched_user)
-        end
-
-        it "returns the user with an exact match" do
-          expect(described_class.by_email("sir.abcdefg.higjklmnop@example.com")).to contain_exactly(matched_user)
-        end
-
-        it "returns users with case insensitive match" do
-          expect(described_class.by_email("HIGJKLMNOP")).to contain_exactly(matched_user)
-        end
-
-        it "returns all users when provided email is nil" do
-          expect(described_class.by_email(nil).size).to eq 4
-        end
-
-        it "returns all users when provided email is blank" do
-          expect(described_class.by_email("").size).to eq 4
-        end
-      end
-
       describe ".by_search" do
         let!(:matched_by_name) { create(:user, name: "Sir Abcdefg Higjklmop", email: "sir.smith@example.com") }
         let!(:matched_by_email) { create(:user, name: "Lord Smith", email: "lord.abcdefg@example.com") }

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe UsersController, type: :request do
         let(:params) do
           {
             filter: {
-              name: "Test",
-              email: "123",
+              search: "123",
               organisation_id: test_org.id,
               organisation_id_raw:,
               role: "standard",
@@ -69,8 +68,7 @@ RSpec.describe UsersController, type: :request do
 
         it "populates the filter input object" do
           filter_input = assigns[:filter_input]
-          expect(filter_input.name).to eq "Test"
-          expect(filter_input.email).to eq "123"
+          expect(filter_input.search).to eq "123"
           expect(filter_input.organisation_id).to eq test_org.id.to_s
           expect(filter_input.role).to eq "standard"
           expect(filter_input.has_access).to eq "true"
@@ -80,8 +78,7 @@ RSpec.describe UsersController, type: :request do
           path = assigns[:filtered_download_path]
           parsed_params = CGI.parse(URI.parse(path).query)
           expect(parsed_params).to match(
-            "filter[name]" => %w[Test],
-            "filter[email]" => %w[123],
+            "filter[search]" => %w[123],
             "filter[organisation_id]" => [test_org.id.to_s],
             "filter[role]" => %w[standard],
             "filter[has_access]" => %w[true],
@@ -104,8 +101,7 @@ RSpec.describe UsersController, type: :request do
             path = assigns[:filtered_download_path]
             parsed_params = CGI.parse(URI.parse(path).query)
             expect(parsed_params).to match(
-              "filter[name]" => %w[Test],
-              "filter[email]" => %w[123],
+              "filter[search]" => %w[123],
               "filter[organisation_id]" => [],
               "filter[role]" => %w[standard],
               "filter[has_access]" => %w[true],
@@ -159,8 +155,7 @@ RSpec.describe UsersController, type: :request do
         let(:params) do
           {
             filter: {
-              name: "Test",
-              email: "123",
+              search: "123",
               organisation_id: test_org.id,
               role: "standard",
               has_access: "true",

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -102,6 +102,10 @@ describe "users/index.html.erb" do
   end
 
   describe "filter" do
+    it "has a single search field" do
+      expect(rendered).to have_field("filter[search]")
+    end
+
     it "has organisation select" do
       expect(rendered).to have_select(
         "Organisation",
@@ -120,7 +124,7 @@ describe "users/index.html.erb" do
     end
 
     context "when there are filters applied" do
-      let(:filter_input) { Users::FilterInput.new(name: "foo") }
+      let(:filter_input) { Users::FilterInput.new(search: "foo") }
 
       it "has a link to clear the filters" do
         expect(rendered).to have_link("Clear filter")
@@ -136,7 +140,7 @@ describe "users/index.html.erb" do
     end
 
     context "when there are filters applied" do
-      let(:filter_input) { Users::FilterInput.new(name: "foo") }
+      let(:filter_input) { Users::FilterInput.new(search: "foo") }
 
       it "has a link to download filtered users" do
         expect(rendered).to have_link(t("users.index.download_filtered"), href: filtered_download_path)


### PR DESCRIPTION
The users page had separate filter fields for name and email, while the organisations page uses a single search box that is simpler to use. 

This brings the users page in line with it: one search box matching either the user's name or their email address, with the other filters unchanged.

This gives us more room to add other filters. (Thinking of adding the "Users interested in research" filter, here so we can remove the report).