### PR TITLE
Increment version when form made live

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -235,7 +235,7 @@ class Form < ApplicationRecord
     live_document = latest_live_or_archived_form_document(language:)
     return false if live_document.blank?
 
-    ignored_keys = %w[live_at available_languages updated_at]
+    ignored_keys = %w[live_at available_languages updated_at tag created_at version]
     return false if live_document.content.except(*ignored_keys) == as_form_document(language:).except(*ignored_keys)
 
     true

--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -11,9 +11,6 @@ class FormDocumentSyncService
 
   def synchronize_live_form
     FormDocument.transaction do
-      # A new live version replaces any previous archived version
-      delete_form_documents_by_tag(ARCHIVED_TAG)
-
       synchronize_documents_for_tag(LIVE_TAG, live_at: form.updated_at)
     end
   end
@@ -52,9 +49,6 @@ class FormDocumentSyncService
       # If we've already made the Welsh version live, changes to the Welsh version must be made live at the same time by calling a different method
       raise ActiveRecord::RecordNotFound, "Cannot make changes to only the live English form if there is already a live Welsh version." if form.has_live_welsh_translation?
 
-      # A new live version replaces any previous archived version
-      delete_form_documents_by_tag(ARCHIVED_TAG)
-
       content = form_content("en", live_at: form.updated_at)
       content["available_languages"] = %w[en] # don't include Welsh in available languages
       create_new_versioned_form_document(LIVE_TAG, content, "en", version_number_of_existing_form_document + 1)
@@ -67,9 +61,6 @@ class FormDocumentSyncService
 
       # Ensure we only make Welsh version live if there is already an existing live English version
       raise ActiveRecord::RecordNotFound, "Cannot make Welsh version live unless there is already a live English version." unless english_form_document&.tag == LIVE_TAG
-
-      # A new live version replaces the archived version
-      delete_form_documents_by_tag(ARCHIVED_TAG)
 
       content = form_content("cy", live_at: form.updated_at)
       new_version_number = english_form_document.version + 1
@@ -100,8 +91,8 @@ private
         update_or_create_form_document(tag, content, language, version)
       end
 
-      # Clean up any documents for languages no longer used by the form
-      delete_form_documents_for_unused_languages(tag)
+      # Delete any draft documents for languages no longer used by the form
+      delete_draft_form_documents_for_unused_languages
     end
   end
 
@@ -139,12 +130,8 @@ private
     form.update_column(:latest_form_document_id, form_document.id) if language == "en" && tag == LIVE_TAG
   end
 
-  def delete_form_documents_by_tag(tag)
-    form_documents_by_tag(tag).delete_all
-  end
-
-  def delete_form_documents_for_unused_languages(tag)
-    form_documents_by_tag(tag)
+  def delete_draft_form_documents_for_unused_languages
+    form_documents_by_tag(DRAFT_TAG)
       .where.not(language: form.available_languages)
       .delete_all
   end

--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -49,14 +49,14 @@ class FormDocumentSyncService
   def synchronize_only_live_english_form
     FormDocument.transaction do
       # If we've already made the Welsh version live, changes to the Welsh version must be made live at the same time by calling a different method
-      raise ActiveRecord::RecordNotFound, "Cannot make changes to only the live English form if there is already a live Welsh version." if FormDocument.where(form:, tag: LIVE_TAG, language: "cy").exists?
+      raise ActiveRecord::RecordNotFound, "Cannot make changes to only the live English form if there is already a live Welsh version." if form.has_live_welsh_translation?
 
       # A new live version replaces any previous archived version
       delete_form_documents_by_tag(ARCHIVED_TAG)
 
       content = form_content("en", live_at: form.updated_at)
       content["available_languages"] = %w[en] # don't include Welsh in available languages
-      update_or_create_form_document(LIVE_TAG, content, "en")
+      create_new_versioned_form_document(LIVE_TAG, content, "en", version_number_of_existing_form_document + 1)
     end
   end
 
@@ -100,13 +100,32 @@ private
   end
 
   def update_or_create_form_document(tag, content, language)
+    if tag == DRAFT_TAG
+      update_or_create_draft_form_document(content, language)
+    else
+      create_new_versioned_form_document(tag, content, language, version_number_of_existing_form_document + 1)
+    end
+  end
+
+  def update_or_create_draft_form_document(content, language)
     form_document = FormDocument.find_or_initialize_by(
       form_id: form.id,
-      tag:,
+      tag: DRAFT_TAG,
       language:,
     )
     form_document.content = content
