### PR TITLE
Find brands by slug in brands API

### DIFF
--- a/app/controllers/api/brands_controller.rb
+++ b/app/controllers/api/brands_controller.rb
@@ -10,6 +10,6 @@ class Api::BrandsController < ApplicationController
 private
 
   def brand
-    Brand.find_by!(id: params[:brand_id])
+    Brand.find_by!(slug: params[:slug])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -322,7 +322,7 @@ Rails.application.routes.draw do
       get "/group", to: "api/forms_metadata#group", as: :form_group
     end
 
-    get "brands/:brand_id", to: "api/brands#show", as: :brand
+    get "brands/:slug", to: "api/brands#show", as: :brand
   end
 
   scope "api/v3", as: "api_v3" do

--- a/spec/requests/api/brands_controller_spec.rb
+++ b/spec/requests/api/brands_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::BrandsController, type: :request do
       end
 
       before do
-        get "/api/v2/brands/#{brand.id}", headers:
+        get "/api/v2/brands/#{brand.slug}", headers:
       end
 
       it "returns http success" do
@@ -65,7 +65,7 @@ RSpec.describe Api::BrandsController, type: :request do
 
     context "when the brand does not exist" do
       before do
-        get "/api/v2/brands/0", headers:
+        get "/api/v2/brands/unknown-brand", headers:
       end
 
       it "returns http not found" do


### PR DESCRIPTION
Form documents identify brands by slug in their `brand_id` field, but `GET /api/v2/brands/:brand_id` resolved the parameter as a numeric database id, not slug. So runner couldn't look up the brand referenced by a form document.

Slugs are unique, non-null and immutable after creation, so they are a stable public identifier.