### PR TITLE
Add exit page routes

### DIFF
--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -14,7 +14,11 @@ class RoutesController < FormsController
     @routes_input = Forms::RoutesInput.new(routes_params)
 
     if @routes_input.submit
-      redirect_to form_pages_path(@routes_input.form), success: t("banner.success.form.routing_saved")
+      if redirect_params.key?(:new_exit_page)
+        redirect_to new_exit_page_path(@routes_input.form, redirect_params[:new_exit_page])
+      else
+        redirect_to form_pages_path(@routes_input.form), success: t("banner.success.form.routing_saved")
+      end
     else
       render :show, status: :unprocessable_content
     end
@@ -34,6 +38,10 @@ private
 
   def routes_params
     params.require(:forms_routes_input).permit(routes_attributes: %i[id page_id answer_value goto]).merge(form: form_with_pages_and_conditions)
+  end
+
+  def redirect_params
+    params.permit(:new_exit_page)
   end
 
   def form_with_pages_and_conditions

--- a/app/input_objects/forms/route_input.rb
+++ b/app/input_objects/forms/route_input.rb
@@ -18,6 +18,10 @@ class Forms::RouteInput < BaseInput
     goto.is_a?(GotoValue::EndOfFormValue)
   end
 
+  def goes_to_exit?
+    goto.is_a?(GotoValue::ExitPage)
+  end
+
   def goes_to_page?
     goto.is_a?(GotoValue::Page)
   end
@@ -30,6 +34,8 @@ class Forms::RouteInput < BaseInput
       { goto_page_id: nil, skip_to_end: true, check_page_id: page.id }
     when GotoValue::Page
       { goto_page_id: goto.page_id, skip_to_end: false, check_page_id: page.id }
+    when GotoValue::ExitPage
+      { goto_page_id: nil, skip_to_end: false, check_page_id: page.id, exit_page_id: goto.exit_page_id }
     end
   end
 

--- a/app/models/goto_value.rb
+++ b/app/models/goto_value.rb
@@ -2,6 +2,7 @@ module GotoValue
   DEFAULT_STRING = "default".freeze
   END_OF_FORM_STRING = "end_of_form".freeze
   PAGE_PREFIX = "page_".freeze
+  EXIT_PAGE_PREFIX = "exit_page_".freeze
 
   DefaultValue = Data.define do
     def to_s = DEFAULT_STRING
@@ -15,6 +16,10 @@ module GotoValue
     def to_s = "#{PAGE_PREFIX}#{page_id}"
   end
 
+  ExitPage = Data.define(:exit_page_id) do
+    def to_s = "#{EXIT_PAGE_PREFIX}#{exit_page_id}"
+  end
+
   def self.from_string(value)
     case value
     when DEFAULT_STRING
@@ -23,6 +28,8 @@ module GotoValue
       EndOfFormValue.new
     when ->(v) { v.start_with?(PAGE_PREFIX) }
       Page.new(value.split("_").last.to_i)
+    when ->(v) { v.start_with?(EXIT_PAGE_PREFIX) }
+      ExitPage.new(value.split("_").last.to_i)
     else
       raise ArgumentError, "Unrecognised goto value: #{value.inspect}"
     end

--- a/app/models/goto_value_type.rb
+++ b/app/models/goto_value_type.rb
@@ -3,7 +3,8 @@ class GotoValueType < ActiveModel::Type::Value
     # If the value is already the correct object type, just return it.
     return value if value.is_a?(GotoValue::DefaultValue) ||
       value.is_a?(GotoValue::EndOfFormValue) ||
-      value.is_a?(GotoValue::Page)
+      value.is_a?(GotoValue::Page) ||
+      value.is_a?(GotoValue::ExitPage)
 
     # Otherwise, parse it from a string.
     string_value = value.to_s

--- a/app/services/routes/build_service.rb
+++ b/app/services/routes/build_service.rb
@@ -36,10 +36,10 @@ class Routes::BuildService
                         option_for_select(matching_page) if matching_page
                       end
 
-      return [
+      return (exit_pages(page) + [
         selected_page,
         [END_OF_FORM_OPTION.first, GotoValue::DefaultValue.new],
-      ].compact
+      ]).compact
     end
 
     # Don't include the current page or pages before in the options,