-    form_document.version = 1 if tag == LIVE_TAG
+
+    form_document.save!
+  end
+
+  def create_new_versioned_form_document(tag, content, language, version)
+    form_document = FormDocument.new(
+      form_id: form.id,
+      tag:,
+      language:,
+      content:,
+      version:,
+    )
 
     form_document.save!
 
@@ -136,5 +155,9 @@ private
     Mobility.with_locale(language) do
       form.as_form_document(language:, **options)
     end
+  end
+
+  def version_number_of_existing_form_document
+    form.latest_form_document&.version || 0
   end
 end

--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -62,20 +62,23 @@ class FormDocumentSyncService
 
   def synchronize_only_live_welsh_form
     FormDocument.transaction do
-      live_english_form_document = FormDocument.find_by(form:, tag: LIVE_TAG, language: "en")
+      english_form_document = form.latest_form_document
 
       # Ensure we only make Welsh version live if there is already an existing live English version
-      raise ActiveRecord::RecordNotFound, "Cannot make Welsh version live unless there is already a live English version." unless live_english_form_document
+      raise ActiveRecord::RecordNotFound, "Cannot make Welsh version live unless there is already a live English version." unless english_form_document&.tag == LIVE_TAG
 
       # A new live version replaces the archived version
       delete_form_documents_by_tag(ARCHIVED_TAG)
 
       content = form_content("cy", live_at: form.updated_at)
-      update_or_create_form_document(LIVE_TAG, content, "cy")
+      new_version_number = english_form_document.version + 1
 
-      # Update the content of the live English version to show that it now supports Welsh
-      live_english_form_document.content["available_languages"] = %w[en cy]
-      live_english_form_document.save!
+      create_new_versioned_form_document(LIVE_TAG, content, "cy", new_version_number)
+
+      # Create a new live English form document with the available languages updated
+      english_content = english_form_document.content
+      english_content["available_languages"] = %w[en cy]
+      create_new_versioned_form_document(LIVE_TAG, english_content, "en", new_version_number)
     end
   end
 
@@ -87,11 +90,13 @@ private
 
   # Create/update documents for all languages for a specific tag
   def synchronize_documents_for_tag(tag, **content_options)
+    version = tag == DRAFT_TAG ? nil : version_number_of_existing_form_document + 1
+
     FormDocument.transaction do
       form.normalise_welsh!
       form.available_languages.each do |language|
         content = form_content(language, **content_options)
-        update_or_create_form_document(tag, content, language)
+        update_or_create_form_document(tag, content, language, version)
       end
 
       # Clean up any documents for languages no longer used by the form
@@ -99,11 +104,11 @@ private
     end
   end
 
-  def update_or_create_form_document(tag, content, language)
+  def update_or_create_form_document(tag, content, language, version)
     if tag == DRAFT_TAG
       update_or_create_draft_form_document(content, language)
     else
-      create_new_versioned_form_document(tag, content, language, version_number_of_existing_form_document + 1)
+      create_new_versioned_form_document(tag, content, language, version)
     end
   end
 

--- a/app/services/form_document_sync_service.rb
+++ b/app/services/form_document_sync_service.rb
@@ -30,17 +30,18 @@ class FormDocumentSyncService
 
   def synchronize_archived_welsh_form
     FormDocument.transaction do
-      live_welsh_form_document = FormDocument.find_by(form:, tag: LIVE_TAG, language: "cy")
+      raise ActiveRecord::RecordNotFound, "Cannot archive a form that has no live version." unless form.has_live_welsh_translation?
 
-      raise ActiveRecord::RecordNotFound, "Cannot archive a form that has no live version." unless live_welsh_form_document
+      welsh_form_document = form.latest_welsh_form_document
+      welsh_form_document.update!(tag: ARCHIVED_TAG)
 
-      live_welsh_form_document.update!(tag: ARCHIVED_TAG)
+      draft_form_document = form.draft_form_document
+      draft_form_document.content["available_languages"].delete("cy")
+      draft_form_document.save!
 
