### PR TITLE
Link to uploaded brand assets

### DIFF
--- a/app/views/brands/edit.html.erb
+++ b/app/views/brands/edit.html.erb
@@ -25,20 +25,23 @@
 
       <%= f.govuk_text_field :copyright_holder, label: { size: 'm' } %>
 
-      <% if @brand.logo.attached? %>
-        <p class="govuk-body"><%= t(".current_file", file_name: t("helpers.label.brand.logo_file"), path: @brand.logo_path) %></p>
+      <%= f.govuk_file_field :logo_file, label: { size: 'm' } do %>
+        <% if @brand.logo.attached? %>
+          <p class="govuk-body"><%= t(".current_file_html", file_name: t("helpers.label.brand.logo_file"), link: govuk_link_to(@brand.logo_path, @brand.logo_path)) %></p>
+        <% end %>
       <% end %>
-      <%= f.govuk_file_field :logo_file, label: { size: 'm' } %>
 
-      <% if @brand.favicon.attached? %>
-        <p class="govuk-body"><%= t(".current_file", file_name: t("helpers.label.brand.favicon_file"), path: @brand.favicon_path) %></p>
+      <%= f.govuk_file_field :favicon_file, label: { size: 'm' } do %>
+        <% if @brand.favicon.attached? %>
+          <p class="govuk-body"><%= t(".current_file_html", file_name: t("helpers.label.brand.favicon_file"), link: govuk_link_to(@brand.favicon_path, @brand.favicon_path)) %></p>
+        <% end %>
       <% end %>
-      <%= f.govuk_file_field :favicon_file, label: { size: 'm' } %>
 
-      <% if @brand.opengraph_image.attached? %>
-        <p class="govuk-body"><%= t(".current_file", file_name: t("helpers.label.brand.opengraph_image_file"), path: @brand.opengraph_image_path) %></p>
+      <%= f.govuk_file_field :opengraph_image_file, label: { size: 'm' } do %>
+        <% if @brand.opengraph_image.attached? %>
+          <p class="govuk-body"><%= t(".current_file_html", file_name: t("helpers.label.brand.opengraph_image_file"), link: govuk_link_to(@brand.opengraph_image_path, @brand.opengraph_image_path)) %></p>
+        <% end %>
       <% end %>
-      <%= f.govuk_file_field :opengraph_image_file, label: { size: 'm' } %>
 
       <%= f.govuk_submit t("save_and_continue") %>
     <% end %>

--- a/app/views/brands/show.html.erb
+++ b/app/views/brands/show.html.erb
@@ -38,17 +38,17 @@
 
       summary_list.with_row do |row|
         row.with_key { t('brands.show.summary.logo') }
-        row.with_value { @brand.logo_path || t('brands.show.summary.not_uploaded') }
+        row.with_value { @brand.logo_path ? govuk_link_to(@brand.logo_path, @brand.logo_path) : t('brands.show.summary.not_uploaded') }
       end
 
       summary_list.with_row do |row|
         row.with_key { t('brands.show.summary.favicon') }
-        row.with_value { @brand.favicon_path || t('brands.show.summary.not_uploaded') }
+        row.with_value { @brand.favicon_path ? govuk_link_to(@brand.favicon_path, @brand.favicon_path) : t('brands.show.summary.not_uploaded') }
       end
 
       summary_list.with_row do |row|
         row.with_key { t('brands.show.summary.opengraph_image') }
-        row.with_value { @brand.opengraph_image_path || t('brands.show.summary.not_uploaded') }
+        row.with_value { @brand.opengraph_image_path ? govuk_link_to(@brand.opengraph_image_path, @brand.opengraph_image_path) : t('brands.show.summary.not_uploaded') }
       end
 
       summary_list.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,7 +326,7 @@ en:
     heading: Choose a brand for your form
   brands:
     edit:
-      current_file: 'Current %{file_name}: %{path}'
+      current_file_html: 'Current %{file_name}: %{link}'
       title: Edit brand
     index:
       create_brand: Create a brand

--- a/spec/requests/brands_controller_spec.rb
+++ b/spec/requests/brands_controller_spec.rb
@@ -95,8 +95,9 @@ RSpec.describe BrandsController, type: :request do
         get path
       end
 
-      it "shows the public path of each uploaded asset" do
-        expect(response.body).to include("/#{brand.logo.blob.key}")
+      it "links to the public path of each uploaded asset" do
+        page = Capybara.string(response.body)
+        expect(page).to have_link("/#{brand.logo.blob.key}", href: "/#{brand.logo.blob.key}")
       end
     end
   end

--- a/spec/requests/brands_controller_spec.rb
+++ b/spec/requests/brands_controller_spec.rb
@@ -286,6 +286,23 @@ RSpec.describe BrandsController, type: :request do
         end
       end
     end
+
+    context "when the user is a super admin and the brand has assets" do
+      before do
+        brand.logo_file = fixture_file_upload("logo.png", "image/png")
+        BrandAssetsService.new(brand:).attach_assets
+
+        login_as_super_admin_user
+
+        get path
+      end
+
+      it "links to the current file for each uploaded asset" do
+        page = Capybara.string(response.body)
+        expect(page).to have_text("Current Logo:")
+        expect(page).to have_link("/#{brand.logo.blob.key}", href: "/#{brand.logo.blob.key}")
+      end
+    end
   end
 
   describe "#update" do


### PR DESCRIPTION
Makes the asset paths on the brand pages links, so uploaded files can be previewed directly.

On the edit page, also moves the "Current <asset>" line from above each file field's label to below it.

<img width="718" height="757" alt="image" src="https://github.com/user-attachments/assets/b2736f44-3864-4f51-a973-f13feb348296" />

<img width="718" height="707" alt="image" src="https://github.com/user-attachments/assets/19aaf5db-7ea1-4c6b-8d8f-21880f17541f" />
