### PR TITLE
Return asset paths from the brands API

### DIFF
--- a/app/controllers/api/brands_controller.rb
+++ b/app/controllers/api/brands_controller.rb
@@ -1,7 +1,10 @@
 class Api::BrandsController < ApplicationController
   def show
     expires_in 5.minutes, public: true
-    render json: brand.as_json(only: %i[name slug header_background_colour border_colour logo_alt_text logo_link copyright_holder])
+    render json: brand.as_json(
+      only: %i[name slug header_background_colour border_colour logo_alt_text logo_link copyright_holder],
+      methods: %i[logo_path favicon_path opengraph_image_path],
+    )
   end
 
 private

--- a/app/helpers/brands_helper.rb
+++ b/app/helpers/brands_helper.rb
@@ -1,5 +1,0 @@
-module BrandsHelper
-  def brand_asset_path(attachment)
-    "/#{attachment.blob.key}" if attachment.attached?
-  end
-end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -21,4 +21,24 @@ class Brand < ApplicationRecord
   validates :logo_file, file_content_type: { in: ASSET_CONTENT_TYPES[:logo] }
   validates :favicon_file, file_content_type: { in: ASSET_CONTENT_TYPES[:favicon] }
   validates :opengraph_image_file, file_content_type: { in: ASSET_CONTENT_TYPES[:opengraph_image] }
+
+  def logo_path
+    asset_path(logo)
+  end
+
+  def favicon_path
+    asset_path(favicon)
+  end
+
+  def opengraph_image_path
+    asset_path(opengraph_image)
+  end
+
+private
+
+  # blob keys are paths under /assets/, which CloudFront serves from the
+  # assets bucket
+  def asset_path(attachment)
+    "/#{attachment.blob.key}" if attachment.attached?
+  end
 end

--- a/app/views/brands/edit.html.erb
+++ b/app/views/brands/edit.html.erb
@@ -26,17 +26,17 @@
       <%= f.govuk_text_field :copyright_holder, label: { size: 'm' } %>
 
       <% if @brand.logo.attached? %>
-        <p class="govuk-body"><%= t(".current_file", file_name: t("helpers.label.brand.logo_file"), path: brand_asset_path(@brand.logo)) %></p>
+        <p class="govuk-body"><%= t(".current_file", file_name: t("helpers.label.brand.logo_file"), path: @brand.logo_path) %></p>
       <% end %>
       <%= f.govuk_file_field :logo_file, label: { size: 'm' } %>
 
       <% if @brand.favicon.attached? %>
-        <p class="govuk-body"><%= t(".current_file", file_name: t("helpers.label.brand.favicon_file"), path: brand_asset_path(@brand.favicon)) %></p>
+        <p class="govuk-body"><%= t(".current_file", file_name: t("helpers.label.brand.favicon_file"), path: @brand.favicon_path) %></p>
       <% end %>
       <%= f.govuk_file_field :favicon_file, label: { size: 'm' } %>
 
       <% if @brand.opengraph_image.attached? %>
-        <p class="govuk-body"><%= t(".current_file", file_name: t("helpers.label.brand.opengraph_image_file"), path: brand_asset_path(@brand.opengraph_image)) %></p>
+        <p class="govuk-body"><%= t(".current_file", file_name: t("helpers.label.brand.opengraph_image_file"), path: @brand.opengraph_image_path) %></p>
       <% end %>
       <%= f.govuk_file_field :opengraph_image_file, label: { size: 'm' } %>
 

--- a/app/views/brands/show.html.erb
+++ b/app/views/brands/show.html.erb
@@ -38,17 +38,17 @@
 
       summary_list.with_row do |row|
         row.with_key { t('brands.show.summary.logo') }
-        row.with_value { brand_asset_path(@brand.logo) || t('brands.show.summary.not_uploaded') }
+        row.with_value { @brand.logo_path || t('brands.show.summary.not_uploaded') }
       end
 
       summary_list.with_row do |row|
         row.with_key { t('brands.show.summary.favicon') }
-        row.with_value { brand_asset_path(@brand.favicon) || t('brands.show.summary.not_uploaded') }
+        row.with_value { @brand.favicon_path || t('brands.show.summary.not_uploaded') }
       end
 
       summary_list.with_row do |row|
         row.with_key { t('brands.show.summary.opengraph_image') }
-        row.with_value { brand_asset_path(@brand.opengraph_image) || t('brands.show.summary.not_uploaded') }
+        row.with_value { @brand.opengraph_image_path || t('brands.show.summary.not_uploaded') }
       end
 
       summary_list.with_row do |row|

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -104,6 +104,21 @@ RSpec.describe Brand, type: :model do
     end
   end
 
+  describe "asset paths" do
+    %i[logo favicon opengraph_image].each do |asset_name|
+      it "returns nil when no #{asset_name.to_s.humanize.downcase} is attached" do
+        expect(brand.public_send(:"#{asset_name}_path")).to be_nil
+      end
+    end
+
+    it "returns the attached asset's key as an absolute path" do
+      brand = create :brand, slug: "testshire", logo_file: Rack::Test::UploadedFile.new(file_fixture("logo.png"))
+      BrandAssetsService.new(brand:).attach_assets
+
+      expect(brand.logo_path).to match %r{\A/assets/brands/testshire/logo-\h{6}\.png\z}
+    end
+  end
+
   it "is an error to insert a brand with an existing slug" do
     existing_brand = create(:brand)
 

--- a/spec/requests/api/brands_controller_spec.rb
+++ b/spec/requests/api/brands_controller_spec.rb
@@ -33,7 +33,29 @@ RSpec.describe Api::BrandsController, type: :request do
           "logo_alt_text" => "Golden Zephyr Council",
           "logo_link" => "https://www.goldenzephyr.example.com",
           "copyright_holder" => "Golden Zephyr Council",
+          "logo_path" => nil,
+          "favicon_path" => nil,
+          "opengraph_image_path" => nil,
         })
+      end
+
+      context "when the brand has assets attached" do
+        let(:brand) do
+          create(:brand, slug: "golden-zephyr").tap do |brand|
+            brand.logo_file = fixture_file_upload("logo.png", "image/png")
+            brand.favicon_file = fixture_file_upload("favicon.ico", "image/vnd.microsoft.icon")
+            brand.opengraph_image_file = fixture_file_upload("logo.jpeg", "image/jpeg")
+            BrandAssetsService.new(brand:).attach_assets
+          end
+        end
+
+        it "returns the asset paths" do
+          expect(response.parsed_body).to include({
+            "logo_path" => match(%r{\A/assets/brands/golden-zephyr/logo-\h{6}\.png\z}),
+            "favicon_path" => match(%r{\A/assets/brands/golden-zephyr/favicon-\h{6}\.ico\z}),
+            "opengraph_image_path" => match(%r{\A/assets/brands/golden-zephyr/opengraph-image-\h{6}\.jpg\z}),
+          })
+        end
       end
 
       it "sets the response to be cached for 5 minutes" do


### PR DESCRIPTION
### What problem does this pull request solve?

Brands can now have a logo, favicon and opengraph image uploaded, but the brands API doesn't tell forms-runner where to find them.

This adds the asset paths to the API response. The paths are relative because the assets will be served through CloudFront on the runner's own domain rather than from forms-admin. Assets that haven't been uploaded are returned as null, so consumers always see the same keys.