-      # Update the content of the live version to show that it doesn't support welsh anymore
-      FormDocument.where(form:, tag: [LIVE_TAG, DRAFT_TAG], language: "en").find_each do |live_document|
-        live_document.content["available_languages"].delete("cy")
-        live_document.save!
-      end
+      english_content = form.latest_form_document.content
+      english_content["available_languages"] = %w[en]
+      create_new_versioned_form_document(LIVE_TAG, english_content, "en", version_number_of_existing_form_document + 1)
 
       form.update_columns(available_languages: %w[en], welsh_completed: false)
     end

--- a/spec/services/form_copy_service_spec.rb
+++ b/spec/services/form_copy_service_spec.rb
@@ -332,12 +332,12 @@ RSpec.describe FormCopyService do
       end
 
       it "copies the Welsh-translated content from the source form" do
-        source_welsh = source_form.form_documents.find_by(language: "cy", tag: "live")
+        source_welsh = source_form.form_documents.order(version: :desc).find_by(language: "cy", tag: "live")
         expect(source_welsh).to be_present
         expect(source_welsh.content["name"]).to eq("Ffurflen Gymraeg")
 
         # Copied form should have Welsh FormDocument with translated content
-        copied_welsh = copied_form.form_documents.find_by(language: "cy", tag: "draft")
+        copied_welsh = copied_form.form_documents.order(version: :desc).find_by(language: "cy", tag: "draft")
         expect(copied_welsh).to be_present
         expect(copied_welsh.content["name"]).to eq("Copy of Ffurflen Gymraeg")
         expect(copied_welsh.content["privacy_policy_url"]).to eq("https://example.com/preifatrwydd")
@@ -401,9 +401,9 @@ RSpec.describe FormCopyService do
       context "when there are multiple versions of the live form" do
         before do
           welsh_content = source_form.latest_welsh_form_document.content.merge({ "what_happens_next_markdown" => "New Welsh content" })
-          create(:form_document, :live, form: source_form, version: 2, language: "cy", content: welsh_content)
+          create(:form_document, :live, form: source_form, version: 3, language: "cy", content: welsh_content)
 
-          new_english_form_document = create(:form_document, :live, form: source_form, version: 2, language: "en", content: source_form.as_form_document)
+          new_english_form_document = create(:form_document, :live, form: source_form, version: 3, language: "en", content: source_form.as_form_document)
           source_form.update!(latest_form_document: new_english_form_document)
         end
 

--- a/spec/services/form_document_sync_service_spec.rb
+++ b/spec/services/form_document_sync_service_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe FormDocumentSyncService do
       it "creates a new live form document with the new content" do
         new_name = "new name"
         form.name = new_name
+        form.save!
         expect {
           service.synchronize_live_form
         }.to change { form.reload.latest_form_document.content["name"] }.to(new_name)
@@ -88,29 +89,20 @@ RSpec.describe FormDocumentSyncService do
       end
     end
 
-    context "when the form has welsh translations" do
-      let(:form) { create(:form, state: "live", available_languages: %w[en cy]) }
+    context "when the form has Welsh translations" do
+      let(:form) { create(:form, :live, :with_welsh_translation) }
 
-      it "creates a draft form document for each language" do
+      it "creates live form documents with an incremented version number" do
         expect {
           service.synchronize_live_form
         }.to change(FormDocument, :count).by(2)
-
-        expect(FormDocument.where(form:, tag: "draft", language: "en")).to exist
-        expect(FormDocument.where(form:, tag: "draft", language: "cy")).to exist
-      end
-
-      it "creates live form documents with version 1" do
-        service.synchronize_live_form
-        english_doc = form.reload.latest_form_document
-        welsh_doc = form.reload.latest_welsh_form_document
-        expect(english_doc.version).to eq(1)
-        expect(welsh_doc.version).to eq(1)
+        .and change { form.reload.latest_form_document.version }.by(1)
+        .and change { form.reload.latest_welsh_form_document.version }.by(1)
       end
 
       it "sets the latest_form_document_id on the form to the English form document" do
         service.synchronize_live_form
-        expect(form.reload.latest_form_document_id).to eq(FormDocument.find_by(form:, tag: "live", language: "en").id)
+        expect(form.reload.latest_form_document_id).to eq(FormDocument.order(version: :desc).find_by(form:, tag: "live", language: "en").id)
       end
 
       context "and the Welsh form fails to save" do
