### PR TITLE
Add form with more than one exit page for a question to database seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -668,6 +668,69 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
   multiple_branch_form.set_task_status_service(TaskStatusService.new(form: multiple_branch_form))
   multiple_branch_form.make_live!
 
+  multiple_exit_pages_form = Form.create!(
+    name: "Multiple exit pages form",
+    pages: [
+      Page.build(
+        question_text: "Selection question with multiple exit pages",
+        answer_type: "selection",
+        answer_settings: {
+          only_one_option: "true",
+          selection_options: [
+            { "name": "Option 1", "value": "Option 1" },
+            { "name": "Go to exit page 1", "value": "Go to exit page 1" },
+            { "name": "Go to exit page 2", "value": "Go to exit page 2" },
+          ],
+        },
+      ),
+    ],
+    question_section_completed: true,
+    declaration_markdown: "",
+    declaration_section_completed: true,
+    privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
+    submission_email:,
+    support_email: "your.email+fakedata84701@gmail.com.gov.uk",
+    support_phone: "08000800",
+    what_happens_next_markdown: "Test",
+    share_preview_completed: true,
+    send_copy_of_answers: "enabled",
+    delivery_configurations: [
+      DeliveryConfiguration.create(
+        delivery_method: :email,
+        delivery_schedule: :immediate,
+        formats: [],
+      ),
+    ],
+  )
+  Condition.create!(
+    check_page: multiple_exit_pages_form.pages.first,
+    routing_page: multiple_exit_pages_form.pages.first,
+    goto_page: nil,
+    answer_value: "Go to exit page 1",
+    exit_page: ExitPage.create!(
+      question_page: multiple_exit_pages_form.pages.first,
+      heading: "Exit page 1",
+      markdown: "This is exit page 1.",
+    ),
+    exit_page_heading: ExitPage.last.heading,
+    exit_page_markdown: ExitPage.last.markdown,
+  )
+  Condition.create!(
+    check_page: multiple_exit_pages_form.pages.first,
+    routing_page: multiple_exit_pages_form.pages.first,
+    goto_page: nil,
+    answer_value: "Go to exit page 2",
+    exit_page: ExitPage.create!(
+      question_page: multiple_exit_pages_form.pages.first,
+      heading: "Exit page 2",
+      markdown: "This is exit page 2.",
+    ),
+    exit_page_heading: ExitPage.last.heading,
+    exit_page_markdown: ExitPage.last.markdown,
+  )
+  multiple_exit_pages_form.set_task_status_service(TaskStatusService.new(form: multiple_exit_pages_form))
+  multiple_exit_pages_form.reload.make_live!
+
   copy_of_answers_form = Form.create!(
     name: "Copy of answers form",
     pages: [
@@ -709,5 +772,6 @@ if (HostingEnvironment.local_development? || HostingEnvironment.review?) && User
   GroupForm.create! group: test_group, form_id: none_of_the_above_form.id
   GroupForm.create! group: test_group, form_id: welsh_form.id
   GroupForm.create! group: multiple_branches_test_group, form_id: multiple_branch_form.id
+  GroupForm.create! group: multiple_branches_test_group, form_id: multiple_exit_pages_form.id
   GroupForm.create! group: test_group, form_id: copy_of_answers_form.id
 end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Add a form with multiple exit pages for one question to the database seed, to make it easier to test multiple branches exit page changes in the review apps.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
