### PR TITLE
Send user research invitation email automatically

### DIFF
--- a/app/input_objects/account/contact_for_research_input.rb
+++ b/app/input_objects/account/contact_for_research_input.rb
@@ -11,9 +11,21 @@ class Account::ContactForResearchInput < BaseInput
     user.research_contact_status = research_contact_status
     user.user_research_opted_in_at = Time.zone.now
     user.save!
+
+    send_invitation_email if user.research_contact_status_previously_changed?(to: "consented")
+
+    true
   end
 
   def values
     RADIO_OPTIONS
+  end
+
+private
+
+  def send_invitation_email
+    UserResearchMailer.invitation_email(user).deliver_now
+  rescue StandardError => e
+    Sentry.capture_exception(e)
   end
 end

--- a/app/mailers/user_research_mailer.rb
+++ b/app/mailers/user_research_mailer.rb
@@ -1,0 +1,10 @@
+class UserResearchMailer < GovukNotifyRails::Mailer
+  def invitation_email(user)
+    set_template(Settings.govuk_notify.user_research_invitation_template_id)
+    set_email_reply_to(Settings.govuk_notify.zendesk_reply_to_id)
+
+    set_personalisation(name: user.name)
+
+    mail(to: user.email)
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,6 +35,7 @@ govuk_notify:
   group_upgraded_template_id: b5d0d3d4-fc24-403e-aba6-b421fdcebd55
   group_upgrade_requested_template_id: e2251c92-9365-429a-9857-56780263718f
   group_upgrade_rejected_template_id: f494999a-1a38-4b01-a3c8-dbb2d60e6e5f
+  user_research_invitation_template_id: 48988e1d-d6e3-4b4e-8bc8-3a4e4e63e1c0
   admin_alerts:
     new_draft_form_made_live_template_id: 95065d23-e7ad-4af7-9a2f-7209276d74d0
     live_form_changes_made_live_template_id: 02c38f9b-197e-480d-8031-bba9498d5907

--- a/spec/input_objects/account/contact_for_research_input_spec.rb
+++ b/spec/input_objects/account/contact_for_research_input_spec.rb
@@ -8,6 +8,13 @@ describe Account::ContactForResearchInput do
   let(:user) { create(:user) }
 
   describe "#submit" do
+    let(:delivery) { double }
+
+    before do
+      allow(UserResearchMailer).to receive(:invitation_email).and_return(delivery)
+      allow(delivery).to receive(:deliver_now).with(no_args)
+    end
+
     context "with valid attributes" do
       before do
         contact_for_research_input.research_contact_status = "consented"
@@ -22,6 +29,56 @@ describe Account::ContactForResearchInput do
 
       it "returns true" do
         expect(contact_for_research_input.submit).to be true
+      end
+    end
+
+    context "when the user consents" do
+      before do
+        contact_for_research_input.research_contact_status = "consented"
+      end
+
+      it "sends the invitation email" do
+        contact_for_research_input.submit
+        expect(UserResearchMailer).to have_received(:invitation_email).with(user)
+        expect(delivery).to have_received(:deliver_now)
+      end
+
+      context "when sending the email fails" do
+        let(:error) { StandardError.new("Notify is down") }
+
+        before do
+          allow(delivery).to receive(:deliver_now).and_raise(error)
+          allow(Sentry).to receive(:capture_exception)
+        end
+
+        it "still returns true and reports the error to Sentry" do
+          expect(contact_for_research_input.submit).to be true
+          expect(Sentry).to have_received(:capture_exception).with(error)
+        end
+      end
+    end
+
+    context "when the user declines" do
+      before do
+        contact_for_research_input.research_contact_status = "declined"
+      end
+
+      it "does not send the invitation email" do
+        contact_for_research_input.submit
+        expect(UserResearchMailer).not_to have_received(:invitation_email)
+      end
+    end
+
+    context "when the user has already consented" do
+      let(:user) { create(:user, research_contact_status: "consented") }
+
+      before do
+        contact_for_research_input.research_contact_status = "consented"
+      end
+
+      it "does not send the invitation email again" do
+        contact_for_research_input.submit
+        expect(UserResearchMailer).not_to have_received(:invitation_email)
       end
     end
   end

--- a/spec/mailers/user_research_mailer_spec.rb
+++ b/spec/mailers/user_research_mailer_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe UserResearchMailer, type: :mailer do
+  describe "#invitation_email" do
+    subject(:mail) { described_class.invitation_email(user) }
+
+    let(:user) { create(:user) }
+
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.user_research_invitation_template_id)
+    end
+
+    it "sends an email to the user" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "includes the user's name" do
+      expect(mail.govuk_notify_personalisation[:name]).to eq(user.name)
+    end
+  end
+end

--- a/spec/requests/account/contact_for_research_controller_spec.rb
+++ b/spec/requests/account/contact_for_research_controller_spec.rb
@@ -35,6 +35,12 @@ describe Account::ContactForResearchController do
         put account_contact_for_research_path, params: valid_params
         expect(response).to redirect_to("/next-path")
       end
+
+      it "sends the user research invitation email" do
+        expect {
+          put account_contact_for_research_path, params: valid_params
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
     end
 
     context "with invalid params" do


### PR DESCRIPTION
When a new user consents to being contacted about user research during onboarding, send them the research sign-up invitation email automatically via GOV.UK Notify. This email is currently sent manually by the user researcher.

The email is only sent when the user's status changes to consented, so re-submitting the form cannot send it twice. Delivery failures are reported to Sentry rather than raised, so a Notify problem does not block the user from completing onboarding.

Tested in dev.