### PR TITLE
Remove redundant label declaration

### DIFF
--- a/app/views/conditions/exit_page/edit.html.erb
+++ b/app/views/conditions/exit_page/edit.html.erb
@@ -21,9 +21,8 @@
         render_preview_path: conditions_exit_page_render_preview_path(form_id: update_exit_page_input.form.id, page_id: update_exit_page_input.page.id, check_preview_validation:),
         preview_html: preview_html,
         form_model: update_exit_page_input,
-        label: t("helpers.label.pages_exit_page_input.exit_page_markdown"),
-label: t("helpers.label.conditions_exit_page_input.exit_page_markdown"),
-hint: t("helpers.hint.conditions_exit_page_input.exit_page_markdown"),
+        label: t("helpers.label.conditions_exit_page_input.exit_page_markdown"),
+        hint: t("helpers.hint.conditions_exit_page_input.exit_page_markdown"),
         allow_headings: true) %>
 
       <div class="govuk-button-group">


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
This label is immediately overwritten on the next line, so we don't need it, and it was generating a `warning: key :label is duplicated and overwritten` warning in the tests.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