@@ -118,7 +110,7 @@ RSpec.describe FormDocumentSyncService do
           allow(service).to receive(:update_or_create_form_document).and_call_original
           # saving welsh form fails
           allow(service).to receive(:update_or_create_form_document)
-            .with("live", anything, "cy")
+            .with("live", anything, "cy", anything)
             .and_raise(ActiveRecord::RecordInvalid.new(form), "simulated FormDocument saving error")
         end
 
@@ -413,7 +405,7 @@ RSpec.describe FormDocumentSyncService do
   end
 
   describe "#synchronize_only_live_welsh_form" do
-    let!(:form) { create(:form, :with_welsh_translation, :ready_for_live, state: "live") }
+    let!(:form) { create(:form, :with_welsh_translation, :ready_for_live, state: "live", available_languages: %w[en]) }
     let(:expected_live_at) { form.reload.updated_at.as_json }
     let(:welsh_form_content) do
       Mobility.with_locale(:cy) do
@@ -423,49 +415,67 @@ RSpec.describe FormDocumentSyncService do
 
     context "when there is a live English form document" do
       before do
-        form_document = create :form_document, :live, form:, language: "en", content: { "available_languages" => %w[en] }
+        form_document = create :form_document, :live, form:, language: "en", content: form.as_form_document
         form.latest_form_document_id = form_document.id
+        form.available_languages = %w[en cy]
+        form.save!
       end
 
       context "when there is no existing Welsh form document" do
-        it "only creates a live Welsh form document" do
+        it "creates a live Welsh form document" do
           expect {
             service.synchronize_only_live_welsh_form
-          }.to change { FormDocument.where(form:, tag: "live", language: "cy").count }.by(1)
-          .and(not_change { FormDocument.where(form:, tag: "live", language: "en").count })
+          }.to change { FormDocument.exists?(form:, tag: "live", language: "cy") }.from(false).to(true)
 
-          welsh_form_document = FormDocument.where(form:, tag: "live", language: "cy").first
+          welsh_form_document = form.reload.latest_welsh_form_document
           expect(welsh_form_document.content["available_languages"]).to eq %w[en cy]
-          expect(welsh_form_document.version).to eq 1
+          expect(welsh_form_document.version).to eq 2
           expect(welsh_form_document).to have_attributes(form:, tag: "live", content: welsh_form_content)
         end
 
-        it "does not change the latest_live_form_document_id" do
+        it "creates a new English form document with only the available_languages field changed from the previous live document" do
+          new_name = "New name"
+          form.name = new_name
+          form.save!
+
           expect {
             service.synchronize_only_live_welsh_form
-          }.to(not_change { form.reload.latest_form_document_id })
+          }.to change { FormDocument.where(form:, tag: "live", language: "en").count }.by(1)
+          .and change { form.reload.latest_form_document.version }.by(1)
+          .and change { form.reload.latest_form_document.content["available_languages"] }.to(%w[en cy])
+          .and not_change { form.reload.latest_form_document.content["name"] }
+          .and(not_change { form.reload.latest_form_document.content["live_at"] })
+        end
+
+        it "updates the latest_live_form_document_id" do
+          expect {
+            service.synchronize_only_live_welsh_form
+          }.to(change { form.reload.latest_form_document_id })
         end
       end
 
       context "when there is an existing live Welsh form document" do
         let!(:form_document) { create :form_document, :live, form:, language: "cy", content: welsh_form_content, version: 1 }
 
-        it "updates the live form document" do
+        it "creates a new live Welsh form document with the new content" do
           new_name = "new name"
           form.name_cy = new_name
+          form.save!
+
           expect {
             service.synchronize_only_live_welsh_form
-          }.to change { form_document.reload.content["name"] }.to(new_name)
+          }.to change { form.reload.latest_welsh_form_document.content["name"] }.to(new_name)
         end
 
-        it "updates the live_at date in the form document" do
+        it "sets the live_at date in the new form document" do
           service.synchronize_only_live_welsh_form
-          expect(FormDocument.last["content"]).to include("live_at" => form.reload.updated_at.as_json)
+          expect(form.reload.latest_welsh_form_document.content).to include("live_at" => form.reload.updated_at.as_json)
         end
 