@@ -49,7 +49,7 @@ class Routes::BuildService
     next_page_id = next_page.id
     drop = true
 
-    all_goto_options.filter_map do |option|
+    options = all_goto_options.filter_map do |option|
       _, value = option
 
       if drop
@@ -63,6 +63,16 @@ class Routes::BuildService
       else
         option
       end
+    end
+
+    exit_pages(page) + options
+  end
+
+  def exit_pages(page)
+    exit_pages_positions = ExitPage.positions_for_page(page)
+
+    page.exit_pages.in_order_of(:id, exit_pages_positions.keys, filter: false).map do |exit_page|
+      ["Exit page #{exit_pages_positions[exit_page.id]}: #{exit_page.heading}", GotoValue::ExitPage.new(exit_page.id)]
     end
   end
 
@@ -123,6 +133,8 @@ private
 
     if condition.skip_to_end?
       GotoValue::EndOfFormValue.new
+    elsif condition.exit_page_id.present?
+      GotoValue::ExitPage.new(condition.exit_page_id)
     else
       GotoValue::Page.new(condition.goto_page_id)
     end

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -49,6 +49,9 @@
                             @routes_input.class.too_many_selection_options?(page) %>
                     <%= t(".too_many_options_html") %>
                   <% end %>
+                  <% if Forms::RoutesInput::route_with_selection_options?(page) %>
+                    <%= f.govuk_submit t(".add_exit_page_html", question_number: page.position), secondary: true, name: 'new_exit_page', value: page.id %>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -52,6 +52,18 @@
                   <% if Forms::RoutesInput::route_with_selection_options?(page) %>
                     <%= f.govuk_submit t(".add_exit_page_html", question_number: page.position), secondary: true, name: 'new_exit_page', value: page.id %>
                   <% end %>
+                  <% if page.exit_pages.any? %>
+                    <h2 class="govuk-heading-s">
+                      <%= t(".exit_pages_list", question_number: page.position) %>
+                    </h2>
+                      <%= govuk_list(
+                        page.exit_pages.order(:created_at).map do |exit_page|
+                          link_to(t(".exit_page_list_entry", exit_page_number: exit_page.position, heading: exit_page.heading), edit_exit_page_path(form_id: @current_form.id, page_id: page.id, id: exit_page.id))
+                        end,
+                        type: ""
+                      ) %>
+                    </ul>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -25,7 +25,7 @@
               row.with_value do
                 capture do %>
                 <p> <%= page.question_text %> </p>
-                <% if @routes_input.form.next_page_after(page).present? || routes.any?(&:invalid?) %>
+                <% if @routes_input.form.next_page_after(page).present? || routes.any?(&:invalid?) || @routes_input.class.route_with_selection_options?(page) %>
                   <ul class="govuk-list">
                     <% routes.each do |route| %>
                       <li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2223,6 +2223,8 @@ en:
   routes:
     show:
       add_exit_page_html: Add a new exit page <span class="govuk-visually-hidden">to question %{question_number}</span>
+      exit_page_list_entry: 'Exit page %{exit_page_number}: %{heading}'
+      exit_pages_list: Question %{question_number}’s exit pages
       not_enough_pages_html: |
         <p>You need more than one question in your form before you can add any routes.</p>
         <p><a href="%{pages_link}">Back to your questions</a></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2222,6 +2222,7 @@ en:
       live-or-archived: live or archived
   routes:
     show:
+      add_exit_page_html: Add a new exit page <span class="govuk-visually-hidden">to question %{question_number}</span>
       not_enough_pages_html: |
         <p>You need more than one question in your form before you can add any routes.</p>
         <p><a href="%{pages_link}">Back to your questions</a></p>

--- a/spec/input_objects/forms/route_input_spec.rb
+++ b/spec/input_objects/forms/route_input_spec.rb
@@ -80,6 +80,22 @@ RSpec.describe Forms::RouteInput, type: :model do
     end
   end
 
