### PR TITLE
Generate brand slug from name

### DIFF
--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -38,7 +38,7 @@ class BrandsController < WebController
   def update
     authorize Brand, :can_edit_brands?
 
-    if @brand.update(update_brand_params)
+    if @brand.update(brand_params)
       BrandAssetsService.new(brand: @brand).attach_assets
       redirect_to @brand, success: t("brands.success_messages.update"), status: :see_other
     else
@@ -53,10 +53,6 @@ private
   end
 
   def brand_params
-    params.require(:brand).permit(:name, :slug, :header_background_colour, :border_colour, :logo_alt_text, :logo_link, :copyright_holder, :logo_file, :favicon_file, :opengraph_image_file)
-  end
-
-  def update_brand_params
     params.require(:brand).permit(:name, :header_background_colour, :border_colour, :logo_alt_text, :logo_link, :copyright_holder, :logo_file, :favicon_file, :opengraph_image_file)
   end
 end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -13,8 +13,11 @@ class Brand < ApplicationRecord
 
   attr_accessor :logo_file, :favicon_file, :opengraph_image_file
 
-  validates :slug, presence: true, uniqueness: true, format: { with: /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/, allow_blank: true }
+  before_validation :set_slug, on: :create
+
+  validates :slug, format: { with: /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/, allow_blank: true }
   validates :name, presence: true