-        it "increments the version by 1" do
+        it "increments the English and Welsh versions by 1" do
           service.synchronize_only_live_welsh_form
-          expect(form_document.reload.version).to eq(1)
+          expect(form.reload.latest_form_document.version).to eq(2)
+          expect(form.reload.latest_welsh_form_document.version).to eq(2)
         end
       end
 

--- a/spec/services/form_document_sync_service_spec.rb
+++ b/spec/services/form_document_sync_service_spec.rb
@@ -158,34 +158,47 @@ RSpec.describe FormDocumentSyncService do
       let!(:live_form_document_cy) { create :form_document, :live, form:, language: "cy", content: { "available_languages" => %w[en cy] } }
       let!(:live_form_document_en) { create :form_document, :live, form:, language: "en", content: { "available_languages" => %w[en cy] } }
 
-      it "updates the live welsh form document to be archived" do
+      before do
+        form.latest_form_document = live_form_document_en
+        form.save!
+      end
+
+      it "updates the live Welsh form document to be archived" do
         expect {
           service.synchronize_archived_form
         }.to(change { live_form_document_cy.reload.tag }.from("live").to("archived"))
       end
 
-      it "changes the available languages in form to only include English" do
+      it "changes the available languages in the form to only include English" do
         expect {
           service.synchronize_archived_welsh_form
         }.to(change(form, :available_languages).from(%w[en cy]).to(%w[en]))
       end
 
-      it "changes the welsh completed in form to false" do
+      it "changes the Welsh completed status in the form to false" do
         expect {
           service.synchronize_archived_welsh_form
         }.to(change(form, :welsh_completed).from(true).to(false))
       end
 
-      it "changes the available languages in the draft english form document to only include English" do
+      it "changes the available languages in the draft English form document to only include English" do
         expect {
           service.synchronize_archived_welsh_form
         }.to(change { form.draft_form_document.reload.content["available_languages"] }.from(%w[en cy]).to(%w[en]))
       end
 
-      it "changes the available languages in the live english form document to only include English" do
+      it "creates a new live English form document with an updated available languages field" do
         expect {
           service.synchronize_archived_welsh_form
-        }.to(change { live_form_document_en.reload.content["available_languages"] }.from(%w[en cy]).to(%w[en]))
+        }.to change { form.reload.latest_form_document.content["available_languages"] }.from(%w[en cy]).to(%w[en])
+        .and change { form.reload.form_documents.count }.by(1)
+        .and change { form.reload.latest_form_document.version }.by(1)
+      end
+
+      it "does not change the available languages in the existing live English form document" do
+        expect {
+          service.synchronize_archived_welsh_form
+        }.to not_change { live_form_document_en.reload.content["available_languages"] }.from(%w[en cy])
       end
     end
   end

--- a/spec/services/form_document_sync_service_spec.rb
+++ b/spec/services/form_document_sync_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FormDocumentSyncService do
           service.synchronize_live_form
         }.to change(FormDocument, :count).by(1)
 
-        expect(FormDocument.last).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at), version: 1)
+        expect(form.latest_form_document).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at), version: 1)
       end
 
       it "sets the latest_form_document_id on the form" do
@@ -26,22 +26,34 @@ RSpec.describe FormDocumentSyncService do
     context "when there is an existing live form document" do
       let!(:form_document) { create :form_document, :live, form:, content: form.as_form_document, version: 1 }
 
-      it "updates the live form document" do
+      before do
+        form.latest_form_document = form_document
+        form.save!
+      end
+
+      it "increments the latest form document with a new version" do
+        expect {
+          service.synchronize_live_form
+        }.to change { form.reload.latest_form_document.version }.from(1).to(2)
+      end
+
+      it "creates a new live form document with the new content" do
         new_name = "new name"
         form.name = new_name
         expect {
           service.synchronize_live_form
-        }.to change { form_document.reload.content["name"] }.to(new_name)
+        }.to change { form.reload.latest_form_document.content["name"] }.to(new_name)
       end
 
-      it "updates the live_at date in the form document" do
+      it "sets the live_at date in the new form document" do
         service.synchronize_live_form
-        expect(FormDocument.last["content"]).to include("live_at" => form.reload.updated_at.as_json)
+        expect(form.reload.latest_form_document.content).to include("live_at" => form.reload.updated_at.as_json)
       end
 
