### PR TITLE
Add UI for adding/removing Organisation Domains

### DIFF
--- a/app/controllers/organisation_domains_controller.rb
+++ b/app/controllers/organisation_domains_controller.rb
@@ -19,13 +19,47 @@ class OrganisationDomainsController < WebController
     end
   end
 
+  def delete
+    authorize organisation, :can_manage_organisation_domains?
+
+    @organisation_domain = organisation_domain
+    @delete_confirmation_input = Organisations::DeleteConfirmationInput.new
+  end
+
+  def destroy
+    authorize organisation, :can_manage_organisation_domains?
+
+    @organisation_domain = organisation_domain
+    @delete_confirmation_input = Organisations::DeleteConfirmationInput.new(delete_confirmation_input_params)
+
+    unless @delete_confirmation_input.valid?
+      return render :delete, status: :unprocessable_entity
+    end
+
+    unless @delete_confirmation_input.confirmed?
+      return redirect_to organisation_path(organisation), status: :see_other
+    end
+
+    @organisation_domain.destroy!
+
+    redirect_to organisation_path(organisation), success: "#{@organisation_domain.domain} has been removed from this organisation", status: :see_other
+  end
+
 private
 
   def organisation
     @organisation ||= Organisation.find(params[:organisation_id])
   end
 
+  def organisation_domain
+    @organisation_domain ||= organisation.organisation_domains.find(params[:id])
+  end
+
   def organisation_input_params
     params.require(:organisations_domain_input).permit(:domain).merge(organisation:)
+  end
+
+  def delete_confirmation_input_params
+    params.require(:organisations_delete_confirmation_input).permit(:confirm)
   end
 end

--- a/app/controllers/organisation_domains_controller.rb
+++ b/app/controllers/organisation_domains_controller.rb
@@ -1,0 +1,31 @@
+class OrganisationDomainsController < WebController
+  after_action :verify_authorized
+
+  def new
+    authorize organisation, :can_manage_organisation_domains?
+
+    @domain_input = Organisations::DomainInput.new(organisation:)
+  end
+
+  def create
+    authorize organisation, :can_manage_organisation_domains?
+
+    @domain_input = Organisations::DomainInput.new(organisation_input_params)
+
+    if @domain_input.submit
+      redirect_to organisation_path(organisation), success: "#{@domain_input.domain} has been added to this organisation"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def organisation
+    @organisation ||= Organisation.find(params[:organisation_id])
+  end
+
+  def organisation_input_params
+    params.require(:organisations_domain_input).permit(:domain).merge(organisation:)
+  end
+end

--- a/app/input_objects/organisations/delete_confirmation_input.rb
+++ b/app/input_objects/organisations/delete_confirmation_input.rb
@@ -1,0 +1,2 @@
+class Organisations::DeleteConfirmationInput < DeleteConfirmationInput
+end

--- a/app/input_objects/organisations/domain_input.rb
+++ b/app/input_objects/organisations/domain_input.rb
@@ -1,0 +1,14 @@
+module Organisations
+  class DomainInput < BaseInput
+    attr_accessor :organisation, :domain
+
+    validates :organisation, presence: true
+    validates :domain, presence: true, domain: true
+
+    def submit
+      return false if invalid?
+
+      organisation.organisation_domains.create!(domain:)
+    end
+  end
+end

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -6,4 +6,8 @@ class OrganisationPolicy < ApplicationPolicy
   def can_manage_organisation_brands?
     user.super_admin?
   end
+
+  def can_manage_organisation_domains?
+    user.super_admin?
+  end
 end

