### PR TITLE
Don't enable email submissions for forms with S3 enabled

### DIFF
--- a/app/input_objects/forms/submission_email_input.rb
+++ b/app/input_objects/forms/submission_email_input.rb
@@ -43,7 +43,11 @@ class Forms::SubmissionEmailInput < BaseInput
 
     # Update the submission email in the form
     form.submission_email = temporary_submission_email
-    form.delivery_configurations.find_or_create_by!(delivery_method: :email, delivery_schedule: :immediate)
+
+    unless form.immediate_email_delivery_configuration.present? || form.s3_delivery_configuration.present?
+      form.delivery_configurations.create!(delivery_method: :email, delivery_schedule: :immediate)
+    end
+
     form.save_draft!
     mark_submission_email_as_confirmed
   end

--- a/spec/input_objects/forms/submission_email_input_spec.rb
+++ b/spec/input_objects/forms/submission_email_input_spec.rb
@@ -202,7 +202,6 @@ RSpec.describe Forms::SubmissionEmailInput, type: :model do
         before do
           # create some DeliveryConfigurations with different delivery_method/delivery_schedule
           create(:delivery_configuration, :daily_email, form:)
-          create(:delivery_configuration, :s3, form:)
           form.reload.save!
         end
 
@@ -229,11 +228,6 @@ RSpec.describe Forms::SubmissionEmailInput, type: :model do
               "formats" => [],
             },
             {
-              "delivery_method" => "s3",
-              "delivery_schedule" => "immediate",
-              "formats" => %w[csv],
-            },
-            {
               "delivery_method" => "email",
               "delivery_schedule" => "daily",
               "formats" => %w[csv],
@@ -245,6 +239,18 @@ RSpec.describe Forms::SubmissionEmailInput, type: :model do
       context "when a DeliveryConfiguration already exists for delivery_method: 'email', delivery_schedule: 'immediate'" do
         before do
           create :delivery_configuration, form: form, formats: %w[csv json]
+        end
+
+        it "does not create a DeliveryConfiguration" do
+          expect {
+            submission_email_input_with_user.confirm_confirmation_code
+          }.not_to(change { form.delivery_configurations.count })
+        end
+      end
+
+      context "when the form already has S3 enabled and not email enabled" do
+        before do
+          create :delivery_configuration, :s3, form: form
         end
 
         it "does not create a DeliveryConfiguration" do


### PR DESCRIPTION
We add the delivery configuration for getting emails for individual submissions when users add the submission email for the first time.

If we've already enabled S3 submissions before the email address it is likely the case that they do not want to get email submissions. As S3 submissions can only be turned on by contacting us, they will need to contact us again to enable email submissions.

As we don't currently allow configuring S3 in the interface we also want to avoid confusion if someone updates this email address for a live form but the form is only expected to send emails to S3 as this could lead to user submissions going to an unexpected place without relevant people being informed.