-      it "maintains the version as 1" do
-        service.synchronize_live_form
-        expect(form_document.reload.version).to eq(1)
+      it "does not change the version of the existing form document" do
+        expect {
+          service.synchronize_live_form
+        }.not_to(change { form_document.reload.version })
       end
     end
 
@@ -90,8 +102,8 @@ RSpec.describe FormDocumentSyncService do
 
       it "creates live form documents with version 1" do
         service.synchronize_live_form
-        english_doc = FormDocument.find_by(form:, tag: "live", language: "en")
-        welsh_doc = FormDocument.find_by(form:, tag: "live", language: "cy")
+        english_doc = form.reload.latest_form_document
+        welsh_doc = form.reload.latest_welsh_form_document
         expect(english_doc.version).to eq(1)
         expect(welsh_doc.version).to eq(1)
       end
@@ -282,34 +294,48 @@ RSpec.describe FormDocumentSyncService do
           service.synchronize_only_live_english_form
         }.to change(FormDocument, :count).by(1)
 
-        expect(FormDocument.last).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at), version: 1)
+        expect(FormDocument.order(version: :desc).last).to have_attributes(form:, tag: "live", content: form.as_form_document(live_at: expected_live_at), version: 1)
       end
 
       it "sets the latest_form_document_id on the form" do
         service.synchronize_only_live_english_form
-        expect(form.reload.latest_form_document_id).to eq(FormDocument.find_by(form:, tag: "live", language: "en").id)
+        expect(form.reload.latest_form_document_id).to eq(FormDocument.order(version: :desc).find_by(form:, tag: "live", language: "en").id)
       end
     end
 
     context "when there is an existing live form document" do
       let!(:form_document) { create :form_document, :live, form:, content: form.as_form_document }
 
+      before do
+        form.latest_form_document = form_document
+        form.save!
+      end
+
       it "updates the live form document" do
         new_name = "new name"
         form.name = new_name
+        form.save!
+
         expect {
           service.synchronize_only_live_english_form
-        }.to change { form_document.reload.content["name"] }.to(new_name)
+        }.to change { form.reload.latest_form_document.content["name"] }.to(new_name)
       end
 
-      it "updates the live_at date in the form document" do
+      it "sets the live_at date in the new form document" do
         service.synchronize_only_live_english_form
         expect(FormDocument.last["content"]).to include("live_at" => form.reload.updated_at.as_json)
       end
 
-      it "maintains the version as 1" do
-        service.synchronize_only_live_english_form
-        expect(form_document.reload.version).to eq(1)
+      it "creates a new English form document with an incremented version" do
+        expect {
+          service.synchronize_only_live_english_form
+        }.to change { form.reload.latest_form_document.version }.by(1)
+      end
+
+      it "does not change the existing form document's version" do
+        expect {
+          service.synchronize_only_live_english_form
+        }.not_to(change { form_document.reload.version })
       end
     end
 
@@ -360,8 +386,8 @@ RSpec.describe FormDocumentSyncService do
 
       context "and the English form fails to save" do
         before do
-          allow(service).to receive(:update_or_create_form_document)
-            .with("live", anything, "en")
+          allow(service).to receive(:create_new_versioned_form_document)
+            .with("live", anything, "en", anything)
             .and_raise(ActiveRecord::RecordInvalid.new(form), "simulated FormDocument saving error")
         end
 
@@ -437,7 +463,7 @@ RSpec.describe FormDocumentSyncService do
           expect(FormDocument.last["content"]).to include("live_at" => form.reload.updated_at.as_json)
         end
 
-        it "maintains the version as 1" do
+        it "increments the version by 1" do
           service.synchronize_only_live_welsh_form
           expect(form_document.reload.version).to eq(1)
         end

--- a/spec/services/form_document_sync_service_spec.rb
+++ b/spec/services/form_document_sync_service_spec.rb
@@ -59,33 +59,25 @@ RSpec.describe FormDocumentSyncService do
     end
 
     context "when there is an existing archived form document" do
+      let(:form) { create(:form, state: "archived") }
+      let(:form_document) { create :form_document, :archived, form:, version: 1 }
+
       before do
-        create :form_document, :archived, form:
+        form.latest_form_document_id = form_document.id
+        form.save!
       end
 