+  validate :name_must_generate_available_slug, on: :create
   validates :header_background_colour, :border_colour, presence: true, format: { with: /\A#[0-9a-f]{6}\z/, allow_blank: true }
   validates :logo_link, presence: true, format: { with: %r{\Ahttps?://.*\z}, allow_blank: true }
   validates :logo_alt_text, :copyright_holder, presence: true
@@ -35,6 +38,22 @@ class Brand < ApplicationRecord
   end
 
 private
+
+  def set_slug
+    self.slug = name.parameterize if slug.blank? && name.present?
+  end
+
+  # the slug is derived from the name, so errors are added to name rather
+  # than slug, which has no field in the new brand form
+  def name_must_generate_available_slug
+    return if name.blank?
+
+    if slug.blank?
+      errors.add(:name, :no_letters_or_numbers)
+    elsif Brand.exists?(slug:)
+      errors.add(:name, :taken)
+    end
+  end
 
   # blob keys are paths under /assets/, which CloudFront serves from the
   # assets bucket

--- a/app/views/brands/new.html.erb
+++ b/app/views/brands/new.html.erb
@@ -12,8 +12,6 @@
 
       <%= f.govuk_text_field :name, label: { size: 'm' } %>
 
-      <%= f.govuk_text_field :slug, label: { size: 'm' } %>
-
       <%= f.govuk_text_field :logo_alt_text, label: { size: 'm' } %>
 
       <%= f.govuk_text_field :logo_link, label: { size: 'm' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,12 +179,12 @@ en:
               invalid: Enter the logo link in the correct format, starting with https://
             name:
               blank: Enter a brand name
+              no_letters_or_numbers: Brand name must include at least one letter or number
+              taken: There is already a brand with this name
             opengraph_image_file:
               invalid_file_type: The opengraph image must be a PNG or JPEG file
             slug:
-              blank: Enter a slug
               invalid: Slug must only include lowercase letters a to z, numbers and hyphens
-              taken: There is already a brand with this slug
         draft_question:
           attributes:
             hint_text:

--- a/spec/factories/models/brands.rb
+++ b/spec/factories/models/brands.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :brand do
-    sequence(:slug) { |n| "brand-#{n}" }
-    name { slug.titleize }
+    sequence(:name) { |n| "Brand #{n}" }
+    slug { name.parameterize }
     header_background_colour { "#ffffff" }
     border_colour { "#206c49" }
     logo_alt_text { name }

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -3,12 +3,6 @@ require "rails_helper"
 RSpec.describe Brand, type: :model do
   subject(:brand) { build :brand }
 
-  it "is invalid without a slug" do
-    brand.slug = nil
-    expect(brand).to be_invalid
-    expect(brand.errors).to be_of_kind(:slug, :blank)
-  end
-
   it "is invalid without a name" do
     brand.name = nil
     expect(brand).to be_invalid
@@ -28,11 +22,39 @@ RSpec.describe Brand, type: :model do
     expect(brand).to be_valid
   end
 
-  it "is invalid with a duplicate slug" do
-    create(:brand, slug: "duplicate-brand")
-    brand.slug = "duplicate-brand"
+  it "is invalid with a duplicate name" do
+    create(:brand, name: "Duplicate Brand")
+    brand.name = "Duplicate Brand"
+    brand.slug = nil
     expect(brand).to be_invalid
-    expect(brand.errors).to be_of_kind(:slug, :taken)
+    expect(brand.errors).to be_of_kind(:name, :taken)
+  end
+
+  it "is invalid when the name contains no letters or numbers" do
+    brand.name = "!!!"
+    brand.slug = nil
+    expect(brand).to be_invalid
+    expect(brand.errors).to be_of_kind(:name, :no_letters_or_numbers)
+  end
+
+  describe "slug generation" do
+    it "generates the slug from the name" do
+      brand = build :brand, name: "Testshire & Wold Council!", slug: nil
+      expect(brand).to be_valid
+      expect(brand.slug).to eq "testshire-wold-council"
+    end
+
+    it "does not replace a slug that is already set" do
+      brand = build :brand, name: "Testshire Council", slug: "custom-slug"
+      expect(brand).to be_valid
+      expect(brand.slug).to eq "custom-slug"
+    end
+
+    it "does not change the slug when the name changes" do
+      brand = create :brand, name: "Testshire Council", slug: nil
+      brand.update!(name: "Greater Testshire Council")
+      expect(brand.reload.slug).to eq "testshire-council"
+    end
   end
 
   %i[header_background_colour border_colour logo_alt_text logo_link copyright_holder].each do |attribute|

--- a/spec/requests/brands_controller_spec.rb
+++ b/spec/requests/brands_controller_spec.rb
@@ -120,9 +120,14 @@ RSpec.describe BrandsController, type: :request do
 
       it "has a labelled field for each brand attribute" do
         page = Capybara.string(response.body)
-        ["Brand name", "Slug", "Logo alt text", "Logo link", "Header background colour", "Header and footer border colour", "Copyright holder", "Logo", "Favicon", "Opengraph image"].each do |label|
+        ["Brand name", "Logo alt text", "Logo link", "Header background colour", "Header and footer border colour", "Copyright holder", "Logo", "Favicon", "Opengraph image"].each do |label|
           expect(page).to have_field(label)
         end
+      end
+
+      it "does not have a field for the slug" do
+        page = Capybara.string(response.body)
+        expect(page).not_to have_field("Slug")
       end
 
       it "renders a multipart form so that files can be uploaded" do
@@ -138,7 +143,6 @@ RSpec.describe BrandsController, type: :request do
       {
         brand: {
           name: "Testshire Council",
-          slug: "testshire",
           header_background_colour: "#ffffff",
           border_colour: "#206c49",
           logo_alt_text: "Testshire Council",
@@ -169,7 +173,7 @@ RSpec.describe BrandsController, type: :request do
         login_as_super_admin_user
       end
 
-      it "creates a brand with the given attributes" do
+      it "creates a brand with the given attributes and a slug generated from the name" do
         expect {
           post path, params: params
         }.to change(Brand, :count).by(1)
@@ -177,7 +181,7 @@ RSpec.describe BrandsController, type: :request do
         brand = Brand.last
         expect(brand).to have_attributes(
           name: "Testshire Council",
-          slug: "testshire",
+          slug: "testshire-council",
           header_background_colour: "#ffffff",
           border_colour: "#206c49",
           logo_alt_text: "Testshire Council",
@@ -223,6 +227,22 @@ RSpec.describe BrandsController, type: :request do
         end
       end
 
+      context "when a brand with the same name already exists" do
+        before do
+          create :brand, name: "Testshire Council"
+        end
+
+        it "does not create a brand and re-renders the new view with an error" do
+          expect {
+            post path, params: params
+          }.not_to change(Brand, :count)
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response).to render_template("brands/new")
+          expect(response.body).to include(I18n.t("activerecord.errors.models.brand.attributes.name.taken"))
+        end
+      end
+
       context "when asset files are uploaded" do
         before do
           params[:brand][:logo_file] = fixture_file_upload("logo.png", "image/png")
@@ -236,9 +256,9 @@ RSpec.describe BrandsController, type: :request do
           }.to change(Brand, :count).by(1)
 
           brand = Brand.last
-          expect(brand.logo.blob.key).to match(%r{\Aassets/brands/testshire/logo-\h{6}\.png\z})
-          expect(brand.favicon.blob.key).to match(%r{\Aassets/brands/testshire/favicon-\h{6}\.ico\z})
-          expect(brand.opengraph_image.blob.key).to match(%r{\Aassets/brands/testshire/opengraph-image-\h{6}\.jpg\z})
+          expect(brand.logo.blob.key).to match(%r{\Aassets/brands/testshire-council/logo-\h{6}\.png\z})
+          expect(brand.favicon.blob.key).to match(%r{\Aassets/brands/testshire-council/favicon-\h{6}\.ico\z})
+          expect(brand.opengraph_image.blob.key).to match(%r{\Aassets/brands/testshire-council/opengraph-image-\h{6}\.jpg\z})
         end
       end
 


### PR DESCRIPTION
Automatically generates the slug from the brand name when creating a brand, and removes the slug input from the new brand form.

There's no reason for a human to need to define the slug.