+  describe "#goes_to_exit?" do
+    context "when goto is an exit page" do
+      it "returns true" do
+        route_input.goto = "exit_page_123"
+        expect(route_input.goes_to_exit?).to be true
+      end
+    end
+
+    context "when goto is not an exit page" do
+      it "returns false" do
+        route_input.goto = "page_123"
+        expect(route_input.goes_to_exit?).to be false
+      end
+    end
+  end
+
   describe "#condition_attributes" do
     it "returns nil if the route is to the default next page" do
       route_input.goto = default_value
@@ -95,6 +111,13 @@ RSpec.describe Forms::RouteInput, type: :model do
       route_input.goto = GotoValue::Page.new(123)
       expect(route_input.condition_attributes).to eq(
         { goto_page_id: 123, skip_to_end: false, check_page_id: page.id },
+      )
+    end
+
+    it "returns attributes for an exit page" do
+      route_input.goto = GotoValue::ExitPage.new(999)
+      expect(route_input.condition_attributes).to eq(
+        { goto_page_id: nil, skip_to_end: false, check_page_id: page.id, exit_page_id: 999 },
       )
     end
   end

--- a/spec/models/goto_value_type_spec.rb
+++ b/spec/models/goto_value_type_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe GotoValueType do
       expect(type.cast("page_5")).to eq(GotoValue::Page.new(5))
     end
 
+    it "casts an 'exit_page_<id>' string to an ExitPage" do
+      expect(type.cast("exit_page_9")).to eq(GotoValue::ExitPage.new(9))
+    end
+
     it "returns already-cast values unchanged" do
       value = GotoValue::Page.new(5)
       expect(type.cast(value)).to equal(value)

--- a/spec/requests/routes_controller_spec.rb
+++ b/spec/requests/routes_controller_spec.rb
@@ -77,6 +77,19 @@ RSpec.describe RoutesController, type: :request do
         post routes_path(form.id), params: valid_params
         expect(flash[:success]).to eq I18n.t("banner.success.form.routing_saved")
       end
+
+      context "when new_exit_page is passed in the params" do
+        let(:valid_params) do
+          super().merge(
+            new_exit_page: pages.first.id,
+          )
+        end
+
+        it "redirects to the new exit page path" do
+          post routes_path(form.id), params: valid_params
+          expect(response).to redirect_to(new_exit_page_path(form, pages.first.id))
+        end
+      end
     end
 
     context "when the user is not in the form's group" do

--- a/spec/services/routes/build_service_spec.rb
+++ b/spec/services/routes/build_service_spec.rb
@@ -170,6 +170,32 @@ RSpec.describe Routes::BuildService do
             expect(route_for_no.id).to eq(condition_for_no.id)
           end
         end
+
+        context "with exit page conditions" do
+          let!(:conditions) do
+            [
+              create(:condition, form:, routing_page: pages.first, exit_page_id: exit_page.id, answer_value: "Yes"),
+            ]
+          end
+          let(:exit_page) { create(:exit_page, heading: "exit", markdown: "asjdkla") }
+
+          it "assigns the correct goto values based on the conditions" do
+            routes_for_page1 = service.build_routes.select { |r| r.page_id == pages.first.id }
+            route_for_yes = routes_for_page1.find { |r| r.answer_value == "Yes" }
+
+            expect(routes_for_page1.length).to eq(2)
+            expect(route_for_yes.goto).to eq(GotoValue::ExitPage.new(exit_page.id))
+          end
+
+          it "assigns correct condition IDs" do
+            routes_for_page1 = service.build_routes.select { |r| r.page_id == pages.first.id }
+            condition_for_yes = conditions.find { |c| c.answer_value == "Yes" }
+
+            route_for_yes = routes_for_page1.find { |r| r.answer_value == "Yes" }
+
+            expect(route_for_yes.id).to eq(condition_for_yes.id)
+          end
+        end
       end
 
       context "with a selection page (checkboxes)" do
@@ -220,6 +246,31 @@ RSpec.describe Routes::BuildService do
           ]
 
           expect(service.options_for_goto_page(pages.third, GotoValue::Page.new(pages.first.id))).to match_array(expected_options)