-      it "destroys the archived form document" do
+      it "retains the archived form document" do
         expect {
           service.synchronize_live_form
-        }.to(change { FormDocument.exists?(form:, tag: "archived") }.from(true).to(false))
+        }.not_to(change { FormDocument.where(form:, tag: "archived").count })
       end
 
-      it "creates the live form document" do
+      it "creates a new live form document" do
         expect {
           service.synchronize_live_form
-        }.to(change { FormDocument.exists?(form:, tag: "live") }.from(false).to(true))
-      end
-
-      context "and deleting the archived FormDocument fails" do
-        before do
-          allow(service).to receive(:delete_form_documents_by_tag).with(FormDocumentSyncService::ARCHIVED_TAG)
-            .and_raise(ActiveRecord::StatementInvalid)
-        end
-
-        it "does not create the live FormDocument" do
-          expect {
-            service.synchronize_live_form
-          }.to raise_error(ActiveRecord::StatementInvalid).and not_change(FormDocument, :count)
-        end
+        }.to change { FormDocument.where(form:, tag: "live").count }.from(0).to(1)
+        .and change { form.reload.latest_form_document.version }.from(1).to(2)
       end
     end
 
@@ -345,33 +337,25 @@ RSpec.describe FormDocumentSyncService do
     end
 
     context "when there is an existing archived form document" do
+      let(:form) { create(:form, state: "archived") }
+      let(:form_document) { create :form_document, :archived, form:, content: form.as_form_document, version: 1 }
+
       before do
-        create :form_document, :archived, form:
+        form.latest_form_document_id = form_document.id
+        form.save!
       end
 
-      it "destroys the archived form document" do
+      it "retains the archived form document" do
         expect {
           service.synchronize_only_live_english_form
-        }.to(change { FormDocument.exists?(form:, tag: "archived") }.from(true).to(false))
+        }.not_to(change { FormDocument.where(form:, tag: "archived").count })
       end
 
-      it "creates the live form document" do
+      it "creates a new live form document" do
         expect {
           service.synchronize_only_live_english_form
-        }.to(change { FormDocument.exists?(form:, tag: "live", version: 1) }.from(false).to(true))
-      end
-
-      context "and deleting the archived FormDocument fails" do
-        before do
-          allow(service).to receive(:delete_form_documents_by_tag).with(FormDocumentSyncService::ARCHIVED_TAG)
-            .and_raise(ActiveRecord::StatementInvalid)
-        end
-
-        it "does not create the live FormDocument" do
-          expect {
-            service.synchronize_only_live_english_form
-          }.to raise_error(ActiveRecord::StatementInvalid).and not_change(FormDocument, :count)
-        end
+        }.to change { FormDocument.where(form:, tag: "live").count }.from(0).to(1)
+        .and change { form.reload.latest_form_document.version }.from(1).to(2)
       end
     end
 
@@ -468,7 +452,9 @@ RSpec.describe FormDocumentSyncService do
       end
 
       context "when there is an existing live Welsh form document" do
-        let!(:form_document) { create :form_document, :live, form:, language: "cy", content: welsh_form_content, version: 1 }
+        before do
+          create :form_document, :live, form:, language: "cy", content: welsh_form_content, version: 1
+        end
 
         it "creates a new live Welsh form document with the new content" do
           new_name = "new name"
@@ -486,40 +472,37 @@ RSpec.describe FormDocumentSyncService do
         end
 
         it "increments the English and Welsh versions by 1" do
-          service.synchronize_only_live_welsh_form
-          expect(form.reload.latest_form_document.version).to eq(2)
-          expect(form.reload.latest_welsh_form_document.version).to eq(2)
+          expect {
+            service.synchronize_only_live_welsh_form
+          }.to change { form.reload.latest_form_document.version }.by(1)
+          .and change { form.reload.latest_welsh_form_document.version }.by(1)
         end
       end
 
       context "when there is an existing archived Welsh form document" do
+        let!(:form) { create(:form, state: "live_with_draft") }
+
         before do
-          create :form_document, :archived, form:, language: "cy"
+          live_english_form_document = create(:form_document, :live, form:, content: form.as_form_document, language: "en", version: 2)
+          create :form_document, :archived, form:, content: form.as_form_document, language: "cy", version: 2
+
+          form.latest_form_document_id = live_english_form_document.id
+          form.save!
         end
 