--- a/app/views/organisation_domains/delete.html.erb
+++ b/app/views/organisation_domains/delete.html.erb
@@ -1,0 +1,13 @@
+<% set_page_title(title_with_error_prefix(t(".title"), @delete_confirmation_input.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(organisation_path(@organisation)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+      @delete_confirmation_input,
+      url: organisation_domain_path(@organisation, @organisation_domain),
+      caption_text: @organisation.name_with_abbreviation,
+      legend_text: t(".title", domain: @organisation_domain.domain),
+    ) %>
+  </div>
+</div>

--- a/app/views/organisation_domains/new.html.erb
+++ b/app/views/organisation_domains/new.html.erb
@@ -1,0 +1,22 @@
+<% set_page_title(title_with_error_prefix(t(".title"), @domain_input.errors.any?)) %>
+<% content_for :back_link, govuk_back_link_to(organisation_path(@domain_input.organisation)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @domain_input, url: organisation_domains_path(@domain_input.organisation)) do |f| %>
+      <% if @domain_input.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l" id="heading">
+        <span class="govuk-caption-l"><%= @domain_input.organisation.name_with_abbreviation %></span>
+        <span class="govuk-visually-hidden"> - </span>
+        <%= t(".title") %>
+      </h1>
+
+      <%= f.govuk_text_field :domain, label: { text: t('.label'), size: "m" } %>
+
+      <%= f.govuk_submit t(".submit") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -102,11 +102,27 @@
 
     <h2 class="govuk-heading-m"><%= t("organisations.show.domains.heading") %></h2>
     <% if @organisation.organisation_domains.any? %>
-      <ul class="govuk-list">
-        <% @organisation.organisation_domains.each do |organisation_domain| %>
-          <li><%= organisation_domain.domain %></li>
+      <%= render ScrollingWrapperComponent::View.new(aria_label: t("organisations.show.domains.heading")) do %>
+        <%= govuk_table do |table| %>
+          <%= table.with_head do |head|
+            head.with_row do |row|
+              row.with_cell(header: true, text: t("organisations.show.domains.table_headings.domain"))
+              row.with_cell(header: true, text: t("organisations.show.domains.table_headings.actions"))
+            end
+          end %>
+
+          <%= table.with_body do |body| %>
+            <% @organisation.organisation_domains.each do |organisation_domain| %>
+              <%= body.with_row do |row| %>
+                <%= row.with_cell(text: organisation_domain.domain) %>
+                <%= row.with_cell do %>
+                  <%= link_to(t("organisations.show.domains.remove"), delete_organisation_domain_path(@organisation, organisation_domain), secondary: true, visually_hidden_suffix: organisation_domain.domain, class: "govuk-!-margin-bottom-0") %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
         <% end %>
-      </ul>
+      <% end %>
     <% else %>
       <p class="govuk-body"><%= t("organisations.show.domains.none") %></p>
     <% end %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -110,6 +110,7 @@
     <% else %>
       <p class="govuk-body"><%= t("organisations.show.domains.none") %></p>
     <% end %>
+    <%= govuk_button_link_to "Add a domain", new_organisation_domain_path(@organisation), secondary: true %>
 
     <h2 class="govuk-heading-m"><%= t("organisations.show.brands.heading") %></h2>
     <p class="govuk-body"><%= t("organisations.show.brands.guidance") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1567,6 +1567,11 @@ en:
     update_default:
       success: "%{brand_name} is now the default brand for new forms in this organisation"
       success_govuk: New forms in this organisation will use GOV.UK branding
+  organisation_domains:
+    new:
+      label: Domain
+      submit: Add domain
+      title: Add a domain
   organisations:
     boolean:
       'false': 'No'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,8 @@ en:
         groups/delete_confirmation_input:
           blank: Select ‘Yes’ to delete the group
           group_has_forms: This group cannot be deleted because it has forms in it
+        organisations/delete_confirmation_input:
+          blank: Select ‘Yes’ to remove the domain
         pages/change_order_input:
           attributes:
             confirm:
@@ -1568,6 +1570,8 @@ en:
       success: "%{brand_name} is now the default brand for new forms in this organisation"
       success_govuk: New forms in this organisation will use GOV.UK branding
   organisation_domains:
+    delete:
+      title: Are you sure you want to remove %{domain} from this organisation?
     new:
       label: Domain
       submit: Add domain
@@ -1628,6 +1632,10 @@ en:
       domains:
         heading: Email domains
         none: This organisation does not have any email domains.
+        remove: Remove
+        table_headings:
+          actions: Actions
+          domain: Domain
       mou_signatures:
         heading: MOUs and agreements
         none: No one has agreed an MOU or agreement for this organisation.

--- a/config/locales/input_objects/organisation_domain.yml
+++ b/config/locales/input_objects/organisation_domain.yml
@@ -1,0 +1,10 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        organisations/domain_input:
+          attributes:
+            domain:
+              blank: Enter a domain name
+              invalid_domain: Enter a domain name in the correct format, like subdomain.gov.uk

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,6 +237,7 @@ Rails.application.routes.draw do
 
   resources :organisations, only: %i[index show] do
     resources :brands, controller: :organisation_brands, only: %i[new create destroy]
+    resources :domains, controller: :organisation_domains, only: %i[new create destroy]
     patch "default-brand", to: "organisation_brands#update_default", as: :default_brand
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,7 +237,11 @@ Rails.application.routes.draw do
 
   resources :organisations, only: %i[index show] do
     resources :brands, controller: :organisation_brands, only: %i[new create destroy]
-    resources :domains, controller: :organisation_domains, only: %i[new create destroy]
+    resources :domains, controller: :organisation_domains, only: %i[new create destroy] do
+      member do
+        get "delete", to: "organisation_domains#delete"
+      end
+    end
     patch "default-brand", to: "organisation_brands#update_default", as: :default_brand
   end
 

--- a/spec/features/organisations/manage_organisation_domains_spec.rb
+++ b/spec/features/organisations/manage_organisation_domains_spec.rb
@@ -9,6 +9,10 @@ describe "Add a new domain to an organisation" do
     and_i_add_a_domain
     and_i_visit_the_organisation_page
     then_i_see_the_new_domain_listed
+    and_there_is_a_remove_button_for_domains
+    when_i_click_on_the_remove_domain_button
+    then_i_confirm
+    i_no_longer_see_the_domain_for_the_organisation
   end
 
 private
@@ -32,5 +36,25 @@ private
 
   def then_i_see_the_new_domain_listed
     expect(page).to have_content "example.com"
+  end
+
+  def and_there_is_a_remove_button_for_domains
+    expect(page).to have_link "Remove"
+  end
+
+  def when_i_click_on_the_remove_domain_button
+    click_link "Remove"
+  end
+
+  def then_i_confirm
+    expect(page).to have_content "Are you sure you want to remove example.com from this organisation?"
+    choose "Yes"
+    click_button "Continue"
+    expect(page).to have_content "example.com has been removed from this organisation"
+  end
+
+  def i_no_longer_see_the_domain_for_the_organisation
+    visit organisation_path(organisation)
+    expect(page).not_to have_content "example.com"
   end
 end

--- a/spec/features/organisations/manage_organisation_domains_spec.rb
+++ b/spec/features/organisations/manage_organisation_domains_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Add a new domain to an organisation" do
+  let(:organisation) { create(:organisation) }
+
+  it "adds the domain to an organisation page" do
+    login_as_super_admin_user
+    when_i_click_on_the_add_a_domain_button
+    and_i_add_a_domain
+    and_i_visit_the_organisation_page
+    then_i_see_the_new_domain_listed
+  end
+
+private
+
+  def when_i_click_on_the_add_a_domain_button
+    visit organisation_path(organisation)
+    click_link "Add a domain"
+  end
+
+  def and_i_add_a_domain
+    domain_field = find_field "Domain"
+    domain_field.fill_in with: "example.com"
+    expect(domain_field.value).to eq "example.com"
+    click_button "Add domain"
+    expect(page).to have_content "example.com has been added"
+  end
+
+  def and_i_visit_the_organisation_page
+    visit organisation_path(organisation)
+  end
+
+  def then_i_see_the_new_domain_listed
+    expect(page).to have_content "example.com"
+  end
+end

--- a/spec/input_objects/organisations/domain_input_spec.rb
+++ b/spec/input_objects/organisations/domain_input_spec.rb
@@ -21,7 +21,7 @@ describe Organisations::DomainInput do
     it "is invalid without a domain" do
       domain_input.organisation = organisation
       expect(domain_input).not_to be_valid
-      expect(domain_input.errors[:domain]).to include("can't be blank")
+      expect(domain_input.errors[:domain]).to include("Enter a domain name")
     end
   end
 
@@ -53,25 +53,22 @@ describe Organisations::DomainInput do
     end
 
     context "when the domain is already associated with the organisation" do
-      before do
+      it "raises an ActiveRecord::RecordInvalid error" do
         create(:organisation_domain, organisation:, domain: "example.com")
         domain_input.organisation = organisation
         domain_input.domain = "example.com"
-      end
 
-      it "raises an ActiveRecord::RecordInvalid error" do
         expect { domain_input.submit }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
 
     context "when the domain is not a valid format" do
-      before do
+      it "raises a validation error" do
         domain_input.organisation = organisation
         domain_input.domain = "not a domain"
-      end
+        domain_input.submit
 
-      it "raises an ActiveRecord::RecordInvalid error" do
-        expect { domain_input.submit }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(domain_input.errors[:domain]).to include("Enter a domain name in the correct format, like subdomain.gov.uk")
       end
     end
   end

--- a/spec/input_objects/organisations/domain_input_spec.rb
+++ b/spec/input_objects/organisations/domain_input_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+describe Organisations::DomainInput do
+  subject(:domain_input) { described_class.new }
+
+  let(:organisation) { create(:organisation) }
+
+  describe "validations" do
+    it "is valid with an organisation and a domain" do
+      domain_input.organisation = organisation
+      domain_input.domain = "example.com"
+      expect(domain_input).to be_valid
+    end
+
+    it "is invalid without an organisation" do
+      domain_input.domain = "example.com"
+      expect(domain_input).not_to be_valid
+      expect(domain_input.errors[:organisation]).to include("can't be blank")
+    end
+
+    it "is invalid without a domain" do
+      domain_input.organisation = organisation
+      expect(domain_input).not_to be_valid
+      expect(domain_input.errors[:domain]).to include("can't be blank")
+    end
+  end
+
+  describe "#submit" do
+    context "when the input is invalid" do
+      it "returns false and does not create an OrganisationDomain" do
+        expect(domain_input.submit).to be false
+        expect(OrganisationDomain.count).to eq 0
+      end
+    end
+
+    context "when the input is valid" do
+      before do
+        domain_input.organisation = organisation
+        domain_input.domain = "example.com"
+      end
+
+      it "creates a new OrganisationDomain for the organisation" do
+        expect { domain_input.submit }.to change(OrganisationDomain, :count).by(1)
+
+        organisation_domain = OrganisationDomain.last
+        expect(organisation_domain.organisation).to eq organisation
+        expect(organisation_domain.domain).to eq "example.com"
+      end
+
+      it "returns the created OrganisationDomain" do
+        expect(domain_input.submit).to be_a OrganisationDomain
+      end
+    end
+
+    context "when the domain is already associated with the organisation" do
+      before do
+        create(:organisation_domain, organisation:, domain: "example.com")
+        domain_input.organisation = organisation
+        domain_input.domain = "example.com"
+      end
+
+      it "raises an ActiveRecord::RecordInvalid error" do
+        expect { domain_input.submit }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context "when the domain is not a valid format" do
+      before do
+        domain_input.organisation = organisation
+        domain_input.domain = "not a domain"
+      end
+
+      it "raises an ActiveRecord::RecordInvalid error" do
+        expect { domain_input.submit }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/BFiR2guc

Adds UI for managing Organisation Domains. We only need to manage adding and deleting domains.

<img width="826" height="1115" alt="localhost_3000_organisations_4" src="https://github.com/user-attachments/assets/11190e71-8c1f-4b84-b4c8-a6d15b2bf30c" />

<img width="826" height="1115" alt="localhost_3000_organisations_4_domains_new" src="https://github.com/user-attachments/assets/ce400e8e-a690-4f2b-81cf-cb841aafdcd9" />

<img width="826" height="1115" alt="localhost_3000_organisations_4 (1)" src="https://github.com/user-attachments/assets/a1f53592-c50d-4793-be33-d381ac27e38f" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