+        end
+      end
+
+      context "when the page has exit pages" do
+        let(:pages) do
+          create_list(:page, 3) do |page, i|
+            page.position = i + 1
+            page.question_text = "question #{i + 1}"
+          end
+        end
+        let!(:exit_page) { create(:exit_page, question_page: pages.third, heading: "Sorry, you cannot use this service") }
+
+        it "includes the exit pages in the options" do
+          expected_options = [
+            ["Exit page 1: Sorry, you cannot use this service", GotoValue::ExitPage.new(exit_page.id)],
+            ["End of the form", GotoValue::DefaultValue.new],
+          ]
+
+          expect(service.options_for_goto_page(pages.third)).to match_array(expected_options)
+        end
+      end
+
+      context "when the selected value is not a page (e.g. an exit page)" do
+        it "does not raise an error" do
+          expect { service.options_for_goto_page(pages.third, GotoValue::ExitPage.new(999)) }.not_to raise_error
         end
       end
     end

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -244,6 +244,12 @@ describe "routes/show.html.erb" do
         end
       end
 
+      it "has a button for adding exit pages" do
+        render_page
+        expect(rendered).to have_button("Add a new exit page")
+        expect(rendered).to have_selector("button[name='new_exit_page'][value='#{pages.first.id}']")
+      end
+
       context "with more than 10 options" do
         let(:selection_options) do
           (1..11).map do |i|

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -210,6 +210,50 @@ describe "routes/show.html.erb" do
       end
     end
 
+    context "when the final page is a selection page" do
+      let(:pages) do
+        [
+          build_stubbed(:page, id: 101),
+          build_stubbed(:page, id: 102),
+          build_stubbed(
+            :page,
+            :with_selection_settings,
+            id: 103,
+            routing_conditions: [
+              build_stubbed(
+                :condition,
+                routing_page_id: 103,
+                goto_page_id: 101,
+                answer_value: "Option 1",
+              ),
+            ],
+          ),
+        ]
+      end
+
+      let(:routes_input) do
+        build(:routes_input, form:).assign_form_values.tap do |routes_input|
+          routes_input.routes.each { |route| allow(route).to receive(:invalid?).and_return(true) }
+        end
+      end
+
+      it "shows the selected goto page for the route" do
+        render_page
+
+        expect(rendered).to have_selector('.govuk-select[name="forms_routes_input[routes_attributes][1][goto]"]') do |field|
+          expect(field).to have_selector("option[selected]") do |option|
+            expect(option["value"]).to eq "default"
+          end
+        end
+      end
+
+      it "has a button for adding exit pages" do
+        render_page
+        expect(rendered).to have_button("Add a new exit page")
+        expect(rendered).to have_selector("button[name='new_exit_page'][value='#{pages.last.id}']")
+      end
+    end
+
     context "when a page is a select from a list question" do
       let(:pages) do
         [

--- a/spec/views/routes/show.html.erb_spec.rb
+++ b/spec/views/routes/show.html.erb_spec.rb
@@ -290,6 +290,28 @@ describe "routes/show.html.erb" do
     end
   end
 
+  context "when the page has an exit page" do
+    let!(:pages) do
+      [
+        create(
+          :page,
+          id: 101,
+        ),
+        create(:page, id: 102),
+        create(:page, id: 103),
+      ]
+    end
+    let!(:exit_page) { create(:exit_page, id: 884, question_page_id: pages.first.id, heading: "Can't continue", markdown: "You can't continue") }
+    let!(:another_exit_page) { create(:exit_page, id: 999, question_page_id: pages.first.id, heading: "Stop using this form", markdown: "You can't continue") }
+
+    it "has links to the exit pages" do
+      render_page
+      expect(rendered).to have_selector("h2", text: "Question 1’s exit pages", normalize_ws: true)
+      expect(rendered).to have_link("Exit page 1: Can't continue", href: edit_exit_page_path(form.id, pages.first.id, exit_page.id))
+      expect(rendered).to have_link("Exit page 2: Stop using this form", href: edit_exit_page_path(form.id, pages.first.id, another_exit_page.id))
+    end
+  end
+
   context "when there are not enough pages" do
     let(:pages) do
       [


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/GQ6Qdn8N/3211-add-exit-pages-to-the-edit-question-routes-page-new-style-exit-pages-only

This PR adds exit pages as an option to send routes to.

To do that, we add a new GotoValue to represent exit pages, define how to convert them from and to conditions and add them to the list of options for pages.

We also add a new exit page button and a list of links to edit the existing exit pages for a page.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