-        it "destroys the archived form document" do
+        it "retains the archived form document" do
           expect {
             service.synchronize_only_live_welsh_form
-          }.to(change { FormDocument.exists?(form:, tag: "archived", language: "cy") }.from(true).to(false))
+          }.not_to(change { FormDocument.where(form:, tag: "archived").count })
         end
 
-        it "creates the live form document" do
+        it "creates new live English and Welsh form documents" do
           expect {
             service.synchronize_only_live_welsh_form
-          }.to(change { FormDocument.exists?(form:, tag: "live", language: "cy") }.from(false).to(true))
-        end
-
-        context "and deleting the archived FormDocument fails" do
-          before do
-            allow(service).to receive(:delete_form_documents_by_tag).with(FormDocumentSyncService::ARCHIVED_TAG)
-              .and_raise(ActiveRecord::StatementInvalid)
-          end
-
-          it "does not create the live FormDocument" do
-            expect {
-              service.synchronize_only_live_welsh_form
-            }.to raise_error(ActiveRecord::StatementInvalid).and not_change(FormDocument, :count)
-          end
+          }.to change { FormDocument.where(form:, tag: "live", language: "en").count }.from(2).to(3)
+          .and change { FormDocument.where(form:, tag: "live", language: "cy").count }.from(0).to(1)
+          .and change { form.reload.latest_form_document.version }.by(1)
+          .and change { form.reload.latest_welsh_form_document&.version }.by(1)
         end
       end
     end

--- a/spec/services/make_form_live_service_spec.rb
+++ b/spec/services/make_form_live_service_spec.rb
@@ -90,7 +90,7 @@ describe MakeFormLiveService do
           expect {
             make_form_live_service.make_language_live
           }.to change(FormDocument.where(form: current_form, tag: "live", language: "cy"), :count).by(1)
-          .and not_change(FormDocument.where(form: current_form, tag: "live", language: "en"), :count)
+          .and change(FormDocument.where(form: current_form, tag: "live", language: "en"), :count).by(1)
         end
 
         it "does not call the SubmissionEmailMailer" do

--- a/spec/services/revert_draft_form_service_spec.rb
+++ b/spec/services/revert_draft_form_service_spec.rb
@@ -294,7 +294,7 @@ describe RevertDraftFormService do
 
         it "restores the Welsh FormDocument to match the live version" do
           # Get the original live Welsh FormDocument content
-          original_welsh_doc = FormDocument.find_by(form_id: live_form.id, tag: "live", language: "cy")
+          original_welsh_doc = FormDocument.order(version: :desc).find_by(form_id: live_form.id, tag: "live", language: "cy")
           expect(original_welsh_doc).to be_present
           original_welsh_name = original_welsh_doc.content["name"]
           expect(original_welsh_name).to eq("Ffurflen Gymraeg")
@@ -312,10 +312,10 @@ describe RevertDraftFormService do
 
       context "when there are multiple live form documents" do
         before do
-          welsh_content = live_form.latest_welsh_form_document.content.merge("name" => "Welsh form v2")
-          create(:form_document, :live, form: live_form, version: 2, language: "cy", content: welsh_content)
+          welsh_content = live_form.latest_welsh_form_document.content.merge("name" => "New Welsh form")
+          create(:form_document, :live, form: live_form, version: 3, language: "cy", content: welsh_content)
 
-          new_live_english_document = create(:form_document, :live, form: live_form, version: 2, language: "en", content: live_form.latest_form_document.content)
+          new_live_english_document = create(:form_document, :live, form: live_form, version: 3, language: "en", content: live_form.latest_form_document.content)
           live_form.update!(latest_form_document: new_live_english_document)
         end
 
@@ -325,7 +325,7 @@ describe RevertDraftFormService do
           live_form.reload
           restored_welsh_doc = live_form.draft_welsh_form_document
           expect(restored_welsh_doc).to be_present
-          expect(restored_welsh_doc.content["name"]).to eq("Welsh form v2")
+          expect(restored_welsh_doc.content["name"]).to eq("New Welsh form")
         end
       end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/TvSaepIJ/3232-increment-the-form-document-version-when-a-form-goes-live

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Updates the FormDocumentSyncService so that the methods for making form documents live create new versioned form documents instead of updating the existing ones.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
